### PR TITLE
perf: add shape-keyed CallMember1 caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf(compiler/runtime): implement issue #1958 Phase 4 with shape-keyed
+  `CallMember1` caches for own methods and direct prototype methods, including
+  the hot `Array.prototype.findGraphNode` path. Generated sites use fixed-arity
+  cached invocation with terminal generic fallback, while own shadowing,
+  accessors, reassignment, prototype mutation, proxies, symbols, and unsupported
+  exotic receivers preserve full dynamic semantics.
 - perf(runtime): implement issue #1958 Phase 3 by replacing exact-receiver
   dynamic property-read cache entries with weak shape-and-slot entries.
   Distinct ordinary objects with the same `JsShape` now share one monomorphic

--- a/docs/runtime/DynamicLookupInlineCaches.md
+++ b/docs/runtime/DynamicLookupInlineCaches.md
@@ -1,9 +1,9 @@
 # Dynamic lookup inline caches
 
 Issue #1893 introduces a conservative per-call-site cache prototype for
-dynamic property reads and zero-argument member calls that remain after AOT
-specialization. The prototype targets repeated access to ordinary user
-objects without weakening JavaScript lookup semantics.
+dynamic property reads and fixed-arity member calls that remain after AOT
+specialization. The prototype targets repeated access to JavaScript-owned
+shapes without weakening JavaScript lookup semantics.
 
 Phase 3 (issues #1958 / #1324) replaced the original exact-receiver-identity
 cache entries described below with **shape-keyed** entries for property
@@ -14,6 +14,13 @@ receiver's live slot value. This lets thousands of distinct `JsObject`
 instances that share one shape and one own plain-data property (for example,
 many `GraphNode` instances each with their own `pos` value) hit the same
 monomorphic entry instead of exhausting the four-entry polymorphic budget.
+Phase 4 (#1963) extends the same contract to `CallMember1`, including direct
+prototype methods on ordinary objects and exact `Array` receivers. A prototype
+entry adds weak prototype/callable references and a prototype lookup-version
+guard, so the unmodified
+Kraken A* `openList.findGraphNode(neighbor)` and
+`closedList.findGraphNode(neighbor)` sites resolve once and then invoke through
+`CallableOperations.Call1` without an argument array.
 Sections below describe this current contract; historical Phase 0/1 sections
 that still describe identity-only behavior are updated in place rather than
 kept as a separate legacy description, since the generated call surface and
@@ -33,8 +40,8 @@ general use in JavaScript engines.
 | **Terminal bypass** | A compiler-emitted static flag for one generated call site. After any realm transitions that site to megamorphic, generated code tests the flag and calls the generic operation without entering the runtime cache helper. The flag is only a conservative deoptimization hint: it contains no JavaScript value or realm reference. |
 | **Receiver** | The JavaScript value to the left of the property access, such as `record` in `record.name` or `record.save()`. |
 | **Dynamic lookup** | Resolving a property or callable at runtime because the compiler cannot determine the result safely in advance. |
-| **Inline cache** | Per-call-site runtime state that reuses a previously resolved own plain-data property slot when the receiver's shape and per-slot descriptor state remain trivial. Entries and transition state are stored in the realm. Generated code contains only the terminal bypass flag, which can select the full generic algorithm but can never supply a cached value. |
-| **Cache entry** | A weak reference to a `JsShape`, the looked-up property name, and the resolved slot index for that (shape, property) pair. It stores neither a receiver nor a value; every hit reads the current receiver's live slot. |
+| **Inline cache** | Per-call-site runtime state that reuses a previously resolved own or direct-prototype plain-data property slot when the receiver and holder guards remain valid. Entries and transition state are stored in the realm. Generated code contains only the terminal bypass flag, which can select the full generic algorithm but can never supply a cached value. |
+| **Cache entry** | An own-slot entry has a weak receiver-shape reference, property name, and resolved slot. A direct-prototype `CallMember1` entry has a weak receiver shape, weak prototype and callable references, and the prototype lookup version observed during resolution. No entry strongly retains a receiver or JavaScript value. |
 | **Empty** | A cache site that has not recorded a usable shape/property/slot triple. |
 | **Monomorphic** | A site containing one live cache entry. Because entries are shape-keyed, every receiver that shares that exact `JsShape` reference hits the same entry, regardless of how many distinct receiver instances exist. |
 | **Polymorphic** | A site containing two through four live cache entries, allowing a small set of distinct shapes to hit the same generated site. |
@@ -43,15 +50,15 @@ general use in JavaScript engines.
 | **Cache miss** | No valid entry matches. The runtime performs exact generic lookup and may record a new entry when the result is an own plain-data property. |
 | **Invalidation** | A structural change — adding, deleting, or redefining a property (including a data/accessor transition) — changes the receiver's shape or per-slot descriptor flags, so the existing entry (keyed to the old shape/slot) can no longer hit for that receiver. There is no separate value or version snapshot to invalidate: reads are always live. |
 | **Generic fallback** | The existing `ObjectRuntime` lookup or call path, which preserves complete JavaScript behavior for misses and cases the cache deliberately excludes. |
-| **Ordinary object** | In this stage, an object whose exact CLR representation is `JsObject`. Only its **own** properties are eligible for shape-keyed caching; inherited/prototype-chain reads always use generic lookup. |
-| **Exotic object** | A representation with specialized property behavior, such as a proxy, array, typed array, or host object. These bypass this cache prototype. |
+| **Ordinary object** | An object whose exact CLR representation is `JsObject`. Property reads and member calls can cache own plain-data slots; `CallMember1` can also cache a plain-data method on the direct prototype. |
+| **Exotic object** | A representation with specialized property behavior, such as a proxy, array, typed array, or host object. Property reads continue to bypass the cache. Phase 4 admits exact `Array` receivers only for guarded `CallMember1` direct-prototype slots; other exotic representations bypass it. |
 | **Realm** | The JavaScript execution environment that owns intrinsic objects and this feature’s cache-site dictionary. Cache entries and site snapshots are never shared between realms. A generated terminal bypass may conservatively deoptimize the same compiled call site in another realm, but it never exposes or reuses another realm's values or lookup state. |
 
 ## Scope and site identity
 
 The compiler routes materialized string-key `LIRGetItem` instructions and
-dynamic `LIRCallMember0` instructions through
-`DynamicLookupInlineCache.GetItem` and `CallMember0`.
+dynamic `LIRCallMember0`/`LIRCallMember1` instructions through
+`DynamicLookupInlineCache.GetItem`, `CallMember0`, and `CallMember1`.
 
 ### Key construction and call-site association
 
@@ -122,7 +129,7 @@ polymorphic or megamorphic earlier than intended. A future key representation
 should remove this performance-level collision as well as string lookup cost.
 
 The property or method name is passed separately and is not part of the site
-key. `CallMember0` has a literal method name, while a string-key `LIRGetItem`
+key. Member calls have a literal method name, while a string-key `LIRGetItem`
 may produce different names on different executions. Cache entries validate
 the property name in addition to the receiver's shape; several names observed
 at one computed-property site can therefore consume separate polymorphic
@@ -148,8 +155,9 @@ monotonic.
 When a fifth distinct live shape/property pair makes a site megamorphic, the
 runtime publishes `1` to the generated field with `Volatile.Write`. Generated
 code tests the field before loading the site key or entering the cache helper.
-A nonzero field branches directly to the same `ObjectRuntime.GetItem` or
-`ObjectRuntime.CallMember0` operation used by an uncached dynamic lookup.
+A nonzero field branches directly to the same `ObjectRuntime.GetItem`,
+`ObjectRuntime.CallMember0`, or `ObjectRuntime.CallMember1` operation used by
+an uncached dynamic lookup.
 
 The field is monotonic for the lifetime of the loaded compiled assembly. It is
 intentionally not realm-tagged: a transition in one realm can cause another
@@ -167,8 +175,9 @@ integer site IDs or realm-owned per-module arrays. Any replacement must
 preserve module namespacing, distinct LIR call sites, realm isolation, and
 collectible-assembly lifetime behavior.
 
-Caching is deliberately narrow (Tier 3 scope, #1958/#1324 Phase 3): only a
-receiver whose exact CLR type is `JsObject`, and only an **own** property
+Caching is deliberately narrow. Property reads and `CallMember0` retain the
+Tier 3 Phase 3 contract: only a receiver whose exact CLR type is `JsObject`,
+and only an **own** property
 resolved to a plain default-attributed data slot (writable, enumerable,
 configurable, no accessor), is eligible. `JsObject.TryGetOwnPlainDataSlot`
 (used to build an entry) and `JsObject.TryGetOwnPlainDataSlotValue` (used on
@@ -176,13 +185,13 @@ every hit) enforce this: they reject missing properties, inherited/prototype
 properties, accessors, attribute-bearing data descriptors, encoded symbol
 keys, and objects marked `HasSharedIntrinsicBaseline` (intrinsic prototype
 objects whose descriptor storage is overlaid outside the inline
-shape/property arrays). Arrays, typed arrays, proxies, host objects, primitive
-receivers, and other exotic representations use the existing generic lookup,
-as `Proxy` deliberately does not inherit `JsObject`. Because prototype-chain
-reads are never cached, prototype mutation cannot invalidate a shape-keyed
-entry — inherited access simply never populates one. AOT direct and
-realm-guarded calls are unchanged because they no longer reach these dynamic
-LIR instructions.
+shape/property arrays). Phase 4 `CallMember1` additionally admits exact
+`Array` receivers and a method found as a plain data slot on the receiver's
+direct exact-`JsObject` prototype. It does not walk or cache deeper prototype
+chains. Typed arrays, proxies, host objects, primitive receivers, encoded
+symbols, accessors, and other exotic representations use the existing generic
+lookup. AOT direct and realm-guarded calls are unchanged because they no longer
+reach these dynamic LIR instructions.
 
 ## Validity contract
 
@@ -192,8 +201,10 @@ An entry records:
 - the property name;
 - the resolved slot index within that shape.
 
-It does not record a receiver, a value, a prototype chain, or a lookup
-version. Every hit re-validates and re-reads live state:
+For a direct-prototype `CallMember1` entry, the entry instead records weak
+references to the direct prototype object and resolved callable plus the
+prototype's `LookupVersion`. It does not record a receiver or a prototype
+chain snapshot. Every hit re-validates live state:
 
 1. The entry's weakly held `JsShape` must still be alive
    (`WeakReference<JsShape>.TryGetTarget`).
@@ -213,10 +224,16 @@ version. Every hit re-validates and re-reads live state:
    guards against descriptor-only mutation that shape identity alone would
    miss.
 
-Only if all four checks pass does the entry read `_properties[slot]` and
-return the receiver's live current value. There is no cached/stale value to
-return: a plain value write to an existing slot changes what this read
-observes on the very next hit, with no separate invalidation step required.
+For a prototype entry, the receiver's current direct prototype must also be
+reference-equal to the weakly held prototype and that prototype's current
+`LookupVersion` must equal the recorded version. Any prototype property write,
+deletion, descriptor change, or prototype mutation increments that version;
+the miss path then re-resolves the property and records the new callable only
+when it is still a writable/enumerable/configurable own data descriptor. The
+weak callable can therefore be invoked without rereading descriptor storage.
+Receiver-shape and direct-prototype guards cover own shadowing and
+`Object.setPrototypeOf`. Own-slot entries continue to read `_properties[slot]`
+live, so plain own-value writes are visible without rebuilding the entry.
 
 Because entries never hold a receiver reference, cache reuse across receivers
 is a natural consequence of shape sharing: `JsShape.TransitionTo` caches child
@@ -228,13 +245,12 @@ same-named own data slot (the `GraphNode.pos` motivating scenario) therefore
 share one monomorphic entry, and each hit still returns that specific
 receiver's own current value.
 
-Because Tier 3 only caches **own** properties, prototype-chain mutation needs
-no invalidation tracking: an inherited read is never represented by a
-shape-keyed entry, so `TryGetOwnPlainDataSlot` naturally reports a miss for it
-and generic lookup (which already walks the prototype chain correctly) always
-runs instead.
+Property reads and `CallMember0` still cache only own properties. The only
+prototype entry is the Phase 4 direct-prototype `CallMember1` form above;
+deeper inherited lookup always runs through the generic algorithm.
 
-Entries weakly reference only the `JsShape`. A live realm cache therefore does
+Entries weakly reference shapes and, for direct-prototype calls, the prototype
+object and callable. A live realm cache therefore does
 not keep otherwise unreachable JavaScript objects (receivers, values, or
 shapes) alive. If the weak shape target has been collected, the entry misses
 and generic resolution runs again. Miss updates remove collected-shape entries
@@ -259,10 +275,11 @@ will observe the realm site's terminal snapshot and still execute generic
 lookup; no race can return a stale cached value.
 
 Every miss, missing-slot, accessor, symbol-key, shared-intrinsic-baseline,
-inherited-only, proxy, primitive, exotic receiver, and megamorphic site
-executes the existing generic `ObjectRuntime` operation. `CallMember0`
-additionally validates callability before caching or invoking a resolved
-value.
+unsupported inherited lookup, proxy, primitive, unsupported exotic receiver,
+and megamorphic site executes the existing generic `ObjectRuntime` operation.
+Member-call helpers additionally validate callability before caching or
+invoking a resolved value, preserve the original receiver as JavaScript
+`this`, and use fixed-arity `CallableOperations.Call0`/`Call1`.
 
 ## Cache size and lifetime policy
 
@@ -274,11 +291,11 @@ process-global eviction.
 
 | Layer | Size policy | Lifetime and release policy |
 | --- | --- | --- |
-| Generated terminal fields | Exactly one four-byte logical flag per emitted cache-bearing property read or zero-argument member call, plus normal CLR metadata/alignment overhead. | The zero-initialized flag changes monotonically to one after a megamorphic transition and remains for the loaded assembly's lifetime. It contains no receiver, value, site key, cache object, or realm reference. |
+| Generated terminal fields | Exactly one four-byte logical flag per emitted cache-bearing property read or zero/one-argument member call, plus normal CLR metadata/alignment overhead. | The zero-initialized flag changes monotonically to one after a megamorphic transition and remains for the loaded assembly's lifetime. It contains no receiver, value, site key, cache object, or realm reference. |
 | Thread-local recent sites | Two MRU slots plus an eight-entry ring per thread. Entries are keyed by realm-cache identity and ordinal site key. | All slots are discarded on every ambient execution-context transition. They are a lookup front end only; the realm dictionary remains authoritative. |
-| Realm site dictionary | One site for each distinct generated site key that produces at least one cacheable own-plain-data-property result. Uncacheable-only operations do not create sites. | The dictionary strongly retains each key and site until realm disposal. Individual sites are not currently removed. |
+| Realm site dictionary | One site for each distinct generated site key that produces at least one cacheable own-slot or direct-prototype-call result. Uncacheable-only operations do not create sites. | The dictionary strongly retains each key and site until realm disposal. Individual sites are not currently removed. |
 | Cache site | At most four live monomorphic/polymorphic entries. | A fifth distinct live (shape, property) pair changes the site permanently to megamorphic state and releases all entries. The site object and key remain in the realm dictionary so later calls can take generic fallback directly. |
-| Cache entry | One weak `JsShape` reference, a property name, and one slot index — a small, fixed-size object regardless of how many receivers share that shape. | The `JsShape` is weakly referenced; the entry never references a receiver, a value, or a prototype chain. The property name and slot index remain strongly held while the entry remains in the current site snapshot. |
+| Cache entry | An own entry has one weak `JsShape`, a property name, and one slot. A direct-prototype call entry has weak receiver-shape, prototype-object, and callable references plus one lookup version. | Weak references keep receiver shapes, prototypes, and callables collectible; the entry never references a receiver. The property name and scalar guards remain strongly held while the entry remains in the current site snapshot. |
 | Published snapshot | One immutable entry array visible to new readers. | A miss update atomically publishes a replacement. An older snapshot remains alive only while an in-flight reader still references it, then becomes collectible. |
 
 A cache entry is created only after exact generic resolution finds a
@@ -409,8 +426,9 @@ stage, while limiting further expansion to measured cases:
    "Validity contract" above), restricted to own plain-data slots. Member
    calls beyond `CallMember0` and AOT-compiled classes remain out of scope for
    this phase.
-3. Use profile and receiver-analysis evidence to gate cache emission and to
-   decide whether `CallMember1..5` merit additional stubs.
+3. **Done for `CallMember1` in Phase 4 (#1963):** generated arity-1 calls use
+   the shape-keyed own/direct-prototype cache and fixed-arity invocation.
+   Measurements should decide whether `CallMember2..5` merit separate stubs.
 4. Consider exotics or primitive families only with dedicated validity
    contracts; never generalize ordinary-object entries across proxies,
    accessors, realm prototypes, or boxing boundaries.

--- a/scripts/runKrackenAStarGuardrails.js
+++ b/scripts/runKrackenAStarGuardrails.js
@@ -685,13 +685,22 @@ function inspectHotMethodIl(il, source) {
       body,
       /ObjectRuntime::CallMember1\(/g
     ),
+    cachedArity1MemberDispatches: countMatches(
+      body,
+      /DynamicLookupInlineCache::CallMember1\(/g
+    ),
     findGraphNodeArity1CallSites: 0,
+    cachedFindGraphNodeArity1CallSites: 0,
   };
 
   for (const callable of bodies) {
     result.findGraphNodeArity1CallSites += countMatches(
       callable.text,
       /ldstr "findGraphNode"[\s\S]{0,500}?ObjectRuntime::CallMember1\(/g
+    );
+    result.cachedFindGraphNodeArity1CallSites += countMatches(
+      callable.text,
+      /ldstr "findGraphNode"[\s\S]{0,500}?DynamicLookupInlineCache::CallMember1\(/g
     );
   }
   return result;
@@ -765,7 +774,13 @@ function printIlCounters(result) {
     `Arity-1 dispatches inside findGraphNode:   ${result.arity1MemberDispatches}`
   );
   console.log(
+    `Cached arity-1 dispatches in findGraphNode:${result.cachedArity1MemberDispatches}`
+  );
+  console.log(
     `Arity-1 calls to findGraphNode elsewhere: ${result.findGraphNodeArity1CallSites}`
+  );
+  console.log(
+    `Cached calls to findGraphNode elsewhere:  ${result.cachedFindGraphNodeArity1CallSites}`
   );
 }
 

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
@@ -1216,17 +1216,51 @@ internal sealed partial class LIRToILCompiler
 
             case LIRCallMember1 callMember1:
                 {
-                    // Emit: ldarg/ldloc receiver, ldstr methodName, ldarg/ldloc a0, call ObjectRuntime.CallMember1
+                    var cachedPath = ilEncoder.DefineLabel();
+                    var done = ilEncoder.DefineLabel();
+                    ilEncoder.OpCode(ILOpCode.Volatile);
+                    ilEncoder.OpCode(ILOpCode.Ldsfld);
+                    ilEncoder.Token(
+                        GetDynamicLookupTerminalField(callMember1));
+                    ilEncoder.Branch(
+                        ILOpCode.Brfalse,
+                        cachedPath);
+
                     EmitLoadTempAsObject(callMember1.Receiver, ilEncoder, allocation, methodDescriptor);
                     ilEncoder.Ldstr(_metadataBuilder, callMember1.MethodName);
                     EmitLoadTempAsObject(callMember1.A0, ilEncoder, allocation, methodDescriptor);
-
-                    var callMemberRef = _memberRefRegistry.GetOrAddMethod(
+                    var genericCallMemberRef =
+                        _memberRefRegistry.GetOrAddMethod(
                         typeof(JavaScriptRuntime.ObjectRuntime),
                         nameof(JavaScriptRuntime.ObjectRuntime.CallMember1),
                         new[] { typeof(object), typeof(string), typeof(object) });
                     ilEncoder.OpCode(ILOpCode.Call);
+                    ilEncoder.Token(genericCallMemberRef);
+                    ilEncoder.Branch(ILOpCode.Br, done);
+
+                    ilEncoder.MarkLabel(cachedPath);
+                    EmitLoadTempAsObject(callMember1.Receiver, ilEncoder, allocation, methodDescriptor);
+                    ilEncoder.Ldstr(_metadataBuilder, callMember1.MethodName);
+                    EmitLoadTempAsObject(callMember1.A0, ilEncoder, allocation, methodDescriptor);
+                    EmitDynamicLookupInlineCacheSite(
+                        ilEncoder,
+                        methodDescriptor,
+                        callMember1);
+
+                    var callMemberRef = _memberRefRegistry.GetOrAddMethod(
+                        typeof(JavaScriptRuntime.DynamicLookupInlineCache),
+                        nameof(JavaScriptRuntime.DynamicLookupInlineCache.CallMember1),
+                        new[]
+                        {
+                            typeof(object),
+                            typeof(string),
+                            typeof(object),
+                            typeof(string),
+                            typeof(int).MakeByRefType()
+                        });
+                    ilEncoder.OpCode(ILOpCode.Call);
                     ilEncoder.Token(callMemberRef);
+                    ilEncoder.MarkLabel(done);
 
                     if (IsMaterialized(callMember1.Result, allocation))
                     {

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -1328,16 +1328,51 @@ internal sealed partial class LIRToILCompiler
 
             case LIRCallMember1 callMember1:
                 {
+                    var cachedPath = ilEncoder.DefineLabel();
+                    var done = ilEncoder.DefineLabel();
+                    ilEncoder.OpCode(ILOpCode.Volatile);
+                    ilEncoder.OpCode(ILOpCode.Ldsfld);
+                    ilEncoder.Token(
+                        GetDynamicLookupTerminalField(callMember1));
+                    ilEncoder.Branch(
+                        ILOpCode.Brfalse,
+                        cachedPath);
+
                     EmitLoadTempAsObject(callMember1.Receiver, ilEncoder, allocation, methodDescriptor);
                     ilEncoder.Ldstr(_metadataBuilder, callMember1.MethodName);
                     EmitLoadTempAsObject(callMember1.A0, ilEncoder, allocation, methodDescriptor);
-
-                    var callMemberRef = _memberRefRegistry.GetOrAddMethod(
+                    var genericCallMemberRef =
+                        _memberRefRegistry.GetOrAddMethod(
                         typeof(JavaScriptRuntime.ObjectRuntime),
                         nameof(JavaScriptRuntime.ObjectRuntime.CallMember1),
                         new[] { typeof(object), typeof(string), typeof(object) });
                     ilEncoder.OpCode(ILOpCode.Call);
+                    ilEncoder.Token(genericCallMemberRef);
+                    ilEncoder.Branch(ILOpCode.Br, done);
+
+                    ilEncoder.MarkLabel(cachedPath);
+                    EmitLoadTempAsObject(callMember1.Receiver, ilEncoder, allocation, methodDescriptor);
+                    ilEncoder.Ldstr(_metadataBuilder, callMember1.MethodName);
+                    EmitLoadTempAsObject(callMember1.A0, ilEncoder, allocation, methodDescriptor);
+                    EmitDynamicLookupInlineCacheSite(
+                        ilEncoder,
+                        methodDescriptor,
+                        callMember1);
+
+                    var callMemberRef = _memberRefRegistry.GetOrAddMethod(
+                        typeof(JavaScriptRuntime.DynamicLookupInlineCache),
+                        nameof(JavaScriptRuntime.DynamicLookupInlineCache.CallMember1),
+                        new[]
+                        {
+                            typeof(object),
+                            typeof(string),
+                            typeof(object),
+                            typeof(string),
+                            typeof(int).MakeByRefType()
+                        });
+                    ilEncoder.OpCode(ILOpCode.Call);
                     ilEncoder.Token(callMemberRef);
+                    ilEncoder.MarkLabel(done);
                     break;
                 }
 

--- a/src/Compiler/IL/LIRToILCompiler.cs
+++ b/src/Compiler/IL/LIRToILCompiler.cs
@@ -78,6 +78,7 @@ internal sealed partial class LIRToILCompiler
             .Where(
                 instruction =>
                     instruction is LIRCallMember0
+                    || instruction is LIRCallMember1
                     || instruction is LIRGetItem getItem
                     && GetTempStorage(getItem.Index).Kind
                         == ValueStorageKind.Reference

--- a/src/JavaScriptRuntime/DynamicLookupInlineCache.cs
+++ b/src/JavaScriptRuntime/DynamicLookupInlineCache.cs
@@ -196,14 +196,35 @@ internal sealed class DynamicLookupInlineCacheEntry
         Slot = slot;
     }
 
+    internal DynamicLookupInlineCacheEntry(
+        JsShape receiverShape,
+        string propertyName,
+        JsObject prototype,
+        long prototypeVersion,
+        object value)
+    {
+        _shape = new WeakReference<JsShape>(receiverShape);
+        _prototype = new WeakReference<JsObject>(prototype);
+        _prototypeValue = new WeakReference<object>(value);
+        _prototypeVersion = prototypeVersion;
+        PropertyName = propertyName;
+        Slot = -1;
+    }
+
     private readonly WeakReference<JsShape> _shape;
+    private readonly WeakReference<JsObject>? _prototype;
+    private readonly WeakReference<object>? _prototypeValue;
+    private readonly long _prototypeVersion;
 
     internal string PropertyName { get; }
 
     internal int Slot { get; }
 
     internal bool HasLiveShape
-        => _shape.TryGetTarget(out _);
+        => _shape.TryGetTarget(out _)
+            && (_prototype is null
+                || _prototype.TryGetTarget(out _)
+                && _prototypeValue!.TryGetTarget(out _));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal bool Matches(DynamicLookupInlineCacheEntry other)
@@ -213,7 +234,8 @@ internal sealed class DynamicLookupInlineCacheEntry
                 StringComparison.Ordinal)
             && _shape.TryGetTarget(out var shape)
             && other._shape.TryGetTarget(out var otherShape)
-            && ReferenceEquals(shape, otherShape);
+            && ReferenceEquals(shape, otherShape)
+            && WeakTargetsMatch(_prototype, other._prototype);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal bool TryGetValue(
@@ -231,10 +253,41 @@ internal sealed class DynamicLookupInlineCacheEntry
             return false;
         }
 
-        return receiver.TryGetOwnPlainDataSlotValue(
-            shape,
-            Slot,
-            out value);
+        if (_prototype is null)
+        {
+            return receiver.TryGetOwnPlainDataSlotValue(
+                shape,
+                Slot,
+                out value);
+        }
+
+        if (!ReferenceEquals(receiver.Shape, shape)
+            || !_prototype.TryGetTarget(out var prototype)
+            || prototype.LookupVersion != _prototypeVersion
+            || !_prototypeValue!.TryGetTarget(out value)
+            || !receiver.TryGetInlinePrototype(out var currentPrototype)
+            || !ReferenceEquals(currentPrototype, prototype))
+        {
+            value = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool WeakTargetsMatch<T>(
+        WeakReference<T>? left,
+        WeakReference<T>? right)
+        where T : class
+    {
+        if (left is null || right is null)
+        {
+            return left is null && right is null;
+        }
+
+        return left.TryGetTarget(out var leftTarget)
+            && right.TryGetTarget(out var rightTarget)
+            && ReferenceEquals(leftTarget, rightTarget);
     }
 }
 
@@ -484,6 +537,136 @@ public static class DynamicLookupInlineCache
         return CallableOperations.Call0(resolvedValue!, receiver);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static object? CallMember1(
+        object receiver,
+        string propertyName,
+        object? argument0,
+        string siteKey)
+    {
+        ArgumentNullException.ThrowIfNull(propertyName);
+        ArgumentNullException.ThrowIfNull(siteKey);
+
+        if (!CanCacheMemberReceiver(receiver))
+        {
+            return ObjectRuntime.CallMember1(
+                receiver,
+                propertyName,
+                argument0);
+        }
+
+        var caches = _currentCaches
+            ?? GetCurrentRealmCaches();
+        return CallMember1Cacheable(
+            (JsObject)receiver,
+            propertyName,
+            argument0,
+            siteKey,
+            caches,
+            out _);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static object? CallMember1(
+        object receiver,
+        string propertyName,
+        object? argument0,
+        string siteKey,
+        ref int terminalMegamorphic)
+    {
+        ArgumentNullException.ThrowIfNull(propertyName);
+        ArgumentNullException.ThrowIfNull(siteKey);
+
+        if (Volatile.Read(ref terminalMegamorphic) != 0
+            || !CanCacheMemberReceiver(receiver))
+        {
+            return ObjectRuntime.CallMember1(
+                receiver,
+                propertyName,
+                argument0);
+        }
+
+        var caches = _currentCaches
+            ?? GetCurrentRealmCaches();
+        var result = CallMember1Cacheable(
+            (JsObject)receiver,
+            propertyName,
+            argument0,
+            siteKey,
+            caches,
+            out var isMegamorphic);
+        if (isMegamorphic)
+        {
+            Volatile.Write(ref terminalMegamorphic, 1);
+        }
+
+        return result;
+    }
+
+    private static object? CallMember1Cacheable(
+        JsObject receiver,
+        string propertyName,
+        object? argument0,
+        string siteKey,
+        RuntimeRealmValueCacheState caches,
+        out bool isMegamorphic)
+    {
+        isMegamorphic = false;
+        var site = GetSite(caches, siteKey);
+        object? cachedValue = null;
+        var probe = site is null
+            ? DynamicLookupInlineCacheProbeResult.Miss
+            : site.Probe(
+                receiver,
+                propertyName,
+                out cachedValue);
+        if (probe == DynamicLookupInlineCacheProbeResult.Hit
+            && CallableOperations.IsCallable(cachedValue))
+        {
+            return CallableOperations.Call1(
+                cachedValue!,
+                receiver,
+                argument0);
+        }
+
+        if (probe == DynamicLookupInlineCacheProbeResult.Megamorphic)
+        {
+            isMegamorphic = true;
+            return ObjectRuntime.CallMember1(
+                receiver,
+                propertyName,
+                argument0);
+        }
+
+        if (!TryResolvePlainDataMember(
+                receiver,
+                propertyName,
+                out var entry,
+                out var resolvedValue)
+            || !CallableOperations.IsCallable(resolvedValue))
+        {
+            return ObjectRuntime.CallMember1(
+                receiver,
+                propertyName,
+                argument0);
+        }
+
+        site ??= caches.DynamicLookupInlineCaches.GetOrAdd(
+            siteKey,
+            static _ => new DynamicLookupInlineCacheSite());
+        RememberSite(caches, siteKey, site);
+        site.Observe(entry);
+        if (site.State == DynamicLookupInlineCacheState.Megamorphic)
+        {
+            isMegamorphic = true;
+        }
+
+        return CallableOperations.Call1(
+            resolvedValue!,
+            receiver,
+            argument0);
+    }
+
     internal static DynamicLookupInlineCacheSite? GetSiteForTests(
         string siteKey)
     {
@@ -658,6 +841,73 @@ public static class DynamicLookupInlineCache
     private static bool CanCacheReceiver(object receiver)
         => receiver is not null
             && receiver.GetType() == typeof(JsObject);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool CanCacheMemberReceiver(object receiver)
+        => receiver is not null
+            && (receiver.GetType() == typeof(JsObject)
+                || receiver.GetType() == typeof(Array));
+
+    private static bool TryResolvePlainDataMember(
+        JsObject receiver,
+        string propertyName,
+        out DynamicLookupInlineCacheEntry entry,
+        out object? value)
+    {
+        entry = null!;
+        value = null;
+        if (ObjectRuntime.IsEncodedSymbolKey(propertyName))
+        {
+            return false;
+        }
+
+        if (receiver.TryGetOwnPlainDataSlot(
+                propertyName,
+                out var receiverShape,
+                out var receiverSlot,
+                out value))
+        {
+            entry = new DynamicLookupInlineCacheEntry(
+                receiverShape,
+                propertyName,
+                receiverSlot);
+            return true;
+        }
+
+        if (receiver.Shape.GetSlot(propertyName) >= 0
+            || PropertyDescriptorStore.GetOwnLookup(
+                receiver,
+                propertyName,
+                out _) != PropertyDescriptorLookup.None
+            || !receiver.TryGetInlinePrototype(out var prototypeValue)
+            || prototypeValue?.GetType() != typeof(JsObject))
+        {
+            return false;
+        }
+
+        var prototype = (JsObject)prototypeValue;
+        if (prototype.GetOwnPropertyDescriptor(
+                propertyName,
+                out var descriptor)
+                != PropertyDescriptorLookup.Found
+            || descriptor.Kind != JsPropertyDescriptorKind.Data
+            || !descriptor.Writable
+            || !descriptor.Enumerable
+            || !descriptor.Configurable
+            || descriptor.Value is null)
+        {
+            return false;
+        }
+
+        value = descriptor.Value;
+        entry = new DynamicLookupInlineCacheEntry(
+            receiver.Shape,
+            propertyName,
+            prototype,
+            prototype.LookupVersion,
+            value);
+        return true;
+    }
 
     /// <summary>
     /// Resolves an own, plain (default-attributed) data-property slot eligible for

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -1235,7 +1235,7 @@
 				74 61 54 6f 6b 65 6e 1e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 195 (0xc3)
+			// Code size: 233 (0xe9)
 			.maxstack 8
 			.locals init (
 				[0] bool,
@@ -1256,76 +1256,88 @@
 
 			IL_0016: ldarg.0
 			IL_0017: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_001c: ldstr "isAbsolute"
-			IL_0021: ldarg.2
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0027: stloc.1
-			IL_0028: ldloc.1
-			IL_0029: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002e: stloc.0
-			IL_002f: ldloc.0
-			IL_0030: brfalse IL_0037
+			IL_001c: volatile.
+			IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_0023: brfalse IL_0038
 
-			IL_0035: ldarg.2
-			IL_0036: ret
+			IL_0028: ldstr "isAbsolute"
+			IL_002d: ldarg.2
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0033: br IL_004d
 
-			IL_0037: ldarg.0
-			IL_0038: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_003d: stloc.2
-			IL_003e: ldstr "process"
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004d: volatile.
-			IL_004f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-			IL_0054: brfalse IL_0068
+			IL_0038: ldstr "isAbsolute"
+			IL_003d: ldarg.2
+			IL_003e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M7>:__js_call__:11"
+			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0059: ldstr "cwd"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0063: br IL_007c
+			IL_004d: stloc.1
+			IL_004e: ldloc.1
+			IL_004f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0054: stloc.0
+			IL_0055: ldloc.0
+			IL_0056: brfalse IL_005d
 
-			IL_0068: ldstr "cwd"
-			IL_006d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M7>:__js_call__:21"
-			IL_0072: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_005b: ldarg.2
+			IL_005c: ret
 
-			IL_007c: stloc.1
-			IL_007d: ldloc.2
-			IL_007e: ldstr "resolve"
-			IL_0083: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0088: brtrue IL_00a7
+			IL_005d: ldarg.0
+			IL_005e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0063: stloc.2
+			IL_0064: ldstr "process"
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0073: volatile.
+			IL_0075: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_007a: brfalse IL_008e
 
-			IL_008d: ldloc.2
-			IL_008e: ldc.i4.2
-			IL_008f: newarr [System.Runtime]System.Object
-			IL_0094: dup
-			IL_0095: ldc.i4.0
-			IL_0096: ldloc.1
-			IL_0097: stelem.ref
-			IL_0098: dup
-			IL_0099: ldc.i4.1
-			IL_009a: ldarg.2
-			IL_009b: stelem.ref
-			IL_009c: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_00a1: stloc.1
-			IL_00a2: br IL_00c1
+			IL_007f: ldstr "cwd"
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0089: br IL_00a2
 
-			IL_00a7: ldloc.2
-			IL_00a8: ldstr "resolve"
-			IL_00ad: ldc.i4.2
-			IL_00ae: newarr [System.Runtime]System.Object
-			IL_00b3: dup
-			IL_00b4: ldc.i4.0
-			IL_00b5: ldloc.1
-			IL_00b6: stelem.ref
-			IL_00b7: dup
-			IL_00b8: ldc.i4.1
-			IL_00b9: ldarg.2
-			IL_00ba: stelem.ref
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_00c0: stloc.1
+			IL_008e: ldstr "cwd"
+			IL_0093: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M7>:__js_call__:21"
+			IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_00c1: ldloc.1
-			IL_00c2: ret
+			IL_00a2: stloc.1
+			IL_00a3: ldloc.2
+			IL_00a4: ldstr "resolve"
+			IL_00a9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_00ae: brtrue IL_00cd
+
+			IL_00b3: ldloc.2
+			IL_00b4: ldc.i4.2
+			IL_00b5: newarr [System.Runtime]System.Object
+			IL_00ba: dup
+			IL_00bb: ldc.i4.0
+			IL_00bc: ldloc.1
+			IL_00bd: stelem.ref
+			IL_00be: dup
+			IL_00bf: ldc.i4.1
+			IL_00c0: ldarg.2
+			IL_00c1: stelem.ref
+			IL_00c2: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_00c7: stloc.1
+			IL_00c8: br IL_00e7
+
+			IL_00cd: ldloc.2
+			IL_00ce: ldstr "resolve"
+			IL_00d3: ldc.i4.2
+			IL_00d4: newarr [System.Runtime]System.Object
+			IL_00d9: dup
+			IL_00da: ldc.i4.0
+			IL_00db: ldloc.1
+			IL_00dc: stelem.ref
+			IL_00dd: dup
+			IL_00de: ldc.i4.1
+			IL_00df: ldarg.2
+			IL_00e0: stelem.ref
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_00e6: stloc.1
+
+			IL_00e7: ldloc.1
+			IL_00e8: ret
 		} // end of method resolvePathFromCwd::__js_call__
 
 	} // end of class resolvePathFromCwd
@@ -2210,7 +2222,7 @@
 			IL_0023: brtrue IL_0084
 
 			IL_0028: volatile.
-			IL_002a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_002a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 			IL_002f: brfalse IL_0044
 
 			IL_0034: ldarg.1
@@ -2221,7 +2233,7 @@
 			IL_0044: ldarg.1
 			IL_0045: ldstr "length"
 			IL_004a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M11>:__js_call__:9"
-			IL_004f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_004f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0059: stloc.s 8
@@ -3045,7 +3057,7 @@
 			IL_0077: throw
 
 			IL_0078: volatile.
-			IL_007a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_007a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 			IL_007f: brfalse IL_0094
 
 			IL_0084: ldarg.2
@@ -3056,7 +3068,7 @@
 			IL_0094: ldarg.2
 			IL_0095: ldstr "upstream"
 			IL_009a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:27"
-			IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00a9: stloc.s 9
@@ -3075,7 +3087,7 @@
 			IL_00c7: brtrue IL_0126
 
 			IL_00cc: volatile.
-			IL_00ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_00ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 			IL_00d3: brfalse IL_00e8
 
 			IL_00d8: ldarg.2
@@ -3086,7 +3098,7 @@
 			IL_00e8: ldarg.2
 			IL_00e9: ldstr "upstream"
 			IL_00ee: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:34"
-			IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00fd: stloc.s 9
@@ -3139,7 +3151,7 @@
 			IL_0169: stelem.ref
 			IL_016a: stloc.s 11
 			IL_016c: volatile.
-			IL_016e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_016e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_0173: brfalse IL_0188
 
 			IL_0178: ldarg.2
@@ -3150,12 +3162,12 @@
 			IL_0188: ldarg.2
 			IL_0189: ldstr "upstream"
 			IL_018e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:57"
-			IL_0193: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_0193: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_019d: stloc.s 12
 			IL_019f: volatile.
-			IL_01a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_01a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_01a6: brfalse IL_01bc
 
 			IL_01ab: ldloc.s 12
@@ -3166,7 +3178,7 @@
 			IL_01bc: ldloc.s 12
 			IL_01be: ldstr "owner"
 			IL_01c3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:59"
-			IL_01c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_01c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01d2: stloc.s 12
@@ -3187,7 +3199,7 @@
 			IL_01f6: stelem.ref
 			IL_01f7: stloc.s 11
 			IL_01f9: volatile.
-			IL_01fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_01fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0200: brfalse IL_0215
 
 			IL_0205: ldarg.2
@@ -3198,12 +3210,12 @@
 			IL_0215: ldarg.2
 			IL_0216: ldstr "upstream"
 			IL_021b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:67"
-			IL_0220: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0220: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_022a: stloc.s 9
 			IL_022c: volatile.
-			IL_022e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_022e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_0233: brfalse IL_0249
 
 			IL_0238: ldloc.s 9
@@ -3214,7 +3226,7 @@
 			IL_0249: ldloc.s 9
 			IL_024b: ldstr "repo"
 			IL_0250: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:69"
-			IL_0255: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_0255: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_025f: stloc.s 9
@@ -3235,7 +3247,7 @@
 			IL_0283: stelem.ref
 			IL_0284: stloc.s 11
 			IL_0286: volatile.
-			IL_0288: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0288: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_028d: brfalse IL_02a2
 
 			IL_0292: ldarg.2
@@ -3246,12 +3258,12 @@
 			IL_02a2: ldarg.2
 			IL_02a3: ldstr "upstream"
 			IL_02a8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:77"
-			IL_02ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_02ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02b7: stloc.s 12
 			IL_02b9: volatile.
-			IL_02bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_02bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 			IL_02c0: brfalse IL_02d6
 
 			IL_02c5: ldloc.s 12
@@ -3262,7 +3274,7 @@
 			IL_02d6: ldloc.s 12
 			IL_02d8: ldstr "cloneUrl"
 			IL_02dd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:79"
-			IL_02e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_02e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02ec: stloc.s 12
@@ -3283,7 +3295,7 @@
 			IL_0310: stelem.ref
 			IL_0311: stloc.s 11
 			IL_0313: volatile.
-			IL_0315: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_0315: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 			IL_031a: brfalse IL_032f
 
 			IL_031f: ldarg.2
@@ -3294,12 +3306,12 @@
 			IL_032f: ldarg.2
 			IL_0330: ldstr "upstream"
 			IL_0335: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:87"
-			IL_033a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_033a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 			IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0344: stloc.s 9
 			IL_0346: volatile.
-			IL_0348: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0348: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 			IL_034d: brfalse IL_0363
 
 			IL_0352: ldloc.s 9
@@ -3310,7 +3322,7 @@
 			IL_0363: ldloc.s 9
 			IL_0365: ldstr "commit"
 			IL_036a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:89"
-			IL_036f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_036f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0379: stloc.s 9
@@ -3331,7 +3343,7 @@
 			IL_039d: stelem.ref
 			IL_039e: stloc.s 11
 			IL_03a0: volatile.
-			IL_03a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_03a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 			IL_03a7: brfalse IL_03bc
 
 			IL_03ac: ldarg.2
@@ -3342,12 +3354,12 @@
 			IL_03bc: ldarg.2
 			IL_03bd: ldstr "upstream"
 			IL_03c2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:97"
-			IL_03c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_03c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_03d1: stloc.s 12
 			IL_03d3: volatile.
-			IL_03d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_03d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 			IL_03da: brfalse IL_03f0
 
 			IL_03df: ldloc.s 12
@@ -3358,7 +3370,7 @@
 			IL_03f0: ldloc.s 12
 			IL_03f2: ldstr "packageVersion"
 			IL_03f7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:99"
-			IL_03fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_03fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 			IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0406: stloc.s 12
@@ -3379,7 +3391,7 @@
 			IL_042a: stelem.ref
 			IL_042b: stloc.s 11
 			IL_042d: volatile.
-			IL_042f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_042f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 			IL_0434: brfalse IL_0449
 
 			IL_0439: ldarg.2
@@ -3390,7 +3402,7 @@
 			IL_0449: ldarg.2
 			IL_044a: ldstr "localOverrideEnvVar"
 			IL_044f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:107"
-			IL_0454: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0454: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 			IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_045e: stloc.s 9
@@ -3411,7 +3423,7 @@
 			IL_0482: stelem.ref
 			IL_0483: stloc.s 11
 			IL_0485: volatile.
-			IL_0487: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0487: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_048c: brfalse IL_04a1
 
 			IL_0491: ldarg.2
@@ -3422,7 +3434,7 @@
 			IL_04a1: ldarg.2
 			IL_04a2: ldstr "managedRoot"
 			IL_04a7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:115"
-			IL_04ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_04ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_04b6: stloc.s 12
@@ -3443,7 +3455,7 @@
 			IL_04da: stelem.ref
 			IL_04db: stloc.s 11
 			IL_04dd: volatile.
-			IL_04df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_04df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_04e4: brfalse IL_04f9
 
 			IL_04e9: ldarg.2
@@ -3454,7 +3466,7 @@
 			IL_04f9: ldarg.2
 			IL_04fa: ldstr "lineEndings"
 			IL_04ff: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:123"
-			IL_0504: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0504: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_050e: stloc.s 9
@@ -3475,7 +3487,7 @@
 			IL_0532: stelem.ref
 			IL_0533: stloc.s 11
 			IL_0535: volatile.
-			IL_0537: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0537: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_053c: brfalse IL_0551
 
 			IL_0541: ldarg.2
@@ -3486,7 +3498,7 @@
 			IL_0551: ldarg.2
 			IL_0552: ldstr "updateStrategy"
 			IL_0557: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:131"
-			IL_055c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_055c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0566: stloc.s 12
@@ -3507,7 +3519,7 @@
 			IL_058a: stelem.ref
 			IL_058b: stloc.s 11
 			IL_058d: volatile.
-			IL_058f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_058f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_0594: brfalse IL_05a9
 
 			IL_0599: ldarg.2
@@ -3518,7 +3530,7 @@
 			IL_05a9: ldarg.2
 			IL_05aa: ldstr "includeFiles"
 			IL_05af: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:139"
-			IL_05b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_05b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_05be: stloc.s 9
@@ -3539,7 +3551,7 @@
 			IL_05e2: stelem.ref
 			IL_05e3: stloc.s 11
 			IL_05e5: volatile.
-			IL_05e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_05e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_05ec: brfalse IL_0601
 
 			IL_05f1: ldarg.2
@@ -3550,7 +3562,7 @@
 			IL_0601: ldarg.2
 			IL_0602: ldstr "includeDirectories"
 			IL_0607: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:147"
-			IL_060c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_060c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0616: stloc.s 12
@@ -3571,7 +3583,7 @@
 			IL_063a: stelem.ref
 			IL_063b: stloc.s 11
 			IL_063d: volatile.
-			IL_063f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_063f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_0644: brfalse IL_0659
 
 			IL_0649: ldarg.2
@@ -3582,7 +3594,7 @@
 			IL_0659: ldarg.2
 			IL_065a: ldstr "requiredFiles"
 			IL_065f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:155"
-			IL_0664: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0664: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_066e: stloc.s 9
@@ -3603,7 +3615,7 @@
 			IL_0692: stelem.ref
 			IL_0693: stloc.s 11
 			IL_0695: volatile.
-			IL_0697: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_0697: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_069c: brfalse IL_06b1
 
 			IL_06a1: ldarg.2
@@ -3614,7 +3626,7 @@
 			IL_06b1: ldarg.2
 			IL_06b2: ldstr "requiredDirectories"
 			IL_06b7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:163"
-			IL_06bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_06bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_06c6: stloc.s 12
@@ -3635,7 +3647,7 @@
 			IL_06ea: stelem.ref
 			IL_06eb: stloc.s 11
 			IL_06ed: volatile.
-			IL_06ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_06ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_06f4: brfalse IL_0709
 
 			IL_06f9: ldarg.2
@@ -3646,7 +3658,7 @@
 			IL_0709: ldarg.2
 			IL_070a: ldstr "defaultHarnessFiles"
 			IL_070f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:171"
-			IL_0714: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0714: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_071e: stloc.s 9
@@ -3667,7 +3679,7 @@
 			IL_0742: stelem.ref
 			IL_0743: stloc.s 11
 			IL_0745: volatile.
-			IL_0747: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0747: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_074c: brfalse IL_0761
 
 			IL_0751: ldarg.2
@@ -3678,7 +3690,7 @@
 			IL_0761: ldarg.2
 			IL_0762: ldstr "excludedFromMvp"
 			IL_0767: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:179"
-			IL_076c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_076c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0776: stloc.s 12
@@ -3698,7 +3710,7 @@
 			IL_0795: stelem.ref
 			IL_0796: stloc.s 11
 			IL_0798: volatile.
-			IL_079a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_079a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_079f: brfalse IL_07b4
 
 			IL_07a4: ldarg.2
@@ -3709,7 +3721,7 @@
 			IL_07b4: ldarg.2
 			IL_07b5: ldstr "attributionFiles"
 			IL_07ba: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:186"
-			IL_07bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_07bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_07c9: stloc.s 9
@@ -3724,7 +3736,7 @@
 			IL_07e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_07eb: stloc.s 13
 			IL_07ed: volatile.
-			IL_07ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_07ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_07f4: brfalse IL_0809
 
 			IL_07f9: ldarg.2
@@ -3735,12 +3747,12 @@
 			IL_0809: ldarg.2
 			IL_080a: ldstr "upstream"
 			IL_080f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:195"
-			IL_0814: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_0814: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_0819: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_081e: stloc.s 9
 			IL_0820: volatile.
-			IL_0822: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0822: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_0827: brfalse IL_083d
 
 			IL_082c: ldloc.s 9
@@ -3751,7 +3763,7 @@
 			IL_083d: ldloc.s 9
 			IL_083f: ldstr "commit"
 			IL_0844: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M13>:__js_call__:197"
-			IL_0849: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0849: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0853: stloc.s 9
@@ -4146,7 +4158,7 @@
 				74 61 54 6f 6b 65 6e 1e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 253 (0xfd)
+			// Code size: 291 (0x123)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4157,106 +4169,118 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0006: ldstr "dirname"
-			IL_000b: ldarg.2
-			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0011: stloc.0
-			IL_0012: ldarg.0
-			IL_0013: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0018: stloc.1
-			IL_0019: volatile.
-			IL_001b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_0020: brfalse IL_0035
+			IL_0006: volatile.
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_000d: brfalse IL_0022
 
-			IL_0025: ldarg.3
-			IL_0026: ldstr "managedRoot"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0030: br IL_004a
+			IL_0012: ldstr "dirname"
+			IL_0017: ldarg.2
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_001d: br IL_0037
 
-			IL_0035: ldarg.3
-			IL_0036: ldstr "managedRoot"
-			IL_003b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M15>:__js_call__:9"
-			IL_0040: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0022: ldstr "dirname"
+			IL_0027: ldarg.2
+			IL_0028: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M15>:__js_call__:3"
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_004a: stloc.2
-			IL_004b: volatile.
-			IL_004d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_0052: brfalse IL_0067
+			IL_0037: stloc.0
+			IL_0038: ldarg.0
+			IL_0039: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_003e: stloc.1
+			IL_003f: volatile.
+			IL_0041: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_0046: brfalse IL_005b
 
-			IL_0057: ldarg.3
-			IL_0058: ldstr "upstream"
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0062: br IL_007c
+			IL_004b: ldarg.3
+			IL_004c: ldstr "managedRoot"
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0056: br IL_0070
 
-			IL_0067: ldarg.3
-			IL_0068: ldstr "upstream"
-			IL_006d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M15>:__js_call__:12"
-			IL_0072: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_005b: ldarg.3
+			IL_005c: ldstr "managedRoot"
+			IL_0061: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M15>:__js_call__:9"
+			IL_0066: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_007c: stloc.3
-			IL_007d: volatile.
-			IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_0084: brfalse IL_0099
+			IL_0070: stloc.2
+			IL_0071: volatile.
+			IL_0073: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0078: brfalse IL_008d
 
-			IL_0089: ldloc.3
-			IL_008a: ldstr "commit"
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0094: br IL_00ae
+			IL_007d: ldarg.3
+			IL_007e: ldstr "upstream"
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0088: br IL_00a2
 
-			IL_0099: ldloc.3
-			IL_009a: ldstr "commit"
-			IL_009f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M15>:__js_call__:14"
-			IL_00a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_008d: ldarg.3
+			IL_008e: ldstr "upstream"
+			IL_0093: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M15>:__js_call__:12"
+			IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00ae: stloc.3
-			IL_00af: ldloc.1
-			IL_00b0: ldstr "resolve"
-			IL_00b5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_00ba: brtrue IL_00dd
+			IL_00a2: stloc.3
+			IL_00a3: volatile.
+			IL_00a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_00aa: brfalse IL_00bf
 
-			IL_00bf: ldloc.1
-			IL_00c0: ldc.i4.3
-			IL_00c1: newarr [System.Runtime]System.Object
-			IL_00c6: dup
-			IL_00c7: ldc.i4.0
-			IL_00c8: ldloc.0
-			IL_00c9: stelem.ref
-			IL_00ca: dup
-			IL_00cb: ldc.i4.1
-			IL_00cc: ldloc.2
-			IL_00cd: stelem.ref
-			IL_00ce: dup
-			IL_00cf: ldc.i4.2
-			IL_00d0: ldloc.3
-			IL_00d1: stelem.ref
-			IL_00d2: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_00d7: stloc.3
-			IL_00d8: br IL_00fb
+			IL_00af: ldloc.3
+			IL_00b0: ldstr "commit"
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ba: br IL_00d4
 
-			IL_00dd: ldloc.1
-			IL_00de: ldstr "resolve"
-			IL_00e3: ldc.i4.3
-			IL_00e4: newarr [System.Runtime]System.Object
-			IL_00e9: dup
-			IL_00ea: ldc.i4.0
-			IL_00eb: ldloc.0
-			IL_00ec: stelem.ref
-			IL_00ed: dup
-			IL_00ee: ldc.i4.1
-			IL_00ef: ldloc.2
-			IL_00f0: stelem.ref
-			IL_00f1: dup
-			IL_00f2: ldc.i4.2
-			IL_00f3: ldloc.3
-			IL_00f4: stelem.ref
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_00fa: stloc.3
+			IL_00bf: ldloc.3
+			IL_00c0: ldstr "commit"
+			IL_00c5: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M15>:__js_call__:14"
+			IL_00ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00fb: ldloc.3
-			IL_00fc: ret
+			IL_00d4: stloc.3
+			IL_00d5: ldloc.1
+			IL_00d6: ldstr "resolve"
+			IL_00db: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_00e0: brtrue IL_0103
+
+			IL_00e5: ldloc.1
+			IL_00e6: ldc.i4.3
+			IL_00e7: newarr [System.Runtime]System.Object
+			IL_00ec: dup
+			IL_00ed: ldc.i4.0
+			IL_00ee: ldloc.0
+			IL_00ef: stelem.ref
+			IL_00f0: dup
+			IL_00f1: ldc.i4.1
+			IL_00f2: ldloc.2
+			IL_00f3: stelem.ref
+			IL_00f4: dup
+			IL_00f5: ldc.i4.2
+			IL_00f6: ldloc.3
+			IL_00f7: stelem.ref
+			IL_00f8: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_00fd: stloc.3
+			IL_00fe: br IL_0121
+
+			IL_0103: ldloc.1
+			IL_0104: ldstr "resolve"
+			IL_0109: ldc.i4.3
+			IL_010a: newarr [System.Runtime]System.Object
+			IL_010f: dup
+			IL_0110: ldc.i4.0
+			IL_0111: ldloc.0
+			IL_0112: stelem.ref
+			IL_0113: dup
+			IL_0114: ldc.i4.1
+			IL_0115: ldloc.2
+			IL_0116: stelem.ref
+			IL_0117: dup
+			IL_0118: ldc.i4.2
+			IL_0119: ldloc.3
+			IL_011a: stelem.ref
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0120: stloc.3
+
+			IL_0121: ldloc.3
+			IL_0122: ret
 		} // end of method resolveManagedCheckoutRoot::__js_call__
 
 	} // end of class resolveManagedCheckoutRoot
@@ -4447,7 +4471,7 @@
 			IL_0045: stelem.ref
 			IL_0046: stloc.2
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldarg.2
@@ -4458,7 +4482,7 @@
 			IL_0063: ldarg.2
 			IL_0064: ldstr "managedRoot"
 			IL_0069: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M16>:__js_call__:8"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.3
@@ -4467,7 +4491,7 @@
 			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_0080: stloc.3
 			IL_0081: volatile.
-			IL_0083: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0083: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_0088: brfalse IL_009d
 
 			IL_008d: ldarg.2
@@ -4478,12 +4502,12 @@
 			IL_009d: ldarg.2
 			IL_009e: ldstr "upstream"
 			IL_00a3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M16>:__js_call__:12"
-			IL_00a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_00a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00b2: stloc.s 4
 			IL_00b4: volatile.
-			IL_00b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_00b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_00bb: brfalse IL_00d1
 
 			IL_00c0: ldloc.s 4
@@ -4494,7 +4518,7 @@
 			IL_00d1: ldloc.s 4
 			IL_00d3: ldstr "commit"
 			IL_00d8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M16>:__js_call__:14"
-			IL_00dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_00dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00e7: stloc.s 4
@@ -4712,7 +4736,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_0007: brfalse IL_001c
 
 			IL_000c: ldarg.2
@@ -4723,7 +4747,7 @@
 			IL_001c: ldarg.2
 			IL_001d: ldstr "root"
 			IL_0022: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M17>:__js_call__:3"
-			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0031: stloc.2
@@ -4736,7 +4760,7 @@
 			IL_003f: ldstr "process"
 			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0049: volatile.
-			IL_004b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_004b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0050: brfalse IL_0064
 
 			IL_0055: ldstr "env"
@@ -4745,12 +4769,12 @@
 
 			IL_0064: ldstr "env"
 			IL_0069: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M17>:__js_call__:9"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.s 4
 			IL_007a: volatile.
-			IL_007c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_007c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_0081: brfalse IL_0096
 
 			IL_0086: ldarg.3
@@ -4761,7 +4785,7 @@
 			IL_0096: ldarg.3
 			IL_0097: ldstr "localOverrideEnvVar"
 			IL_009c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M17>:__js_call__:12"
-			IL_00a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_00a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00ab: stloc.s 5
@@ -4801,7 +4825,7 @@
 			IL_00f7: ret
 
 			IL_00f8: volatile.
-			IL_00fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_00fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 			IL_00ff: brfalse IL_0114
 
 			IL_0104: ldarg.2
@@ -4812,7 +4836,7 @@
 			IL_0114: ldarg.2
 			IL_0115: ldstr "root"
 			IL_011a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M17>:__js_call__:39"
-			IL_011f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_011f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0129: stloc.2
@@ -4827,7 +4851,7 @@
 			IL_013d: br IL_0176
 
 			IL_0142: volatile.
-			IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 			IL_0149: brfalse IL_015e
 
 			IL_014e: ldarg.3
@@ -4838,7 +4862,7 @@
 			IL_015e: ldarg.3
 			IL_015f: ldstr "localOverrideEnvVar"
 			IL_0164: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M17>:__js_call__:48"
-			IL_0169: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_0169: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0173: stloc.2
@@ -5045,7 +5069,7 @@
 				74 61 54 6f 6b 65 6e 1e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1860 (0x744)
+			// Code size: 2154 (0x86a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5092,7 +5116,7 @@
 			IL_002b: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0030: stloc.3
 			IL_0031: volatile.
-			IL_0033: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_0033: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 			IL_0038: brfalse IL_004d
 
 			IL_003d: ldarg.2
@@ -5103,12 +5127,12 @@
 			IL_004d: ldarg.2
 			IL_004e: ldstr "upstream"
 			IL_0053: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:17"
-			IL_0058: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_0058: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0062: stloc.s 4
 			IL_0064: volatile.
-			IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 			IL_006b: brfalse IL_0081
 
 			IL_0070: ldloc.s 4
@@ -5119,7 +5143,7 @@
 			IL_0081: ldloc.s 4
 			IL_0083: ldstr "cloneUrl"
 			IL_0088: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:19"
-			IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0097: stloc.s 4
@@ -5131,7 +5155,7 @@
 			IL_00a9: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00ae: stloc.s 5
 			IL_00b0: volatile.
-			IL_00b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_00b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 			IL_00b7: brfalse IL_00cc
 
 			IL_00bc: ldarg.2
@@ -5142,12 +5166,12 @@
 			IL_00cc: ldarg.2
 			IL_00cd: ldstr "upstream"
 			IL_00d2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:25"
-			IL_00d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_00d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00e1: stloc.s 4
 			IL_00e3: volatile.
-			IL_00e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+			IL_00e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 			IL_00ea: brfalse IL_0100
 
 			IL_00ef: ldloc.s 4
@@ -5158,7 +5182,7 @@
 			IL_0100: ldloc.s 4
 			IL_0102: ldstr "commit"
 			IL_0107: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:27"
-			IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+			IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0116: stloc.s 4
@@ -5170,7 +5194,7 @@
 			IL_0128: call string [System.Runtime]System.String::Concat(string, string)
 			IL_012d: stloc.s 6
 			IL_012f: volatile.
-			IL_0131: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+			IL_0131: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 			IL_0136: brfalse IL_014b
 
 			IL_013b: ldarg.2
@@ -5181,12 +5205,12 @@
 			IL_014b: ldarg.2
 			IL_014c: ldstr "upstream"
 			IL_0151: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:33"
-			IL_0156: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+			IL_0156: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0160: stloc.s 4
 			IL_0162: volatile.
-			IL_0164: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+			IL_0164: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 			IL_0169: brfalse IL_017f
 
 			IL_016e: ldloc.s 4
@@ -5197,7 +5221,7 @@
 			IL_017f: ldloc.s 4
 			IL_0181: ldstr "packageVersion"
 			IL_0186: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:35"
-			IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+			IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0195: stloc.s 4
@@ -5218,7 +5242,7 @@
 			IL_01bd: stelem.ref
 			IL_01be: stloc.s 8
 			IL_01c0: volatile.
-			IL_01c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
+			IL_01c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 			IL_01c7: brfalse IL_01dc
 
 			IL_01cc: ldarg.2
@@ -5229,7 +5253,7 @@
 			IL_01dc: ldarg.2
 			IL_01dd: ldstr "managedRoot"
 			IL_01e2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:43"
-			IL_01e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
+			IL_01e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01f1: stloc.s 4
@@ -5265,7 +5289,7 @@
 			IL_0241: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0246: stloc.s 10
 			IL_0248: volatile.
-			IL_024a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
+			IL_024a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
 			IL_024f: brfalse IL_0264
 
 			IL_0254: ldarg.2
@@ -5276,7 +5300,7 @@
 			IL_0264: ldarg.2
 			IL_0265: ldstr "localOverrideEnvVar"
 			IL_026a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:57"
-			IL_026f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
+			IL_026f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
 			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0279: stloc.s 4
@@ -5288,7 +5312,7 @@
 			IL_028b: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0290: stloc.s 11
 			IL_0292: volatile.
-			IL_0294: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+			IL_0294: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
 			IL_0299: brfalse IL_02ae
 
 			IL_029e: ldarg.2
@@ -5299,7 +5323,7 @@
 			IL_02ae: ldarg.2
 			IL_02af: ldstr "lineEndings"
 			IL_02b4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:63"
-			IL_02b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+			IL_02b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
 			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02c3: stloc.s 4
@@ -5311,7 +5335,7 @@
 			IL_02d5: call string [System.Runtime]System.String::Concat(string, string)
 			IL_02da: stloc.s 12
 			IL_02dc: volatile.
-			IL_02de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
+			IL_02de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
 			IL_02e3: brfalse IL_02f8
 
 			IL_02e8: ldarg.2
@@ -5322,7 +5346,7 @@
 			IL_02f8: ldarg.2
 			IL_02f9: ldstr "updateStrategy"
 			IL_02fe: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:69"
-			IL_0303: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
+			IL_0303: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
 			IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_030d: stloc.s 4
@@ -5334,7 +5358,7 @@
 			IL_031f: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0324: stloc.s 13
 			IL_0326: volatile.
-			IL_0328: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+			IL_0328: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
 			IL_032d: brfalse IL_0342
 
 			IL_0332: ldarg.2
@@ -5345,333 +5369,417 @@
 			IL_0342: ldarg.2
 			IL_0343: ldstr "includeFiles"
 			IL_0348: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:75"
-			IL_034d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+			IL_034d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
 			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0357: stloc.s 4
 			IL_0359: ldloc.s 4
 			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0360: ldstr "join"
-			IL_0365: ldstr ", "
-			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_036f: stloc.s 4
-			IL_0371: ldloc.s 4
-			IL_0373: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0378: stloc.s 14
-			IL_037a: ldstr "includeFiles "
-			IL_037f: ldloc.s 14
-			IL_0381: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0386: stloc.s 14
-			IL_0388: volatile.
-			IL_038a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-			IL_038f: brfalse IL_03a4
+			IL_0360: volatile.
+			IL_0362: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+			IL_0367: brfalse IL_0380
 
-			IL_0394: ldarg.2
-			IL_0395: ldstr "includeDirectories"
-			IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_039f: br IL_03b9
+			IL_036c: ldstr "join"
+			IL_0371: ldstr ", "
+			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_037b: br IL_0399
 
-			IL_03a4: ldarg.2
-			IL_03a5: ldstr "includeDirectories"
-			IL_03aa: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:84"
-			IL_03af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-			IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0380: ldstr "join"
+			IL_0385: ldstr ", "
+			IL_038a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:78"
+			IL_038f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+			IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_03b9: stloc.s 4
-			IL_03bb: ldloc.s 4
-			IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03c2: ldstr "join"
-			IL_03c7: ldstr ", "
-			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03d1: stloc.s 4
-			IL_03d3: ldloc.s 4
-			IL_03d5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03da: stloc.s 15
-			IL_03dc: ldstr "includeDirectories "
-			IL_03e1: ldloc.s 15
-			IL_03e3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03e8: stloc.s 15
-			IL_03ea: volatile.
-			IL_03ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-			IL_03f1: brfalse IL_0406
+			IL_0399: stloc.s 4
+			IL_039b: ldloc.s 4
+			IL_039d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03a2: stloc.s 14
+			IL_03a4: ldstr "includeFiles "
+			IL_03a9: ldloc.s 14
+			IL_03ab: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03b0: stloc.s 14
+			IL_03b2: volatile.
+			IL_03b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+			IL_03b9: brfalse IL_03ce
 
-			IL_03f6: ldarg.2
-			IL_03f7: ldstr "requiredFiles"
-			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0401: br IL_041b
+			IL_03be: ldarg.2
+			IL_03bf: ldstr "includeDirectories"
+			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c9: br IL_03e3
 
-			IL_0406: ldarg.2
-			IL_0407: ldstr "requiredFiles"
-			IL_040c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:93"
-			IL_0411: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-			IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03ce: ldarg.2
+			IL_03cf: ldstr "includeDirectories"
+			IL_03d4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:84"
+			IL_03d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_041b: stloc.s 4
-			IL_041d: ldloc.s 4
-			IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0424: ldstr "join"
-			IL_0429: ldstr ", "
-			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0433: stloc.s 4
-			IL_0435: ldloc.s 4
-			IL_0437: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_043c: stloc.s 16
-			IL_043e: ldstr "requiredFiles "
-			IL_0443: ldloc.s 16
-			IL_0445: call string [System.Runtime]System.String::Concat(string, string)
-			IL_044a: stloc.s 16
-			IL_044c: volatile.
-			IL_044e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-			IL_0453: brfalse IL_0468
+			IL_03e3: stloc.s 4
+			IL_03e5: ldloc.s 4
+			IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ec: volatile.
+			IL_03ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+			IL_03f3: brfalse IL_040c
 
-			IL_0458: ldarg.2
-			IL_0459: ldstr "requiredDirectories"
-			IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0463: br IL_047d
+			IL_03f8: ldstr "join"
+			IL_03fd: ldstr ", "
+			IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0407: br IL_0425
 
-			IL_0468: ldarg.2
-			IL_0469: ldstr "requiredDirectories"
-			IL_046e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:102"
-			IL_0473: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-			IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_040c: ldstr "join"
+			IL_0411: ldstr ", "
+			IL_0416: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:87"
+			IL_041b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_047d: stloc.s 4
-			IL_047f: ldloc.s 4
-			IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0486: ldstr "join"
-			IL_048b: ldstr ", "
-			IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0495: stloc.s 4
-			IL_0497: ldloc.s 4
-			IL_0499: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_049e: stloc.s 17
-			IL_04a0: ldstr "requiredDirectories "
-			IL_04a5: ldloc.s 17
-			IL_04a7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04ac: stloc.s 17
-			IL_04ae: volatile.
-			IL_04b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-			IL_04b5: brfalse IL_04ca
+			IL_0425: stloc.s 4
+			IL_0427: ldloc.s 4
+			IL_0429: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_042e: stloc.s 15
+			IL_0430: ldstr "includeDirectories "
+			IL_0435: ldloc.s 15
+			IL_0437: call string [System.Runtime]System.String::Concat(string, string)
+			IL_043c: stloc.s 15
+			IL_043e: volatile.
+			IL_0440: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+			IL_0445: brfalse IL_045a
 
-			IL_04ba: ldarg.2
-			IL_04bb: ldstr "defaultHarnessFiles"
-			IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04c5: br IL_04df
+			IL_044a: ldarg.2
+			IL_044b: ldstr "requiredFiles"
+			IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0455: br IL_046f
 
-			IL_04ca: ldarg.2
-			IL_04cb: ldstr "defaultHarnessFiles"
-			IL_04d0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:111"
-			IL_04d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-			IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_045a: ldarg.2
+			IL_045b: ldstr "requiredFiles"
+			IL_0460: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:93"
+			IL_0465: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04df: stloc.s 4
-			IL_04e1: ldloc.s 4
-			IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04e8: ldstr "join"
-			IL_04ed: ldstr ", "
-			IL_04f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04f7: stloc.s 4
-			IL_04f9: ldloc.s 4
-			IL_04fb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0500: stloc.s 18
-			IL_0502: ldstr "defaultHarnessFiles "
-			IL_0507: ldloc.s 18
-			IL_0509: call string [System.Runtime]System.String::Concat(string, string)
-			IL_050e: stloc.s 18
-			IL_0510: volatile.
-			IL_0512: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-			IL_0517: brfalse IL_052c
+			IL_046f: stloc.s 4
+			IL_0471: ldloc.s 4
+			IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0478: volatile.
+			IL_047a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+			IL_047f: brfalse IL_0498
 
-			IL_051c: ldarg.2
-			IL_051d: ldstr "excludedFromMvp"
-			IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0527: br IL_0541
+			IL_0484: ldstr "join"
+			IL_0489: ldstr ", "
+			IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0493: br IL_04b1
 
-			IL_052c: ldarg.2
-			IL_052d: ldstr "excludedFromMvp"
-			IL_0532: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:120"
-			IL_0537: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-			IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0498: ldstr "join"
+			IL_049d: ldstr ", "
+			IL_04a2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:96"
+			IL_04a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+			IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0541: stloc.s 4
-			IL_0543: ldloc.s 4
-			IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_054a: ldstr "join"
-			IL_054f: ldstr "; "
-			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0559: stloc.s 4
-			IL_055b: ldloc.s 4
-			IL_055d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0562: stloc.s 19
-			IL_0564: ldstr "excludedFromMvp "
-			IL_0569: ldloc.s 19
-			IL_056b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0570: stloc.s 19
-			IL_0572: volatile.
-			IL_0574: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-			IL_0579: brfalse IL_058e
+			IL_04b1: stloc.s 4
+			IL_04b3: ldloc.s 4
+			IL_04b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04ba: stloc.s 16
+			IL_04bc: ldstr "requiredFiles "
+			IL_04c1: ldloc.s 16
+			IL_04c3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04c8: stloc.s 16
+			IL_04ca: volatile.
+			IL_04cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_04d1: brfalse IL_04e6
 
-			IL_057e: ldarg.2
-			IL_057f: ldstr "attributionFiles"
-			IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0589: br IL_05a3
+			IL_04d6: ldarg.2
+			IL_04d7: ldstr "requiredDirectories"
+			IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04e1: br IL_04fb
 
-			IL_058e: ldarg.2
-			IL_058f: ldstr "attributionFiles"
-			IL_0594: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:129"
-			IL_0599: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04e6: ldarg.2
+			IL_04e7: ldstr "requiredDirectories"
+			IL_04ec: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:102"
+			IL_04f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_05a3: stloc.s 4
-			IL_05a5: ldloc.s 4
-			IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ac: ldstr "join"
-			IL_05b1: ldstr ", "
-			IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05bb: stloc.s 4
-			IL_05bd: ldloc.s 4
-			IL_05bf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05c4: stloc.s 20
-			IL_05c6: ldstr "attributionFiles "
-			IL_05cb: ldloc.s 20
-			IL_05cd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05d2: stloc.s 20
-			IL_05d4: ldc.i4.s 16
-			IL_05d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_05db: dup
-			IL_05dc: ldloc.3
-			IL_05dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05e2: dup
-			IL_05e3: ldloc.s 5
-			IL_05e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05ea: dup
-			IL_05eb: ldloc.s 6
-			IL_05ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05f2: dup
-			IL_05f3: ldloc.s 7
-			IL_05f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05fa: dup
-			IL_05fb: ldloc.s 9
-			IL_05fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0602: dup
-			IL_0603: ldloc.s 10
-			IL_0605: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_060a: dup
-			IL_060b: ldloc.s 11
-			IL_060d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0612: dup
-			IL_0613: ldloc.s 12
-			IL_0615: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_061a: dup
-			IL_061b: ldloc.s 13
-			IL_061d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0622: dup
-			IL_0623: ldloc.s 14
-			IL_0625: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_062a: dup
-			IL_062b: ldloc.s 15
-			IL_062d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0632: dup
-			IL_0633: ldloc.s 16
-			IL_0635: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_063a: dup
-			IL_063b: ldloc.s 17
-			IL_063d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0642: dup
-			IL_0643: ldloc.s 18
-			IL_0645: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_064a: dup
-			IL_064b: ldloc.s 19
-			IL_064d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0652: dup
-			IL_0653: ldloc.s 20
-			IL_0655: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_065a: stloc.1
-			IL_065b: ldarg.3
-			IL_065c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0661: stloc.2
-			IL_0662: ldloc.2
-			IL_0663: brfalse IL_072b
+			IL_04fb: stloc.s 4
+			IL_04fd: ldloc.s 4
+			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0504: volatile.
+			IL_0506: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_050b: brfalse IL_0524
 
-			IL_0668: volatile.
-			IL_066a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-			IL_066f: brfalse IL_0684
+			IL_0510: ldstr "join"
+			IL_0515: ldstr ", "
+			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_051f: br IL_053d
 
-			IL_0674: ldarg.3
-			IL_0675: ldstr "source"
-			IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_067f: br IL_0699
+			IL_0524: ldstr "join"
+			IL_0529: ldstr ", "
+			IL_052e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:105"
+			IL_0533: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0684: ldarg.3
-			IL_0685: ldstr "source"
-			IL_068a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:145"
-			IL_068f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-			IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_053d: stloc.s 4
+			IL_053f: ldloc.s 4
+			IL_0541: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0546: stloc.s 17
+			IL_0548: ldstr "requiredDirectories "
+			IL_054d: ldloc.s 17
+			IL_054f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0554: stloc.s 17
+			IL_0556: volatile.
+			IL_0558: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_055d: brfalse IL_0572
 
-			IL_0699: stloc.s 4
-			IL_069b: ldloc.s 4
-			IL_069d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06a2: stloc.s 20
-			IL_06a4: ldstr "overrideSource "
-			IL_06a9: ldloc.s 20
-			IL_06ab: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06b0: stloc.s 20
-			IL_06b2: ldloc.1
-			IL_06b3: ldloc.s 20
-			IL_06b5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_06ba: pop
-			IL_06bb: ldarg.0
-			IL_06bc: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
-			IL_06c1: ldc.i4.1
-			IL_06c2: newarr [System.Runtime]System.Object
-			IL_06c7: dup
-			IL_06c8: ldc.i4.0
-			IL_06c9: ldarg.0
-			IL_06ca: stelem.ref
-			IL_06cb: stloc.s 8
-			IL_06cd: volatile.
-			IL_06cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-			IL_06d4: brfalse IL_06e9
+			IL_0562: ldarg.2
+			IL_0563: ldstr "defaultHarnessFiles"
+			IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056d: br IL_0587
 
-			IL_06d9: ldarg.3
-			IL_06da: ldstr "rootPath"
-			IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06e4: br IL_06fe
+			IL_0572: ldarg.2
+			IL_0573: ldstr "defaultHarnessFiles"
+			IL_0578: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:111"
+			IL_057d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06e9: ldarg.3
-			IL_06ea: ldstr "rootPath"
-			IL_06ef: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:155"
-			IL_06f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-			IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0587: stloc.s 4
+			IL_0589: ldloc.s 4
+			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0590: volatile.
+			IL_0592: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+			IL_0597: brfalse IL_05b0
 
-			IL_06fe: stloc.s 4
-			IL_0700: ldloc.s 8
-			IL_0702: ldloc.s 4
-			IL_0704: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0709: stloc.s 4
-			IL_070b: ldloc.s 4
-			IL_070d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0712: stloc.s 20
-			IL_0714: ldstr "overrideRoot "
-			IL_0719: ldloc.s 20
-			IL_071b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0720: stloc.s 20
-			IL_0722: ldloc.1
-			IL_0723: ldloc.s 20
-			IL_0725: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_072a: pop
+			IL_059c: ldstr "join"
+			IL_05a1: ldstr ", "
+			IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05ab: br IL_05c9
 
-			IL_072b: ldloc.1
-			IL_072c: ldc.i4.1
-			IL_072d: newarr [System.Runtime]System.Object
-			IL_0732: dup
-			IL_0733: ldc.i4.0
-			IL_0734: ldstr "\n"
-			IL_0739: stelem.ref
-			IL_073a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_073f: stloc.s 20
-			IL_0741: ldloc.s 20
-			IL_0743: ret
+			IL_05b0: ldstr "join"
+			IL_05b5: ldstr ", "
+			IL_05ba: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:114"
+			IL_05bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_05c9: stloc.s 4
+			IL_05cb: ldloc.s 4
+			IL_05cd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05d2: stloc.s 18
+			IL_05d4: ldstr "defaultHarnessFiles "
+			IL_05d9: ldloc.s 18
+			IL_05db: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05e0: stloc.s 18
+			IL_05e2: volatile.
+			IL_05e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
+			IL_05e9: brfalse IL_05fe
+
+			IL_05ee: ldarg.2
+			IL_05ef: ldstr "excludedFromMvp"
+			IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f9: br IL_0613
+
+			IL_05fe: ldarg.2
+			IL_05ff: ldstr "excludedFromMvp"
+			IL_0604: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:120"
+			IL_0609: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
+			IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0613: stloc.s 4
+			IL_0615: ldloc.s 4
+			IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_061c: volatile.
+			IL_061e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
+			IL_0623: brfalse IL_063c
+
+			IL_0628: ldstr "join"
+			IL_062d: ldstr "; "
+			IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0637: br IL_0655
+
+			IL_063c: ldstr "join"
+			IL_0641: ldstr "; "
+			IL_0646: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:123"
+			IL_064b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
+			IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0655: stloc.s 4
+			IL_0657: ldloc.s 4
+			IL_0659: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_065e: stloc.s 19
+			IL_0660: ldstr "excludedFromMvp "
+			IL_0665: ldloc.s 19
+			IL_0667: call string [System.Runtime]System.String::Concat(string, string)
+			IL_066c: stloc.s 19
+			IL_066e: volatile.
+			IL_0670: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
+			IL_0675: brfalse IL_068a
+
+			IL_067a: ldarg.2
+			IL_067b: ldstr "attributionFiles"
+			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0685: br IL_069f
+
+			IL_068a: ldarg.2
+			IL_068b: ldstr "attributionFiles"
+			IL_0690: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:129"
+			IL_0695: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
+			IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_069f: stloc.s 4
+			IL_06a1: ldloc.s 4
+			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06a8: volatile.
+			IL_06aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
+			IL_06af: brfalse IL_06c8
+
+			IL_06b4: ldstr "join"
+			IL_06b9: ldstr ", "
+			IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06c3: br IL_06e1
+
+			IL_06c8: ldstr "join"
+			IL_06cd: ldstr ", "
+			IL_06d2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:132"
+			IL_06d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
+			IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_06e1: stloc.s 4
+			IL_06e3: ldloc.s 4
+			IL_06e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06ea: stloc.s 20
+			IL_06ec: ldstr "attributionFiles "
+			IL_06f1: ldloc.s 20
+			IL_06f3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06f8: stloc.s 20
+			IL_06fa: ldc.i4.s 16
+			IL_06fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0701: dup
+			IL_0702: ldloc.3
+			IL_0703: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0708: dup
+			IL_0709: ldloc.s 5
+			IL_070b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0710: dup
+			IL_0711: ldloc.s 6
+			IL_0713: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0718: dup
+			IL_0719: ldloc.s 7
+			IL_071b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0720: dup
+			IL_0721: ldloc.s 9
+			IL_0723: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0728: dup
+			IL_0729: ldloc.s 10
+			IL_072b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0730: dup
+			IL_0731: ldloc.s 11
+			IL_0733: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0738: dup
+			IL_0739: ldloc.s 12
+			IL_073b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0740: dup
+			IL_0741: ldloc.s 13
+			IL_0743: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0748: dup
+			IL_0749: ldloc.s 14
+			IL_074b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0750: dup
+			IL_0751: ldloc.s 15
+			IL_0753: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0758: dup
+			IL_0759: ldloc.s 16
+			IL_075b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0760: dup
+			IL_0761: ldloc.s 17
+			IL_0763: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0768: dup
+			IL_0769: ldloc.s 18
+			IL_076b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0770: dup
+			IL_0771: ldloc.s 19
+			IL_0773: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0778: dup
+			IL_0779: ldloc.s 20
+			IL_077b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0780: stloc.1
+			IL_0781: ldarg.3
+			IL_0782: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0787: stloc.2
+			IL_0788: ldloc.2
+			IL_0789: brfalse IL_0851
+
+			IL_078e: volatile.
+			IL_0790: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
+			IL_0795: brfalse IL_07aa
+
+			IL_079a: ldarg.3
+			IL_079b: ldstr "source"
+			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07a5: br IL_07bf
+
+			IL_07aa: ldarg.3
+			IL_07ab: ldstr "source"
+			IL_07b0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:145"
+			IL_07b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
+			IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_07bf: stloc.s 4
+			IL_07c1: ldloc.s 4
+			IL_07c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07c8: stloc.s 20
+			IL_07ca: ldstr "overrideSource "
+			IL_07cf: ldloc.s 20
+			IL_07d1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07d6: stloc.s 20
+			IL_07d8: ldloc.1
+			IL_07d9: ldloc.s 20
+			IL_07db: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_07e0: pop
+			IL_07e1: ldarg.0
+			IL_07e2: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
+			IL_07e7: ldc.i4.1
+			IL_07e8: newarr [System.Runtime]System.Object
+			IL_07ed: dup
+			IL_07ee: ldc.i4.0
+			IL_07ef: ldarg.0
+			IL_07f0: stelem.ref
+			IL_07f1: stloc.s 8
+			IL_07f3: volatile.
+			IL_07f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
+			IL_07fa: brfalse IL_080f
+
+			IL_07ff: ldarg.3
+			IL_0800: ldstr "rootPath"
+			IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_080a: br IL_0824
+
+			IL_080f: ldarg.3
+			IL_0810: ldstr "rootPath"
+			IL_0815: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M18>:__js_call__:155"
+			IL_081a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
+			IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0824: stloc.s 4
+			IL_0826: ldloc.s 8
+			IL_0828: ldloc.s 4
+			IL_082a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_082f: stloc.s 4
+			IL_0831: ldloc.s 4
+			IL_0833: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0838: stloc.s 20
+			IL_083a: ldstr "overrideRoot "
+			IL_083f: ldloc.s 20
+			IL_0841: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0846: stloc.s 20
+			IL_0848: ldloc.1
+			IL_0849: ldloc.s 20
+			IL_084b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0850: pop
+
+			IL_0851: ldloc.1
+			IL_0852: ldc.i4.1
+			IL_0853: newarr [System.Runtime]System.Object
+			IL_0858: dup
+			IL_0859: ldc.i4.0
+			IL_085a: ldstr "\n"
+			IL_085f: stelem.ref
+			IL_0860: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0865: stloc.s 20
+			IL_0867: ldloc.s 20
+			IL_0869: ret
 		} // end of method describePlan::__js_call__
 
 	} // end of class describePlan
@@ -6319,7 +6427,7 @@
 				74 61 54 6f 6b 65 6e 1e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 972 (0x3cc)
+			// Code size: 1014 (0x3f6)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6399,7 +6507,7 @@
 			IL_00a8: stloc.0
 
 			IL_00a9: volatile.
-			IL_00ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_00ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
 			IL_00b0: brfalse IL_00c5
 
 			IL_00b5: ldloc.0
@@ -6410,7 +6518,7 @@
 			IL_00c5: ldloc.0
 			IL_00c6: ldstr "error"
 			IL_00cb: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M21>:__js_call__:17"
-			IL_00d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_00d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
 			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00da: stloc.s 9
@@ -6421,7 +6529,7 @@
 			IL_00e7: brfalse IL_0133
 
 			IL_00ec: volatile.
-			IL_00ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_00ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
 			IL_00f3: brfalse IL_0108
 
 			IL_00f8: ldloc.0
@@ -6432,7 +6540,7 @@
 			IL_0108: ldloc.0
 			IL_0109: ldstr "error"
 			IL_010e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M21>:__js_call__:22"
-			IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
 			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_011d: stloc.1
@@ -6449,7 +6557,7 @@
 			IL_0132: throw
 
 			IL_0133: volatile.
-			IL_0135: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_0135: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
 			IL_013a: brfalse IL_014f
 
 			IL_013f: ldloc.0
@@ -6460,7 +6568,7 @@
 			IL_014f: ldloc.0
 			IL_0150: ldstr "status"
 			IL_0155: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M21>:__js_call__:28"
-			IL_015a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_015a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
 			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0164: stloc.s 9
@@ -6470,10 +6578,10 @@
 			IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 			IL_017b: stloc.s 10
 			IL_017d: ldloc.s 10
-			IL_017f: brfalse IL_0380
+			IL_017f: brfalse IL_03aa
 
 			IL_0184: volatile.
-			IL_0186: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+			IL_0186: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
 			IL_018b: brfalse IL_01a0
 
 			IL_0190: ldloc.0
@@ -6484,7 +6592,7 @@
 			IL_01a0: ldloc.0
 			IL_01a1: ldstr "stderr"
 			IL_01a6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M21>:__js_call__:35"
-			IL_01ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+			IL_01ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
 			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01b5: stloc.s 9
@@ -6520,7 +6628,7 @@
 			IL_0209: stloc.2
 
 			IL_020a: volatile.
-			IL_020c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
+			IL_020c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
 			IL_0211: brfalse IL_0226
 
 			IL_0216: ldloc.0
@@ -6531,7 +6639,7 @@
 			IL_0226: ldloc.0
 			IL_0227: ldstr "stdout"
 			IL_022c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M21>:__js_call__:49"
-			IL_0231: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
+			IL_0231: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
 			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_023b: stloc.s 9
@@ -6598,88 +6706,100 @@
 			IL_02db: stloc.s 4
 			IL_02dd: ldarg.2
 			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e3: ldstr "join"
-			IL_02e8: ldstr " "
-			IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02f2: stloc.s 9
-			IL_02f4: ldloc.s 9
-			IL_02f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02fb: stloc.s 15
-			IL_02fd: ldstr "git "
-			IL_0302: ldloc.s 15
-			IL_0304: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0309: ldstr " failed"
-			IL_030e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0313: stloc.s 15
-			IL_0315: ldloc.s 4
-			IL_0317: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_031c: stloc.s 10
-			IL_031e: ldloc.s 10
-			IL_0320: brfalse IL_0345
+			IL_02e3: volatile.
+			IL_02e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
+			IL_02ea: brfalse IL_0303
 
-			IL_0325: ldloc.s 4
-			IL_0327: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_032c: stloc.s 16
-			IL_032e: ldstr ":\n"
-			IL_0333: ldloc.s 16
-			IL_0335: call string [System.Runtime]System.String::Concat(string, string)
-			IL_033a: stloc.s 16
-			IL_033c: ldloc.s 16
-			IL_033e: stloc.s 5
-			IL_0340: br IL_034c
+			IL_02ef: ldstr "join"
+			IL_02f4: ldstr " "
+			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02fe: br IL_031c
 
-			IL_0345: ldstr "."
-			IL_034a: stloc.s 5
+			IL_0303: ldstr "join"
+			IL_0308: ldstr " "
+			IL_030d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M21>:__js_call__:74"
+			IL_0312: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_034c: ldloc.s 5
-			IL_034e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0353: stloc.s 16
-			IL_0355: ldloc.s 15
-			IL_0357: ldloc.s 16
-			IL_0359: call string [System.Runtime]System.String::Concat(string, string)
-			IL_035e: stloc.s 16
-			IL_0360: ldloc.s 16
-			IL_0362: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0367: stloc.s 6
-			IL_0369: ldloc.s 6
-			IL_036b: isinst [System.Runtime]System.Exception
-			IL_0370: dup
-			IL_0371: brtrue IL_037f
+			IL_031c: stloc.s 9
+			IL_031e: ldloc.s 9
+			IL_0320: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0325: stloc.s 15
+			IL_0327: ldstr "git "
+			IL_032c: ldloc.s 15
+			IL_032e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0333: ldstr " failed"
+			IL_0338: call string [System.Runtime]System.String::Concat(string, string)
+			IL_033d: stloc.s 15
+			IL_033f: ldloc.s 4
+			IL_0341: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0346: stloc.s 10
+			IL_0348: ldloc.s 10
+			IL_034a: brfalse IL_036f
 
-			IL_0376: pop
-			IL_0377: ldloc.s 6
-			IL_0379: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_037e: throw
+			IL_034f: ldloc.s 4
+			IL_0351: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0356: stloc.s 16
+			IL_0358: ldstr ":\n"
+			IL_035d: ldloc.s 16
+			IL_035f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0364: stloc.s 16
+			IL_0366: ldloc.s 16
+			IL_0368: stloc.s 5
+			IL_036a: br IL_0376
 
-			IL_037f: throw
+			IL_036f: ldstr "."
+			IL_0374: stloc.s 5
 
-			IL_0380: volatile.
-			IL_0382: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
-			IL_0387: brfalse IL_039c
+			IL_0376: ldloc.s 5
+			IL_0378: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_037d: stloc.s 16
+			IL_037f: ldloc.s 15
+			IL_0381: ldloc.s 16
+			IL_0383: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0388: stloc.s 16
+			IL_038a: ldloc.s 16
+			IL_038c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0391: stloc.s 6
+			IL_0393: ldloc.s 6
+			IL_0395: isinst [System.Runtime]System.Exception
+			IL_039a: dup
+			IL_039b: brtrue IL_03a9
 
-			IL_038c: ldloc.0
-			IL_038d: ldstr "stdout"
-			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0397: br IL_03b1
+			IL_03a0: pop
+			IL_03a1: ldloc.s 6
+			IL_03a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03a8: throw
 
-			IL_039c: ldloc.0
-			IL_039d: ldstr "stdout"
-			IL_03a2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M21>:__js_call__:98"
-			IL_03a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
-			IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03a9: throw
 
-			IL_03b1: stloc.s 9
-			IL_03b3: ldloc.s 9
-			IL_03b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03ba: stloc.s 10
-			IL_03bc: ldloc.s 10
-			IL_03be: brtrue IL_03c9
+			IL_03aa: volatile.
+			IL_03ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
+			IL_03b1: brfalse IL_03c6
 
-			IL_03c3: ldstr ""
-			IL_03c8: ret
+			IL_03b6: ldloc.0
+			IL_03b7: ldstr "stdout"
+			IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c1: br IL_03db
 
-			IL_03c9: ldloc.s 9
-			IL_03cb: ret
+			IL_03c6: ldloc.0
+			IL_03c7: ldstr "stdout"
+			IL_03cc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M21>:__js_call__:98"
+			IL_03d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
+			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_03db: stloc.s 9
+			IL_03dd: ldloc.s 9
+			IL_03df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03e4: stloc.s 10
+			IL_03e6: ldloc.s 10
+			IL_03e8: brtrue IL_03f3
+
+			IL_03ed: ldstr ""
+			IL_03f2: ret
+
+			IL_03f3: ldloc.s 9
+			IL_03f5: ret
 		} // end of method runGit::__js_call__
 
 	} // end of class runGit
@@ -6931,7 +7051,7 @@
 			IL_0001: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0006: stloc.0
 			IL_0007: volatile.
-			IL_0009: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
+			IL_0009: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
 			IL_000e: brfalse IL_0023
 
 			IL_0013: ldarg.2
@@ -6942,7 +7062,7 @@
 			IL_0023: ldarg.2
 			IL_0024: ldstr "includeFiles"
 			IL_0029: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M22>:__js_call__:6"
-			IL_002e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
+			IL_002e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
 			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0038: stloc.s 10
@@ -7023,7 +7143,7 @@
 			} // end handler
 
 			IL_00d4: volatile.
-			IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
+			IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
 			IL_00db: brfalse IL_00f0
 
 			IL_00e0: ldarg.2
@@ -7034,7 +7154,7 @@
 			IL_00f0: ldarg.2
 			IL_00f1: ldstr "includeDirectories"
 			IL_00f6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M22>:__js_call__:51"
-			IL_00fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
+			IL_00fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
 			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0105: stloc.s 10
@@ -7489,7 +7609,7 @@
 				74 61 54 6f 6b 65 6e 1e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2267 (0x8db)
+			// Code size: 2351 (0x92f)
 			.maxstack 12
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -7535,7 +7655,7 @@
 			IL_0008: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_000d: stloc.1
 			IL_000e: volatile.
-			IL_0010: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
+			IL_0010: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
 			IL_0015: brfalse IL_002a
 
 			IL_001a: ldarg.3
@@ -7546,7 +7666,7 @@
 			IL_002a: ldarg.3
 			IL_002b: ldstr "requiredFiles"
 			IL_0030: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:9"
-			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
+			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
 			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_003f: stloc.s 16
@@ -7569,7 +7689,7 @@
 					IL_005a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_005f: stloc.s 17
 					IL_0061: ldloc.s 17
-					IL_0063: brtrue IL_021e
+					IL_0063: brtrue IL_0248
 
 					IL_0068: ldloc.s 16
 					IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -7603,767 +7723,791 @@
 					IL_00ae: stloc.s 16
 					IL_00b0: ldloc.s 16
 					IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00b7: ldstr "split"
-					IL_00bc: ldstr "/"
-					IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_00c6: stloc.s 16
-					IL_00c8: ldloc.s 19
-					IL_00ca: ldloc.s 16
-					IL_00cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_00d1: ldloc.s 19
-					IL_00d3: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_00d8: stloc.s 20
-					IL_00da: ldloc.s 18
-					IL_00dc: ldstr "join"
-					IL_00e1: ldloc.s 20
-					IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-					IL_00e8: stloc.s 6
-					IL_00ea: ldarg.0
-					IL_00eb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_00f0: stloc.s 21
-					IL_00f2: ldloc.s 21
-					IL_00f4: ldstr "existsSync"
-					IL_00f9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_00fe: brtrue IL_0118
+					IL_00b7: volatile.
+					IL_00b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
+					IL_00be: brfalse IL_00d7
 
-					IL_0103: ldloc.s 21
-					IL_0105: ldloc.s 6
-					IL_0107: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_010c: box [System.Runtime]System.Boolean
-					IL_0111: stloc.s 16
-					IL_0113: br IL_0131
+					IL_00c3: ldstr "split"
+					IL_00c8: ldstr "/"
+					IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_00d2: br IL_00f0
 
-					IL_0118: ldloc.s 21
-					IL_011a: ldstr "existsSync"
-					IL_011f: ldc.i4.1
-					IL_0120: newarr [System.Runtime]System.Object
-					IL_0125: dup
-					IL_0126: ldc.i4.0
-					IL_0127: ldloc.s 6
-					IL_0129: stelem.ref
-					IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_012f: stloc.s 16
+					IL_00d7: ldstr "split"
+					IL_00dc: ldstr "/"
+					IL_00e1: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:35"
+					IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
+					IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-					IL_0131: ldloc.s 16
-					IL_0133: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0138: ldc.i4.0
-					IL_0139: ceq
-					IL_013b: stloc.s 17
-					IL_013d: ldloc.s 17
-					IL_013f: box [System.Runtime]System.Boolean
-					IL_0144: stloc.s 22
-					IL_0146: ldloc.s 22
-					IL_0148: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_014d: stloc.s 17
-					IL_014f: ldloc.s 17
-					IL_0151: brtrue IL_01ee
+					IL_00f0: stloc.s 16
+					IL_00f2: ldloc.s 19
+					IL_00f4: ldloc.s 16
+					IL_00f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_00fb: ldloc.s 19
+					IL_00fd: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_0102: stloc.s 20
+					IL_0104: ldloc.s 18
+					IL_0106: ldstr "join"
+					IL_010b: ldloc.s 20
+					IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+					IL_0112: stloc.s 6
+					IL_0114: ldarg.0
+					IL_0115: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_011a: stloc.s 21
+					IL_011c: ldloc.s 21
+					IL_011e: ldstr "existsSync"
+					IL_0123: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_0128: brtrue IL_0142
 
-					IL_0156: ldarg.0
-					IL_0157: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_015c: stloc.s 21
-					IL_015e: ldloc.s 21
-					IL_0160: ldstr "statSync"
-					IL_0165: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_016a: brtrue IL_017f
+					IL_012d: ldloc.s 21
+					IL_012f: ldloc.s 6
+					IL_0131: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_0136: box [System.Runtime]System.Boolean
+					IL_013b: stloc.s 16
+					IL_013d: br IL_015b
 
-					IL_016f: ldloc.s 21
-					IL_0171: ldloc.s 6
-					IL_0173: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
-					IL_0178: stloc.s 16
-					IL_017a: br IL_0198
+					IL_0142: ldloc.s 21
+					IL_0144: ldstr "existsSync"
+					IL_0149: ldc.i4.1
+					IL_014a: newarr [System.Runtime]System.Object
+					IL_014f: dup
+					IL_0150: ldc.i4.0
+					IL_0151: ldloc.s 6
+					IL_0153: stelem.ref
+					IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_0159: stloc.s 16
 
-					IL_017f: ldloc.s 21
-					IL_0181: ldstr "statSync"
-					IL_0186: ldc.i4.1
-					IL_0187: newarr [System.Runtime]System.Object
-					IL_018c: dup
-					IL_018d: ldc.i4.0
-					IL_018e: ldloc.s 6
-					IL_0190: stelem.ref
-					IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_0196: stloc.s 16
+					IL_015b: ldloc.s 16
+					IL_015d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0162: ldc.i4.0
+					IL_0163: ceq
+					IL_0165: stloc.s 17
+					IL_0167: ldloc.s 17
+					IL_0169: box [System.Runtime]System.Boolean
+					IL_016e: stloc.s 22
+					IL_0170: ldloc.s 22
+					IL_0172: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0177: stloc.s 17
+					IL_0179: ldloc.s 17
+					IL_017b: brtrue IL_0218
 
-					IL_0198: ldloc.s 16
-					IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_019f: volatile.
-					IL_01a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
-					IL_01a6: brfalse IL_01ba
+					IL_0180: ldarg.0
+					IL_0181: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0186: stloc.s 21
+					IL_0188: ldloc.s 21
+					IL_018a: ldstr "statSync"
+					IL_018f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_0194: brtrue IL_01a9
 
-					IL_01ab: ldstr "isFile"
-					IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_01b5: br IL_01ce
+					IL_0199: ldloc.s 21
+					IL_019b: ldloc.s 6
+					IL_019d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_01a2: stloc.s 16
+					IL_01a4: br IL_01c2
 
-					IL_01ba: ldstr "isFile"
-					IL_01bf: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:50"
-					IL_01c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
-					IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+					IL_01a9: ldloc.s 21
+					IL_01ab: ldstr "statSync"
+					IL_01b0: ldc.i4.1
+					IL_01b1: newarr [System.Runtime]System.Object
+					IL_01b6: dup
+					IL_01b7: ldc.i4.0
+					IL_01b8: ldloc.s 6
+					IL_01ba: stelem.ref
+					IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_01c0: stloc.s 16
 
-					IL_01ce: stloc.s 16
-					IL_01d0: ldloc.s 16
-					IL_01d2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_01d7: ldc.i4.0
-					IL_01d8: ceq
-					IL_01da: stloc.s 17
-					IL_01dc: ldloc.s 17
-					IL_01de: box [System.Runtime]System.Boolean
-					IL_01e3: stloc.s 23
-					IL_01e5: ldloc.s 23
-					IL_01e7: stloc.s 25
-					IL_01e9: br IL_01f2
+					IL_01c2: ldloc.s 16
+					IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01c9: volatile.
+					IL_01cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
+					IL_01d0: brfalse IL_01e4
 
-					IL_01ee: ldloc.s 22
-					IL_01f0: stloc.s 25
+					IL_01d5: ldstr "isFile"
+					IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_01df: br IL_01f8
 
-					IL_01f2: ldloc.s 25
-					IL_01f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01f9: stloc.s 17
-					IL_01fb: ldloc.s 17
-					IL_01fd: brfalse IL_020b
+					IL_01e4: ldstr "isFile"
+					IL_01e9: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:50"
+					IL_01ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
+					IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-					IL_0202: ldloc.0
-					IL_0203: ldloc.s 5
-					IL_0205: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_020a: pop
+					IL_01f8: stloc.s 16
+					IL_01fa: ldloc.s 16
+					IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0201: ldc.i4.0
+					IL_0202: ceq
+					IL_0204: stloc.s 17
+					IL_0206: ldloc.s 17
+					IL_0208: box [System.Runtime]System.Boolean
+					IL_020d: stloc.s 23
+					IL_020f: ldloc.s 23
+					IL_0211: stloc.s 25
+					IL_0213: br IL_021c
 
-					IL_020b: br IL_004e
+					IL_0218: ldloc.s 22
+					IL_021a: stloc.s 25
+
+					IL_021c: ldloc.s 25
+					IL_021e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0223: stloc.s 17
+					IL_0225: ldloc.s 17
+					IL_0227: brfalse IL_0235
+
+					IL_022c: ldloc.0
+					IL_022d: ldloc.s 5
+					IL_022f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0234: pop
+
+					IL_0235: br IL_004e
 				// end loop
-				IL_0210: ldloc.2
-				IL_0211: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0216: ldc.i4.1
-				IL_0217: stloc.s 4
-				IL_0219: leave IL_0239
+				IL_023a: ldloc.2
+				IL_023b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0240: ldc.i4.1
+				IL_0241: stloc.s 4
+				IL_0243: leave IL_0263
 
-				IL_021e: ldc.i4.1
-				IL_021f: stloc.3
-				IL_0220: leave IL_0239
+				IL_0248: ldc.i4.1
+				IL_0249: stloc.3
+				IL_024a: leave IL_0263
 			} // end .try
 			finally
 			{
-				IL_0225: ldloc.3
-				IL_0226: brtrue IL_0238
+				IL_024f: ldloc.3
+				IL_0250: brtrue IL_0262
 
-				IL_022b: ldloc.s 4
-				IL_022d: brtrue IL_0238
+				IL_0255: ldloc.s 4
+				IL_0257: brtrue IL_0262
 
-				IL_0232: ldloc.2
-				IL_0233: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_025c: ldloc.2
+				IL_025d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0238: endfinally
+				IL_0262: endfinally
 			} // end handler
 
-			IL_0239: volatile.
-			IL_023b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
-			IL_0240: brfalse IL_0255
+			IL_0263: volatile.
+			IL_0265: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
+			IL_026a: brfalse IL_027f
 
-			IL_0245: ldarg.3
-			IL_0246: ldstr "requiredDirectories"
-			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0250: br IL_026a
+			IL_026f: ldarg.3
+			IL_0270: ldstr "requiredDirectories"
+			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027a: br IL_0294
 
-			IL_0255: ldarg.3
-			IL_0256: ldstr "requiredDirectories"
-			IL_025b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:84"
-			IL_0260: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_027f: ldarg.3
+			IL_0280: ldstr "requiredDirectories"
+			IL_0285: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:84"
+			IL_028a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
+			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_026a: stloc.s 16
-			IL_026c: ldloc.s 16
-			IL_026e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_0273: stloc.s 7
-			IL_0275: ldc.i4.0
-			IL_0276: stloc.s 8
-			IL_0278: ldc.i4.0
-			IL_0279: stloc.s 9
+			IL_0294: stloc.s 16
+			IL_0296: ldloc.s 16
+			IL_0298: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_029d: stloc.s 7
+			IL_029f: ldc.i4.0
+			IL_02a0: stloc.s 8
+			IL_02a2: ldc.i4.0
+			IL_02a3: stloc.s 9
 			.try
 			{
-				// loop start (head: IL_027b)
-					IL_027b: ldc.i4.1
-					IL_027c: stloc.s 8
-					IL_027e: ldloc.s 7
-					IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_0285: stloc.s 16
-					IL_0287: ldloc.s 16
-					IL_0289: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_028e: stloc.s 17
-					IL_0290: ldloc.s 17
-					IL_0292: brtrue IL_044f
+				// loop start (head: IL_02a5)
+					IL_02a5: ldc.i4.1
+					IL_02a6: stloc.s 8
+					IL_02a8: ldloc.s 7
+					IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_02af: stloc.s 16
+					IL_02b1: ldloc.s 16
+					IL_02b3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_02b8: stloc.s 17
+					IL_02ba: ldloc.s 17
+					IL_02bc: brtrue IL_04a3
 
-					IL_0297: ldloc.s 16
-					IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_029e: stloc.s 16
-					IL_02a0: ldc.i4.0
-					IL_02a1: stloc.s 8
-					IL_02a3: ldloc.s 16
-					IL_02a5: stloc.s 10
-					IL_02a7: ldarg.0
-					IL_02a8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_02ad: stloc.s 18
-					IL_02af: ldloc.s 18
-					IL_02b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(!!0)
-					IL_02b6: stloc.s 18
-					IL_02b8: ldc.i4.1
-					IL_02b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_02be: dup
-					IL_02bf: ldarg.2
-					IL_02c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_02c5: stloc.s 19
-					IL_02c7: ldarg.0
-					IL_02c8: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_02cd: ldc.i4.1
-					IL_02ce: newarr [System.Runtime]System.Object
-					IL_02d3: dup
-					IL_02d4: ldc.i4.0
-					IL_02d5: ldarg.0
-					IL_02d6: stelem.ref
-					IL_02d7: ldloc.s 10
-					IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_02de: stloc.s 16
-					IL_02e0: ldloc.s 16
-					IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02e7: ldstr "split"
-					IL_02ec: ldstr "/"
-					IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_02f6: stloc.s 16
-					IL_02f8: ldloc.s 19
-					IL_02fa: ldloc.s 16
-					IL_02fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_0301: ldloc.s 19
-					IL_0303: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_0308: stloc.s 20
-					IL_030a: ldloc.s 18
-					IL_030c: ldstr "join"
-					IL_0311: ldloc.s 20
-					IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-					IL_0318: stloc.s 11
-					IL_031a: ldarg.0
-					IL_031b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0320: stloc.s 21
-					IL_0322: ldloc.s 21
-					IL_0324: ldstr "existsSync"
-					IL_0329: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_032e: brtrue IL_0348
+					IL_02c1: ldloc.s 16
+					IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_02c8: stloc.s 16
+					IL_02ca: ldc.i4.0
+					IL_02cb: stloc.s 8
+					IL_02cd: ldloc.s 16
+					IL_02cf: stloc.s 10
+					IL_02d1: ldarg.0
+					IL_02d2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_02d7: stloc.s 18
+					IL_02d9: ldloc.s 18
+					IL_02db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(!!0)
+					IL_02e0: stloc.s 18
+					IL_02e2: ldc.i4.1
+					IL_02e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_02e8: dup
+					IL_02e9: ldarg.2
+					IL_02ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_02ef: stloc.s 19
+					IL_02f1: ldarg.0
+					IL_02f2: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_02f7: ldc.i4.1
+					IL_02f8: newarr [System.Runtime]System.Object
+					IL_02fd: dup
+					IL_02fe: ldc.i4.0
+					IL_02ff: ldarg.0
+					IL_0300: stelem.ref
+					IL_0301: ldloc.s 10
+					IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0308: stloc.s 16
+					IL_030a: ldloc.s 16
+					IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0311: volatile.
+					IL_0313: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
+					IL_0318: brfalse IL_0331
 
-					IL_0333: ldloc.s 21
-					IL_0335: ldloc.s 11
-					IL_0337: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_033c: box [System.Runtime]System.Boolean
-					IL_0341: stloc.s 16
-					IL_0343: br IL_0361
+					IL_031d: ldstr "split"
+					IL_0322: ldstr "/"
+					IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_032c: br IL_034a
 
-					IL_0348: ldloc.s 21
-					IL_034a: ldstr "existsSync"
-					IL_034f: ldc.i4.1
-					IL_0350: newarr [System.Runtime]System.Object
-					IL_0355: dup
-					IL_0356: ldc.i4.0
-					IL_0357: ldloc.s 11
-					IL_0359: stelem.ref
-					IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_035f: stloc.s 16
+					IL_0331: ldstr "split"
+					IL_0336: ldstr "/"
+					IL_033b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:110"
+					IL_0340: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
+					IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-					IL_0361: ldloc.s 16
-					IL_0363: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0368: ldc.i4.0
-					IL_0369: ceq
-					IL_036b: stloc.s 17
-					IL_036d: ldloc.s 17
-					IL_036f: box [System.Runtime]System.Boolean
-					IL_0374: stloc.s 22
-					IL_0376: ldloc.s 22
-					IL_0378: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_037d: stloc.s 17
-					IL_037f: ldloc.s 17
-					IL_0381: brtrue IL_041e
+					IL_034a: stloc.s 16
+					IL_034c: ldloc.s 19
+					IL_034e: ldloc.s 16
+					IL_0350: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_0355: ldloc.s 19
+					IL_0357: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_035c: stloc.s 20
+					IL_035e: ldloc.s 18
+					IL_0360: ldstr "join"
+					IL_0365: ldloc.s 20
+					IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+					IL_036c: stloc.s 11
+					IL_036e: ldarg.0
+					IL_036f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0374: stloc.s 21
+					IL_0376: ldloc.s 21
+					IL_0378: ldstr "existsSync"
+					IL_037d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_0382: brtrue IL_039c
 
-					IL_0386: ldarg.0
-					IL_0387: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_038c: stloc.s 21
-					IL_038e: ldloc.s 21
-					IL_0390: ldstr "statSync"
-					IL_0395: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_039a: brtrue IL_03af
+					IL_0387: ldloc.s 21
+					IL_0389: ldloc.s 11
+					IL_038b: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_0390: box [System.Runtime]System.Boolean
+					IL_0395: stloc.s 16
+					IL_0397: br IL_03b5
 
-					IL_039f: ldloc.s 21
-					IL_03a1: ldloc.s 11
-					IL_03a3: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
-					IL_03a8: stloc.s 16
-					IL_03aa: br IL_03c8
+					IL_039c: ldloc.s 21
+					IL_039e: ldstr "existsSync"
+					IL_03a3: ldc.i4.1
+					IL_03a4: newarr [System.Runtime]System.Object
+					IL_03a9: dup
+					IL_03aa: ldc.i4.0
+					IL_03ab: ldloc.s 11
+					IL_03ad: stelem.ref
+					IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_03b3: stloc.s 16
 
-					IL_03af: ldloc.s 21
-					IL_03b1: ldstr "statSync"
-					IL_03b6: ldc.i4.1
-					IL_03b7: newarr [System.Runtime]System.Object
-					IL_03bc: dup
-					IL_03bd: ldc.i4.0
-					IL_03be: ldloc.s 11
-					IL_03c0: stelem.ref
-					IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_03c6: stloc.s 16
+					IL_03b5: ldloc.s 16
+					IL_03b7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_03bc: ldc.i4.0
+					IL_03bd: ceq
+					IL_03bf: stloc.s 17
+					IL_03c1: ldloc.s 17
+					IL_03c3: box [System.Runtime]System.Boolean
+					IL_03c8: stloc.s 22
+					IL_03ca: ldloc.s 22
+					IL_03cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_03d1: stloc.s 17
+					IL_03d3: ldloc.s 17
+					IL_03d5: brtrue IL_0472
 
-					IL_03c8: ldloc.s 16
-					IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03cf: volatile.
-					IL_03d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
-					IL_03d6: brfalse IL_03ea
+					IL_03da: ldarg.0
+					IL_03db: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_03e0: stloc.s 21
+					IL_03e2: ldloc.s 21
+					IL_03e4: ldstr "statSync"
+					IL_03e9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_03ee: brtrue IL_0403
 
-					IL_03db: ldstr "isDirectory"
-					IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_03e5: br IL_03fe
+					IL_03f3: ldloc.s 21
+					IL_03f5: ldloc.s 11
+					IL_03f7: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_03fc: stloc.s 16
+					IL_03fe: br IL_041c
 
-					IL_03ea: ldstr "isDirectory"
-					IL_03ef: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:125"
-					IL_03f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
-					IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+					IL_0403: ldloc.s 21
+					IL_0405: ldstr "statSync"
+					IL_040a: ldc.i4.1
+					IL_040b: newarr [System.Runtime]System.Object
+					IL_0410: dup
+					IL_0411: ldc.i4.0
+					IL_0412: ldloc.s 11
+					IL_0414: stelem.ref
+					IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_041a: stloc.s 16
 
-					IL_03fe: stloc.s 16
-					IL_0400: ldloc.s 16
-					IL_0402: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0407: ldc.i4.0
-					IL_0408: ceq
-					IL_040a: stloc.s 17
-					IL_040c: ldloc.s 17
-					IL_040e: box [System.Runtime]System.Boolean
-					IL_0413: stloc.s 23
-					IL_0415: ldloc.s 23
-					IL_0417: stloc.s 26
-					IL_0419: br IL_0422
+					IL_041c: ldloc.s 16
+					IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0423: volatile.
+					IL_0425: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
+					IL_042a: brfalse IL_043e
 
-					IL_041e: ldloc.s 22
-					IL_0420: stloc.s 26
+					IL_042f: ldstr "isDirectory"
+					IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_0439: br IL_0452
 
-					IL_0422: ldloc.s 26
-					IL_0424: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0429: stloc.s 17
-					IL_042b: ldloc.s 17
-					IL_042d: brfalse IL_043b
+					IL_043e: ldstr "isDirectory"
+					IL_0443: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:125"
+					IL_0448: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
+					IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-					IL_0432: ldloc.1
-					IL_0433: ldloc.s 10
-					IL_0435: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_043a: pop
+					IL_0452: stloc.s 16
+					IL_0454: ldloc.s 16
+					IL_0456: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_045b: ldc.i4.0
+					IL_045c: ceq
+					IL_045e: stloc.s 17
+					IL_0460: ldloc.s 17
+					IL_0462: box [System.Runtime]System.Boolean
+					IL_0467: stloc.s 23
+					IL_0469: ldloc.s 23
+					IL_046b: stloc.s 26
+					IL_046d: br IL_0476
 
-					IL_043b: br IL_027b
+					IL_0472: ldloc.s 22
+					IL_0474: stloc.s 26
+
+					IL_0476: ldloc.s 26
+					IL_0478: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_047d: stloc.s 17
+					IL_047f: ldloc.s 17
+					IL_0481: brfalse IL_048f
+
+					IL_0486: ldloc.1
+					IL_0487: ldloc.s 10
+					IL_0489: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_048e: pop
+
+					IL_048f: br IL_02a5
 				// end loop
-				IL_0440: ldloc.s 7
-				IL_0442: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0447: ldc.i4.1
-				IL_0448: stloc.s 9
-				IL_044a: leave IL_046d
+				IL_0494: ldloc.s 7
+				IL_0496: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_049b: ldc.i4.1
+				IL_049c: stloc.s 9
+				IL_049e: leave IL_04c1
 
-				IL_044f: ldc.i4.1
-				IL_0450: stloc.s 8
-				IL_0452: leave IL_046d
+				IL_04a3: ldc.i4.1
+				IL_04a4: stloc.s 8
+				IL_04a6: leave IL_04c1
 			} // end .try
 			finally
 			{
-				IL_0457: ldloc.s 8
-				IL_0459: brtrue IL_046c
+				IL_04ab: ldloc.s 8
+				IL_04ad: brtrue IL_04c0
 
-				IL_045e: ldloc.s 9
-				IL_0460: brtrue IL_046c
+				IL_04b2: ldloc.s 9
+				IL_04b4: brtrue IL_04c0
 
-				IL_0465: ldloc.s 7
-				IL_0467: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_04b9: ldloc.s 7
+				IL_04bb: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_046c: endfinally
+				IL_04c0: endfinally
 			} // end handler
 
-			IL_046d: ldloc.0
-			IL_046e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0473: ldc.r8 0.0
-			IL_047c: cgt
-			IL_047e: stloc.s 17
-			IL_0480: ldloc.s 17
-			IL_0482: box [System.Runtime]System.Boolean
-			IL_0487: stloc.s 22
-			IL_0489: ldloc.s 22
-			IL_048b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0490: stloc.s 17
-			IL_0492: ldloc.s 17
-			IL_0494: brtrue IL_04be
+			IL_04c1: ldloc.0
+			IL_04c2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_04c7: ldc.r8 0.0
+			IL_04d0: cgt
+			IL_04d2: stloc.s 17
+			IL_04d4: ldloc.s 17
+			IL_04d6: box [System.Runtime]System.Boolean
+			IL_04db: stloc.s 22
+			IL_04dd: ldloc.s 22
+			IL_04df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04e4: stloc.s 17
+			IL_04e6: ldloc.s 17
+			IL_04e8: brtrue IL_0512
 
-			IL_0499: ldloc.1
-			IL_049a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_049f: ldc.r8 0.0
-			IL_04a8: cgt
-			IL_04aa: stloc.s 17
-			IL_04ac: ldloc.s 17
-			IL_04ae: box [System.Runtime]System.Boolean
-			IL_04b3: stloc.s 23
-			IL_04b5: ldloc.s 23
-			IL_04b7: stloc.s 27
-			IL_04b9: br IL_04c2
+			IL_04ed: ldloc.1
+			IL_04ee: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_04f3: ldc.r8 0.0
+			IL_04fc: cgt
+			IL_04fe: stloc.s 17
+			IL_0500: ldloc.s 17
+			IL_0502: box [System.Runtime]System.Boolean
+			IL_0507: stloc.s 23
+			IL_0509: ldloc.s 23
+			IL_050b: stloc.s 27
+			IL_050d: br IL_0516
 
-			IL_04be: ldloc.s 22
-			IL_04c0: stloc.s 27
+			IL_0512: ldloc.s 22
+			IL_0514: stloc.s 27
 
-			IL_04c2: ldloc.s 27
-			IL_04c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04c9: stloc.s 17
-			IL_04cb: ldloc.s 17
-			IL_04cd: brfalse IL_05ae
+			IL_0516: ldloc.s 27
+			IL_0518: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_051d: stloc.s 17
+			IL_051f: ldloc.s 17
+			IL_0521: brfalse IL_0602
 
-			IL_04d2: ldc.i4.0
-			IL_04d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_04d8: stloc.s 12
-			IL_04da: ldloc.0
-			IL_04db: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_04e0: ldc.r8 0.0
-			IL_04e9: cgt
-			IL_04eb: brfalse IL_0527
+			IL_0526: ldc.i4.0
+			IL_0527: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_052c: stloc.s 12
+			IL_052e: ldloc.0
+			IL_052f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0534: ldc.r8 0.0
+			IL_053d: cgt
+			IL_053f: brfalse IL_057b
 
-			IL_04f0: ldloc.0
-			IL_04f1: ldc.i4.1
-			IL_04f2: newarr [System.Runtime]System.Object
-			IL_04f7: dup
-			IL_04f8: ldc.i4.0
-			IL_04f9: ldstr ", "
-			IL_04fe: stelem.ref
-			IL_04ff: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0504: stloc.s 28
-			IL_0506: ldloc.s 28
-			IL_0508: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_050d: stloc.s 28
-			IL_050f: ldstr "missing files: "
-			IL_0514: ldloc.s 28
-			IL_0516: call string [System.Runtime]System.String::Concat(string, string)
-			IL_051b: stloc.s 28
-			IL_051d: ldloc.s 12
-			IL_051f: ldloc.s 28
-			IL_0521: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0526: pop
+			IL_0544: ldloc.0
+			IL_0545: ldc.i4.1
+			IL_0546: newarr [System.Runtime]System.Object
+			IL_054b: dup
+			IL_054c: ldc.i4.0
+			IL_054d: ldstr ", "
+			IL_0552: stelem.ref
+			IL_0553: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0558: stloc.s 28
+			IL_055a: ldloc.s 28
+			IL_055c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0561: stloc.s 28
+			IL_0563: ldstr "missing files: "
+			IL_0568: ldloc.s 28
+			IL_056a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_056f: stloc.s 28
+			IL_0571: ldloc.s 12
+			IL_0573: ldloc.s 28
+			IL_0575: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_057a: pop
 
-			IL_0527: ldloc.1
-			IL_0528: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_052d: ldc.r8 0.0
-			IL_0536: cgt
-			IL_0538: brfalse IL_0574
+			IL_057b: ldloc.1
+			IL_057c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0581: ldc.r8 0.0
+			IL_058a: cgt
+			IL_058c: brfalse IL_05c8
 
-			IL_053d: ldloc.1
-			IL_053e: ldc.i4.1
-			IL_053f: newarr [System.Runtime]System.Object
-			IL_0544: dup
-			IL_0545: ldc.i4.0
-			IL_0546: ldstr ", "
-			IL_054b: stelem.ref
-			IL_054c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0551: stloc.s 28
-			IL_0553: ldloc.s 28
-			IL_0555: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_055a: stloc.s 28
-			IL_055c: ldstr "missing directories: "
-			IL_0561: ldloc.s 28
-			IL_0563: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0568: stloc.s 28
-			IL_056a: ldloc.s 12
-			IL_056c: ldloc.s 28
-			IL_056e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0573: pop
+			IL_0591: ldloc.1
+			IL_0592: ldc.i4.1
+			IL_0593: newarr [System.Runtime]System.Object
+			IL_0598: dup
+			IL_0599: ldc.i4.0
+			IL_059a: ldstr ", "
+			IL_059f: stelem.ref
+			IL_05a0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_05a5: stloc.s 28
+			IL_05a7: ldloc.s 28
+			IL_05a9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05ae: stloc.s 28
+			IL_05b0: ldstr "missing directories: "
+			IL_05b5: ldloc.s 28
+			IL_05b7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05bc: stloc.s 28
+			IL_05be: ldloc.s 12
+			IL_05c0: ldloc.s 28
+			IL_05c2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_05c7: pop
 
-			IL_0574: ldloc.s 12
-			IL_0576: ldc.i4.1
-			IL_0577: newarr [System.Runtime]System.Object
-			IL_057c: dup
-			IL_057d: ldc.i4.0
-			IL_057e: ldstr "; "
-			IL_0583: stelem.ref
-			IL_0584: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0589: stloc.s 28
-			IL_058b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0590: dup
-			IL_0591: ldstr "ok"
-			IL_0596: ldc.i4.0
-			IL_0597: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_059c: dup
-			IL_059d: ldstr "message"
-			IL_05a2: ldloc.s 28
-			IL_05a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05a9: stloc.s 29
-			IL_05ab: ldloc.s 29
-			IL_05ad: ret
+			IL_05c8: ldloc.s 12
+			IL_05ca: ldc.i4.1
+			IL_05cb: newarr [System.Runtime]System.Object
+			IL_05d0: dup
+			IL_05d1: ldc.i4.0
+			IL_05d2: ldstr "; "
+			IL_05d7: stelem.ref
+			IL_05d8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_05dd: stloc.s 28
+			IL_05df: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05e4: dup
+			IL_05e5: ldstr "ok"
+			IL_05ea: ldc.i4.0
+			IL_05eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05f0: dup
+			IL_05f1: ldstr "message"
+			IL_05f6: ldloc.s 28
+			IL_05f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05fd: stloc.s 29
+			IL_05ff: ldloc.s 29
+			IL_0601: ret
 
-			IL_05ae: ldarg.0
-			IL_05af: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_05b4: stloc.s 18
-			IL_05b6: ldloc.s 18
-			IL_05b8: ldstr "join"
-			IL_05bd: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_05c2: brtrue IL_05e7
+			IL_0602: ldarg.0
+			IL_0603: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0608: stloc.s 18
+			IL_060a: ldloc.s 18
+			IL_060c: ldstr "join"
+			IL_0611: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0616: brtrue IL_063b
 
-			IL_05c7: ldloc.s 18
-			IL_05c9: ldc.i4.2
-			IL_05ca: newarr [System.Runtime]System.Object
-			IL_05cf: dup
-			IL_05d0: ldc.i4.0
-			IL_05d1: ldarg.2
-			IL_05d2: stelem.ref
-			IL_05d3: dup
-			IL_05d4: ldc.i4.1
-			IL_05d5: ldstr "package.json"
-			IL_05da: stelem.ref
-			IL_05db: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_05e0: stloc.s 13
-			IL_05e2: br IL_0607
+			IL_061b: ldloc.s 18
+			IL_061d: ldc.i4.2
+			IL_061e: newarr [System.Runtime]System.Object
+			IL_0623: dup
+			IL_0624: ldc.i4.0
+			IL_0625: ldarg.2
+			IL_0626: stelem.ref
+			IL_0627: dup
+			IL_0628: ldc.i4.1
+			IL_0629: ldstr "package.json"
+			IL_062e: stelem.ref
+			IL_062f: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0634: stloc.s 13
+			IL_0636: br IL_065b
 
-			IL_05e7: ldloc.s 18
-			IL_05e9: ldstr "join"
-			IL_05ee: ldc.i4.2
-			IL_05ef: newarr [System.Runtime]System.Object
-			IL_05f4: dup
-			IL_05f5: ldc.i4.0
-			IL_05f6: ldarg.2
-			IL_05f7: stelem.ref
-			IL_05f8: dup
-			IL_05f9: ldc.i4.1
-			IL_05fa: ldstr "package.json"
-			IL_05ff: stelem.ref
-			IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0605: stloc.s 13
+			IL_063b: ldloc.s 18
+			IL_063d: ldstr "join"
+			IL_0642: ldc.i4.2
+			IL_0643: newarr [System.Runtime]System.Object
+			IL_0648: dup
+			IL_0649: ldc.i4.0
+			IL_064a: ldarg.2
+			IL_064b: stelem.ref
+			IL_064c: dup
+			IL_064d: ldc.i4.1
+			IL_064e: ldstr "package.json"
+			IL_0653: stelem.ref
+			IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0659: stloc.s 13
 
-			IL_0607: ldarg.0
-			IL_0608: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_060d: stloc.s 21
-			IL_060f: ldloc.s 21
-			IL_0611: ldstr "readFileSync"
-			IL_0616: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_061b: brtrue IL_0635
+			IL_065b: ldarg.0
+			IL_065c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_0661: stloc.s 21
+			IL_0663: ldloc.s 21
+			IL_0665: ldstr "readFileSync"
+			IL_066a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_066f: brtrue IL_0689
 
-			IL_0620: ldloc.s 21
-			IL_0622: ldloc.s 13
-			IL_0624: ldstr "utf8"
-			IL_0629: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_062e: stloc.s 16
-			IL_0630: br IL_0656
+			IL_0674: ldloc.s 21
+			IL_0676: ldloc.s 13
+			IL_0678: ldstr "utf8"
+			IL_067d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0682: stloc.s 16
+			IL_0684: br IL_06aa
 
-			IL_0635: ldloc.s 21
-			IL_0637: ldstr "readFileSync"
-			IL_063c: ldc.i4.2
-			IL_063d: newarr [System.Runtime]System.Object
-			IL_0642: dup
-			IL_0643: ldc.i4.0
-			IL_0644: ldloc.s 13
-			IL_0646: stelem.ref
-			IL_0647: dup
-			IL_0648: ldc.i4.1
-			IL_0649: ldstr "utf8"
-			IL_064e: stelem.ref
-			IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0654: stloc.s 16
+			IL_0689: ldloc.s 21
+			IL_068b: ldstr "readFileSync"
+			IL_0690: ldc.i4.2
+			IL_0691: newarr [System.Runtime]System.Object
+			IL_0696: dup
+			IL_0697: ldc.i4.0
+			IL_0698: ldloc.s 13
+			IL_069a: stelem.ref
+			IL_069b: dup
+			IL_069c: ldc.i4.1
+			IL_069d: ldstr "utf8"
+			IL_06a2: stelem.ref
+			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_06a8: stloc.s 16
 
-			IL_0656: ldloc.s 16
-			IL_0658: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_065d: stloc.s 14
-			IL_065f: ldloc.s 14
-			IL_0661: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0666: ldc.i4.0
-			IL_0667: ceq
-			IL_0669: stloc.s 17
-			IL_066b: ldloc.s 17
-			IL_066d: box [System.Runtime]System.Boolean
-			IL_0672: stloc.s 22
-			IL_0674: ldloc.s 22
-			IL_0676: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_067b: stloc.s 17
-			IL_067d: ldloc.s 17
-			IL_067f: brtrue IL_073e
+			IL_06aa: ldloc.s 16
+			IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_06b1: stloc.s 14
+			IL_06b3: ldloc.s 14
+			IL_06b5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06ba: ldc.i4.0
+			IL_06bb: ceq
+			IL_06bd: stloc.s 17
+			IL_06bf: ldloc.s 17
+			IL_06c1: box [System.Runtime]System.Boolean
+			IL_06c6: stloc.s 22
+			IL_06c8: ldloc.s 22
+			IL_06ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_06cf: stloc.s 17
+			IL_06d1: ldloc.s 17
+			IL_06d3: brtrue IL_0792
 
-			IL_0684: volatile.
-			IL_0686: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
-			IL_068b: brfalse IL_06a1
+			IL_06d8: volatile.
+			IL_06da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
+			IL_06df: brfalse IL_06f5
 
-			IL_0690: ldloc.s 14
-			IL_0692: ldstr "version"
-			IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_069c: br IL_06b7
+			IL_06e4: ldloc.s 14
+			IL_06e6: ldstr "version"
+			IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06f0: br IL_070b
 
-			IL_06a1: ldloc.s 14
-			IL_06a3: ldstr "version"
-			IL_06a8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:228"
-			IL_06ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
-			IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06f5: ldloc.s 14
+			IL_06f7: ldstr "version"
+			IL_06fc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:228"
+			IL_0701: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
+			IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06b7: stloc.s 16
-			IL_06b9: volatile.
-			IL_06bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
-			IL_06c0: brfalse IL_06d5
+			IL_070b: stloc.s 16
+			IL_070d: volatile.
+			IL_070f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
+			IL_0714: brfalse IL_0729
 
-			IL_06c5: ldarg.3
-			IL_06c6: ldstr "upstream"
-			IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06d0: br IL_06ea
+			IL_0719: ldarg.3
+			IL_071a: ldstr "upstream"
+			IL_071f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0724: br IL_073e
 
-			IL_06d5: ldarg.3
-			IL_06d6: ldstr "upstream"
-			IL_06db: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:231"
-			IL_06e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
-			IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0729: ldarg.3
+			IL_072a: ldstr "upstream"
+			IL_072f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:231"
+			IL_0734: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
+			IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06ea: stloc.s 30
-			IL_06ec: volatile.
-			IL_06ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
-			IL_06f3: brfalse IL_0709
+			IL_073e: stloc.s 30
+			IL_0740: volatile.
+			IL_0742: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
+			IL_0747: brfalse IL_075d
 
-			IL_06f8: ldloc.s 30
-			IL_06fa: ldstr "packageVersion"
-			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0704: br IL_071f
+			IL_074c: ldloc.s 30
+			IL_074e: ldstr "packageVersion"
+			IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0758: br IL_0773
 
-			IL_0709: ldloc.s 30
-			IL_070b: ldstr "packageVersion"
-			IL_0710: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:233"
-			IL_0715: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
-			IL_071a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_075d: ldloc.s 30
+			IL_075f: ldstr "packageVersion"
+			IL_0764: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:233"
+			IL_0769: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
+			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_071f: stloc.s 30
-			IL_0721: ldloc.s 16
-			IL_0723: ldloc.s 30
-			IL_0725: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_072a: stloc.s 17
-			IL_072c: ldloc.s 17
-			IL_072e: box [System.Runtime]System.Boolean
-			IL_0733: stloc.s 23
-			IL_0735: ldloc.s 23
-			IL_0737: stloc.s 31
-			IL_0739: br IL_0742
+			IL_0773: stloc.s 30
+			IL_0775: ldloc.s 16
+			IL_0777: ldloc.s 30
+			IL_0779: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_077e: stloc.s 17
+			IL_0780: ldloc.s 17
+			IL_0782: box [System.Runtime]System.Boolean
+			IL_0787: stloc.s 23
+			IL_0789: ldloc.s 23
+			IL_078b: stloc.s 31
+			IL_078d: br IL_0796
 
-			IL_073e: ldloc.s 22
-			IL_0740: stloc.s 31
+			IL_0792: ldloc.s 22
+			IL_0794: stloc.s 31
 
-			IL_0742: ldloc.s 31
-			IL_0744: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0749: stloc.s 17
-			IL_074b: ldloc.s 17
-			IL_074d: brfalse IL_08b9
+			IL_0796: ldloc.s 31
+			IL_0798: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_079d: stloc.s 17
+			IL_079f: ldloc.s 17
+			IL_07a1: brfalse IL_090d
 
-			IL_0752: volatile.
-			IL_0754: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
-			IL_0759: brfalse IL_076e
+			IL_07a6: volatile.
+			IL_07a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
+			IL_07ad: brfalse IL_07c2
 
-			IL_075e: ldarg.3
-			IL_075f: ldstr "upstream"
-			IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0769: br IL_0783
+			IL_07b2: ldarg.3
+			IL_07b3: ldstr "upstream"
+			IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07bd: br IL_07d7
 
-			IL_076e: ldarg.3
-			IL_076f: ldstr "upstream"
-			IL_0774: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:248"
-			IL_0779: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
-			IL_077e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07c2: ldarg.3
+			IL_07c3: ldstr "upstream"
+			IL_07c8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:248"
+			IL_07cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
+			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0783: stloc.s 30
-			IL_0785: volatile.
-			IL_0787: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
-			IL_078c: brfalse IL_07a2
+			IL_07d7: stloc.s 30
+			IL_07d9: volatile.
+			IL_07db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
+			IL_07e0: brfalse IL_07f6
 
-			IL_0791: ldloc.s 30
-			IL_0793: ldstr "packageVersion"
-			IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_079d: br IL_07b8
+			IL_07e5: ldloc.s 30
+			IL_07e7: ldstr "packageVersion"
+			IL_07ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07f1: br IL_080c
 
-			IL_07a2: ldloc.s 30
-			IL_07a4: ldstr "packageVersion"
-			IL_07a9: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:250"
-			IL_07ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
-			IL_07b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07f6: ldloc.s 30
+			IL_07f8: ldstr "packageVersion"
+			IL_07fd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:250"
+			IL_0802: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
+			IL_0807: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07b8: stloc.s 30
-			IL_07ba: ldloc.s 30
-			IL_07bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_07c1: stloc.s 28
-			IL_07c3: ldstr "package.json version mismatch: expected "
-			IL_07c8: ldloc.s 28
-			IL_07ca: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07cf: ldstr ", got "
-			IL_07d4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07d9: stloc.s 28
-			IL_07db: ldloc.s 14
-			IL_07dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_07e2: stloc.s 17
-			IL_07e4: ldloc.s 17
-			IL_07e6: brfalse IL_0829
+			IL_080c: stloc.s 30
+			IL_080e: ldloc.s 30
+			IL_0810: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0815: stloc.s 28
+			IL_0817: ldstr "package.json version mismatch: expected "
+			IL_081c: ldloc.s 28
+			IL_081e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0823: ldstr ", got "
+			IL_0828: call string [System.Runtime]System.String::Concat(string, string)
+			IL_082d: stloc.s 28
+			IL_082f: ldloc.s 14
+			IL_0831: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0836: stloc.s 17
+			IL_0838: ldloc.s 17
+			IL_083a: brfalse IL_087d
 
-			IL_07eb: volatile.
-			IL_07ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
-			IL_07f2: brfalse IL_0808
+			IL_083f: volatile.
+			IL_0841: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
+			IL_0846: brfalse IL_085c
 
-			IL_07f7: ldloc.s 14
-			IL_07f9: ldstr "version"
-			IL_07fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0803: br IL_081e
+			IL_084b: ldloc.s 14
+			IL_084d: ldstr "version"
+			IL_0852: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0857: br IL_0872
 
-			IL_0808: ldloc.s 14
-			IL_080a: ldstr "version"
-			IL_080f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:258"
-			IL_0814: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
-			IL_0819: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_085c: ldloc.s 14
+			IL_085e: ldstr "version"
+			IL_0863: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:258"
+			IL_0868: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
+			IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_081e: stloc.s 30
-			IL_0820: ldloc.s 30
-			IL_0822: stloc.s 32
-			IL_0824: br IL_082d
+			IL_0872: stloc.s 30
+			IL_0874: ldloc.s 30
+			IL_0876: stloc.s 32
+			IL_0878: br IL_0881
 
-			IL_0829: ldloc.s 14
-			IL_082b: stloc.s 32
+			IL_087d: ldloc.s 14
+			IL_087f: stloc.s 32
 
-			IL_082d: ldloc.s 32
-			IL_082f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0834: stloc.s 17
-			IL_0836: ldloc.s 17
-			IL_0838: brfalse IL_087b
+			IL_0881: ldloc.s 32
+			IL_0883: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0888: stloc.s 17
+			IL_088a: ldloc.s 17
+			IL_088c: brfalse IL_08cf
 
-			IL_083d: volatile.
-			IL_083f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
-			IL_0844: brfalse IL_085a
+			IL_0891: volatile.
+			IL_0893: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
+			IL_0898: brfalse IL_08ae
 
-			IL_0849: ldloc.s 14
-			IL_084b: ldstr "version"
-			IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0855: br IL_0870
+			IL_089d: ldloc.s 14
+			IL_089f: ldstr "version"
+			IL_08a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08a9: br IL_08c4
 
-			IL_085a: ldloc.s 14
-			IL_085c: ldstr "version"
-			IL_0861: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:267"
-			IL_0866: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
-			IL_086b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_08ae: ldloc.s 14
+			IL_08b0: ldstr "version"
+			IL_08b5: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M23>:__js_call__:267"
+			IL_08ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
+			IL_08bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0870: stloc.s 30
-			IL_0872: ldloc.s 30
-			IL_0874: stloc.s 15
-			IL_0876: br IL_0882
+			IL_08c4: stloc.s 30
+			IL_08c6: ldloc.s 30
+			IL_08c8: stloc.s 15
+			IL_08ca: br IL_08d6
 
-			IL_087b: ldstr "<missing>"
-			IL_0880: stloc.s 15
+			IL_08cf: ldstr "<missing>"
+			IL_08d4: stloc.s 15
 
-			IL_0882: ldloc.s 15
-			IL_0884: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0889: stloc.s 33
-			IL_088b: ldloc.s 28
-			IL_088d: ldloc.s 33
-			IL_088f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0894: stloc.s 33
-			IL_0896: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_089b: dup
-			IL_089c: ldstr "ok"
-			IL_08a1: ldc.i4.0
-			IL_08a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_08a7: dup
-			IL_08a8: ldstr "message"
-			IL_08ad: ldloc.s 33
-			IL_08af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08b4: stloc.s 29
-			IL_08b6: ldloc.s 29
-			IL_08b8: ret
+			IL_08d6: ldloc.s 15
+			IL_08d8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08dd: stloc.s 33
+			IL_08df: ldloc.s 28
+			IL_08e1: ldloc.s 33
+			IL_08e3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08e8: stloc.s 33
+			IL_08ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_08ef: dup
+			IL_08f0: ldstr "ok"
+			IL_08f5: ldc.i4.0
+			IL_08f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_08fb: dup
+			IL_08fc: ldstr "message"
+			IL_0901: ldloc.s 33
+			IL_0903: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0908: stloc.s 29
+			IL_090a: ldloc.s 29
+			IL_090c: ret
 
-			IL_08b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_08be: dup
-			IL_08bf: ldstr "ok"
-			IL_08c4: ldc.i4.1
-			IL_08c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_08ca: dup
-			IL_08cb: ldstr "message"
-			IL_08d0: ldstr ""
-			IL_08d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08da: ret
+			IL_090d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0912: dup
+			IL_0913: ldstr "ok"
+			IL_0918: ldc.i4.1
+			IL_0919: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_091e: dup
+			IL_091f: ldstr "message"
+			IL_0924: ldstr ""
+			IL_0929: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_092e: ret
 		} // end of method validateResolvedRoot::__js_call__
 
 	} // end of class validateResolvedRoot
@@ -8626,7 +8770,7 @@
 			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_002c: stloc.0
 			IL_002d: volatile.
-			IL_002f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
+			IL_002f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
 			IL_0034: brfalse IL_0049
 
 			IL_0039: ldloc.0
@@ -8637,7 +8781,7 @@
 			IL_0049: ldloc.0
 			IL_004a: ldstr "ok"
 			IL_004f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M24>:__js_call__:13"
-			IL_0054: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
+			IL_0054: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
 			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_005e: stloc.s 5
@@ -8781,7 +8925,7 @@
 			IL_01b3: stelem.ref
 			IL_01b4: stloc.s 4
 			IL_01b6: volatile.
-			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
+			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
 			IL_01bd: brfalse IL_01d2
 
 			IL_01c2: ldarg.3
@@ -8792,12 +8936,12 @@
 			IL_01d2: ldarg.3
 			IL_01d3: ldstr "upstream"
 			IL_01d8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M24>:__js_call__:67"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
+			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01e7: stloc.s 7
 			IL_01e9: volatile.
-			IL_01eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
+			IL_01eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
 			IL_01f0: brfalse IL_0206
 
 			IL_01f5: ldloc.s 7
@@ -8808,7 +8952,7 @@
 			IL_0206: ldloc.s 7
 			IL_0208: ldstr "cloneUrl"
 			IL_020d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M24>:__js_call__:69"
-			IL_0212: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
+			IL_0212: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
 			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_021c: stloc.s 7
@@ -8922,7 +9066,7 @@
 			IL_0331: stelem.ref
 			IL_0332: stloc.s 4
 			IL_0334: volatile.
-			IL_0336: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
+			IL_0336: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
 			IL_033b: brfalse IL_0350
 
 			IL_0340: ldarg.3
@@ -8933,12 +9077,12 @@
 			IL_0350: ldarg.3
 			IL_0351: ldstr "upstream"
 			IL_0356: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M24>:__js_call__:105"
-			IL_035b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
+			IL_035b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
 			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0365: stloc.s 7
 			IL_0367: volatile.
-			IL_0369: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
+			IL_0369: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
 			IL_036e: brfalse IL_0384
 
 			IL_0373: ldloc.s 7
@@ -8949,7 +9093,7 @@
 			IL_0384: ldloc.s 7
 			IL_0386: ldstr "commit"
 			IL_038b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M24>:__js_call__:107"
-			IL_0390: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
+			IL_0390: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
 			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_039a: stloc.s 7
@@ -9020,7 +9164,7 @@
 			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_044a: stloc.1
 			IL_044b: volatile.
-			IL_044d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
+			IL_044d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
 			IL_0452: brfalse IL_0467
 
 			IL_0457: ldloc.1
@@ -9031,7 +9175,7 @@
 			IL_0467: ldloc.1
 			IL_0468: ldstr "ok"
 			IL_046d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M24>:__js_call__:129"
-			IL_0472: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
+			IL_0472: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
 			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_047c: stloc.s 5
@@ -9044,7 +9188,7 @@
 			IL_048a: brfalse IL_04f6
 
 			IL_048f: volatile.
-			IL_0491: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
+			IL_0491: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
 			IL_0496: brfalse IL_04ab
 
 			IL_049b: ldloc.1
@@ -9055,7 +9199,7 @@
 			IL_04ab: ldloc.1
 			IL_04ac: ldstr "message"
 			IL_04b1: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M24>:__js_call__:135"
-			IL_04b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
+			IL_04b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
 			IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_04c0: stloc.s 5
@@ -9344,7 +9488,7 @@
 			IL_0039: stelem.ref
 			IL_003a: stloc.3
 			IL_003b: volatile.
-			IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
+			IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
 			IL_0042: brfalse IL_0057
 
 			IL_0047: ldloc.0
@@ -9355,7 +9499,7 @@
 			IL_0057: ldloc.0
 			IL_0058: ldstr "rootPath"
 			IL_005d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M25>:__js_call__:14"
-			IL_0062: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
+			IL_0062: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
 			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_006c: stloc.s 5
@@ -9365,7 +9509,7 @@
 			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_0077: stloc.1
 			IL_0078: volatile.
-			IL_007a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
+			IL_007a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
 			IL_007f: brfalse IL_0094
 
 			IL_0084: ldloc.1
@@ -9376,7 +9520,7 @@
 			IL_0094: ldloc.1
 			IL_0095: ldstr "ok"
 			IL_009a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M25>:__js_call__:20"
-			IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
+			IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
 			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00a9: stloc.s 5
@@ -9389,7 +9533,7 @@
 			IL_00b9: brfalse IL_0172
 
 			IL_00be: volatile.
-			IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
+			IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
 			IL_00c5: brfalse IL_00da
 
 			IL_00ca: ldloc.0
@@ -9400,7 +9544,7 @@
 			IL_00da: ldloc.0
 			IL_00db: ldstr "rootPath"
 			IL_00e0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M25>:__js_call__:26"
-			IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
+			IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
 			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00ef: stloc.s 5
@@ -9413,7 +9557,7 @@
 			IL_0106: ldstr "' is invalid: "
 			IL_010b: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0110: volatile.
-			IL_0112: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
+			IL_0112: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
 			IL_0117: brfalse IL_012c
 
 			IL_011c: ldloc.1
@@ -9424,7 +9568,7 @@
 			IL_012c: ldloc.1
 			IL_012d: ldstr "message"
 			IL_0132: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M25>:__js_call__:32"
-			IL_0137: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
+			IL_0137: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
 			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0141: stloc.s 5
@@ -9450,7 +9594,7 @@
 			IL_0171: throw
 
 			IL_0172: volatile.
-			IL_0174: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
+			IL_0174: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
 			IL_0179: brfalse IL_018e
 
 			IL_017e: ldloc.0
@@ -9461,12 +9605,12 @@
 			IL_018e: ldloc.0
 			IL_018f: ldstr "source"
 			IL_0194: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M25>:__js_call__:41"
-			IL_0199: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
+			IL_0199: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
 			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01a3: stloc.s 5
 			IL_01a5: volatile.
-			IL_01a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
+			IL_01a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
 			IL_01ac: brfalse IL_01c1
 
 			IL_01b1: ldloc.0
@@ -9477,7 +9621,7 @@
 			IL_01c1: ldloc.0
 			IL_01c2: ldstr "rootPath"
 			IL_01c7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M25>:__js_call__:43"
-			IL_01cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
+			IL_01cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
 			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01d6: stloc.s 7
@@ -9513,7 +9657,7 @@
 			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_0221: stloc.s 7
 			IL_0223: volatile.
-			IL_0225: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
+			IL_0225: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
 			IL_022a: brfalse IL_0240
 
 			IL_022f: ldarg.s args
@@ -9524,7 +9668,7 @@
 			IL_0240: ldarg.s args
 			IL_0242: ldstr "force"
 			IL_0247: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M25>:__js_call__:57"
-			IL_024c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
+			IL_024c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
 			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0256: stloc.s 5
@@ -9759,7 +9903,7 @@
 			IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0013: stloc.3
 			IL_0014: volatile.
-			IL_0016: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
+			IL_0016: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
 			IL_001b: brfalse IL_0030
 
 			IL_0020: ldarg.2
@@ -9770,7 +9914,7 @@
 			IL_0030: ldarg.2
 			IL_0031: ldstr "rootPath"
 			IL_0036: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M26>:__js_call__:8"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.s 4
@@ -9782,7 +9926,7 @@
 			IL_0051: ret
 
 			IL_0052: volatile.
-			IL_0054: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
+			IL_0054: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_156
 			IL_0059: brfalse IL_006e
 
 			IL_005e: ldarg.2
@@ -9793,7 +9937,7 @@
 			IL_006e: ldarg.2
 			IL_006f: ldstr "reused"
 			IL_0074: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M26>:__js_call__:17"
-			IL_0079: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
+			IL_0079: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_156
 			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0083: stloc.s 4
@@ -9815,7 +9959,7 @@
 			IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_00ab: stloc.3
 			IL_00ac: volatile.
-			IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
+			IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_157
 			IL_00b3: brfalse IL_00c8
 
 			IL_00b8: ldarg.2
@@ -9826,7 +9970,7 @@
 			IL_00c8: ldarg.2
 			IL_00c9: ldstr "source"
 			IL_00ce: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M26>:__js_call__:33"
-			IL_00d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
+			IL_00d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_157
 			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00dd: stloc.s 4
@@ -9847,7 +9991,7 @@
 			IL_0105: stelem.ref
 			IL_0106: stloc.s 6
 			IL_0108: volatile.
-			IL_010a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
+			IL_010a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_158
 			IL_010f: brfalse IL_0124
 
 			IL_0114: ldarg.2
@@ -9858,7 +10002,7 @@
 			IL_0124: ldarg.2
 			IL_0125: ldstr "rootPath"
 			IL_012a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M26>:__js_call__:41"
-			IL_012f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
+			IL_012f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_158
 			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0139: stloc.s 4
@@ -9874,7 +10018,7 @@
 			IL_0156: call string [System.Runtime]System.String::Concat(string, string)
 			IL_015b: stloc.s 7
 			IL_015d: volatile.
-			IL_015f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
+			IL_015f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
 			IL_0164: brfalse IL_0179
 
 			IL_0169: ldarg.3
@@ -9885,12 +10029,12 @@
 			IL_0179: ldarg.3
 			IL_017a: ldstr "upstream"
 			IL_017f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M26>:__js_call__:48"
-			IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
+			IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
 			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_018e: stloc.s 4
 			IL_0190: volatile.
-			IL_0192: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
+			IL_0192: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
 			IL_0197: brfalse IL_01ad
 
 			IL_019c: ldloc.s 4
@@ -9901,7 +10045,7 @@
 			IL_01ad: ldloc.s 4
 			IL_01af: ldstr "commit"
 			IL_01b4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M26>:__js_call__:50"
-			IL_01b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
+			IL_01b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
 			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01c3: stloc.s 4
@@ -9913,7 +10057,7 @@
 			IL_01d5: call string [System.Runtime]System.String::Concat(string, string)
 			IL_01da: stloc.s 8
 			IL_01dc: volatile.
-			IL_01de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
+			IL_01de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
 			IL_01e3: brfalse IL_01f8
 
 			IL_01e8: ldarg.3
@@ -9924,12 +10068,12 @@
 			IL_01f8: ldarg.3
 			IL_01f9: ldstr "upstream"
 			IL_01fe: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M26>:__js_call__:56"
-			IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
+			IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
 			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_020d: stloc.s 4
 			IL_020f: volatile.
-			IL_0211: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
+			IL_0211: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
 			IL_0216: brfalse IL_022c
 
 			IL_021b: ldloc.s 4
@@ -9940,7 +10084,7 @@
 			IL_022c: ldloc.s 4
 			IL_022e: ldstr "packageVersion"
 			IL_0233: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M26>:__js_call__:58"
-			IL_0238: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
+			IL_0238: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0242: stloc.s 4
@@ -10204,7 +10348,7 @@
 			IL_0014: ldstr "process"
 			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_001e: volatile.
-			IL_0020: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
+			IL_0020: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
 			IL_0025: brfalse IL_0039
 
 			IL_002a: ldstr "argv"
@@ -10213,7 +10357,7 @@
 
 			IL_0039: ldstr "argv"
 			IL_003e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M27>:__js_call__:6"
-			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
+			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004d: stloc.s 7
@@ -10257,7 +10401,7 @@
 			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_00c5: stloc.0
 			IL_00c6: volatile.
-			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
+			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
 			IL_00cd: brfalse IL_00e2
 
 			IL_00d2: ldloc.0
@@ -10268,7 +10412,7 @@
 			IL_00e2: ldloc.0
 			IL_00e3: ldstr "help"
 			IL_00e8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M27>:__js_call__:15"
-			IL_00ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
+			IL_00ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
 			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00f7: stloc.s 7
@@ -10304,7 +10448,7 @@
 			IL_0136: stelem.ref
 			IL_0137: stloc.s 6
 			IL_0139: volatile.
-			IL_013b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
+			IL_013b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
 			IL_0140: brfalse IL_0155
 
 			IL_0145: ldloc.0
@@ -10315,7 +10459,7 @@
 			IL_0155: ldloc.0
 			IL_0156: ldstr "pin"
 			IL_015b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M27>:__js_call__:30"
-			IL_0160: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
+			IL_0160: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
 			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_016a: stloc.s 5
@@ -10371,7 +10515,7 @@
 			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_01da: stloc.3
 			IL_01db: volatile.
-			IL_01dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
+			IL_01dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
 			IL_01e2: brfalse IL_01f7
 
 			IL_01e7: ldloc.0
@@ -10382,7 +10526,7 @@
 			IL_01f7: ldloc.0
 			IL_01f8: ldstr "describe"
 			IL_01fd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M27>:__js_call__:55"
-			IL_0202: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
+			IL_0202: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
 			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_020c: stloc.s 7
@@ -10437,7 +10581,7 @@
 			IL_0275: stelem.ref
 			IL_0276: stloc.s 6
 			IL_0278: volatile.
-			IL_027a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
+			IL_027a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
 			IL_027f: brfalse IL_0294
 
 			IL_0284: ldloc.0
@@ -10448,7 +10592,7 @@
 			IL_0294: ldloc.0
 			IL_0295: ldstr "printRoot"
 			IL_029a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M27>:__js_call__:77"
-			IL_029f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
+			IL_029f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
 			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02a9: stloc.s 5
@@ -10603,7 +10747,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1874 (0x752)
+		// Code size: 1913 (0x779)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262Bootstrap/Scope,
@@ -11319,7 +11463,7 @@
 		IL_0611: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_0616: stloc.s 46
 		IL_0618: ldloc.s 46
-		IL_061a: brfalse IL_074e
+		IL_061a: brfalse IL_0775
 		.try
 		{
 			IL_061f: nop
@@ -11327,7 +11471,7 @@
 			IL_0621: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 			IL_062b: pop
-			IL_062c: leave IL_074e
+			IL_062c: leave IL_0775
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -11420,23 +11564,35 @@
 			IL_070e: ldstr "console"
 			IL_0713: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_071d: ldstr "error"
-			IL_0722: ldloc.s 6
-			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0729: pop
-			IL_072a: ldstr "process"
-			IL_072f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0734: ldstr "exitCode"
-			IL_0739: ldc.r8 1
-			IL_0742: ldc.i4.1
-			IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0748: pop
-			IL_0749: leave IL_074e
+			IL_071d: volatile.
+			IL_071f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_0724: brfalse IL_073a
+
+			IL_0729: ldstr "error"
+			IL_072e: ldloc.s 6
+			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0735: br IL_0750
+
+			IL_073a: ldstr "error"
+			IL_073f: ldloc.s 6
+			IL_0741: ldstr "Compile_Scripts_Test262Bootstrap:Modules.Compile_Scripts_Test262Bootstrap:__js_module_init__:174"
+			IL_0746: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0750: pop
+			IL_0751: ldstr "process"
+			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_075b: ldstr "exitCode"
+			IL_0760: ldc.r8 1
+			IL_0769: ldc.i4.1
+			IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_076f: pop
+			IL_0770: leave IL_0775
 		} // end handler
 
-		IL_074e: ldnull
-		IL_074f: stloc.s 7
-		IL_0751: ret
+		IL_0775: ldnull
+		IL_0776: stloc.s 7
+		IL_0778: ret
 	} // end of method Compile_Scripts_Test262Bootstrap::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262Bootstrap
@@ -11572,6 +11728,19 @@
 	.field assembly static int32 __jroc_dynamicLookup_152
 	.field assembly static int32 __jroc_dynamicLookup_153
 	.field assembly static int32 __jroc_dynamicLookup_154
+	.field assembly static int32 __jroc_dynamicLookup_155
+	.field assembly static int32 __jroc_dynamicLookup_156
+	.field assembly static int32 __jroc_dynamicLookup_157
+	.field assembly static int32 __jroc_dynamicLookup_158
+	.field assembly static int32 __jroc_dynamicLookup_159
+	.field assembly static int32 __jroc_dynamicLookup_160
+	.field assembly static int32 __jroc_dynamicLookup_161
+	.field assembly static int32 __jroc_dynamicLookup_162
+	.field assembly static int32 __jroc_dynamicLookup_163
+	.field assembly static int32 __jroc_dynamicLookup_164
+	.field assembly static int32 __jroc_dynamicLookup_165
+	.field assembly static int32 __jroc_dynamicLookup_166
+	.field assembly static int32 __jroc_dynamicLookup_167
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -5356,7 +5356,7 @@
 				74 61 54 6f 6b 65 6e 2f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 525 (0x20d)
+			// Code size: 567 (0x237)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5478,93 +5478,105 @@
 
 			IL_0129: ldloc.0
 			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012f: ldstr "split"
-			IL_0134: ldstr ","
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_013e: stloc.1
-			IL_013f: ldc.i4.0
-			IL_0140: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0145: stloc.2
-			IL_0146: ldc.r8 0.0
-			IL_014f: stloc.3
-			// loop start (head: IL_0150)
-				IL_0150: ldloc.3
-				IL_0151: stloc.s 7
-				IL_0153: ldloc.1
-				IL_0154: ldstr "length"
-				IL_0159: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_015e: stloc.s 11
-				IL_0160: ldloc.s 7
-				IL_0162: ldloc.s 11
-				IL_0164: clt
-				IL_0166: brfalse IL_020b
+			IL_012f: volatile.
+			IL_0131: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
+			IL_0136: brfalse IL_014f
 
-				IL_016b: ldloc.1
-				IL_016c: ldloc.3
-				IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0172: stloc.s 5
-				IL_0174: ldloc.s 5
-				IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_017b: stloc.s 5
-				IL_017d: ldc.i4.0
-				IL_017e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0183: brfalse IL_01b5
+			IL_013b: ldstr "split"
+			IL_0140: ldstr ","
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_014a: br IL_0168
 
-				IL_0188: ldloc.s 5
-				IL_018a: isinst [System.Runtime]System.String
-				IL_018f: dup
-				IL_0190: brtrue IL_01a8
+			IL_014f: ldstr "split"
+			IL_0154: ldstr ","
+			IL_0159: ldstr "test262/metadataParser:<TwoPhaseDummy_M14>:__js_call__:27"
+			IL_015e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0195: pop
-				IL_0196: ldloc.s 5
-				IL_0198: ldstr "trim"
-				IL_019d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_01a2: dup
-				IL_01a3: brfalse IL_01b4
+			IL_0168: stloc.1
+			IL_0169: ldc.i4.0
+			IL_016a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_016f: stloc.2
+			IL_0170: ldc.r8 0.0
+			IL_0179: stloc.3
+			// loop start (head: IL_017a)
+				IL_017a: ldloc.3
+				IL_017b: stloc.s 7
+				IL_017d: ldloc.1
+				IL_017e: ldstr "length"
+				IL_0183: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0188: stloc.s 11
+				IL_018a: ldloc.s 7
+				IL_018c: ldloc.s 11
+				IL_018e: clt
+				IL_0190: brfalse IL_0235
 
-				IL_01a8: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_01ad: stloc.s 4
-				IL_01af: br IL_01c3
+				IL_0195: ldloc.1
+				IL_0196: ldloc.3
+				IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_019c: stloc.s 5
+				IL_019e: ldloc.s 5
+				IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01a5: stloc.s 5
+				IL_01a7: ldc.i4.0
+				IL_01a8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01ad: brfalse IL_01df
 
-				IL_01b4: pop
+				IL_01b2: ldloc.s 5
+				IL_01b4: isinst [System.Runtime]System.String
+				IL_01b9: dup
+				IL_01ba: brtrue IL_01d2
 
-				IL_01b5: ldloc.s 5
-				IL_01b7: ldstr "trim"
-				IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_01c1: stloc.s 4
+				IL_01bf: pop
+				IL_01c0: ldloc.s 5
+				IL_01c2: ldstr "trim"
+				IL_01c7: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01cc: dup
+				IL_01cd: brfalse IL_01de
 
-				IL_01c3: ldloc.s 4
-				IL_01c5: ldstr ""
-				IL_01ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_01cf: stloc.s 9
-				IL_01d1: ldloc.s 9
-				IL_01d3: brfalse IL_01fa
+				IL_01d2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_01d7: stloc.s 4
+				IL_01d9: br IL_01ed
 
-				IL_01d8: ldarg.0
-				IL_01d9: ldfld object Modules.test262_metadataParser/Scope::unquote
-				IL_01de: ldc.i4.1
-				IL_01df: newarr [System.Runtime]System.Object
-				IL_01e4: dup
-				IL_01e5: ldc.i4.0
-				IL_01e6: ldarg.0
-				IL_01e7: stelem.ref
-				IL_01e8: ldloc.s 4
-				IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_01ef: stloc.s 5
-				IL_01f1: ldloc.2
-				IL_01f2: ldloc.s 5
-				IL_01f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_01f9: pop
+				IL_01de: pop
 
-				IL_01fa: ldloc.3
-				IL_01fb: ldc.r8 1
-				IL_0204: add
-				IL_0205: stloc.3
-				IL_0206: br IL_0150
+				IL_01df: ldloc.s 5
+				IL_01e1: ldstr "trim"
+				IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01eb: stloc.s 4
+
+				IL_01ed: ldloc.s 4
+				IL_01ef: ldstr ""
+				IL_01f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_01f9: stloc.s 9
+				IL_01fb: ldloc.s 9
+				IL_01fd: brfalse IL_0224
+
+				IL_0202: ldarg.0
+				IL_0203: ldfld object Modules.test262_metadataParser/Scope::unquote
+				IL_0208: ldc.i4.1
+				IL_0209: newarr [System.Runtime]System.Object
+				IL_020e: dup
+				IL_020f: ldc.i4.0
+				IL_0210: ldarg.0
+				IL_0211: stelem.ref
+				IL_0212: ldloc.s 4
+				IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0219: stloc.s 5
+				IL_021b: ldloc.2
+				IL_021c: ldloc.s 5
+				IL_021e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0223: pop
+
+				IL_0224: ldloc.3
+				IL_0225: ldc.r8 1
+				IL_022e: add
+				IL_022f: stloc.3
+				IL_0230: br IL_017a
 			// end loop
 
-			IL_020b: ldloc.2
-			IL_020c: ret
+			IL_0235: ldloc.2
+			IL_0236: ret
 		} // end of method parseInlineList::__js_call__
 
 	} // end of class parseInlineList
@@ -6167,7 +6179,7 @@
 				74 61 54 6f 6b 65 6e 2f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 293 (0x125)
+			// Code size: 337 (0x151)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -6199,7 +6211,7 @@
 				IL_0026: ldloc.s 4
 				IL_0028: ldloc.s 5
 				IL_002a: clt
-				IL_002c: brfalse IL_010c
+				IL_002c: brfalse IL_0138
 
 				IL_0031: ldarg.2
 				IL_0032: ldloc.2
@@ -6216,7 +6228,7 @@
 				IL_004e: ldc.r8 1
 				IL_0057: add
 				IL_0058: stloc.1
-				IL_0059: br IL_00fb
+				IL_0059: br IL_0127
 
 				IL_005e: ldloc.0
 				IL_005f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
@@ -6228,14 +6240,14 @@
 				IL_0075: ldloc.3
 				IL_0076: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 				IL_007b: pop
-				IL_007c: br IL_00f1
+				IL_007c: br IL_011d
 
 				IL_0081: ldloc.1
 				IL_0082: stloc.s 5
 				IL_0084: ldloc.s 5
 				IL_0086: ldc.r8 0.0
 				IL_008f: cgt
-				IL_0091: brfalse IL_00db
+				IL_0091: brfalse IL_0107
 
 				IL_0096: ldloc.1
 				IL_0097: stloc.s 5
@@ -6246,51 +6258,64 @@
 				IL_00a7: ldloc.s 5
 				IL_00a9: box [System.Runtime]System.Double
 				IL_00ae: stloc.s 7
-				IL_00b0: ldstr "\n"
-				IL_00b5: ldstr "repeat"
-				IL_00ba: ldloc.s 7
-				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00c1: stloc.s 8
-				IL_00c3: ldloc.s 8
-				IL_00c5: ldloc.3
-				IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00cb: stloc.s 9
-				IL_00cd: ldloc.0
-				IL_00ce: ldloc.s 9
-				IL_00d0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00d5: pop
-				IL_00d6: br IL_00f1
+				IL_00b0: volatile.
+				IL_00b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
+				IL_00b7: brfalse IL_00d2
 
-				IL_00db: ldstr " "
-				IL_00e0: ldloc.3
-				IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00e6: stloc.s 9
-				IL_00e8: ldloc.0
-				IL_00e9: ldloc.s 9
-				IL_00eb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00f0: pop
+				IL_00bc: ldstr "\n"
+				IL_00c1: ldstr "repeat"
+				IL_00c6: ldloc.s 7
+				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00cd: br IL_00ed
 
-				IL_00f1: ldc.r8 0.0
-				IL_00fa: stloc.1
+				IL_00d2: ldstr "\n"
+				IL_00d7: ldstr "repeat"
+				IL_00dc: ldloc.s 7
+				IL_00de: ldstr "test262/metadataParser:<TwoPhaseDummy_M16>:__js_call__:50"
+				IL_00e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
+				IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_00fb: ldloc.2
-				IL_00fc: ldc.r8 1
-				IL_0105: add
-				IL_0106: stloc.2
-				IL_0107: br IL_001b
+				IL_00ed: stloc.s 8
+				IL_00ef: ldloc.s 8
+				IL_00f1: ldloc.3
+				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00f7: stloc.s 9
+				IL_00f9: ldloc.0
+				IL_00fa: ldloc.s 9
+				IL_00fc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0101: pop
+				IL_0102: br IL_011d
+
+				IL_0107: ldstr " "
+				IL_010c: ldloc.3
+				IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0112: stloc.s 9
+				IL_0114: ldloc.0
+				IL_0115: ldloc.s 9
+				IL_0117: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_011c: pop
+
+				IL_011d: ldc.r8 0.0
+				IL_0126: stloc.1
+
+				IL_0127: ldloc.2
+				IL_0128: ldc.r8 1
+				IL_0131: add
+				IL_0132: stloc.2
+				IL_0133: br IL_001b
 			// end loop
 
-			IL_010c: ldloc.0
-			IL_010d: ldc.i4.1
-			IL_010e: newarr [System.Runtime]System.Object
-			IL_0113: dup
-			IL_0114: ldc.i4.0
-			IL_0115: ldstr ""
-			IL_011a: stelem.ref
-			IL_011b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0120: stloc.s 10
-			IL_0122: ldloc.s 10
-			IL_0124: ret
+			IL_0138: ldloc.0
+			IL_0139: ldc.i4.1
+			IL_013a: newarr [System.Runtime]System.Object
+			IL_013f: dup
+			IL_0140: ldc.i4.0
+			IL_0141: ldstr ""
+			IL_0146: stelem.ref
+			IL_0147: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_014c: stloc.s 10
+			IL_014e: ldloc.s 10
+			IL_0150: ret
 		} // end of method foldBlockLines::__js_call__
 
 	} // end of class foldBlockLines
@@ -6570,7 +6595,7 @@
 			IL_001a: stloc.1
 			// loop start (head: IL_001b)
 				IL_001b: volatile.
-				IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
+				IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
 				IL_0022: brfalse IL_0037
 
 				IL_0027: ldarg.3
@@ -6581,12 +6606,12 @@
 				IL_0037: ldarg.3
 				IL_0038: ldstr "index"
 				IL_003d: ldstr "test262/metadataParser:<TwoPhaseDummy_M17>:__js_call__:12"
-				IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
+				IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
 				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_004c: stloc.s 5
 				IL_004e: volatile.
-				IL_0050: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
+				IL_0050: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
 				IL_0055: brfalse IL_006a
 
 				IL_005a: ldarg.2
@@ -6597,7 +6622,7 @@
 				IL_006a: ldarg.2
 				IL_006b: ldstr "length"
 				IL_0070: ldstr "test262/metadataParser:<TwoPhaseDummy_M17>:__js_call__:15"
-				IL_0075: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
+				IL_0075: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
 				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_007f: stloc.s 6
@@ -6609,7 +6634,7 @@
 				IL_0091: brfalse IL_024f
 
 				IL_0096: volatile.
-				IL_0098: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
+				IL_0098: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
 				IL_009d: brfalse IL_00b2
 
 				IL_00a2: ldarg.3
@@ -6620,7 +6645,7 @@
 				IL_00b2: ldarg.3
 				IL_00b3: ldstr "index"
 				IL_00b8: ldstr "test262/metadataParser:<TwoPhaseDummy_M17>:__js_call__:24"
-				IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
+				IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
 				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00c7: stloc.s 6
@@ -7053,7 +7078,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
 			IL_0007: brfalse IL_001c
 
 			IL_000c: ldarg.3
@@ -7064,7 +7089,7 @@
 			IL_001c: ldarg.3
 			IL_001d: ldstr "index"
 			IL_0022: ldstr "test262/metadataParser:<TwoPhaseDummy_M18>:__js_call__:3"
-			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
+			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0031: stloc.0
@@ -7072,7 +7097,7 @@
 				IL_0032: ldloc.0
 				IL_0033: stloc.2
 				IL_0034: volatile.
-				IL_0036: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
+				IL_0036: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
 				IL_003b: brfalse IL_0050
 
 				IL_0040: ldarg.2
@@ -7083,7 +7108,7 @@
 				IL_0050: ldarg.2
 				IL_0051: ldstr "length"
 				IL_0056: ldstr "test262/metadataParser:<TwoPhaseDummy_M18>:__js_call__:10"
-				IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
+				IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
 				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0065: stloc.3
@@ -7172,7 +7197,7 @@
 			IL_0135: ldloc.0
 			IL_0136: stloc.s 10
 			IL_0138: volatile.
-			IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
+			IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
 			IL_013f: brfalse IL_0154
 
 			IL_0144: ldarg.2
@@ -7183,7 +7208,7 @@
 			IL_0154: ldarg.2
 			IL_0155: ldstr "length"
 			IL_015a: ldstr "test262/metadataParser:<TwoPhaseDummy_M18>:__js_call__:44"
-			IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
+			IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
 			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0169: stloc.3
@@ -7592,7 +7617,7 @@
 				74 61 54 6f 6b 65 6e 2f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1227 (0x4cb)
+			// Code size: 1268 (0x4f4)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -7623,7 +7648,7 @@
 			IL_0005: stloc.0
 			// loop start (head: IL_0006)
 				IL_0006: volatile.
-				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
+				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
 				IL_000d: brfalse IL_0022
 
 				IL_0012: ldarg.3
@@ -7634,12 +7659,12 @@
 				IL_0022: ldarg.3
 				IL_0023: ldstr "index"
 				IL_0028: ldstr "test262/metadataParser:<TwoPhaseDummy_M19>:__js_call__:7"
-				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
+				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
 				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0037: stloc.s 10
 				IL_0039: volatile.
-				IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
+				IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
 				IL_0040: brfalse IL_0055
 
 				IL_0045: ldarg.2
@@ -7650,7 +7675,7 @@
 				IL_0055: ldarg.2
 				IL_0056: ldstr "length"
 				IL_005b: ldstr "test262/metadataParser:<TwoPhaseDummy_M19>:__js_call__:10"
-				IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
+				IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
 				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_006a: stloc.s 11
@@ -7659,10 +7684,10 @@
 				IL_0073: ldloc.s 11
 				IL_0075: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_007a: clt
-				IL_007c: brfalse IL_04c9
+				IL_007c: brfalse IL_04f2
 
 				IL_0081: volatile.
-				IL_0083: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
+				IL_0083: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_156
 				IL_0088: brfalse IL_009d
 
 				IL_008d: ldarg.3
@@ -7673,7 +7698,7 @@
 				IL_009d: ldarg.3
 				IL_009e: ldstr "index"
 				IL_00a3: ldstr "test262/metadataParser:<TwoPhaseDummy_M19>:__js_call__:19"
-				IL_00a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
+				IL_00a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_156
 				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00b2: stloc.s 11
@@ -7753,7 +7778,7 @@
 				IL_0172: clt
 				IL_0174: brfalse IL_017e
 
-				IL_0179: br IL_04c9
+				IL_0179: br IL_04f2
 
 				IL_017e: ldloc.2
 				IL_017f: ldarg.s baseIndent
@@ -7761,7 +7786,7 @@
 				IL_0183: brfalse IL_020b
 
 				IL_0188: volatile.
-				IL_018a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
+				IL_018a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_157
 				IL_018f: brfalse IL_01a4
 
 				IL_0194: ldarg.3
@@ -7772,7 +7797,7 @@
 				IL_01a4: ldarg.3
 				IL_01a5: ldstr "index"
 				IL_01aa: ldstr "test262/metadataParser:<TwoPhaseDummy_M19>:__js_call__:59"
-				IL_01af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
+				IL_01af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_157
 				IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_01b9: stloc.s 11
@@ -7843,228 +7868,241 @@
 				IL_026a: ldstr ""
 				IL_026f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_0274: stloc.s 17
-				IL_0276: ldloc.s 17
-				IL_0278: ldstr "exec"
-				IL_027d: ldloc.s 4
-				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0284: stloc.s 5
-				IL_0286: ldloc.s 5
-				IL_0288: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_028d: ldc.i4.0
-				IL_028e: ceq
-				IL_0290: stloc.s 12
-				IL_0292: ldloc.s 12
-				IL_0294: brfalse IL_032f
+				IL_0276: volatile.
+				IL_0278: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_158
+				IL_027d: brfalse IL_0295
 
-				IL_0299: volatile.
-				IL_029b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_156
-				IL_02a0: brfalse IL_02b5
+				IL_0282: ldloc.s 17
+				IL_0284: ldstr "exec"
+				IL_0289: ldloc.s 4
+				IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0290: br IL_02ad
 
-				IL_02a5: ldarg.3
-				IL_02a6: ldstr "index"
-				IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02b0: br IL_02ca
+				IL_0295: ldloc.s 17
+				IL_0297: ldstr "exec"
+				IL_029c: ldloc.s 4
+				IL_029e: ldstr "test262/metadataParser:<TwoPhaseDummy_M19>:__js_call__:79"
+				IL_02a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_158
+				IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_02b5: ldarg.3
-				IL_02b6: ldstr "index"
-				IL_02bb: ldstr "test262/metadataParser:<TwoPhaseDummy_M19>:__js_call__:88"
-				IL_02c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_156
-				IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_02ad: stloc.s 5
+				IL_02af: ldloc.s 5
+				IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02b6: ldc.i4.0
+				IL_02b7: ceq
+				IL_02b9: stloc.s 12
+				IL_02bb: ldloc.s 12
+				IL_02bd: brfalse IL_0358
 
-				IL_02ca: stloc.s 11
-				IL_02cc: ldloc.s 11
-				IL_02ce: ldc.r8 1
-				IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_02dc: stloc.s 14
-				IL_02de: ldloc.s 14
-				IL_02e0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_02e5: stloc.s 15
-				IL_02e7: ldstr "Invalid frontmatter line "
-				IL_02ec: ldloc.s 15
-				IL_02ee: call string [System.Runtime]System.String::Concat(string, string)
-				IL_02f3: ldstr ": "
-				IL_02f8: call string [System.Runtime]System.String::Concat(string, string)
-				IL_02fd: ldloc.s 4
-				IL_02ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0304: stloc.s 15
-				IL_0306: ldloc.s 15
-				IL_0308: call string [System.Runtime]System.String::Concat(string, string)
-				IL_030d: stloc.s 15
-				IL_030f: ldloc.s 15
-				IL_0311: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0316: stloc.s 6
-				IL_0318: ldloc.s 6
-				IL_031a: isinst [System.Runtime]System.Exception
-				IL_031f: dup
-				IL_0320: brtrue IL_032e
+				IL_02c2: volatile.
+				IL_02c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
+				IL_02c9: brfalse IL_02de
 
-				IL_0325: pop
-				IL_0326: ldloc.s 6
-				IL_0328: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_032d: throw
+				IL_02ce: ldarg.3
+				IL_02cf: ldstr "index"
+				IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02d9: br IL_02f3
 
-				IL_032e: throw
+				IL_02de: ldarg.3
+				IL_02df: ldstr "index"
+				IL_02e4: ldstr "test262/metadataParser:<TwoPhaseDummy_M19>:__js_call__:88"
+				IL_02e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
+				IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_032f: ldloc.s 5
-				IL_0331: ldc.r8 1
-				IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_033f: stloc.s 7
-				IL_0341: ldloc.s 5
-				IL_0343: ldc.r8 2
-				IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0351: stloc.s 11
-				IL_0353: ldloc.s 11
-				IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_035a: stloc.s 11
-				IL_035c: ldc.i4.0
-				IL_035d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0362: brfalse IL_0394
+				IL_02f3: stloc.s 11
+				IL_02f5: ldloc.s 11
+				IL_02f7: ldc.r8 1
+				IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0305: stloc.s 14
+				IL_0307: ldloc.s 14
+				IL_0309: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_030e: stloc.s 15
+				IL_0310: ldstr "Invalid frontmatter line "
+				IL_0315: ldloc.s 15
+				IL_0317: call string [System.Runtime]System.String::Concat(string, string)
+				IL_031c: ldstr ": "
+				IL_0321: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0326: ldloc.s 4
+				IL_0328: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_032d: stloc.s 15
+				IL_032f: ldloc.s 15
+				IL_0331: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0336: stloc.s 15
+				IL_0338: ldloc.s 15
+				IL_033a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_033f: stloc.s 6
+				IL_0341: ldloc.s 6
+				IL_0343: isinst [System.Runtime]System.Exception
+				IL_0348: dup
+				IL_0349: brtrue IL_0357
 
-				IL_0367: ldloc.s 11
-				IL_0369: isinst [System.Runtime]System.String
-				IL_036e: dup
-				IL_036f: brtrue IL_0387
+				IL_034e: pop
+				IL_034f: ldloc.s 6
+				IL_0351: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0356: throw
 
-				IL_0374: pop
-				IL_0375: ldloc.s 11
-				IL_0377: ldstr "trim"
-				IL_037c: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_0381: dup
-				IL_0382: brfalse IL_0393
+				IL_0357: throw
 
-				IL_0387: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_038c: stloc.s 8
-				IL_038e: br IL_03a2
+				IL_0358: ldloc.s 5
+				IL_035a: ldc.r8 1
+				IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0368: stloc.s 7
+				IL_036a: ldloc.s 5
+				IL_036c: ldc.r8 2
+				IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_037a: stloc.s 11
+				IL_037c: ldloc.s 11
+				IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0383: stloc.s 11
+				IL_0385: ldc.i4.0
+				IL_0386: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_038b: brfalse IL_03bd
 
-				IL_0393: pop
+				IL_0390: ldloc.s 11
+				IL_0392: isinst [System.Runtime]System.String
+				IL_0397: dup
+				IL_0398: brtrue IL_03b0
 
-				IL_0394: ldloc.s 11
-				IL_0396: ldstr "trim"
-				IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_03a0: stloc.s 8
+				IL_039d: pop
+				IL_039e: ldloc.s 11
+				IL_03a0: ldstr "trim"
+				IL_03a5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_03aa: dup
+				IL_03ab: brfalse IL_03bc
 
-				IL_03a2: ldarg.3
-				IL_03a3: ldstr "index"
-				IL_03a8: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_03ad: stloc.s 13
-				IL_03af: ldloc.s 13
-				IL_03b1: ldc.r8 1
-				IL_03ba: add
-				IL_03bb: stloc.s 13
-				IL_03bd: ldarg.3
-				IL_03be: ldstr "index"
-				IL_03c3: ldloc.s 13
-				IL_03c5: ldc.i4.1
-				IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_03cb: pop
-				IL_03cc: ldnull
-				IL_03cd: stloc.s 9
-				IL_03cf: ldloc.s 8
-				IL_03d1: ldstr "|"
-				IL_03d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_03db: stloc.s 12
-				IL_03dd: ldloc.s 12
-				IL_03df: box [System.Runtime]System.Boolean
-				IL_03e4: stloc.s 18
-				IL_03e6: ldloc.s 18
-				IL_03e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03ed: stloc.s 12
-				IL_03ef: ldloc.s 12
-				IL_03f1: brtrue IL_0416
+				IL_03b0: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_03b5: stloc.s 8
+				IL_03b7: br IL_03cb
 
-				IL_03f6: ldloc.s 8
-				IL_03f8: ldstr ">"
-				IL_03fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0402: stloc.s 12
-				IL_0404: ldloc.s 12
-				IL_0406: box [System.Runtime]System.Boolean
-				IL_040b: stloc.s 19
-				IL_040d: ldloc.s 19
-				IL_040f: stloc.s 20
-				IL_0411: br IL_041a
+				IL_03bc: pop
 
-				IL_0416: ldloc.s 18
-				IL_0418: stloc.s 20
+				IL_03bd: ldloc.s 11
+				IL_03bf: ldstr "trim"
+				IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_03c9: stloc.s 8
 
-				IL_041a: ldloc.s 20
-				IL_041c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0421: stloc.s 12
-				IL_0423: ldloc.s 12
-				IL_0425: brfalse IL_0459
+				IL_03cb: ldarg.3
+				IL_03cc: ldstr "index"
+				IL_03d1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_03d6: stloc.s 13
+				IL_03d8: ldloc.s 13
+				IL_03da: ldc.r8 1
+				IL_03e3: add
+				IL_03e4: stloc.s 13
+				IL_03e6: ldarg.3
+				IL_03e7: ldstr "index"
+				IL_03ec: ldloc.s 13
+				IL_03ee: ldc.i4.1
+				IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_03f4: pop
+				IL_03f5: ldnull
+				IL_03f6: stloc.s 9
+				IL_03f8: ldloc.s 8
+				IL_03fa: ldstr "|"
+				IL_03ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0404: stloc.s 12
+				IL_0406: ldloc.s 12
+				IL_0408: box [System.Runtime]System.Boolean
+				IL_040d: stloc.s 18
+				IL_040f: ldloc.s 18
+				IL_0411: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0416: stloc.s 12
+				IL_0418: ldloc.s 12
+				IL_041a: brtrue IL_043f
 
-				IL_042a: ldarg.0
-				IL_042b: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_0430: ldc.i4.1
-				IL_0431: newarr [System.Runtime]System.Object
-				IL_0436: dup
-				IL_0437: ldc.i4.0
-				IL_0438: ldarg.0
-				IL_0439: stelem.ref
-				IL_043a: stloc.s 21
-				IL_043c: ldloc.s 21
-				IL_043e: ldarg.2
-				IL_043f: ldarg.3
-				IL_0440: ldarg.s baseIndent
-				IL_0442: box [System.Runtime]System.Double
-				IL_0447: ldloc.s 8
-				IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-				IL_044e: stloc.s 11
-				IL_0450: ldloc.s 11
-				IL_0452: stloc.s 9
-				IL_0454: br IL_04b8
+				IL_041f: ldloc.s 8
+				IL_0421: ldstr ">"
+				IL_0426: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_042b: stloc.s 12
+				IL_042d: ldloc.s 12
+				IL_042f: box [System.Runtime]System.Boolean
+				IL_0434: stloc.s 19
+				IL_0436: ldloc.s 19
+				IL_0438: stloc.s 20
+				IL_043a: br IL_0443
 
-				IL_0459: ldloc.s 8
-				IL_045b: ldstr ""
-				IL_0460: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0465: stloc.s 12
-				IL_0467: ldloc.s 12
-				IL_0469: brfalse IL_049b
+				IL_043f: ldloc.s 18
+				IL_0441: stloc.s 20
 
-				IL_046e: ldarg.0
-				IL_046f: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_0474: ldc.i4.1
-				IL_0475: newarr [System.Runtime]System.Object
-				IL_047a: dup
-				IL_047b: ldc.i4.0
-				IL_047c: ldarg.0
-				IL_047d: stelem.ref
-				IL_047e: stloc.s 21
-				IL_0480: ldloc.s 21
-				IL_0482: ldarg.2
-				IL_0483: ldarg.3
-				IL_0484: ldarg.s baseIndent
-				IL_0486: box [System.Runtime]System.Double
-				IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_0490: stloc.s 11
-				IL_0492: ldloc.s 11
-				IL_0494: stloc.s 9
-				IL_0496: br IL_04b8
+				IL_0443: ldloc.s 20
+				IL_0445: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_044a: stloc.s 12
+				IL_044c: ldloc.s 12
+				IL_044e: brfalse IL_0482
 
-				IL_049b: ldarg.0
-				IL_049c: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_04a1: ldc.i4.1
-				IL_04a2: newarr [System.Runtime]System.Object
-				IL_04a7: dup
-				IL_04a8: ldc.i4.0
-				IL_04a9: ldarg.0
-				IL_04aa: stelem.ref
-				IL_04ab: ldloc.s 8
-				IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_04b2: stloc.s 11
-				IL_04b4: ldloc.s 11
-				IL_04b6: stloc.s 9
+				IL_0453: ldarg.0
+				IL_0454: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_0459: ldc.i4.1
+				IL_045a: newarr [System.Runtime]System.Object
+				IL_045f: dup
+				IL_0460: ldc.i4.0
+				IL_0461: ldarg.0
+				IL_0462: stelem.ref
+				IL_0463: stloc.s 21
+				IL_0465: ldloc.s 21
+				IL_0467: ldarg.2
+				IL_0468: ldarg.3
+				IL_0469: ldarg.s baseIndent
+				IL_046b: box [System.Runtime]System.Double
+				IL_0470: ldloc.s 8
+				IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
+				IL_0477: stloc.s 11
+				IL_0479: ldloc.s 11
+				IL_047b: stloc.s 9
+				IL_047d: br IL_04e1
 
-				IL_04b8: ldloc.0
-				IL_04b9: ldloc.s 7
-				IL_04bb: ldloc.s 9
-				IL_04bd: ldc.i4.1
-				IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_04c3: pop
-				IL_04c4: br IL_0006
+				IL_0482: ldloc.s 8
+				IL_0484: ldstr ""
+				IL_0489: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_048e: stloc.s 12
+				IL_0490: ldloc.s 12
+				IL_0492: brfalse IL_04c4
+
+				IL_0497: ldarg.0
+				IL_0498: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_049d: ldc.i4.1
+				IL_049e: newarr [System.Runtime]System.Object
+				IL_04a3: dup
+				IL_04a4: ldc.i4.0
+				IL_04a5: ldarg.0
+				IL_04a6: stelem.ref
+				IL_04a7: stloc.s 21
+				IL_04a9: ldloc.s 21
+				IL_04ab: ldarg.2
+				IL_04ac: ldarg.3
+				IL_04ad: ldarg.s baseIndent
+				IL_04af: box [System.Runtime]System.Double
+				IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_04b9: stloc.s 11
+				IL_04bb: ldloc.s 11
+				IL_04bd: stloc.s 9
+				IL_04bf: br IL_04e1
+
+				IL_04c4: ldarg.0
+				IL_04c5: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_04ca: ldc.i4.1
+				IL_04cb: newarr [System.Runtime]System.Object
+				IL_04d0: dup
+				IL_04d1: ldc.i4.0
+				IL_04d2: ldarg.0
+				IL_04d3: stelem.ref
+				IL_04d4: ldloc.s 8
+				IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_04db: stloc.s 11
+				IL_04dd: ldloc.s 11
+				IL_04df: stloc.s 9
+
+				IL_04e1: ldloc.0
+				IL_04e2: ldloc.s 7
+				IL_04e4: ldloc.s 9
+				IL_04e6: ldc.i4.1
+				IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_04ec: pop
+				IL_04ed: br IL_0006
 			// end loop
 
-			IL_04c9: ldloc.0
-			IL_04ca: ret
+			IL_04f2: ldloc.0
+			IL_04f3: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -8214,7 +8252,7 @@
 				74 61 54 6f 6b 65 6e 2f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 114 (0x72)
+			// Code size: 156 (0x9c)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -8238,37 +8276,49 @@
 			IL_0018: stloc.2
 			IL_0019: ldloc.2
 			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: ldstr "split"
-			IL_0024: ldstr "\n"
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_002e: stloc.0
-			IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0034: dup
-			IL_0035: ldstr "index"
-			IL_003a: ldc.r8 0.0
-			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0048: stloc.3
-			IL_0049: ldc.i4.1
-			IL_004a: newarr [System.Runtime]System.Object
-			IL_004f: dup
-			IL_0050: ldc.i4.0
-			IL_0051: ldarg.0
-			IL_0052: stelem.ref
-			IL_0053: stloc.1
-			IL_0054: ldloc.1
-			IL_0055: ldc.i4.0
-			IL_0056: ldelem.ref
-			IL_0057: castclass Modules.test262_metadataParser/Scope
-			IL_005c: ldnull
-			IL_005d: ldloc.0
-			IL_005e: ldloc.3
-			IL_005f: ldc.r8 0.0
-			IL_0068: tail.
-			IL_006a: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
-			IL_006f: ret
+			IL_001f: volatile.
+			IL_0021: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
+			IL_0026: brfalse IL_003f
 
-			IL_0070: ldnull
-			IL_0071: ret
+			IL_002b: ldstr "split"
+			IL_0030: ldstr "\n"
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_003a: br IL_0058
+
+			IL_003f: ldstr "split"
+			IL_0044: ldstr "\n"
+			IL_0049: ldstr "test262/metadataParser:<TwoPhaseDummy_M20>:__js_call__:7"
+			IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0058: stloc.0
+			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005e: dup
+			IL_005f: ldstr "index"
+			IL_0064: ldc.r8 0.0
+			IL_006d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0072: stloc.3
+			IL_0073: ldc.i4.1
+			IL_0074: newarr [System.Runtime]System.Object
+			IL_0079: dup
+			IL_007a: ldc.i4.0
+			IL_007b: ldarg.0
+			IL_007c: stelem.ref
+			IL_007d: stloc.1
+			IL_007e: ldloc.1
+			IL_007f: ldc.i4.0
+			IL_0080: ldelem.ref
+			IL_0081: castclass Modules.test262_metadataParser/Scope
+			IL_0086: ldnull
+			IL_0087: ldloc.0
+			IL_0088: ldloc.3
+			IL_0089: ldc.r8 0.0
+			IL_0092: tail.
+			IL_0094: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+			IL_0099: ret
+
+			IL_009a: ldnull
+			IL_009b: ret
 		} // end of method parseTest262Frontmatter::__js_call__
 
 	} // end of class parseTest262Frontmatter
@@ -9293,7 +9343,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 44 (0x2c)
+			// Code size: 82 (0x52)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -9301,18 +9351,30 @@
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "indexOf"
-			IL_000b: ldarg.2
-			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0011: stloc.0
-			IL_0012: ldloc.0
-			IL_0013: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0018: ldc.r8 0.0
-			IL_0021: clt
-			IL_0023: ldc.i4.0
-			IL_0024: ceq
-			IL_0026: box [System.Runtime]System.Boolean
-			IL_002b: ret
+			IL_0006: volatile.
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
+			IL_000d: brfalse IL_0022
+
+			IL_0012: ldstr "indexOf"
+			IL_0017: ldarg.2
+			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_001d: br IL_0037
+
+			IL_0022: ldstr "indexOf"
+			IL_0027: ldarg.2
+			IL_0028: ldstr "test262/metadataParser:<TwoPhaseDummy_M24>:__js_call__:4"
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0037: stloc.0
+			IL_0038: ldloc.0
+			IL_0039: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_003e: ldc.r8 0.0
+			IL_0047: clt
+			IL_0049: ldc.i4.0
+			IL_004a: ceq
+			IL_004c: box [System.Runtime]System.Boolean
+			IL_0051: ret
 		} // end of method contains::__js_call__
 
 	} // end of class contains
@@ -10743,7 +10805,7 @@
 			IL_0156: stelem.ref
 			IL_0157: stloc.s 16
 			IL_0159: volatile.
-			IL_015b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_157
+			IL_015b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
 			IL_0160: brfalse IL_0175
 
 			IL_0165: ldarg.2
@@ -10754,7 +10816,7 @@
 			IL_0175: ldarg.2
 			IL_0176: ldstr "phase"
 			IL_017b: ldstr "test262/metadataParser:<TwoPhaseDummy_M28>:__js_call__:81"
-			IL_0180: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_157
+			IL_0180: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
 			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_018a: stloc.s 15
@@ -10774,7 +10836,7 @@
 			IL_01ab: stelem.ref
 			IL_01ac: stloc.s 16
 			IL_01ae: volatile.
-			IL_01b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_158
+			IL_01b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
 			IL_01b5: brfalse IL_01ca
 
 			IL_01ba: ldarg.2
@@ -10785,7 +10847,7 @@
 			IL_01ca: ldarg.2
 			IL_01cb: ldstr "type"
 			IL_01d0: ldstr "test262/metadataParser:<TwoPhaseDummy_M28>:__js_call__:91"
-			IL_01d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_158
+			IL_01d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
 			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01df: stloc.s 15
@@ -11971,7 +12033,7 @@
 			IL_0520: stloc.s 20
 
 			IL_0522: volatile.
-			IL_0524: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
+			IL_0524: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
 			IL_0529: brfalse IL_053f
 
 			IL_052e: ldloc.s 13
@@ -11982,7 +12044,7 @@
 			IL_053f: ldloc.s 13
 			IL_0541: ldstr "length"
 			IL_0546: ldstr "test262/metadataParser:<TwoPhaseDummy_M29>:__js_call__:271"
-			IL_054b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
+			IL_054b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
 			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0555: stloc.s 22
@@ -12419,7 +12481,7 @@
 			IL_0001: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0006: stloc.0
 			IL_0007: volatile.
-			IL_0009: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
+			IL_0009: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
 			IL_000e: brfalse IL_0024
 
 			IL_0013: ldarg.s execution
@@ -12430,7 +12492,7 @@
 			IL_0024: ldarg.s execution
 			IL_0026: ldstr "isFixture"
 			IL_002b: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:6"
-			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
+			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_003a: stloc.2
@@ -12473,7 +12535,7 @@
 			IL_008c: pop
 
 			IL_008d: volatile.
-			IL_008f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
+			IL_008f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
 			IL_0094: brfalse IL_00aa
 
 			IL_0099: ldarg.s execution
@@ -12484,7 +12546,7 @@
 			IL_00aa: ldarg.s execution
 			IL_00ac: ldstr "isModule"
 			IL_00b1: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:28"
-			IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
+			IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
 			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00c0: stloc.2
@@ -12514,7 +12576,7 @@
 			IL_00f9: pop
 
 			IL_00fa: volatile.
-			IL_00fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
+			IL_00fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
 			IL_0101: brfalse IL_0117
 
 			IL_0106: ldarg.s execution
@@ -12525,7 +12587,7 @@
 			IL_0117: ldarg.s execution
 			IL_0119: ldstr "isRaw"
 			IL_011e: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:42"
-			IL_0123: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
+			IL_0123: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
 			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_012d: stloc.2
@@ -12555,7 +12617,7 @@
 			IL_0166: pop
 
 			IL_0167: volatile.
-			IL_0169: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
+			IL_0169: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
 			IL_016e: brfalse IL_0184
 
 			IL_0173: ldarg.s execution
@@ -12566,7 +12628,7 @@
 			IL_0184: ldarg.s execution
 			IL_0186: ldstr "requiresAsyncHarness"
 			IL_018b: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:56"
-			IL_0190: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
+			IL_0190: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
 			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_019a: stloc.2
@@ -12596,7 +12658,7 @@
 			IL_01d3: pop
 
 			IL_01d4: volatile.
-			IL_01d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
+			IL_01d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_169
 			IL_01db: brfalse IL_01f1
 
 			IL_01e0: ldarg.s execution
@@ -12607,7 +12669,7 @@
 			IL_01f1: ldarg.s execution
 			IL_01f3: ldstr "requiresAgent"
 			IL_01f8: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:70"
-			IL_01fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
+			IL_01fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_169
 			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0207: stloc.2
@@ -12637,7 +12699,7 @@
 			IL_0240: pop
 
 			IL_0241: volatile.
-			IL_0243: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
+			IL_0243: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_170
 			IL_0248: brfalse IL_025e
 
 			IL_024d: ldarg.s execution
@@ -12648,7 +12710,7 @@
 			IL_025e: ldarg.s execution
 			IL_0260: ldstr "canBlock"
 			IL_0265: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:84"
-			IL_026a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
+			IL_026a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_170
 			IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0274: stloc.2
@@ -12670,7 +12732,7 @@
 			IL_0297: stelem.ref
 			IL_0298: stloc.s 4
 			IL_029a: volatile.
-			IL_029c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
+			IL_029c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_171
 			IL_02a1: brfalse IL_02b7
 
 			IL_02a6: ldarg.s execution
@@ -12681,7 +12743,7 @@
 			IL_02b7: ldarg.s execution
 			IL_02b9: ldstr "canBlock"
 			IL_02be: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:95"
-			IL_02c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
+			IL_02c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_171
 			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02cd: stloc.s 7
@@ -12722,7 +12784,7 @@
 			IL_0327: brfalse IL_037b
 
 			IL_032c: volatile.
-			IL_032e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
+			IL_032e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_172
 			IL_0333: brfalse IL_0348
 
 			IL_0338: ldarg.3
@@ -12733,7 +12795,7 @@
 			IL_0348: ldarg.3
 			IL_0349: ldstr "phase"
 			IL_034e: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:117"
-			IL_0353: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
+			IL_0353: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_172
 			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_035d: stloc.2
@@ -13150,7 +13212,7 @@
 			IL_0036: stelem.ref
 			IL_0037: stloc.s 25
 			IL_0039: volatile.
-			IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
+			IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_173
 			IL_0040: brfalse IL_0055
 
 			IL_0045: ldloc.0
@@ -13161,7 +13223,7 @@
 			IL_0055: ldloc.0
 			IL_0056: ldstr "filePath"
 			IL_005b: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:15"
-			IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
+			IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_173
 			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_006a: stloc.s 26
@@ -13328,7 +13390,7 @@
 			IL_01fb: stelem.ref
 			IL_01fc: stloc.s 25
 			IL_01fe: volatile.
-			IL_0200: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_169
+			IL_0200: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_174
 			IL_0205: brfalse IL_021b
 
 			IL_020a: ldloc.s 7
@@ -13339,7 +13401,7 @@
 			IL_021b: ldloc.s 7
 			IL_021d: ldstr "includes"
 			IL_0222: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:104"
-			IL_0227: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_169
+			IL_0227: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_174
 			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0231: stloc.s 24
@@ -13359,7 +13421,7 @@
 			IL_0254: stelem.ref
 			IL_0255: stloc.s 25
 			IL_0257: volatile.
-			IL_0259: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_170
+			IL_0259: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_175
 			IL_025e: brfalse IL_0274
 
 			IL_0263: ldloc.s 7
@@ -13370,7 +13432,7 @@
 			IL_0274: ldloc.s 7
 			IL_0276: ldstr "flags"
 			IL_027b: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:112"
-			IL_0280: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_170
+			IL_0280: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_175
 			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_028a: stloc.s 24
@@ -13390,7 +13452,7 @@
 			IL_02ad: stelem.ref
 			IL_02ae: stloc.s 25
 			IL_02b0: volatile.
-			IL_02b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_171
+			IL_02b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_176
 			IL_02b7: brfalse IL_02cd
 
 			IL_02bc: ldloc.s 7
@@ -13401,7 +13463,7 @@
 			IL_02cd: ldloc.s 7
 			IL_02cf: ldstr "features"
 			IL_02d4: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:120"
-			IL_02d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_171
+			IL_02d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_176
 			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02e3: stloc.s 24
@@ -13421,7 +13483,7 @@
 			IL_0306: stelem.ref
 			IL_0307: stloc.s 25
 			IL_0309: volatile.
-			IL_030b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_172
+			IL_030b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_177
 			IL_0310: brfalse IL_0326
 
 			IL_0315: ldloc.s 7
@@ -13432,7 +13494,7 @@
 			IL_0326: ldloc.s 7
 			IL_0328: ldstr "locale"
 			IL_032d: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:128"
-			IL_0332: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_172
+			IL_0332: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_177
 			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_033c: stloc.s 24
@@ -13452,7 +13514,7 @@
 			IL_035f: stelem.ref
 			IL_0360: stloc.s 25
 			IL_0362: volatile.
-			IL_0364: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_173
+			IL_0364: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_178
 			IL_0369: brfalse IL_037f
 
 			IL_036e: ldloc.s 7
@@ -13463,7 +13525,7 @@
 			IL_037f: ldloc.s 7
 			IL_0381: ldstr "defines"
 			IL_0386: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:136"
-			IL_038b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_173
+			IL_038b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_178
 			IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0395: stloc.s 24
@@ -13483,7 +13545,7 @@
 			IL_03b8: stelem.ref
 			IL_03b9: stloc.s 25
 			IL_03bb: volatile.
-			IL_03bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_174
+			IL_03bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_179
 			IL_03c2: brfalse IL_03d8
 
 			IL_03c7: ldloc.s 7
@@ -13494,7 +13556,7 @@
 			IL_03d8: ldloc.s 7
 			IL_03da: ldstr "negative"
 			IL_03df: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:144"
-			IL_03e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_174
+			IL_03e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_179
 			IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_03ee: stloc.s 24
@@ -13599,7 +13661,7 @@
 			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
 			IL_04f9: stloc.s 19
 			IL_04fb: volatile.
-			IL_04fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_175
+			IL_04fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_180
 			IL_0502: brfalse IL_0518
 
 			IL_0507: ldloc.s 19
@@ -13610,7 +13672,7 @@
 			IL_0518: ldloc.s 19
 			IL_051a: ldstr "strictMode"
 			IL_051f: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:191"
-			IL_0524: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_175
+			IL_0524: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_180
 			IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_052e: stloc.s 24
@@ -13678,7 +13740,7 @@
 			IL_05c1: stelem.ref
 			IL_05c2: stloc.s 25
 			IL_05c4: volatile.
-			IL_05c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_176
+			IL_05c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_181
 			IL_05cb: brfalse IL_05e1
 
 			IL_05d0: ldloc.s 7
@@ -13689,7 +13751,7 @@
 			IL_05e1: ldloc.s 7
 			IL_05e3: ldstr "description"
 			IL_05e8: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:225"
-			IL_05ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_176
+			IL_05ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_181
 			IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_05f7: stloc.s 24
@@ -13709,7 +13771,7 @@
 			IL_061a: stelem.ref
 			IL_061b: stloc.s 25
 			IL_061d: volatile.
-			IL_061f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_177
+			IL_061f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_182
 			IL_0624: brfalse IL_063a
 
 			IL_0629: ldloc.s 7
@@ -13720,7 +13782,7 @@
 			IL_063a: ldloc.s 7
 			IL_063c: ldstr "info"
 			IL_0641: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:231"
-			IL_0646: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_177
+			IL_0646: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_182
 			IL_064b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0650: stloc.s 26
@@ -13740,7 +13802,7 @@
 			IL_0673: stelem.ref
 			IL_0674: stloc.s 25
 			IL_0676: volatile.
-			IL_0678: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_178
+			IL_0678: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_183
 			IL_067d: brfalse IL_0693
 
 			IL_0682: ldloc.s 7
@@ -13751,7 +13813,7 @@
 			IL_0693: ldloc.s 7
 			IL_0695: ldstr "esid"
 			IL_069a: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:237"
-			IL_069f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_178
+			IL_069f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_183
 			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_06a9: stloc.s 35
@@ -13771,7 +13833,7 @@
 			IL_06cc: stelem.ref
 			IL_06cd: stloc.s 25
 			IL_06cf: volatile.
-			IL_06d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_179
+			IL_06d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_184
 			IL_06d6: brfalse IL_06ec
 
 			IL_06db: ldloc.s 7
@@ -13782,7 +13844,7 @@
 			IL_06ec: ldloc.s 7
 			IL_06ee: ldstr "es5id"
 			IL_06f3: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:243"
-			IL_06f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_179
+			IL_06f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_184
 			IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0702: stloc.s 36
@@ -13802,7 +13864,7 @@
 			IL_0725: stelem.ref
 			IL_0726: stloc.s 25
 			IL_0728: volatile.
-			IL_072a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_180
+			IL_072a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_185
 			IL_072f: brfalse IL_0745
 
 			IL_0734: ldloc.s 7
@@ -13813,7 +13875,7 @@
 			IL_0745: ldloc.s 7
 			IL_0747: ldstr "es6id"
 			IL_074c: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:249"
-			IL_0751: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_180
+			IL_0751: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_185
 			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_075b: stloc.s 37
@@ -13833,7 +13895,7 @@
 			IL_077e: stelem.ref
 			IL_077f: stloc.s 25
 			IL_0781: volatile.
-			IL_0783: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_181
+			IL_0783: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_186
 			IL_0788: brfalse IL_079e
 
 			IL_078d: ldloc.s 7
@@ -13844,7 +13906,7 @@
 			IL_079e: ldloc.s 7
 			IL_07a0: ldstr "author"
 			IL_07a5: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:255"
-			IL_07aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_181
+			IL_07aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_186
 			IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_07b4: stloc.s 38
@@ -15037,6 +15099,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_179
 	.field assembly static int32 __jroc_dynamicLookup_180
 	.field assembly static int32 __jroc_dynamicLookup_181
+	.field assembly static int32 __jroc_dynamicLookup_182
+	.field assembly static int32 __jroc_dynamicLookup_183
+	.field assembly static int32 __jroc_dynamicLookup_184
+	.field assembly static int32 __jroc_dynamicLookup_185
+	.field assembly static int32 __jroc_dynamicLookup_186
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Abort/Snapshots/GeneratorTests.Abort_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Abort/Snapshots/GeneratorTests.Abort_ExplicitReceiverAbi.verified.txt
@@ -733,7 +733,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3580 (0xdfc)
+		// Code size: 3811 (0xee3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Abort_ExplicitReceiverAbi/Scope,
@@ -969,993 +969,1065 @@
 		IL_0267: stloc.s 27
 		IL_0269: ldloc.s 27
 		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0270: ldstr "call"
-		IL_0275: ldloc.1
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027b: stloc.s 27
-		IL_027d: ldloc.s 27
-		IL_027f: ldloc.2
-		IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0285: stloc.s 30
-		IL_0287: ldloc.s 30
-		IL_0289: box [System.Runtime]System.Boolean
-		IL_028e: stloc.s 31
-		IL_0290: ldloc.s 28
-		IL_0292: ldloc.s 31
-		IL_0294: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0299: pop
-		IL_029a: ldstr "AbortController"
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a4: stloc.s 27
-		IL_02a6: ldloc.s 27
-		IL_02a8: dup
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_02ae: stloc.s 4
-		IL_02b0: volatile.
-		IL_02b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_02b7: brfalse IL_02cd
+		IL_0270: volatile.
+		IL_0272: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0277: brfalse IL_028c
 
-		IL_02bc: ldloc.s 4
-		IL_02be: ldstr "signal"
-		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02c8: br IL_02e3
+		IL_027c: ldstr "call"
+		IL_0281: ldloc.1
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0287: br IL_02a1
 
-		IL_02cd: ldloc.s 4
-		IL_02cf: ldstr "signal"
-		IL_02d4: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:70"
-		IL_02d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_028c: ldstr "call"
+		IL_0291: ldloc.1
+		IL_0292: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:59"
+		IL_0297: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02e3: stloc.s 5
-		IL_02e5: ldloc.0
-		IL_02e6: ldc.i4.0
-		IL_02e7: box [System.Runtime]System.Boolean
-		IL_02ec: stfld object Modules.Abort_ExplicitReceiverAbi/Scope::listenerFired
-		IL_02f1: ldstr "AbortSignal"
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02fb: volatile.
-		IL_02fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0302: brfalse IL_0316
+		IL_02a1: stloc.s 27
+		IL_02a3: ldloc.s 27
+		IL_02a5: ldloc.2
+		IL_02a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02ab: stloc.s 30
+		IL_02ad: ldloc.s 30
+		IL_02af: box [System.Runtime]System.Boolean
+		IL_02b4: stloc.s 31
+		IL_02b6: ldloc.s 28
+		IL_02b8: ldloc.s 31
+		IL_02ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02bf: pop
+		IL_02c0: ldstr "AbortController"
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ca: stloc.s 27
+		IL_02cc: ldloc.s 27
+		IL_02ce: dup
+		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_02d4: stloc.s 4
+		IL_02d6: volatile.
+		IL_02d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_02dd: brfalse IL_02f3
 
-		IL_0307: ldstr "prototype"
-		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0311: br IL_032a
+		IL_02e2: ldloc.s 4
+		IL_02e4: ldstr "signal"
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ee: br IL_0309
 
-		IL_0316: ldstr "prototype"
-		IL_031b: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:80"
-		IL_0320: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02f3: ldloc.s 4
+		IL_02f5: ldstr "signal"
+		IL_02fa: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:70"
+		IL_02ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_032a: stloc.s 27
-		IL_032c: volatile.
-		IL_032e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0333: brfalse IL_0349
+		IL_0309: stloc.s 5
+		IL_030b: ldloc.0
+		IL_030c: ldc.i4.0
+		IL_030d: box [System.Runtime]System.Boolean
+		IL_0312: stfld object Modules.Abort_ExplicitReceiverAbi/Scope::listenerFired
+		IL_0317: ldstr "AbortSignal"
+		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0321: volatile.
+		IL_0323: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0328: brfalse IL_033c
 
-		IL_0338: ldloc.s 27
-		IL_033a: ldstr "addEventListener"
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0344: br IL_035f
+		IL_032d: ldstr "prototype"
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0337: br IL_0350
 
-		IL_0349: ldloc.s 27
-		IL_034b: ldstr "addEventListener"
-		IL_0350: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:82"
-		IL_0355: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_033c: ldstr "prototype"
+		IL_0341: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:80"
+		IL_0346: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_035f: stloc.s 27
-		IL_0361: ldloc.s 27
-		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0368: stloc.s 27
-		IL_036a: ldc.i4.1
-		IL_036b: newarr [System.Runtime]System.Object
-		IL_0370: dup
-		IL_0371: ldc.i4.0
-		IL_0372: ldloc.0
-		IL_0373: stelem.ref
-		IL_0374: stloc.s 32
-		IL_0376: ldloc.s 32
-		IL_0378: ldc.i4.0
-		IL_0379: ldelem.ref
-		IL_037a: castclass Modules.Abort_ExplicitReceiverAbi/Scope
-		IL_037f: newobj instance void Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L17C63/FunctionObject::.ctor(class Modules.Abort_ExplicitReceiverAbi/Scope)
-		IL_0384: ldc.i4.0
-		IL_0385: conv.r8
-		IL_0386: ldstr ""
-		IL_038b: ldc.i4.0
-		IL_038c: ldc.i4.0
-		IL_038d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L17C63/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0392: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L17C63/FunctionObject>(!!0)
-		IL_0397: stloc.s 33
-		IL_0399: ldloc.s 27
-		IL_039b: ldstr "call"
-		IL_03a0: ldloc.s 5
-		IL_03a2: ldstr "abort"
-		IL_03a7: ldloc.s 33
-		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_03ae: pop
-		IL_03af: ldloc.s 4
-		IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b6: volatile.
-		IL_03b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_03bd: brfalse IL_03d1
+		IL_0350: stloc.s 27
+		IL_0352: volatile.
+		IL_0354: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0359: brfalse IL_036f
 
-		IL_03c2: ldstr "abort"
-		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_03cc: br IL_03e5
+		IL_035e: ldloc.s 27
+		IL_0360: ldstr "addEventListener"
+		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_036a: br IL_0385
 
-		IL_03d1: ldstr "abort"
-		IL_03d6: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:90"
-		IL_03db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_036f: ldloc.s 27
+		IL_0371: ldstr "addEventListener"
+		IL_0376: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:82"
+		IL_037b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03e5: pop
-		IL_03e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03eb: stloc.s 28
-		IL_03ed: ldloc.0
-		IL_03ee: ldfld object Modules.Abort_ExplicitReceiverAbi/Scope::listenerFired
-		IL_03f3: stloc.s 27
-		IL_03f5: ldloc.s 27
-		IL_03f7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_03fc: stloc.s 29
-		IL_03fe: ldstr "listener fired after abort: "
-		IL_0403: ldloc.s 29
-		IL_0405: call string [System.Runtime]System.String::Concat(string, string)
-		IL_040a: stloc.s 29
-		IL_040c: ldloc.s 28
-		IL_040e: ldloc.s 29
-		IL_0410: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0415: pop
-		IL_0416: ldstr "AbortController"
-		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0420: stloc.s 27
-		IL_0422: ldloc.s 27
-		IL_0424: dup
-		IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_042a: stloc.s 6
-		IL_042c: volatile.
-		IL_042e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0433: brfalse IL_0449
+		IL_0385: stloc.s 27
+		IL_0387: ldloc.s 27
+		IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_038e: stloc.s 27
+		IL_0390: ldc.i4.1
+		IL_0391: newarr [System.Runtime]System.Object
+		IL_0396: dup
+		IL_0397: ldc.i4.0
+		IL_0398: ldloc.0
+		IL_0399: stelem.ref
+		IL_039a: stloc.s 32
+		IL_039c: ldloc.s 32
+		IL_039e: ldc.i4.0
+		IL_039f: ldelem.ref
+		IL_03a0: castclass Modules.Abort_ExplicitReceiverAbi/Scope
+		IL_03a5: newobj instance void Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L17C63/FunctionObject::.ctor(class Modules.Abort_ExplicitReceiverAbi/Scope)
+		IL_03aa: ldc.i4.0
+		IL_03ab: conv.r8
+		IL_03ac: ldstr ""
+		IL_03b1: ldc.i4.0
+		IL_03b2: ldc.i4.0
+		IL_03b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L17C63/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L17C63/FunctionObject>(!!0)
+		IL_03bd: stloc.s 33
+		IL_03bf: ldloc.s 27
+		IL_03c1: ldstr "call"
+		IL_03c6: ldloc.s 5
+		IL_03c8: ldstr "abort"
+		IL_03cd: ldloc.s 33
+		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_03d4: pop
+		IL_03d5: ldloc.s 4
+		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03dc: volatile.
+		IL_03de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_03e3: brfalse IL_03f7
 
-		IL_0438: ldloc.s 6
-		IL_043a: ldstr "signal"
-		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0444: br IL_045f
+		IL_03e8: ldstr "abort"
+		IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_03f2: br IL_040b
 
-		IL_0449: ldloc.s 6
-		IL_044b: ldstr "signal"
-		IL_0450: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:105"
-		IL_0455: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03f7: ldstr "abort"
+		IL_03fc: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:90"
+		IL_0401: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_045f: stloc.s 7
-		IL_0461: ldloc.0
-		IL_0462: ldc.i4.0
-		IL_0463: box [System.Runtime]System.Boolean
-		IL_0468: stfld object Modules.Abort_ExplicitReceiverAbi/Scope::removedListenerFired
-		IL_046d: ldc.i4.1
-		IL_046e: newarr [System.Runtime]System.Object
-		IL_0473: dup
-		IL_0474: ldc.i4.0
-		IL_0475: ldloc.0
-		IL_0476: stelem.ref
-		IL_0477: stloc.s 32
-		IL_0479: ldloc.s 32
-		IL_047b: ldc.i4.0
-		IL_047c: ldelem.ref
-		IL_047d: castclass Modules.Abort_ExplicitReceiverAbi/Scope
-		IL_0482: newobj instance void Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L24C18/FunctionObject::.ctor(class Modules.Abort_ExplicitReceiverAbi/Scope)
-		IL_0487: ldc.i4.0
-		IL_0488: conv.r8
-		IL_0489: ldstr ""
-		IL_048e: ldc.i4.0
-		IL_048f: ldc.i4.0
-		IL_0490: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L24C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0495: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L24C18/FunctionObject>(!!0)
-		IL_049a: stloc.s 34
-		IL_049c: ldloc.s 34
-		IL_049e: ldstr "listener"
-		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_04a8: stloc.s 8
-		IL_04aa: ldloc.s 7
-		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b1: ldstr "addEventListener"
-		IL_04b6: ldstr "abort"
-		IL_04bb: ldloc.s 8
-		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04c2: pop
-		IL_04c3: ldstr "AbortSignal"
-		IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04cd: volatile.
-		IL_04cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_04d4: brfalse IL_04e8
+		IL_040b: pop
+		IL_040c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0411: stloc.s 28
+		IL_0413: ldloc.0
+		IL_0414: ldfld object Modules.Abort_ExplicitReceiverAbi/Scope::listenerFired
+		IL_0419: stloc.s 27
+		IL_041b: ldloc.s 27
+		IL_041d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0422: stloc.s 29
+		IL_0424: ldstr "listener fired after abort: "
+		IL_0429: ldloc.s 29
+		IL_042b: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0430: stloc.s 29
+		IL_0432: ldloc.s 28
+		IL_0434: ldloc.s 29
+		IL_0436: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_043b: pop
+		IL_043c: ldstr "AbortController"
+		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0446: stloc.s 27
+		IL_0448: ldloc.s 27
+		IL_044a: dup
+		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0450: stloc.s 6
+		IL_0452: volatile.
+		IL_0454: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0459: brfalse IL_046f
 
-		IL_04d9: ldstr "prototype"
-		IL_04de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04e3: br IL_04fc
+		IL_045e: ldloc.s 6
+		IL_0460: ldstr "signal"
+		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_046a: br IL_0485
 
-		IL_04e8: ldstr "prototype"
-		IL_04ed: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:125"
-		IL_04f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_046f: ldloc.s 6
+		IL_0471: ldstr "signal"
+		IL_0476: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:105"
+		IL_047b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04fc: stloc.s 27
-		IL_04fe: volatile.
-		IL_0500: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0505: brfalse IL_051b
+		IL_0485: stloc.s 7
+		IL_0487: ldloc.0
+		IL_0488: ldc.i4.0
+		IL_0489: box [System.Runtime]System.Boolean
+		IL_048e: stfld object Modules.Abort_ExplicitReceiverAbi/Scope::removedListenerFired
+		IL_0493: ldc.i4.1
+		IL_0494: newarr [System.Runtime]System.Object
+		IL_0499: dup
+		IL_049a: ldc.i4.0
+		IL_049b: ldloc.0
+		IL_049c: stelem.ref
+		IL_049d: stloc.s 32
+		IL_049f: ldloc.s 32
+		IL_04a1: ldc.i4.0
+		IL_04a2: ldelem.ref
+		IL_04a3: castclass Modules.Abort_ExplicitReceiverAbi/Scope
+		IL_04a8: newobj instance void Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L24C18/FunctionObject::.ctor(class Modules.Abort_ExplicitReceiverAbi/Scope)
+		IL_04ad: ldc.i4.0
+		IL_04ae: conv.r8
+		IL_04af: ldstr ""
+		IL_04b4: ldc.i4.0
+		IL_04b5: ldc.i4.0
+		IL_04b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L24C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L24C18/FunctionObject>(!!0)
+		IL_04c0: stloc.s 34
+		IL_04c2: ldloc.s 34
+		IL_04c4: ldstr "listener"
+		IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_04ce: stloc.s 8
+		IL_04d0: ldloc.s 7
+		IL_04d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d7: ldstr "addEventListener"
+		IL_04dc: ldstr "abort"
+		IL_04e1: ldloc.s 8
+		IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04e8: pop
+		IL_04e9: ldstr "AbortSignal"
+		IL_04ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04f3: volatile.
+		IL_04f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_04fa: brfalse IL_050e
 
-		IL_050a: ldloc.s 27
-		IL_050c: ldstr "removeEventListener"
-		IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0516: br IL_0531
+		IL_04ff: ldstr "prototype"
+		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0509: br IL_0522
 
-		IL_051b: ldloc.s 27
-		IL_051d: ldstr "removeEventListener"
-		IL_0522: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:127"
-		IL_0527: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_050e: ldstr "prototype"
+		IL_0513: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:125"
+		IL_0518: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0531: stloc.s 27
-		IL_0533: ldloc.s 27
-		IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_053a: ldstr "call"
-		IL_053f: ldloc.s 7
-		IL_0541: ldstr "abort"
-		IL_0546: ldloc.s 8
-		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_054d: pop
-		IL_054e: ldloc.s 6
-		IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0555: volatile.
-		IL_0557: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_055c: brfalse IL_0570
+		IL_0522: stloc.s 27
+		IL_0524: volatile.
+		IL_0526: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_052b: brfalse IL_0541
 
-		IL_0561: ldstr "abort"
-		IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_056b: br IL_0584
+		IL_0530: ldloc.s 27
+		IL_0532: ldstr "removeEventListener"
+		IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_053c: br IL_0557
 
-		IL_0570: ldstr "abort"
-		IL_0575: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:133"
-		IL_057a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0541: ldloc.s 27
+		IL_0543: ldstr "removeEventListener"
+		IL_0548: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:127"
+		IL_054d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0584: pop
-		IL_0585: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_058a: stloc.s 28
-		IL_058c: ldloc.0
-		IL_058d: ldfld object Modules.Abort_ExplicitReceiverAbi/Scope::removedListenerFired
-		IL_0592: stloc.s 27
-		IL_0594: ldloc.s 27
-		IL_0596: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_059b: stloc.s 29
-		IL_059d: ldstr "removed listener fired: "
-		IL_05a2: ldloc.s 29
-		IL_05a4: call string [System.Runtime]System.String::Concat(string, string)
-		IL_05a9: stloc.s 29
-		IL_05ab: ldloc.s 28
-		IL_05ad: ldloc.s 29
-		IL_05af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05b4: pop
+		IL_0557: stloc.s 27
+		IL_0559: ldloc.s 27
+		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0560: ldstr "call"
+		IL_0565: ldloc.s 7
+		IL_0567: ldstr "abort"
+		IL_056c: ldloc.s 8
+		IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0573: pop
+		IL_0574: ldloc.s 6
+		IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_057b: volatile.
+		IL_057d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0582: brfalse IL_0596
+
+		IL_0587: ldstr "abort"
+		IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0591: br IL_05aa
+
+		IL_0596: ldstr "abort"
+		IL_059b: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:133"
+		IL_05a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_05a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_05aa: pop
+		IL_05ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05b0: stloc.s 28
+		IL_05b2: ldloc.0
+		IL_05b3: ldfld object Modules.Abort_ExplicitReceiverAbi/Scope::removedListenerFired
+		IL_05b8: stloc.s 27
+		IL_05ba: ldloc.s 27
+		IL_05bc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_05c1: stloc.s 29
+		IL_05c3: ldstr "removed listener fired: "
+		IL_05c8: ldloc.s 29
+		IL_05ca: call string [System.Runtime]System.String::Concat(string, string)
+		IL_05cf: stloc.s 29
+		IL_05d1: ldloc.s 28
+		IL_05d3: ldloc.s 29
+		IL_05d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05da: pop
 		.try
 		{
-			IL_05b5: nop
-			IL_05b6: ldstr "AbortController"
-			IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05c0: volatile.
-			IL_05c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_05c7: brfalse IL_05db
+			IL_05db: nop
+			IL_05dc: ldstr "AbortController"
+			IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05e6: volatile.
+			IL_05e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_05ed: brfalse IL_0601
 
-			IL_05cc: ldstr "prototype"
-			IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05d6: br IL_05ef
+			IL_05f2: ldstr "prototype"
+			IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05fc: br IL_0615
 
-			IL_05db: ldstr "prototype"
-			IL_05e0: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:148"
-			IL_05e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0601: ldstr "prototype"
+			IL_0606: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:148"
+			IL_060b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0610: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_05ef: stloc.s 27
-			IL_05f1: volatile.
-			IL_05f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_05f8: brfalse IL_060e
+			IL_0615: stloc.s 27
+			IL_0617: volatile.
+			IL_0619: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_061e: brfalse IL_0634
 
-			IL_05fd: ldloc.s 27
-			IL_05ff: ldstr "abort"
-			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0609: br IL_0624
+			IL_0623: ldloc.s 27
+			IL_0625: ldstr "abort"
+			IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_062f: br IL_064a
 
-			IL_060e: ldloc.s 27
-			IL_0610: ldstr "abort"
-			IL_0615: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:150"
-			IL_061a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0634: ldloc.s 27
+			IL_0636: ldstr "abort"
+			IL_063b: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:150"
+			IL_0640: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0624: stloc.s 27
-			IL_0626: ldloc.s 27
-			IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_062d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0632: stloc.s 35
-			IL_0634: ldstr "call"
-			IL_0639: ldloc.s 35
-			IL_063b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0640: pop
-			IL_0641: leave IL_06b2
+			IL_064a: stloc.s 27
+			IL_064c: ldloc.s 27
+			IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0653: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0658: stloc.s 35
+			IL_065a: volatile.
+			IL_065c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0661: brfalse IL_0677
+
+			IL_0666: ldstr "call"
+			IL_066b: ldloc.s 35
+			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0672: br IL_068d
+
+			IL_0677: ldstr "call"
+			IL_067c: ldloc.s 35
+			IL_067e: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:153"
+			IL_0683: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_068d: pop
+			IL_068e: leave IL_06ff
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0646: stloc.s 9
-			IL_0648: ldloc.s 9
-			IL_064a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_064f: dup
-			IL_0650: brtrue IL_0666
+			IL_0693: stloc.s 9
+			IL_0695: ldloc.s 9
+			IL_0697: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_069c: dup
+			IL_069d: brtrue IL_06b3
 
-			IL_0655: pop
-			IL_0656: ldloc.s 9
-			IL_0658: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_065d: dup
-			IL_065e: brtrue IL_0672
+			IL_06a2: pop
+			IL_06a3: ldloc.s 9
+			IL_06a5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06aa: dup
+			IL_06ab: brtrue IL_06bf
 
-			IL_0663: pop
-			IL_0664: rethrow
+			IL_06b0: pop
+			IL_06b1: rethrow
 
-			IL_0666: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_066b: stloc.s 10
-			IL_066d: br IL_0674
+			IL_06b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_06b8: stloc.s 10
+			IL_06ba: br IL_06c1
 
-			IL_0672: stloc.s 10
+			IL_06bf: stloc.s 10
 
-			IL_0674: ldloc.s 10
-			IL_0676: stloc.s 11
-			IL_0678: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_067d: stloc.s 28
-			IL_067f: ldloc.s 11
-			IL_0681: stloc.s 27
-			IL_0683: ldstr "TypeError"
-			IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_068d: stloc.s 36
-			IL_068f: ldloc.s 27
-			IL_0691: ldloc.s 36
-			IL_0693: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0698: stloc.s 30
-			IL_069a: ldloc.s 30
-			IL_069c: box [System.Runtime]System.Boolean
-			IL_06a1: stloc.s 31
-			IL_06a3: ldloc.s 28
-			IL_06a5: ldloc.s 31
-			IL_06a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06ac: pop
-			IL_06ad: leave IL_06b2
+			IL_06c1: ldloc.s 10
+			IL_06c3: stloc.s 11
+			IL_06c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06ca: stloc.s 28
+			IL_06cc: ldloc.s 11
+			IL_06ce: stloc.s 27
+			IL_06d0: ldstr "TypeError"
+			IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06da: stloc.s 36
+			IL_06dc: ldloc.s 27
+			IL_06de: ldloc.s 36
+			IL_06e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_06e5: stloc.s 30
+			IL_06e7: ldloc.s 30
+			IL_06e9: box [System.Runtime]System.Boolean
+			IL_06ee: stloc.s 31
+			IL_06f0: ldloc.s 28
+			IL_06f2: ldloc.s 31
+			IL_06f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06f9: pop
+			IL_06fa: leave IL_06ff
 		} // end handler
 		.try
 		{
-			IL_06b2: nop
-			IL_06b3: volatile.
-			IL_06b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_06ba: brfalse IL_06cf
+			IL_06ff: nop
+			IL_0700: volatile.
+			IL_0702: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0707: brfalse IL_071c
 
-			IL_06bf: ldloc.3
-			IL_06c0: ldstr "get"
-			IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06ca: br IL_06e4
+			IL_070c: ldloc.3
+			IL_070d: ldstr "get"
+			IL_0712: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0717: br IL_0731
 
-			IL_06cf: ldloc.3
-			IL_06d0: ldstr "get"
-			IL_06d5: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:178"
-			IL_06da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_071c: ldloc.3
+			IL_071d: ldstr "get"
+			IL_0722: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:178"
+			IL_0727: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_072c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06e4: stloc.s 36
-			IL_06e6: ldloc.s 36
-			IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06f2: stloc.s 35
-			IL_06f4: ldstr "call"
-			IL_06f9: ldloc.s 35
-			IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0700: pop
-			IL_0701: leave IL_0772
+			IL_0731: stloc.s 36
+			IL_0733: ldloc.s 36
+			IL_0735: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_073a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_073f: stloc.s 35
+			IL_0741: volatile.
+			IL_0743: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0748: brfalse IL_075e
+
+			IL_074d: ldstr "call"
+			IL_0752: ldloc.s 35
+			IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0759: br IL_0774
+
+			IL_075e: ldstr "call"
+			IL_0763: ldloc.s 35
+			IL_0765: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:181"
+			IL_076a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0774: pop
+			IL_0775: leave IL_07e6
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0706: stloc.s 12
-			IL_0708: ldloc.s 12
-			IL_070a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_070f: dup
-			IL_0710: brtrue IL_0726
+			IL_077a: stloc.s 12
+			IL_077c: ldloc.s 12
+			IL_077e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0783: dup
+			IL_0784: brtrue IL_079a
 
-			IL_0715: pop
-			IL_0716: ldloc.s 12
-			IL_0718: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_071d: dup
-			IL_071e: brtrue IL_0732
+			IL_0789: pop
+			IL_078a: ldloc.s 12
+			IL_078c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0791: dup
+			IL_0792: brtrue IL_07a6
 
-			IL_0723: pop
-			IL_0724: rethrow
+			IL_0797: pop
+			IL_0798: rethrow
 
-			IL_0726: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_072b: stloc.s 13
-			IL_072d: br IL_0734
+			IL_079a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_079f: stloc.s 13
+			IL_07a1: br IL_07a8
 
-			IL_0732: stloc.s 13
+			IL_07a6: stloc.s 13
 
-			IL_0734: ldloc.s 13
-			IL_0736: stloc.s 14
-			IL_0738: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_073d: stloc.s 28
-			IL_073f: ldloc.s 14
-			IL_0741: stloc.s 36
-			IL_0743: ldstr "TypeError"
-			IL_0748: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_074d: stloc.s 27
-			IL_074f: ldloc.s 36
-			IL_0751: ldloc.s 27
-			IL_0753: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0758: stloc.s 30
-			IL_075a: ldloc.s 30
-			IL_075c: box [System.Runtime]System.Boolean
-			IL_0761: stloc.s 31
-			IL_0763: ldloc.s 28
-			IL_0765: ldloc.s 31
-			IL_0767: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_076c: pop
-			IL_076d: leave IL_0772
+			IL_07a8: ldloc.s 13
+			IL_07aa: stloc.s 14
+			IL_07ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07b1: stloc.s 28
+			IL_07b3: ldloc.s 14
+			IL_07b5: stloc.s 36
+			IL_07b7: ldstr "TypeError"
+			IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07c1: stloc.s 27
+			IL_07c3: ldloc.s 36
+			IL_07c5: ldloc.s 27
+			IL_07c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_07cc: stloc.s 30
+			IL_07ce: ldloc.s 30
+			IL_07d0: box [System.Runtime]System.Boolean
+			IL_07d5: stloc.s 31
+			IL_07d7: ldloc.s 28
+			IL_07d9: ldloc.s 31
+			IL_07db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07e0: pop
+			IL_07e1: leave IL_07e6
 		} // end handler
 		.try
 		{
-			IL_0772: nop
-			IL_0773: ldstr "AbortSignal"
-			IL_0778: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_077d: volatile.
-			IL_077f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0784: brfalse IL_0798
+			IL_07e6: nop
+			IL_07e7: ldstr "AbortSignal"
+			IL_07ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07f1: volatile.
+			IL_07f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_07f8: brfalse IL_080c
 
-			IL_0789: ldstr "prototype"
-			IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0793: br IL_07ac
+			IL_07fd: ldstr "prototype"
+			IL_0802: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0807: br IL_0820
 
-			IL_0798: ldstr "prototype"
-			IL_079d: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:208"
-			IL_07a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_07a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_080c: ldstr "prototype"
+			IL_0811: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:208"
+			IL_0816: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_081b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07ac: stloc.s 27
-			IL_07ae: volatile.
-			IL_07b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_07b5: brfalse IL_07cb
+			IL_0820: stloc.s 27
+			IL_0822: volatile.
+			IL_0824: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0829: brfalse IL_083f
 
-			IL_07ba: ldloc.s 27
-			IL_07bc: ldstr "addEventListener"
-			IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07c6: br IL_07e1
+			IL_082e: ldloc.s 27
+			IL_0830: ldstr "addEventListener"
+			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_083a: br IL_0855
 
-			IL_07cb: ldloc.s 27
-			IL_07cd: ldstr "addEventListener"
-			IL_07d2: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:210"
-			IL_07d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_07dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_083f: ldloc.s 27
+			IL_0841: ldstr "addEventListener"
+			IL_0846: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:210"
+			IL_084b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07e1: stloc.s 27
-			IL_07e3: ldloc.s 27
-			IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07ea: stloc.s 27
-			IL_07ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_07f1: stloc.s 35
-			IL_07f3: ldc.i4.1
-			IL_07f4: newarr [System.Runtime]System.Object
-			IL_07f9: dup
-			IL_07fa: ldc.i4.0
-			IL_07fb: ldloc.0
-			IL_07fc: stelem.ref
-			IL_07fd: stloc.s 32
-			IL_07ff: newobj instance void Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L42C62/FunctionObject::.ctor()
-			IL_0804: ldc.i4.0
-			IL_0805: conv.r8
-			IL_0806: ldstr ""
-			IL_080b: ldc.i4.0
-			IL_080c: ldc.i4.0
-			IL_080d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L42C62/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0812: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L42C62/FunctionObject>(!!0)
-			IL_0817: stloc.s 37
-			IL_0819: ldloc.s 27
-			IL_081b: ldstr "call"
-			IL_0820: ldloc.s 35
-			IL_0822: ldstr "abort"
-			IL_0827: ldloc.s 37
-			IL_0829: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_082e: pop
-			IL_082f: leave IL_08a0
+			IL_0855: stloc.s 27
+			IL_0857: ldloc.s 27
+			IL_0859: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_085e: stloc.s 27
+			IL_0860: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0865: stloc.s 35
+			IL_0867: ldc.i4.1
+			IL_0868: newarr [System.Runtime]System.Object
+			IL_086d: dup
+			IL_086e: ldc.i4.0
+			IL_086f: ldloc.0
+			IL_0870: stelem.ref
+			IL_0871: stloc.s 32
+			IL_0873: newobj instance void Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L42C62/FunctionObject::.ctor()
+			IL_0878: ldc.i4.0
+			IL_0879: conv.r8
+			IL_087a: ldstr ""
+			IL_087f: ldc.i4.0
+			IL_0880: ldc.i4.0
+			IL_0881: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L42C62/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0886: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L42C62/FunctionObject>(!!0)
+			IL_088b: stloc.s 37
+			IL_088d: ldloc.s 27
+			IL_088f: ldstr "call"
+			IL_0894: ldloc.s 35
+			IL_0896: ldstr "abort"
+			IL_089b: ldloc.s 37
+			IL_089d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_08a2: pop
+			IL_08a3: leave IL_0914
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0834: stloc.s 15
-			IL_0836: ldloc.s 15
-			IL_0838: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_083d: dup
-			IL_083e: brtrue IL_0854
+			IL_08a8: stloc.s 15
+			IL_08aa: ldloc.s 15
+			IL_08ac: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_08b1: dup
+			IL_08b2: brtrue IL_08c8
 
-			IL_0843: pop
-			IL_0844: ldloc.s 15
-			IL_0846: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_084b: dup
-			IL_084c: brtrue IL_0860
+			IL_08b7: pop
+			IL_08b8: ldloc.s 15
+			IL_08ba: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_08bf: dup
+			IL_08c0: brtrue IL_08d4
 
-			IL_0851: pop
-			IL_0852: rethrow
+			IL_08c5: pop
+			IL_08c6: rethrow
 
-			IL_0854: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0859: stloc.s 16
-			IL_085b: br IL_0862
+			IL_08c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_08cd: stloc.s 16
+			IL_08cf: br IL_08d6
 
-			IL_0860: stloc.s 16
+			IL_08d4: stloc.s 16
 
-			IL_0862: ldloc.s 16
-			IL_0864: stloc.s 17
-			IL_0866: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_086b: stloc.s 28
-			IL_086d: ldloc.s 17
-			IL_086f: stloc.s 27
-			IL_0871: ldstr "TypeError"
-			IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_087b: stloc.s 36
-			IL_087d: ldloc.s 27
-			IL_087f: ldloc.s 36
-			IL_0881: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0886: stloc.s 30
-			IL_0888: ldloc.s 30
-			IL_088a: box [System.Runtime]System.Boolean
-			IL_088f: stloc.s 31
-			IL_0891: ldloc.s 28
-			IL_0893: ldloc.s 31
-			IL_0895: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_089a: pop
-			IL_089b: leave IL_08a0
+			IL_08d6: ldloc.s 16
+			IL_08d8: stloc.s 17
+			IL_08da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08df: stloc.s 28
+			IL_08e1: ldloc.s 17
+			IL_08e3: stloc.s 27
+			IL_08e5: ldstr "TypeError"
+			IL_08ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08ef: stloc.s 36
+			IL_08f1: ldloc.s 27
+			IL_08f3: ldloc.s 36
+			IL_08f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_08fa: stloc.s 30
+			IL_08fc: ldloc.s 30
+			IL_08fe: box [System.Runtime]System.Boolean
+			IL_0903: stloc.s 31
+			IL_0905: ldloc.s 28
+			IL_0907: ldloc.s 31
+			IL_0909: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_090e: pop
+			IL_090f: leave IL_0914
 		} // end handler
 		.try
 		{
-			IL_08a0: nop
-			IL_08a1: ldstr "AbortSignal"
-			IL_08a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_08ab: volatile.
-			IL_08ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-			IL_08b2: brfalse IL_08c6
+			IL_0914: nop
+			IL_0915: ldstr "AbortSignal"
+			IL_091a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_091f: volatile.
+			IL_0921: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0926: brfalse IL_093a
 
-			IL_08b7: ldstr "prototype"
-			IL_08bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08c1: br IL_08da
+			IL_092b: ldstr "prototype"
+			IL_0930: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0935: br IL_094e
 
-			IL_08c6: ldstr "prototype"
-			IL_08cb: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:243"
-			IL_08d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-			IL_08d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_093a: ldstr "prototype"
+			IL_093f: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:243"
+			IL_0944: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0949: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08da: stloc.s 36
-			IL_08dc: volatile.
-			IL_08de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_08e3: brfalse IL_08f9
+			IL_094e: stloc.s 36
+			IL_0950: volatile.
+			IL_0952: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0957: brfalse IL_096d
 
-			IL_08e8: ldloc.s 36
-			IL_08ea: ldstr "removeEventListener"
-			IL_08ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08f4: br IL_090f
+			IL_095c: ldloc.s 36
+			IL_095e: ldstr "removeEventListener"
+			IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0968: br IL_0983
 
-			IL_08f9: ldloc.s 36
-			IL_08fb: ldstr "removeEventListener"
-			IL_0900: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:245"
-			IL_0905: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_090a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_096d: ldloc.s 36
+			IL_096f: ldstr "removeEventListener"
+			IL_0974: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:245"
+			IL_0979: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_097e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_090f: stloc.s 36
-			IL_0911: ldloc.s 36
-			IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0918: stloc.s 36
-			IL_091a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_091f: stloc.s 35
-			IL_0921: ldc.i4.1
-			IL_0922: newarr [System.Runtime]System.Object
-			IL_0927: dup
-			IL_0928: ldc.i4.0
-			IL_0929: ldloc.0
-			IL_092a: stelem.ref
-			IL_092b: stloc.s 32
-			IL_092d: newobj instance void Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L47C65/FunctionObject::.ctor()
-			IL_0932: ldc.i4.0
-			IL_0933: conv.r8
-			IL_0934: ldstr ""
-			IL_0939: ldc.i4.0
-			IL_093a: ldc.i4.0
-			IL_093b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L47C65/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0940: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L47C65/FunctionObject>(!!0)
-			IL_0945: stloc.s 38
-			IL_0947: ldloc.s 36
-			IL_0949: ldstr "call"
-			IL_094e: ldloc.s 35
-			IL_0950: ldstr "abort"
-			IL_0955: ldloc.s 38
-			IL_0957: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_095c: pop
-			IL_095d: leave IL_09ce
+			IL_0983: stloc.s 36
+			IL_0985: ldloc.s 36
+			IL_0987: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_098c: stloc.s 36
+			IL_098e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0993: stloc.s 35
+			IL_0995: ldc.i4.1
+			IL_0996: newarr [System.Runtime]System.Object
+			IL_099b: dup
+			IL_099c: ldc.i4.0
+			IL_099d: ldloc.0
+			IL_099e: stelem.ref
+			IL_099f: stloc.s 32
+			IL_09a1: newobj instance void Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L47C65/FunctionObject::.ctor()
+			IL_09a6: ldc.i4.0
+			IL_09a7: conv.r8
+			IL_09a8: ldstr ""
+			IL_09ad: ldc.i4.0
+			IL_09ae: ldc.i4.0
+			IL_09af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L47C65/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_09b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Abort_ExplicitReceiverAbi/ArrowFunction_L47C65/FunctionObject>(!!0)
+			IL_09b9: stloc.s 38
+			IL_09bb: ldloc.s 36
+			IL_09bd: ldstr "call"
+			IL_09c2: ldloc.s 35
+			IL_09c4: ldstr "abort"
+			IL_09c9: ldloc.s 38
+			IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_09d0: pop
+			IL_09d1: leave IL_0a42
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0962: stloc.s 18
-			IL_0964: ldloc.s 18
-			IL_0966: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_096b: dup
-			IL_096c: brtrue IL_0982
+			IL_09d6: stloc.s 18
+			IL_09d8: ldloc.s 18
+			IL_09da: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_09df: dup
+			IL_09e0: brtrue IL_09f6
 
-			IL_0971: pop
-			IL_0972: ldloc.s 18
-			IL_0974: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0979: dup
-			IL_097a: brtrue IL_098e
+			IL_09e5: pop
+			IL_09e6: ldloc.s 18
+			IL_09e8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_09ed: dup
+			IL_09ee: brtrue IL_0a02
 
-			IL_097f: pop
-			IL_0980: rethrow
+			IL_09f3: pop
+			IL_09f4: rethrow
 
-			IL_0982: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0987: stloc.s 19
-			IL_0989: br IL_0990
+			IL_09f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_09fb: stloc.s 19
+			IL_09fd: br IL_0a04
 
-			IL_098e: stloc.s 19
+			IL_0a02: stloc.s 19
 
-			IL_0990: ldloc.s 19
-			IL_0992: stloc.s 20
-			IL_0994: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0999: stloc.s 28
-			IL_099b: ldloc.s 20
-			IL_099d: stloc.s 36
-			IL_099f: ldstr "TypeError"
-			IL_09a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09a9: stloc.s 27
-			IL_09ab: ldloc.s 36
-			IL_09ad: ldloc.s 27
-			IL_09af: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_09b4: stloc.s 30
-			IL_09b6: ldloc.s 30
-			IL_09b8: box [System.Runtime]System.Boolean
-			IL_09bd: stloc.s 31
-			IL_09bf: ldloc.s 28
-			IL_09c1: ldloc.s 31
-			IL_09c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_09c8: pop
-			IL_09c9: leave IL_09ce
+			IL_0a04: ldloc.s 19
+			IL_0a06: stloc.s 20
+			IL_0a08: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a0d: stloc.s 28
+			IL_0a0f: ldloc.s 20
+			IL_0a11: stloc.s 36
+			IL_0a13: ldstr "TypeError"
+			IL_0a18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a1d: stloc.s 27
+			IL_0a1f: ldloc.s 36
+			IL_0a21: ldloc.s 27
+			IL_0a23: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0a28: stloc.s 30
+			IL_0a2a: ldloc.s 30
+			IL_0a2c: box [System.Runtime]System.Boolean
+			IL_0a31: stloc.s 31
+			IL_0a33: ldloc.s 28
+			IL_0a35: ldloc.s 31
+			IL_0a37: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a3c: pop
+			IL_0a3d: leave IL_0a42
 		} // end handler
 
-		IL_09ce: ldstr "AbortSignal"
-		IL_09d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_09d8: volatile.
-		IL_09da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_09df: brfalse IL_09f3
+		IL_0a42: ldstr "AbortSignal"
+		IL_0a47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a4c: volatile.
+		IL_0a4e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0a53: brfalse IL_0a67
 
-		IL_09e4: ldstr "prototype"
-		IL_09e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09ee: br IL_0a07
+		IL_0a58: ldstr "prototype"
+		IL_0a5d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a62: br IL_0a7b
 
-		IL_09f3: ldstr "prototype"
-		IL_09f8: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:275"
-		IL_09fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0a02: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0a67: ldstr "prototype"
+		IL_0a6c: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:275"
+		IL_0a71: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0a76: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a07: stloc.s 27
-		IL_0a09: ldloc.s 27
-		IL_0a0b: ldstr "aborted"
-		IL_0a10: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0a15: stloc.s 21
-		IL_0a17: ldstr "AbortSignal"
-		IL_0a1c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0a21: volatile.
-		IL_0a23: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0a28: brfalse IL_0a3c
+		IL_0a7b: stloc.s 27
+		IL_0a7d: ldloc.s 27
+		IL_0a7f: ldstr "aborted"
+		IL_0a84: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0a89: stloc.s 21
+		IL_0a8b: ldstr "AbortSignal"
+		IL_0a90: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a95: volatile.
+		IL_0a97: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0a9c: brfalse IL_0ab0
 
-		IL_0a2d: ldstr "prototype"
-		IL_0a32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a37: br IL_0a50
+		IL_0aa1: ldstr "prototype"
+		IL_0aa6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0aab: br IL_0ac4
 
-		IL_0a3c: ldstr "prototype"
-		IL_0a41: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:283"
-		IL_0a46: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0a4b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ab0: ldstr "prototype"
+		IL_0ab5: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:283"
+		IL_0aba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0abf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a50: stloc.s 27
-		IL_0a52: ldloc.s 27
-		IL_0a54: ldstr "reason"
-		IL_0a59: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0a5e: stloc.s 22
-		IL_0a60: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0a65: stloc.s 28
-		IL_0a67: volatile.
-		IL_0a69: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0a6e: brfalse IL_0a84
+		IL_0ac4: stloc.s 27
+		IL_0ac6: ldloc.s 27
+		IL_0ac8: ldstr "reason"
+		IL_0acd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0ad2: stloc.s 22
+		IL_0ad4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ad9: stloc.s 28
+		IL_0adb: volatile.
+		IL_0add: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0ae2: brfalse IL_0af8
 
-		IL_0a73: ldloc.s 21
-		IL_0a75: ldstr "get"
-		IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a7f: br IL_0a9a
+		IL_0ae7: ldloc.s 21
+		IL_0ae9: ldstr "get"
+		IL_0aee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0af3: br IL_0b0e
 
-		IL_0a84: ldloc.s 21
-		IL_0a86: ldstr "get"
-		IL_0a8b: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:290"
-		IL_0a90: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0a95: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0af8: ldloc.s 21
+		IL_0afa: ldstr "get"
+		IL_0aff: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:290"
+		IL_0b04: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0b09: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a9a: stloc.s 27
-		IL_0a9c: ldloc.s 27
-		IL_0a9e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0aa3: ldstr "call"
-		IL_0aa8: ldloc.2
-		IL_0aa9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0aae: stloc.s 27
-		IL_0ab0: ldloc.s 28
-		IL_0ab2: ldloc.s 27
-		IL_0ab4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0ab9: pop
-		IL_0aba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0abf: stloc.s 28
-		IL_0ac1: volatile.
-		IL_0ac3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0ac8: brfalse IL_0ade
+		IL_0b0e: stloc.s 27
+		IL_0b10: ldloc.s 27
+		IL_0b12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b17: volatile.
+		IL_0b19: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0b1e: brfalse IL_0b33
 
-		IL_0acd: ldloc.s 22
-		IL_0acf: ldstr "get"
-		IL_0ad4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ad9: br IL_0af4
+		IL_0b23: ldstr "call"
+		IL_0b28: ldloc.2
+		IL_0b29: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0b2e: br IL_0b48
 
-		IL_0ade: ldloc.s 22
-		IL_0ae0: ldstr "get"
-		IL_0ae5: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:297"
-		IL_0aea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0aef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0b33: ldstr "call"
+		IL_0b38: ldloc.2
+		IL_0b39: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:292"
+		IL_0b3e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0b43: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0af4: stloc.s 27
-		IL_0af6: ldloc.s 27
-		IL_0af8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0afd: ldstr "call"
-		IL_0b02: ldloc.2
-		IL_0b03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0b08: stloc.s 27
-		IL_0b0a: ldloc.s 28
-		IL_0b0c: ldloc.s 27
-		IL_0b0e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0b13: pop
+		IL_0b48: stloc.s 27
+		IL_0b4a: ldloc.s 28
+		IL_0b4c: ldloc.s 27
+		IL_0b4e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b53: pop
+		IL_0b54: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b59: stloc.s 28
+		IL_0b5b: volatile.
+		IL_0b5d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0b62: brfalse IL_0b78
+
+		IL_0b67: ldloc.s 22
+		IL_0b69: ldstr "get"
+		IL_0b6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b73: br IL_0b8e
+
+		IL_0b78: ldloc.s 22
+		IL_0b7a: ldstr "get"
+		IL_0b7f: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:297"
+		IL_0b84: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0b89: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0b8e: stloc.s 27
+		IL_0b90: ldloc.s 27
+		IL_0b92: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b97: volatile.
+		IL_0b99: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0b9e: brfalse IL_0bb3
+
+		IL_0ba3: ldstr "call"
+		IL_0ba8: ldloc.2
+		IL_0ba9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0bae: br IL_0bc8
+
+		IL_0bb3: ldstr "call"
+		IL_0bb8: ldloc.2
+		IL_0bb9: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:299"
+		IL_0bbe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0bc3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0bc8: stloc.s 27
+		IL_0bca: ldloc.s 28
+		IL_0bcc: ldloc.s 27
+		IL_0bce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0bd3: pop
 		.try
 		{
-			IL_0b14: nop
-			IL_0b15: volatile.
-			IL_0b17: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-			IL_0b1c: brfalse IL_0b32
+			IL_0bd4: nop
+			IL_0bd5: volatile.
+			IL_0bd7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0bdc: brfalse IL_0bf2
 
-			IL_0b21: ldloc.s 21
-			IL_0b23: ldstr "get"
-			IL_0b28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b2d: br IL_0b48
+			IL_0be1: ldloc.s 21
+			IL_0be3: ldstr "get"
+			IL_0be8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bed: br IL_0c08
 
-			IL_0b32: ldloc.s 21
-			IL_0b34: ldstr "get"
-			IL_0b39: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:306"
-			IL_0b3e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-			IL_0b43: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0bf2: ldloc.s 21
+			IL_0bf4: ldstr "get"
+			IL_0bf9: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:306"
+			IL_0bfe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0c03: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0b48: stloc.s 27
-			IL_0b4a: ldloc.s 27
-			IL_0b4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b51: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0b56: stloc.s 35
-			IL_0b58: ldstr "call"
-			IL_0b5d: ldloc.s 35
-			IL_0b5f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0b64: pop
-			IL_0b65: leave IL_0bd6
+			IL_0c08: stloc.s 27
+			IL_0c0a: ldloc.s 27
+			IL_0c0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c11: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0c16: stloc.s 35
+			IL_0c18: volatile.
+			IL_0c1a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0c1f: brfalse IL_0c35
+
+			IL_0c24: ldstr "call"
+			IL_0c29: ldloc.s 35
+			IL_0c2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0c30: br IL_0c4b
+
+			IL_0c35: ldstr "call"
+			IL_0c3a: ldloc.s 35
+			IL_0c3c: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:309"
+			IL_0c41: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0c46: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0c4b: pop
+			IL_0c4c: leave IL_0cbd
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0b6a: stloc.s 23
-			IL_0b6c: ldloc.s 23
-			IL_0b6e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0b73: dup
-			IL_0b74: brtrue IL_0b8a
+			IL_0c51: stloc.s 23
+			IL_0c53: ldloc.s 23
+			IL_0c55: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0c5a: dup
+			IL_0c5b: brtrue IL_0c71
 
-			IL_0b79: pop
-			IL_0b7a: ldloc.s 23
-			IL_0b7c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0b81: dup
-			IL_0b82: brtrue IL_0b96
+			IL_0c60: pop
+			IL_0c61: ldloc.s 23
+			IL_0c63: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0c68: dup
+			IL_0c69: brtrue IL_0c7d
 
-			IL_0b87: pop
-			IL_0b88: rethrow
+			IL_0c6e: pop
+			IL_0c6f: rethrow
 
-			IL_0b8a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0b8f: stloc.s 24
-			IL_0b91: br IL_0b98
+			IL_0c71: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0c76: stloc.s 24
+			IL_0c78: br IL_0c7f
 
-			IL_0b96: stloc.s 24
+			IL_0c7d: stloc.s 24
 
-			IL_0b98: ldloc.s 24
-			IL_0b9a: stloc.s 25
-			IL_0b9c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0ba1: stloc.s 28
-			IL_0ba3: ldloc.s 25
-			IL_0ba5: stloc.s 27
-			IL_0ba7: ldstr "TypeError"
-			IL_0bac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0bb1: stloc.s 36
-			IL_0bb3: ldloc.s 27
-			IL_0bb5: ldloc.s 36
-			IL_0bb7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0bbc: stloc.s 30
-			IL_0bbe: ldloc.s 30
-			IL_0bc0: box [System.Runtime]System.Boolean
-			IL_0bc5: stloc.s 31
-			IL_0bc7: ldloc.s 28
-			IL_0bc9: ldloc.s 31
-			IL_0bcb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0bd0: pop
-			IL_0bd1: leave IL_0bd6
+			IL_0c7f: ldloc.s 24
+			IL_0c81: stloc.s 25
+			IL_0c83: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c88: stloc.s 28
+			IL_0c8a: ldloc.s 25
+			IL_0c8c: stloc.s 27
+			IL_0c8e: ldstr "TypeError"
+			IL_0c93: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0c98: stloc.s 36
+			IL_0c9a: ldloc.s 27
+			IL_0c9c: ldloc.s 36
+			IL_0c9e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0ca3: stloc.s 30
+			IL_0ca5: ldloc.s 30
+			IL_0ca7: box [System.Runtime]System.Boolean
+			IL_0cac: stloc.s 31
+			IL_0cae: ldloc.s 28
+			IL_0cb0: ldloc.s 31
+			IL_0cb2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0cb7: pop
+			IL_0cb8: leave IL_0cbd
 		} // end handler
 
-		IL_0bd6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0bdb: stloc.s 28
-		IL_0bdd: ldstr "AbortController"
-		IL_0be2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0be7: volatile.
-		IL_0be9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0bee: brfalse IL_0c02
-
-		IL_0bf3: ldstr "prototype"
-		IL_0bf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0bfd: br IL_0c16
-
-		IL_0c02: ldstr "prototype"
-		IL_0c07: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:334"
-		IL_0c0c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0c11: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0c16: stloc.s 36
-		IL_0c18: volatile.
-		IL_0c1a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0c1f: brfalse IL_0c35
-
-		IL_0c24: ldloc.s 36
-		IL_0c26: ldstr "abort"
-		IL_0c2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c30: br IL_0c4b
-
-		IL_0c35: ldloc.s 36
-		IL_0c37: ldstr "abort"
-		IL_0c3c: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:336"
-		IL_0c41: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0c46: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0c4b: stloc.s 36
-		IL_0c4d: volatile.
-		IL_0c4f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0c54: brfalse IL_0c6a
-
-		IL_0c59: ldloc.s 36
-		IL_0c5b: ldstr "length"
-		IL_0c60: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c65: br IL_0c80
-
-		IL_0c6a: ldloc.s 36
-		IL_0c6c: ldstr "length"
-		IL_0c71: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:338"
-		IL_0c76: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0c7b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0c80: stloc.s 36
-		IL_0c82: ldloc.s 28
-		IL_0c84: ldloc.s 36
-		IL_0c86: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0c8b: pop
-		IL_0c8c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0c91: stloc.s 28
-		IL_0c93: ldstr "AbortSignal"
-		IL_0c98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0c9d: volatile.
-		IL_0c9f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_0ca4: brfalse IL_0cb8
-
-		IL_0ca9: ldstr "prototype"
-		IL_0cae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0cb3: br IL_0ccc
-
-		IL_0cb8: ldstr "prototype"
-		IL_0cbd: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:345"
-		IL_0cc2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_0cc7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0ccc: stloc.s 36
+		IL_0cbd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0cc2: stloc.s 28
+		IL_0cc4: ldstr "AbortController"
+		IL_0cc9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0cce: volatile.
-		IL_0cd0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_0cd5: brfalse IL_0ceb
+		IL_0cd0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_0cd5: brfalse IL_0ce9
 
-		IL_0cda: ldloc.s 36
-		IL_0cdc: ldstr "addEventListener"
-		IL_0ce1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ce6: br IL_0d01
+		IL_0cda: ldstr "prototype"
+		IL_0cdf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ce4: br IL_0cfd
 
-		IL_0ceb: ldloc.s 36
-		IL_0ced: ldstr "addEventListener"
-		IL_0cf2: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:347"
-		IL_0cf7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_0cfc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ce9: ldstr "prototype"
+		IL_0cee: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:334"
+		IL_0cf3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_0cf8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0d01: stloc.s 36
-		IL_0d03: volatile.
-		IL_0d05: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_0d0a: brfalse IL_0d20
+		IL_0cfd: stloc.s 36
+		IL_0cff: volatile.
+		IL_0d01: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0d06: brfalse IL_0d1c
 
-		IL_0d0f: ldloc.s 36
-		IL_0d11: ldstr "length"
-		IL_0d16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0d1b: br IL_0d36
+		IL_0d0b: ldloc.s 36
+		IL_0d0d: ldstr "abort"
+		IL_0d12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d17: br IL_0d32
 
-		IL_0d20: ldloc.s 36
-		IL_0d22: ldstr "length"
-		IL_0d27: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:349"
-		IL_0d2c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_0d31: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0d1c: ldloc.s 36
+		IL_0d1e: ldstr "abort"
+		IL_0d23: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:336"
+		IL_0d28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0d2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0d36: stloc.s 36
-		IL_0d38: ldloc.s 28
-		IL_0d3a: ldloc.s 36
-		IL_0d3c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0d41: pop
-		IL_0d42: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0d47: stloc.s 28
-		IL_0d49: ldstr "AbortSignal"
-		IL_0d4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0d53: volatile.
-		IL_0d55: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_0d5a: brfalse IL_0d6e
+		IL_0d32: stloc.s 36
+		IL_0d34: volatile.
+		IL_0d36: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_0d3b: brfalse IL_0d51
 
-		IL_0d5f: ldstr "prototype"
-		IL_0d64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0d69: br IL_0d82
+		IL_0d40: ldloc.s 36
+		IL_0d42: ldstr "length"
+		IL_0d47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d4c: br IL_0d67
 
-		IL_0d6e: ldstr "prototype"
-		IL_0d73: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:356"
-		IL_0d78: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_0d7d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0d51: ldloc.s 36
+		IL_0d53: ldstr "length"
+		IL_0d58: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:338"
+		IL_0d5d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_0d62: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0d82: stloc.s 36
+		IL_0d67: stloc.s 36
+		IL_0d69: ldloc.s 28
+		IL_0d6b: ldloc.s 36
+		IL_0d6d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0d72: pop
+		IL_0d73: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0d78: stloc.s 28
+		IL_0d7a: ldstr "AbortSignal"
+		IL_0d7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0d84: volatile.
-		IL_0d86: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_0d8b: brfalse IL_0da1
+		IL_0d86: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_0d8b: brfalse IL_0d9f
 
-		IL_0d90: ldloc.s 36
-		IL_0d92: ldstr "removeEventListener"
-		IL_0d97: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0d9c: br IL_0db7
+		IL_0d90: ldstr "prototype"
+		IL_0d95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d9a: br IL_0db3
 
-		IL_0da1: ldloc.s 36
-		IL_0da3: ldstr "removeEventListener"
-		IL_0da8: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:358"
-		IL_0dad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_0db2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0d9f: ldstr "prototype"
+		IL_0da4: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:345"
+		IL_0da9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_0dae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0db7: stloc.s 36
-		IL_0db9: volatile.
-		IL_0dbb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-		IL_0dc0: brfalse IL_0dd6
+		IL_0db3: stloc.s 36
+		IL_0db5: volatile.
+		IL_0db7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_0dbc: brfalse IL_0dd2
 
-		IL_0dc5: ldloc.s 36
-		IL_0dc7: ldstr "length"
-		IL_0dcc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0dd1: br IL_0dec
+		IL_0dc1: ldloc.s 36
+		IL_0dc3: ldstr "addEventListener"
+		IL_0dc8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0dcd: br IL_0de8
 
-		IL_0dd6: ldloc.s 36
-		IL_0dd8: ldstr "length"
-		IL_0ddd: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:360"
-		IL_0de2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-		IL_0de7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0dd2: ldloc.s 36
+		IL_0dd4: ldstr "addEventListener"
+		IL_0dd9: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:347"
+		IL_0dde: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_0de3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0dec: stloc.s 36
-		IL_0dee: ldloc.s 28
-		IL_0df0: ldloc.s 36
-		IL_0df2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0df7: pop
-		IL_0df8: ldnull
-		IL_0df9: stloc.s 26
-		IL_0dfb: ret
+		IL_0de8: stloc.s 36
+		IL_0dea: volatile.
+		IL_0dec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_0df1: brfalse IL_0e07
+
+		IL_0df6: ldloc.s 36
+		IL_0df8: ldstr "length"
+		IL_0dfd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0e02: br IL_0e1d
+
+		IL_0e07: ldloc.s 36
+		IL_0e09: ldstr "length"
+		IL_0e0e: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:349"
+		IL_0e13: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_0e18: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0e1d: stloc.s 36
+		IL_0e1f: ldloc.s 28
+		IL_0e21: ldloc.s 36
+		IL_0e23: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0e28: pop
+		IL_0e29: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0e2e: stloc.s 28
+		IL_0e30: ldstr "AbortSignal"
+		IL_0e35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0e3a: volatile.
+		IL_0e3c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+		IL_0e41: brfalse IL_0e55
+
+		IL_0e46: ldstr "prototype"
+		IL_0e4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0e50: br IL_0e69
+
+		IL_0e55: ldstr "prototype"
+		IL_0e5a: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:356"
+		IL_0e5f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+		IL_0e64: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0e69: stloc.s 36
+		IL_0e6b: volatile.
+		IL_0e6d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+		IL_0e72: brfalse IL_0e88
+
+		IL_0e77: ldloc.s 36
+		IL_0e79: ldstr "removeEventListener"
+		IL_0e7e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0e83: br IL_0e9e
+
+		IL_0e88: ldloc.s 36
+		IL_0e8a: ldstr "removeEventListener"
+		IL_0e8f: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:358"
+		IL_0e94: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+		IL_0e99: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0e9e: stloc.s 36
+		IL_0ea0: volatile.
+		IL_0ea2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+		IL_0ea7: brfalse IL_0ebd
+
+		IL_0eac: ldloc.s 36
+		IL_0eae: ldstr "length"
+		IL_0eb3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0eb8: br IL_0ed3
+
+		IL_0ebd: ldloc.s 36
+		IL_0ebf: ldstr "length"
+		IL_0ec4: ldstr "Abort_ExplicitReceiverAbi:Modules.Abort_ExplicitReceiverAbi:__js_module_init__:360"
+		IL_0ec9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+		IL_0ece: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0ed3: stloc.s 36
+		IL_0ed5: ldloc.s 28
+		IL_0ed7: ldloc.s 36
+		IL_0ed9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0ede: pop
+		IL_0edf: ldnull
+		IL_0ee0: stloc.s 26
+		IL_0ee2: ret
 	} // end of method Abort_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.Abort_ExplicitReceiverAbi
@@ -2022,6 +2094,12 @@
 	.field assembly static int32 __jroc_dynamicLookup_39
 	.field assembly static int32 __jroc_dynamicLookup_40
 	.field assembly static int32 __jroc_dynamicLookup_41
+	.field assembly static int32 __jroc_dynamicLookup_42
+	.field assembly static int32 __jroc_dynamicLookup_43
+	.field assembly static int32 __jroc_dynamicLookup_44
+	.field assembly static int32 __jroc_dynamicLookup_45
+	.field assembly static int32 __jroc_dynamicLookup_46
+	.field assembly static int32 __jroc_dynamicLookup_47
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Concat_SymbolIsConcatSpreadable.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Concat_SymbolIsConcatSpreadable.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 908 (0x38c)
+		// Code size: 992 (0x3e0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Concat_SymbolIsConcatSpreadable/Scope,
@@ -297,103 +297,127 @@
 		IL_0235: ldc.r8 2
 		IL_023e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0248: ldstr "join"
-		IL_024d: ldstr ","
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0257: stloc.s 9
-		IL_0259: ldloc.s 11
-		IL_025b: ldloc.s 9
-		IL_025d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0262: pop
-		IL_0263: ldc.i4.1
-		IL_0264: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0269: dup
-		IL_026a: ldc.r8 1
-		IL_0273: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0278: stloc.s 10
-		IL_027a: ldloc.s 10
-		IL_027c: ldc.i4.1
-		IL_027d: newarr [System.Runtime]System.Object
-		IL_0282: dup
-		IL_0283: ldc.i4.0
-		IL_0284: ldloc.3
-		IL_0285: stelem.ref
-		IL_0286: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
-		IL_028b: stloc.s 7
-		IL_028d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0292: stloc.s 11
-		IL_0294: ldloc.s 7
-		IL_0296: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_029b: box [System.Runtime]System.Double
-		IL_02a0: stloc.s 12
-		IL_02a2: ldloc.s 11
-		IL_02a4: ldloc.s 12
-		IL_02a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ab: pop
-		IL_02ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b1: stloc.s 11
-		IL_02b3: ldloc.s 7
-		IL_02b5: ldc.r8 1
-		IL_02be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_02c3: ldc.r8 0.0
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02d1: stloc.s 9
-		IL_02d3: ldloc.s 11
-		IL_02d5: ldloc.s 9
-		IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02dc: pop
-		IL_02dd: ldc.i4.1
-		IL_02de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02e3: dup
-		IL_02e4: ldc.r8 1
-		IL_02ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02f2: stloc.s 10
-		IL_02f4: ldloc.s 10
-		IL_02f6: ldc.i4.1
-		IL_02f7: newarr [System.Runtime]System.Object
-		IL_02fc: dup
-		IL_02fd: ldc.i4.0
-		IL_02fe: ldloc.s 4
-		IL_0300: stelem.ref
-		IL_0301: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
-		IL_0306: stloc.s 8
-		IL_0308: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_030d: stloc.s 11
-		IL_030f: ldloc.s 8
-		IL_0311: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0316: box [System.Runtime]System.Double
-		IL_031b: stloc.s 12
-		IL_031d: ldloc.s 11
-		IL_031f: ldloc.s 12
-		IL_0321: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0326: pop
-		IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_032c: stloc.s 11
-		IL_032e: ldloc.s 8
-		IL_0330: ldc.r8 1
-		IL_0339: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_033e: call bool [JavaScriptRuntime]JavaScriptRuntime.Array::isArray(object)
-		IL_0343: box [System.Runtime]System.Boolean
-		IL_0348: stloc.s 14
-		IL_034a: ldloc.s 11
-		IL_034c: ldloc.s 14
-		IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0353: pop
-		IL_0354: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0359: stloc.s 11
-		IL_035b: ldloc.s 8
-		IL_035d: ldc.r8 1
-		IL_0366: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0370: ldstr "join"
-		IL_0375: ldstr ","
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_037f: stloc.s 9
-		IL_0381: ldloc.s 11
-		IL_0383: ldloc.s 9
-		IL_0385: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_038a: pop
-		IL_038b: ret
+		IL_0248: volatile.
+		IL_024a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_024f: brfalse IL_0268
+
+		IL_0254: ldstr "join"
+		IL_0259: ldstr ","
+		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0263: br IL_0281
+
+		IL_0268: ldstr "join"
+		IL_026d: ldstr ","
+		IL_0272: ldstr "Array_Concat_SymbolIsConcatSpreadable:Modules.Array_Concat_SymbolIsConcatSpreadable:__js_module_init__:88"
+		IL_0277: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0281: stloc.s 9
+		IL_0283: ldloc.s 11
+		IL_0285: ldloc.s 9
+		IL_0287: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_028c: pop
+		IL_028d: ldc.i4.1
+		IL_028e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0293: dup
+		IL_0294: ldc.r8 1
+		IL_029d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02a2: stloc.s 10
+		IL_02a4: ldloc.s 10
+		IL_02a6: ldc.i4.1
+		IL_02a7: newarr [System.Runtime]System.Object
+		IL_02ac: dup
+		IL_02ad: ldc.i4.0
+		IL_02ae: ldloc.3
+		IL_02af: stelem.ref
+		IL_02b0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
+		IL_02b5: stloc.s 7
+		IL_02b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02bc: stloc.s 11
+		IL_02be: ldloc.s 7
+		IL_02c0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_02c5: box [System.Runtime]System.Double
+		IL_02ca: stloc.s 12
+		IL_02cc: ldloc.s 11
+		IL_02ce: ldloc.s 12
+		IL_02d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d5: pop
+		IL_02d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02db: stloc.s 11
+		IL_02dd: ldloc.s 7
+		IL_02df: ldc.r8 1
+		IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_02ed: ldc.r8 0.0
+		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02fb: stloc.s 9
+		IL_02fd: ldloc.s 11
+		IL_02ff: ldloc.s 9
+		IL_0301: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0306: pop
+		IL_0307: ldc.i4.1
+		IL_0308: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_030d: dup
+		IL_030e: ldc.r8 1
+		IL_0317: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_031c: stloc.s 10
+		IL_031e: ldloc.s 10
+		IL_0320: ldc.i4.1
+		IL_0321: newarr [System.Runtime]System.Object
+		IL_0326: dup
+		IL_0327: ldc.i4.0
+		IL_0328: ldloc.s 4
+		IL_032a: stelem.ref
+		IL_032b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
+		IL_0330: stloc.s 8
+		IL_0332: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0337: stloc.s 11
+		IL_0339: ldloc.s 8
+		IL_033b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0340: box [System.Runtime]System.Double
+		IL_0345: stloc.s 12
+		IL_0347: ldloc.s 11
+		IL_0349: ldloc.s 12
+		IL_034b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0350: pop
+		IL_0351: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0356: stloc.s 11
+		IL_0358: ldloc.s 8
+		IL_035a: ldc.r8 1
+		IL_0363: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0368: call bool [JavaScriptRuntime]JavaScriptRuntime.Array::isArray(object)
+		IL_036d: box [System.Runtime]System.Boolean
+		IL_0372: stloc.s 14
+		IL_0374: ldloc.s 11
+		IL_0376: ldloc.s 14
+		IL_0378: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_037d: pop
+		IL_037e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0383: stloc.s 11
+		IL_0385: ldloc.s 8
+		IL_0387: ldc.r8 1
+		IL_0390: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_039a: volatile.
+		IL_039c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_03a1: brfalse IL_03ba
+
+		IL_03a6: ldstr "join"
+		IL_03ab: ldstr ","
+		IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03b5: br IL_03d3
+
+		IL_03ba: ldstr "join"
+		IL_03bf: ldstr ","
+		IL_03c4: ldstr "Array_Concat_SymbolIsConcatSpreadable:Modules.Array_Concat_SymbolIsConcatSpreadable:__js_module_init__:130"
+		IL_03c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03d3: stloc.s 9
+		IL_03d5: ldloc.s 11
+		IL_03d7: ldloc.s 9
+		IL_03d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03de: pop
+		IL_03df: ret
 	} // end of method Array_Concat_SymbolIsConcatSpreadable::__js_module_init__
 
 } // end of class Modules.Array_Concat_SymbolIsConcatSpreadable
@@ -418,4 +442,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
@@ -1238,7 +1238,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 5377 (0x1501)
+		// Code size: 5419 (0x152b)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Array_Exotic_Property_Descriptors/Scope,
@@ -1397,199 +1397,192 @@
 		IL_00e7: ldloc.2
 		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f2: ldstr "join"
-		IL_00f7: ldstr ","
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0101: stloc.s 69
-		IL_0103: ldloc.s 65
-		IL_0105: ldloc.s 66
-		IL_0107: ldloc.s 68
-		IL_0109: ldloc.s 69
-		IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0110: pop
-		IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0116: stloc.s 65
-		IL_0118: volatile.
-		IL_011a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_011f: brfalse IL_0134
+		IL_00f2: volatile.
+		IL_00f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00f9: brfalse IL_0112
 
-		IL_0124: ldloc.3
-		IL_0125: ldstr "value"
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012f: br IL_0149
+		IL_00fe: ldstr "join"
+		IL_0103: ldstr ","
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010d: br IL_012b
 
-		IL_0134: ldloc.3
-		IL_0135: ldstr "value"
-		IL_013a: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:40"
-		IL_013f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0112: ldstr "join"
+		IL_0117: ldstr ","
+		IL_011c: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:35"
+		IL_0121: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0149: stloc.s 69
-		IL_014b: volatile.
-		IL_014d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0152: brfalse IL_0167
+		IL_012b: stloc.s 69
+		IL_012d: ldloc.s 65
+		IL_012f: ldloc.s 66
+		IL_0131: ldloc.s 68
+		IL_0133: ldloc.s 69
+		IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_013a: pop
+		IL_013b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0140: stloc.s 65
+		IL_0142: volatile.
+		IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0149: brfalse IL_015e
 
-		IL_0157: ldloc.3
-		IL_0158: ldstr "writable"
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0162: br IL_017c
+		IL_014e: ldloc.3
+		IL_014f: ldstr "value"
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0159: br IL_0173
 
-		IL_0167: ldloc.3
-		IL_0168: ldstr "writable"
-		IL_016d: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:42"
-		IL_0172: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_015e: ldloc.3
+		IL_015f: ldstr "value"
+		IL_0164: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:40"
+		IL_0169: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_017c: stloc.s 66
-		IL_017e: volatile.
-		IL_0180: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0185: brfalse IL_019a
+		IL_0173: stloc.s 69
+		IL_0175: volatile.
+		IL_0177: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_017c: brfalse IL_0191
 
-		IL_018a: ldloc.3
-		IL_018b: ldstr "enumerable"
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0195: br IL_01af
+		IL_0181: ldloc.3
+		IL_0182: ldstr "writable"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018c: br IL_01a6
 
-		IL_019a: ldloc.3
-		IL_019b: ldstr "enumerable"
-		IL_01a0: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:44"
-		IL_01a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0191: ldloc.3
+		IL_0192: ldstr "writable"
+		IL_0197: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:42"
+		IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01af: stloc.s 70
-		IL_01b1: volatile.
-		IL_01b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_01b8: brfalse IL_01cd
+		IL_01a6: stloc.s 66
+		IL_01a8: volatile.
+		IL_01aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_01af: brfalse IL_01c4
 
-		IL_01bd: ldloc.3
-		IL_01be: ldstr "configurable"
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c8: br IL_01e2
+		IL_01b4: ldloc.3
+		IL_01b5: ldstr "enumerable"
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01bf: br IL_01d9
 
-		IL_01cd: ldloc.3
-		IL_01ce: ldstr "configurable"
-		IL_01d3: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:46"
-		IL_01d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01c4: ldloc.3
+		IL_01c5: ldstr "enumerable"
+		IL_01ca: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:44"
+		IL_01cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01e2: stloc.s 71
-		IL_01e4: ldloc.s 65
-		IL_01e6: ldc.i4.4
-		IL_01e7: newarr [System.Runtime]System.Object
-		IL_01ec: dup
-		IL_01ed: ldc.i4.0
-		IL_01ee: ldloc.s 69
-		IL_01f0: stelem.ref
-		IL_01f1: dup
-		IL_01f2: ldc.i4.1
-		IL_01f3: ldloc.s 66
-		IL_01f5: stelem.ref
-		IL_01f6: dup
-		IL_01f7: ldc.i4.2
-		IL_01f8: ldloc.s 70
-		IL_01fa: stelem.ref
-		IL_01fb: dup
-		IL_01fc: ldc.i4.3
-		IL_01fd: ldloc.s 71
-		IL_01ff: stelem.ref
-		IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0205: pop
+		IL_01d9: stloc.s 70
+		IL_01db: volatile.
+		IL_01dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_01e2: brfalse IL_01f7
+
+		IL_01e7: ldloc.3
+		IL_01e8: ldstr "configurable"
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f2: br IL_020c
+
+		IL_01f7: ldloc.3
+		IL_01f8: ldstr "configurable"
+		IL_01fd: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:46"
+		IL_0202: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_020c: stloc.s 71
+		IL_020e: ldloc.s 65
+		IL_0210: ldc.i4.4
+		IL_0211: newarr [System.Runtime]System.Object
+		IL_0216: dup
+		IL_0217: ldc.i4.0
+		IL_0218: ldloc.s 69
+		IL_021a: stelem.ref
+		IL_021b: dup
+		IL_021c: ldc.i4.1
+		IL_021d: ldloc.s 66
+		IL_021f: stelem.ref
+		IL_0220: dup
+		IL_0221: ldc.i4.2
+		IL_0222: ldloc.s 70
+		IL_0224: stelem.ref
+		IL_0225: dup
+		IL_0226: ldc.i4.3
+		IL_0227: ldloc.s 71
+		IL_0229: stelem.ref
+		IL_022a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_022f: pop
 		.try
 		{
-			IL_0206: nop
-			IL_0207: ldloc.2
-			IL_0208: ldc.r8 1
-			IL_0211: ldc.r8 99
-			IL_021a: ldc.i4.1
-			IL_021b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_0220: leave IL_02a2
+			IL_0230: nop
+			IL_0231: ldloc.2
+			IL_0232: ldc.r8 1
+			IL_023b: ldc.r8 99
+			IL_0244: ldc.i4.1
+			IL_0245: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_024a: leave IL_02cc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0225: stloc.s 4
-			IL_0227: ldloc.s 4
-			IL_0229: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_022e: dup
-			IL_022f: brtrue IL_0245
+			IL_024f: stloc.s 4
+			IL_0251: ldloc.s 4
+			IL_0253: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0258: dup
+			IL_0259: brtrue IL_026f
 
-			IL_0234: pop
-			IL_0235: ldloc.s 4
-			IL_0237: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_023c: dup
-			IL_023d: brtrue IL_0251
+			IL_025e: pop
+			IL_025f: ldloc.s 4
+			IL_0261: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0266: dup
+			IL_0267: brtrue IL_027b
 
-			IL_0242: pop
-			IL_0243: rethrow
+			IL_026c: pop
+			IL_026d: rethrow
 
-			IL_0245: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_024a: stloc.s 5
-			IL_024c: br IL_0253
+			IL_026f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0274: stloc.s 5
+			IL_0276: br IL_027d
 
-			IL_0251: stloc.s 5
+			IL_027b: stloc.s 5
 
-			IL_0253: ldloc.s 5
-			IL_0255: stloc.s 6
-			IL_0257: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_025c: stloc.s 65
-			IL_025e: volatile.
-			IL_0260: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_0265: brfalse IL_027b
+			IL_027d: ldloc.s 5
+			IL_027f: stloc.s 6
+			IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0286: stloc.s 65
+			IL_0288: volatile.
+			IL_028a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_028f: brfalse IL_02a5
 
-			IL_026a: ldloc.s 6
-			IL_026c: ldstr "name"
-			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0276: br IL_0291
+			IL_0294: ldloc.s 6
+			IL_0296: ldstr "name"
+			IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a0: br IL_02bb
 
-			IL_027b: ldloc.s 6
-			IL_027d: ldstr "name"
-			IL_0282: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:65"
-			IL_0287: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02a5: ldloc.s 6
+			IL_02a7: ldstr "name"
+			IL_02ac: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:65"
+			IL_02b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0291: stloc.s 71
-			IL_0293: ldloc.s 65
-			IL_0295: ldloc.s 71
-			IL_0297: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_029c: pop
-			IL_029d: leave IL_02a2
+			IL_02bb: stloc.s 71
+			IL_02bd: ldloc.s 65
+			IL_02bf: ldloc.s 71
+			IL_02c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02c6: pop
+			IL_02c7: leave IL_02cc
 		} // end handler
 
-		IL_02a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02a7: stloc.s 65
-		IL_02a9: ldloc.2
-		IL_02aa: ldc.r8 1
-		IL_02b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_02b8: stloc.s 71
-		IL_02ba: ldloc.s 65
-		IL_02bc: ldloc.s 71
-		IL_02be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c3: pop
-		IL_02c4: ldloc.0
-		IL_02c5: ldc.r8 4
-		IL_02ce: box [System.Runtime]System.Double
-		IL_02d3: stfld object Modules.Array_Exotic_Property_Descriptors/Scope::accessorValue
-		IL_02d8: ldc.i4.0
-		IL_02d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02de: stloc.s 7
-		IL_02e0: ldc.i4.1
-		IL_02e1: newarr [System.Runtime]System.Object
-		IL_02e6: dup
-		IL_02e7: ldc.i4.0
-		IL_02e8: ldloc.0
-		IL_02e9: stelem.ref
-		IL_02ea: stloc.s 64
-		IL_02ec: ldloc.s 64
-		IL_02ee: ldc.i4.0
-		IL_02ef: ldelem.ref
-		IL_02f0: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_02f5: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
-		IL_02fa: ldc.i4.0
-		IL_02fb: conv.r8
-		IL_02fc: ldstr ""
-		IL_0301: ldc.i4.0
-		IL_0302: ldc.i4.1
-		IL_0303: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0308: stloc.s 72
+		IL_02cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d1: stloc.s 65
+		IL_02d3: ldloc.2
+		IL_02d4: ldc.r8 1
+		IL_02dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_02e2: stloc.s 71
+		IL_02e4: ldloc.s 65
+		IL_02e6: ldloc.s 71
+		IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ed: pop
+		IL_02ee: ldloc.0
+		IL_02ef: ldc.r8 4
+		IL_02f8: box [System.Runtime]System.Double
+		IL_02fd: stfld object Modules.Array_Exotic_Property_Descriptors/Scope::accessorValue
+		IL_0302: ldc.i4.0
+		IL_0303: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0308: stloc.s 7
 		IL_030a: ldc.i4.1
 		IL_030b: newarr [System.Runtime]System.Object
 		IL_0310: dup
@@ -1601,1533 +1594,1552 @@
 		IL_0318: ldc.i4.0
 		IL_0319: ldelem.ref
 		IL_031a: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_031f: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
-		IL_0324: ldc.i4.1
+		IL_031f: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
+		IL_0324: ldc.i4.0
 		IL_0325: conv.r8
 		IL_0326: ldstr ""
 		IL_032b: ldc.i4.0
 		IL_032c: ldc.i4.1
-		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0332: stloc.s 73
-		IL_0334: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0339: dup
-		IL_033a: ldstr "get"
-		IL_033f: ldloc.s 72
-		IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0346: dup
-		IL_0347: ldstr "set"
-		IL_034c: ldloc.s 73
-		IL_034e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0353: dup
-		IL_0354: ldstr "enumerable"
-		IL_0359: ldc.i4.1
-		IL_035a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_035f: dup
-		IL_0360: ldstr "configurable"
-		IL_0365: ldc.i4.1
-		IL_0366: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_036b: stloc.s 74
-		IL_036d: ldloc.s 7
-		IL_036f: ldstr "2"
-		IL_0374: ldloc.s 74
-		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_037b: pop
-		IL_037c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0381: stloc.s 65
-		IL_0383: ldloc.s 7
-		IL_0385: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_038a: box [System.Runtime]System.Double
-		IL_038f: stloc.s 75
-		IL_0391: ldloc.s 7
-		IL_0393: ldc.r8 2
-		IL_039c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_03a1: stloc.s 71
-		IL_03a3: ldc.r8 2
-		IL_03ac: box [System.Runtime]System.Double
-		IL_03b1: ldloc.s 7
-		IL_03b3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_03b8: stloc.s 67
-		IL_03ba: ldloc.s 67
-		IL_03bc: box [System.Runtime]System.Boolean
-		IL_03c1: stloc.s 68
-		IL_03c3: ldloc.s 65
-		IL_03c5: ldloc.s 75
-		IL_03c7: ldloc.s 71
-		IL_03c9: ldloc.s 68
-		IL_03cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_03d0: pop
-		IL_03d1: ldloc.s 7
-		IL_03d3: ldc.r8 2
-		IL_03dc: ldc.r8 7
-		IL_03e5: ldc.i4.1
-		IL_03e6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_03eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03f0: stloc.s 65
-		IL_03f2: ldloc.0
-		IL_03f3: ldfld object Modules.Array_Exotic_Property_Descriptors/Scope::accessorValue
-		IL_03f8: stloc.s 71
-		IL_03fa: ldloc.s 7
-		IL_03fc: ldc.r8 2
-		IL_0405: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_040a: stloc.s 70
-		IL_040c: ldloc.s 65
-		IL_040e: ldloc.s 71
-		IL_0410: ldloc.s 70
-		IL_0412: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0417: pop
-		IL_0418: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_041d: stloc.s 65
-		IL_041f: ldloc.s 7
-		IL_0421: ldc.r8 2
-		IL_042a: box [System.Runtime]System.Double
-		IL_042f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
-		IL_0434: stloc.s 67
-		IL_0436: ldloc.s 67
-		IL_0438: box [System.Runtime]System.Boolean
-		IL_043d: stloc.s 68
-		IL_043f: ldloc.s 7
-		IL_0441: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0446: box [System.Runtime]System.Double
-		IL_044b: stloc.s 75
-		IL_044d: ldc.r8 2
-		IL_0456: box [System.Runtime]System.Double
-		IL_045b: ldloc.s 7
-		IL_045d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0462: stloc.s 67
-		IL_0464: ldloc.s 67
-		IL_0466: box [System.Runtime]System.Boolean
-		IL_046b: stloc.s 76
-		IL_046d: ldloc.s 65
-		IL_046f: ldloc.s 68
-		IL_0471: ldloc.s 75
-		IL_0473: ldloc.s 76
-		IL_0475: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_047a: pop
-		IL_047b: ldc.i4.4
-		IL_047c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0481: dup
-		IL_0482: ldc.r8 0.0
-		IL_048b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0490: dup
-		IL_0491: ldc.r8 1
-		IL_049a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_049f: dup
-		IL_04a0: ldc.r8 2
-		IL_04a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_04ae: dup
-		IL_04af: ldc.r8 3
-		IL_04b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_04bd: stloc.s 8
-		IL_04bf: ldloc.s 8
-		IL_04c1: ldstr "2"
-		IL_04c6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04cb: dup
-		IL_04cc: ldstr "configurable"
-		IL_04d1: ldc.i4.0
-		IL_04d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_04d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_04dc: pop
+		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0332: stloc.s 72
+		IL_0334: ldc.i4.1
+		IL_0335: newarr [System.Runtime]System.Object
+		IL_033a: dup
+		IL_033b: ldc.i4.0
+		IL_033c: ldloc.0
+		IL_033d: stelem.ref
+		IL_033e: stloc.s 64
+		IL_0340: ldloc.s 64
+		IL_0342: ldc.i4.0
+		IL_0343: ldelem.ref
+		IL_0344: castclass Modules.Array_Exotic_Property_Descriptors/Scope
+		IL_0349: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
+		IL_034e: ldc.i4.1
+		IL_034f: conv.r8
+		IL_0350: ldstr ""
+		IL_0355: ldc.i4.0
+		IL_0356: ldc.i4.1
+		IL_0357: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_035c: stloc.s 73
+		IL_035e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0363: dup
+		IL_0364: ldstr "get"
+		IL_0369: ldloc.s 72
+		IL_036b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0370: dup
+		IL_0371: ldstr "set"
+		IL_0376: ldloc.s 73
+		IL_0378: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_037d: dup
+		IL_037e: ldstr "enumerable"
+		IL_0383: ldc.i4.1
+		IL_0384: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0389: dup
+		IL_038a: ldstr "configurable"
+		IL_038f: ldc.i4.1
+		IL_0390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0395: stloc.s 74
+		IL_0397: ldloc.s 7
+		IL_0399: ldstr "2"
+		IL_039e: ldloc.s 74
+		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_03a5: pop
+		IL_03a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03ab: stloc.s 65
+		IL_03ad: ldloc.s 7
+		IL_03af: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_03b4: box [System.Runtime]System.Double
+		IL_03b9: stloc.s 75
+		IL_03bb: ldloc.s 7
+		IL_03bd: ldc.r8 2
+		IL_03c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_03cb: stloc.s 71
+		IL_03cd: ldc.r8 2
+		IL_03d6: box [System.Runtime]System.Double
+		IL_03db: ldloc.s 7
+		IL_03dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_03e2: stloc.s 67
+		IL_03e4: ldloc.s 67
+		IL_03e6: box [System.Runtime]System.Boolean
+		IL_03eb: stloc.s 68
+		IL_03ed: ldloc.s 65
+		IL_03ef: ldloc.s 75
+		IL_03f1: ldloc.s 71
+		IL_03f3: ldloc.s 68
+		IL_03f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_03fa: pop
+		IL_03fb: ldloc.s 7
+		IL_03fd: ldc.r8 2
+		IL_0406: ldc.r8 7
+		IL_040f: ldc.i4.1
+		IL_0410: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0415: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_041a: stloc.s 65
+		IL_041c: ldloc.0
+		IL_041d: ldfld object Modules.Array_Exotic_Property_Descriptors/Scope::accessorValue
+		IL_0422: stloc.s 71
+		IL_0424: ldloc.s 7
+		IL_0426: ldc.r8 2
+		IL_042f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0434: stloc.s 70
+		IL_0436: ldloc.s 65
+		IL_0438: ldloc.s 71
+		IL_043a: ldloc.s 70
+		IL_043c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0441: pop
+		IL_0442: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0447: stloc.s 65
+		IL_0449: ldloc.s 7
+		IL_044b: ldc.r8 2
+		IL_0454: box [System.Runtime]System.Double
+		IL_0459: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
+		IL_045e: stloc.s 67
+		IL_0460: ldloc.s 67
+		IL_0462: box [System.Runtime]System.Boolean
+		IL_0467: stloc.s 68
+		IL_0469: ldloc.s 7
+		IL_046b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0470: box [System.Runtime]System.Double
+		IL_0475: stloc.s 75
+		IL_0477: ldc.r8 2
+		IL_0480: box [System.Runtime]System.Double
+		IL_0485: ldloc.s 7
+		IL_0487: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_048c: stloc.s 67
+		IL_048e: ldloc.s 67
+		IL_0490: box [System.Runtime]System.Boolean
+		IL_0495: stloc.s 76
+		IL_0497: ldloc.s 65
+		IL_0499: ldloc.s 68
+		IL_049b: ldloc.s 75
+		IL_049d: ldloc.s 76
+		IL_049f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_04a4: pop
+		IL_04a5: ldc.i4.4
+		IL_04a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_04ab: dup
+		IL_04ac: ldc.r8 0.0
+		IL_04b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_04ba: dup
+		IL_04bb: ldc.r8 1
+		IL_04c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_04c9: dup
+		IL_04ca: ldc.r8 2
+		IL_04d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_04d8: dup
+		IL_04d9: ldc.r8 3
+		IL_04e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_04e7: stloc.s 8
+		IL_04e9: ldloc.s 8
+		IL_04eb: ldstr "2"
+		IL_04f0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04f5: dup
+		IL_04f6: ldstr "configurable"
+		IL_04fb: ldc.i4.0
+		IL_04fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0501: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0506: pop
 		.try
 		{
-			IL_04dd: nop
-			IL_04de: ldloc.s 8
-			IL_04e0: ldstr "length"
-			IL_04e5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04ea: dup
-			IL_04eb: ldstr "value"
-			IL_04f0: ldc.r8 1
-			IL_04f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_04fe: dup
-			IL_04ff: ldstr "writable"
-			IL_0504: ldc.i4.0
-			IL_0505: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_050a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_050f: pop
-			IL_0510: leave IL_0592
+			IL_0507: nop
+			IL_0508: ldloc.s 8
+			IL_050a: ldstr "length"
+			IL_050f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0514: dup
+			IL_0515: ldstr "value"
+			IL_051a: ldc.r8 1
+			IL_0523: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0528: dup
+			IL_0529: ldstr "writable"
+			IL_052e: ldc.i4.0
+			IL_052f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0539: pop
+			IL_053a: leave IL_05bc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0515: stloc.s 9
-			IL_0517: ldloc.s 9
-			IL_0519: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_051e: dup
-			IL_051f: brtrue IL_0535
+			IL_053f: stloc.s 9
+			IL_0541: ldloc.s 9
+			IL_0543: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0548: dup
+			IL_0549: brtrue IL_055f
 
-			IL_0524: pop
-			IL_0525: ldloc.s 9
-			IL_0527: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_052c: dup
-			IL_052d: brtrue IL_0541
+			IL_054e: pop
+			IL_054f: ldloc.s 9
+			IL_0551: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0556: dup
+			IL_0557: brtrue IL_056b
 
-			IL_0532: pop
-			IL_0533: rethrow
+			IL_055c: pop
+			IL_055d: rethrow
 
-			IL_0535: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_053a: stloc.s 10
-			IL_053c: br IL_0543
+			IL_055f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0564: stloc.s 10
+			IL_0566: br IL_056d
 
-			IL_0541: stloc.s 10
+			IL_056b: stloc.s 10
 
-			IL_0543: ldloc.s 10
-			IL_0545: stloc.s 11
-			IL_0547: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_054c: stloc.s 65
-			IL_054e: volatile.
-			IL_0550: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_0555: brfalse IL_056b
+			IL_056d: ldloc.s 10
+			IL_056f: stloc.s 11
+			IL_0571: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0576: stloc.s 65
+			IL_0578: volatile.
+			IL_057a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_057f: brfalse IL_0595
 
-			IL_055a: ldloc.s 11
-			IL_055c: ldstr "name"
-			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0566: br IL_0581
+			IL_0584: ldloc.s 11
+			IL_0586: ldstr "name"
+			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0590: br IL_05ab
 
-			IL_056b: ldloc.s 11
-			IL_056d: ldstr "name"
-			IL_0572: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:159"
-			IL_0577: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0595: ldloc.s 11
+			IL_0597: ldstr "name"
+			IL_059c: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:159"
+			IL_05a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0581: stloc.s 70
-			IL_0583: ldloc.s 65
-			IL_0585: ldloc.s 70
-			IL_0587: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_058c: pop
-			IL_058d: leave IL_0592
+			IL_05ab: stloc.s 70
+			IL_05ad: ldloc.s 65
+			IL_05af: ldloc.s 70
+			IL_05b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05b6: pop
+			IL_05b7: leave IL_05bc
 		} // end handler
 
-		IL_0592: ldloc.s 8
-		IL_0594: ldstr "length"
-		IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_059e: stloc.s 12
-		IL_05a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05a5: stloc.s 65
-		IL_05a7: ldloc.s 8
-		IL_05a9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_05ae: box [System.Runtime]System.Double
-		IL_05b3: stloc.s 75
-		IL_05b5: ldc.r8 2
-		IL_05be: box [System.Runtime]System.Double
-		IL_05c3: ldloc.s 8
-		IL_05c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05ca: stloc.s 67
-		IL_05cc: ldloc.s 67
-		IL_05ce: box [System.Runtime]System.Boolean
-		IL_05d3: stloc.s 76
-		IL_05d5: ldc.r8 3
-		IL_05de: box [System.Runtime]System.Double
-		IL_05e3: ldloc.s 8
-		IL_05e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05ea: stloc.s 67
-		IL_05ec: ldloc.s 67
-		IL_05ee: box [System.Runtime]System.Boolean
-		IL_05f3: stloc.s 68
-		IL_05f5: volatile.
-		IL_05f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_05fc: brfalse IL_0612
+		IL_05bc: ldloc.s 8
+		IL_05be: ldstr "length"
+		IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_05c8: stloc.s 12
+		IL_05ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05cf: stloc.s 65
+		IL_05d1: ldloc.s 8
+		IL_05d3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_05d8: box [System.Runtime]System.Double
+		IL_05dd: stloc.s 75
+		IL_05df: ldc.r8 2
+		IL_05e8: box [System.Runtime]System.Double
+		IL_05ed: ldloc.s 8
+		IL_05ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_05f4: stloc.s 67
+		IL_05f6: ldloc.s 67
+		IL_05f8: box [System.Runtime]System.Boolean
+		IL_05fd: stloc.s 76
+		IL_05ff: ldc.r8 3
+		IL_0608: box [System.Runtime]System.Double
+		IL_060d: ldloc.s 8
+		IL_060f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0614: stloc.s 67
+		IL_0616: ldloc.s 67
+		IL_0618: box [System.Runtime]System.Boolean
+		IL_061d: stloc.s 68
+		IL_061f: volatile.
+		IL_0621: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0626: brfalse IL_063c
 
-		IL_0601: ldloc.s 12
-		IL_0603: ldstr "writable"
-		IL_0608: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_060d: br IL_0628
+		IL_062b: ldloc.s 12
+		IL_062d: ldstr "writable"
+		IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0637: br IL_0652
 
-		IL_0612: ldloc.s 12
-		IL_0614: ldstr "writable"
-		IL_0619: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:182"
-		IL_061e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_063c: ldloc.s 12
+		IL_063e: ldstr "writable"
+		IL_0643: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:182"
+		IL_0648: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_064d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0628: stloc.s 70
-		IL_062a: ldloc.s 65
-		IL_062c: ldc.i4.4
-		IL_062d: newarr [System.Runtime]System.Object
-		IL_0632: dup
-		IL_0633: ldc.i4.0
-		IL_0634: ldloc.s 75
-		IL_0636: stelem.ref
-		IL_0637: dup
-		IL_0638: ldc.i4.1
-		IL_0639: ldloc.s 76
-		IL_063b: stelem.ref
-		IL_063c: dup
-		IL_063d: ldc.i4.2
-		IL_063e: ldloc.s 68
-		IL_0640: stelem.ref
-		IL_0641: dup
-		IL_0642: ldc.i4.3
-		IL_0643: ldloc.s 70
-		IL_0645: stelem.ref
-		IL_0646: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_064b: pop
-		IL_064c: ldc.i4.1
-		IL_064d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0652: dup
-		IL_0653: ldc.r8 1
-		IL_065c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0661: stloc.s 13
-		IL_0663: ldloc.s 13
-		IL_0665: ldstr "length"
-		IL_066a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_066f: dup
-		IL_0670: ldstr "writable"
-		IL_0675: ldc.i4.0
-		IL_0676: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0680: pop
+		IL_0652: stloc.s 70
+		IL_0654: ldloc.s 65
+		IL_0656: ldc.i4.4
+		IL_0657: newarr [System.Runtime]System.Object
+		IL_065c: dup
+		IL_065d: ldc.i4.0
+		IL_065e: ldloc.s 75
+		IL_0660: stelem.ref
+		IL_0661: dup
+		IL_0662: ldc.i4.1
+		IL_0663: ldloc.s 76
+		IL_0665: stelem.ref
+		IL_0666: dup
+		IL_0667: ldc.i4.2
+		IL_0668: ldloc.s 68
+		IL_066a: stelem.ref
+		IL_066b: dup
+		IL_066c: ldc.i4.3
+		IL_066d: ldloc.s 70
+		IL_066f: stelem.ref
+		IL_0670: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0675: pop
+		IL_0676: ldc.i4.1
+		IL_0677: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_067c: dup
+		IL_067d: ldc.r8 1
+		IL_0686: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_068b: stloc.s 13
+		IL_068d: ldloc.s 13
+		IL_068f: ldstr "length"
+		IL_0694: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0699: dup
+		IL_069a: ldstr "writable"
+		IL_069f: ldc.i4.0
+		IL_06a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_06a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_06aa: pop
 		.try
 		{
-			IL_0681: nop
-			IL_0682: ldloc.s 13
-			IL_0684: ldc.r8 1
-			IL_068d: ldc.r8 2
-			IL_0696: ldc.i4.1
-			IL_0697: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_069c: leave IL_071e
+			IL_06ab: nop
+			IL_06ac: ldloc.s 13
+			IL_06ae: ldc.r8 1
+			IL_06b7: ldc.r8 2
+			IL_06c0: ldc.i4.1
+			IL_06c1: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_06c6: leave IL_0748
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06a1: stloc.s 14
-			IL_06a3: ldloc.s 14
-			IL_06a5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_06aa: dup
-			IL_06ab: brtrue IL_06c1
+			IL_06cb: stloc.s 14
+			IL_06cd: ldloc.s 14
+			IL_06cf: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06d4: dup
+			IL_06d5: brtrue IL_06eb
 
-			IL_06b0: pop
-			IL_06b1: ldloc.s 14
-			IL_06b3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_06b8: dup
-			IL_06b9: brtrue IL_06cd
+			IL_06da: pop
+			IL_06db: ldloc.s 14
+			IL_06dd: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06e2: dup
+			IL_06e3: brtrue IL_06f7
 
-			IL_06be: pop
-			IL_06bf: rethrow
+			IL_06e8: pop
+			IL_06e9: rethrow
 
-			IL_06c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_06c6: stloc.s 15
-			IL_06c8: br IL_06cf
+			IL_06eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_06f0: stloc.s 15
+			IL_06f2: br IL_06f9
 
-			IL_06cd: stloc.s 15
+			IL_06f7: stloc.s 15
 
-			IL_06cf: ldloc.s 15
-			IL_06d1: stloc.s 16
-			IL_06d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06d8: stloc.s 65
-			IL_06da: volatile.
-			IL_06dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_06e1: brfalse IL_06f7
+			IL_06f9: ldloc.s 15
+			IL_06fb: stloc.s 16
+			IL_06fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0702: stloc.s 65
+			IL_0704: volatile.
+			IL_0706: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_070b: brfalse IL_0721
 
-			IL_06e6: ldloc.s 16
-			IL_06e8: ldstr "name"
-			IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06f2: br IL_070d
+			IL_0710: ldloc.s 16
+			IL_0712: ldstr "name"
+			IL_0717: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_071c: br IL_0737
 
-			IL_06f7: ldloc.s 16
-			IL_06f9: ldstr "name"
-			IL_06fe: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:210"
-			IL_0703: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0721: ldloc.s 16
+			IL_0723: ldstr "name"
+			IL_0728: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:210"
+			IL_072d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_070d: stloc.s 70
-			IL_070f: ldloc.s 65
-			IL_0711: ldloc.s 70
-			IL_0713: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0718: pop
-			IL_0719: leave IL_071e
+			IL_0737: stloc.s 70
+			IL_0739: ldloc.s 65
+			IL_073b: ldloc.s 70
+			IL_073d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0742: pop
+			IL_0743: leave IL_0748
 		} // end handler
 
-		IL_071e: ldloc.s 13
-		IL_0720: ldc.r8 0.0
-		IL_0729: ldc.r8 3
-		IL_0732: ldc.i4.1
-		IL_0733: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0738: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_073d: stloc.s 65
-		IL_073f: ldloc.s 13
-		IL_0741: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0746: box [System.Runtime]System.Double
-		IL_074b: stloc.s 75
-		IL_074d: ldloc.s 13
-		IL_074f: ldc.r8 0.0
-		IL_0758: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_075d: stloc.s 70
-		IL_075f: ldc.r8 1
-		IL_0768: box [System.Runtime]System.Double
-		IL_076d: ldloc.s 13
-		IL_076f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0774: stloc.s 67
-		IL_0776: ldloc.s 67
-		IL_0778: box [System.Runtime]System.Boolean
-		IL_077d: stloc.s 68
-		IL_077f: ldloc.s 65
-		IL_0781: ldloc.s 75
-		IL_0783: ldloc.s 70
-		IL_0785: ldloc.s 68
-		IL_0787: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_078c: pop
-		IL_078d: ldc.i4.0
-		IL_078e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0793: stloc.s 17
-		IL_0795: ldloc.s 17
-		IL_0797: ldstr "length"
-		IL_079c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_07a1: dup
-		IL_07a2: ldstr "writable"
-		IL_07a7: ldc.i4.0
-		IL_07a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_07ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_07b2: pop
-		IL_07b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07b8: stloc.s 65
-		IL_07ba: ldloc.s 17
-		IL_07bc: ldstr "0"
-		IL_07c1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_07c6: dup
-		IL_07c7: ldstr "value"
-		IL_07cc: ldc.r8 1
-		IL_07d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_07da: dup
-		IL_07db: ldstr "writable"
-		IL_07e0: ldc.i4.1
-		IL_07e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_07e6: dup
-		IL_07e7: ldstr "enumerable"
-		IL_07ec: ldc.i4.1
-		IL_07ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_07f2: dup
-		IL_07f3: ldstr "configurable"
-		IL_07f8: ldc.i4.1
-		IL_07f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_07fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Reflect::defineProperty(object, object, object)
-		IL_0803: box [System.Runtime]System.Boolean
-		IL_0808: stloc.s 68
-		IL_080a: ldloc.s 17
-		IL_080c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0811: box [System.Runtime]System.Double
-		IL_0816: stloc.s 75
-		IL_0818: ldc.r8 0.0
-		IL_0821: box [System.Runtime]System.Double
-		IL_0826: ldloc.s 17
-		IL_0828: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_082d: stloc.s 67
-		IL_082f: ldloc.s 67
-		IL_0831: box [System.Runtime]System.Boolean
-		IL_0836: stloc.s 76
-		IL_0838: ldloc.s 65
-		IL_083a: ldloc.s 68
-		IL_083c: ldloc.s 75
-		IL_083e: ldloc.s 76
-		IL_0840: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0845: pop
+		IL_0748: ldloc.s 13
+		IL_074a: ldc.r8 0.0
+		IL_0753: ldc.r8 3
+		IL_075c: ldc.i4.1
+		IL_075d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0762: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0767: stloc.s 65
+		IL_0769: ldloc.s 13
+		IL_076b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0770: box [System.Runtime]System.Double
+		IL_0775: stloc.s 75
+		IL_0777: ldloc.s 13
+		IL_0779: ldc.r8 0.0
+		IL_0782: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0787: stloc.s 70
+		IL_0789: ldc.r8 1
+		IL_0792: box [System.Runtime]System.Double
+		IL_0797: ldloc.s 13
+		IL_0799: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_079e: stloc.s 67
+		IL_07a0: ldloc.s 67
+		IL_07a2: box [System.Runtime]System.Boolean
+		IL_07a7: stloc.s 68
+		IL_07a9: ldloc.s 65
+		IL_07ab: ldloc.s 75
+		IL_07ad: ldloc.s 70
+		IL_07af: ldloc.s 68
+		IL_07b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_07b6: pop
+		IL_07b7: ldc.i4.0
+		IL_07b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_07bd: stloc.s 17
+		IL_07bf: ldloc.s 17
+		IL_07c1: ldstr "length"
+		IL_07c6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_07cb: dup
+		IL_07cc: ldstr "writable"
+		IL_07d1: ldc.i4.0
+		IL_07d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_07d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_07dc: pop
+		IL_07dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07e2: stloc.s 65
+		IL_07e4: ldloc.s 17
+		IL_07e6: ldstr "0"
+		IL_07eb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_07f0: dup
+		IL_07f1: ldstr "value"
+		IL_07f6: ldc.r8 1
+		IL_07ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0804: dup
+		IL_0805: ldstr "writable"
+		IL_080a: ldc.i4.1
+		IL_080b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0810: dup
+		IL_0811: ldstr "enumerable"
+		IL_0816: ldc.i4.1
+		IL_0817: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_081c: dup
+		IL_081d: ldstr "configurable"
+		IL_0822: ldc.i4.1
+		IL_0823: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0828: call bool [JavaScriptRuntime]JavaScriptRuntime.Reflect::defineProperty(object, object, object)
+		IL_082d: box [System.Runtime]System.Boolean
+		IL_0832: stloc.s 68
+		IL_0834: ldloc.s 17
+		IL_0836: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_083b: box [System.Runtime]System.Double
+		IL_0840: stloc.s 75
+		IL_0842: ldc.r8 0.0
+		IL_084b: box [System.Runtime]System.Double
+		IL_0850: ldloc.s 17
+		IL_0852: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0857: stloc.s 67
+		IL_0859: ldloc.s 67
+		IL_085b: box [System.Runtime]System.Boolean
+		IL_0860: stloc.s 76
+		IL_0862: ldloc.s 65
+		IL_0864: ldloc.s 68
+		IL_0866: ldloc.s 75
+		IL_0868: ldloc.s 76
+		IL_086a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_086f: pop
 		.try
 		{
-			IL_0846: nop
-			IL_0847: ldloc.s 17
-			IL_0849: ldstr "length"
-			IL_084e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0853: dup
-			IL_0854: ldstr "value"
-			IL_0859: ldc.r8 1.5
-			IL_0862: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0867: call bool [JavaScriptRuntime]JavaScriptRuntime.Reflect::defineProperty(object, object, object)
-			IL_086c: pop
-			IL_086d: leave IL_08ef
+			IL_0870: nop
+			IL_0871: ldloc.s 17
+			IL_0873: ldstr "length"
+			IL_0878: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_087d: dup
+			IL_087e: ldstr "value"
+			IL_0883: ldc.r8 1.5
+			IL_088c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0891: call bool [JavaScriptRuntime]JavaScriptRuntime.Reflect::defineProperty(object, object, object)
+			IL_0896: pop
+			IL_0897: leave IL_0919
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0872: stloc.s 18
-			IL_0874: ldloc.s 18
-			IL_0876: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_087b: dup
-			IL_087c: brtrue IL_0892
+			IL_089c: stloc.s 18
+			IL_089e: ldloc.s 18
+			IL_08a0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_08a5: dup
+			IL_08a6: brtrue IL_08bc
 
-			IL_0881: pop
-			IL_0882: ldloc.s 18
-			IL_0884: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0889: dup
-			IL_088a: brtrue IL_089e
+			IL_08ab: pop
+			IL_08ac: ldloc.s 18
+			IL_08ae: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_08b3: dup
+			IL_08b4: brtrue IL_08c8
 
-			IL_088f: pop
-			IL_0890: rethrow
+			IL_08b9: pop
+			IL_08ba: rethrow
 
-			IL_0892: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0897: stloc.s 19
-			IL_0899: br IL_08a0
+			IL_08bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_08c1: stloc.s 19
+			IL_08c3: br IL_08ca
 
-			IL_089e: stloc.s 19
+			IL_08c8: stloc.s 19
 
-			IL_08a0: ldloc.s 19
-			IL_08a2: stloc.s 20
-			IL_08a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08a9: stloc.s 65
-			IL_08ab: volatile.
-			IL_08ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_08b2: brfalse IL_08c8
+			IL_08ca: ldloc.s 19
+			IL_08cc: stloc.s 20
+			IL_08ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08d3: stloc.s 65
+			IL_08d5: volatile.
+			IL_08d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_08dc: brfalse IL_08f2
 
-			IL_08b7: ldloc.s 20
-			IL_08b9: ldstr "name"
-			IL_08be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08c3: br IL_08de
+			IL_08e1: ldloc.s 20
+			IL_08e3: ldstr "name"
+			IL_08e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08ed: br IL_0908
 
-			IL_08c8: ldloc.s 20
-			IL_08ca: ldstr "name"
-			IL_08cf: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:274"
-			IL_08d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_08d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_08f2: ldloc.s 20
+			IL_08f4: ldstr "name"
+			IL_08f9: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:274"
+			IL_08fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08de: stloc.s 70
-			IL_08e0: ldloc.s 65
-			IL_08e2: ldloc.s 70
-			IL_08e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08e9: pop
-			IL_08ea: leave IL_08ef
+			IL_0908: stloc.s 70
+			IL_090a: ldloc.s 65
+			IL_090c: ldloc.s 70
+			IL_090e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0913: pop
+			IL_0914: leave IL_0919
 		} // end handler
 
-		IL_08ef: ldc.i4.0
-		IL_08f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_08f5: stloc.s 21
-		IL_08f7: ldloc.s 21
-		IL_08f9: ldstr "4294967294"
-		IL_08fe: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0903: dup
-		IL_0904: ldstr "value"
-		IL_0909: ldstr "edge"
-		IL_090e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0913: dup
-		IL_0914: ldstr "writable"
-		IL_0919: ldc.i4.1
-		IL_091a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_091f: dup
-		IL_0920: ldstr "enumerable"
-		IL_0925: ldc.i4.1
-		IL_0926: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_092b: dup
-		IL_092c: ldstr "configurable"
-		IL_0931: ldc.i4.1
-		IL_0932: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0937: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_093c: pop
-		IL_093d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0942: stloc.s 65
-		IL_0944: ldloc.s 21
-		IL_0946: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_094b: box [System.Runtime]System.Double
-		IL_0950: stloc.s 75
-		IL_0952: ldloc.s 21
-		IL_0954: ldc.r8 4294967294
-		IL_095d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0962: castclass [System.Runtime]System.String
-		IL_0967: stloc.s 77
-		IL_0969: ldloc.s 65
-		IL_096b: ldloc.s 75
-		IL_096d: ldloc.s 77
-		IL_096f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0974: pop
-		IL_0975: ldloc.s 21
-		IL_0977: ldc.r8 4294967295
-		IL_0980: ldstr "named"
-		IL_0985: ldc.i4.1
-		IL_0986: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_098b: pop
-		IL_098c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0991: stloc.s 65
-		IL_0993: ldloc.s 21
-		IL_0995: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_099a: box [System.Runtime]System.Double
-		IL_099f: stloc.s 75
-		IL_09a1: ldloc.s 21
-		IL_09a3: ldc.r8 4294967295
-		IL_09ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_09b1: castclass [System.Runtime]System.String
-		IL_09b6: stloc.s 77
-		IL_09b8: ldloc.s 65
-		IL_09ba: ldloc.s 75
-		IL_09bc: ldloc.s 77
-		IL_09be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_09c3: pop
-		IL_09c4: ldc.i4.0
-		IL_09c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_09ca: stloc.s 22
-		IL_09cc: ldloc.s 22
-		IL_09ce: ldc.r8 2147483647
-		IL_09d7: ldstr "sparse"
-		IL_09dc: ldc.i4.1
-		IL_09dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_09e2: pop
-		IL_09e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09e8: stloc.s 65
-		IL_09ea: ldloc.s 22
-		IL_09ec: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_09f1: box [System.Runtime]System.Double
-		IL_09f6: stloc.s 75
-		IL_09f8: ldloc.s 22
-		IL_09fa: ldc.r8 2147483647
-		IL_0a03: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0a08: castclass [System.Runtime]System.String
-		IL_0a0d: stloc.s 77
-		IL_0a0f: ldc.r8 2147483647
-		IL_0a18: box [System.Runtime]System.Double
-		IL_0a1d: ldloc.s 22
-		IL_0a1f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0a24: stloc.s 67
-		IL_0a26: ldloc.s 67
-		IL_0a28: box [System.Runtime]System.Boolean
-		IL_0a2d: stloc.s 76
-		IL_0a2f: ldloc.s 65
-		IL_0a31: ldloc.s 75
-		IL_0a33: ldloc.s 77
-		IL_0a35: ldloc.s 76
-		IL_0a37: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0a3c: pop
-		IL_0a3d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0a42: stloc.s 65
-		IL_0a44: ldloc.s 22
-		IL_0a46: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
-		IL_0a4b: stloc.s 70
-		IL_0a4d: ldloc.s 22
-		IL_0a4f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0a54: box [System.Runtime]System.Double
-		IL_0a59: stloc.s 75
-		IL_0a5b: ldc.r8 2147483647
-		IL_0a64: box [System.Runtime]System.Double
-		IL_0a69: ldloc.s 22
-		IL_0a6b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0a70: stloc.s 67
-		IL_0a72: ldloc.s 67
-		IL_0a74: box [System.Runtime]System.Boolean
-		IL_0a79: stloc.s 76
-		IL_0a7b: ldloc.s 65
-		IL_0a7d: ldloc.s 70
-		IL_0a7f: ldloc.s 75
-		IL_0a81: ldloc.s 76
-		IL_0a83: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0a88: pop
-		IL_0a89: ldc.i4.0
-		IL_0a8a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0a8f: stloc.s 23
-		IL_0a91: ldloc.s 23
-		IL_0a93: ldc.r8 4294967295
-		IL_0a9c: ldc.i4.1
-		IL_0a9d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+		IL_0919: ldc.i4.0
+		IL_091a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_091f: stloc.s 21
+		IL_0921: ldloc.s 21
+		IL_0923: ldstr "4294967294"
+		IL_0928: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_092d: dup
+		IL_092e: ldstr "value"
+		IL_0933: ldstr "edge"
+		IL_0938: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_093d: dup
+		IL_093e: ldstr "writable"
+		IL_0943: ldc.i4.1
+		IL_0944: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0949: dup
+		IL_094a: ldstr "enumerable"
+		IL_094f: ldc.i4.1
+		IL_0950: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0955: dup
+		IL_0956: ldstr "configurable"
+		IL_095b: ldc.i4.1
+		IL_095c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0961: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0966: pop
+		IL_0967: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_096c: stloc.s 65
+		IL_096e: ldloc.s 21
+		IL_0970: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0975: box [System.Runtime]System.Double
+		IL_097a: stloc.s 75
+		IL_097c: ldloc.s 21
+		IL_097e: ldc.r8 4294967294
+		IL_0987: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_098c: castclass [System.Runtime]System.String
+		IL_0991: stloc.s 77
+		IL_0993: ldloc.s 65
+		IL_0995: ldloc.s 75
+		IL_0997: ldloc.s 77
+		IL_0999: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_099e: pop
+		IL_099f: ldloc.s 21
+		IL_09a1: ldc.r8 4294967295
+		IL_09aa: ldstr "named"
+		IL_09af: ldc.i4.1
+		IL_09b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_09b5: pop
+		IL_09b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_09bb: stloc.s 65
+		IL_09bd: ldloc.s 21
+		IL_09bf: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_09c4: box [System.Runtime]System.Double
+		IL_09c9: stloc.s 75
+		IL_09cb: ldloc.s 21
+		IL_09cd: ldc.r8 4294967295
+		IL_09d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_09db: castclass [System.Runtime]System.String
+		IL_09e0: stloc.s 77
+		IL_09e2: ldloc.s 65
+		IL_09e4: ldloc.s 75
+		IL_09e6: ldloc.s 77
+		IL_09e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_09ed: pop
+		IL_09ee: ldc.i4.0
+		IL_09ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_09f4: stloc.s 22
+		IL_09f6: ldloc.s 22
+		IL_09f8: ldc.r8 2147483647
+		IL_0a01: ldstr "sparse"
+		IL_0a06: ldc.i4.1
+		IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0a0c: pop
+		IL_0a0d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0a12: stloc.s 65
+		IL_0a14: ldloc.s 22
+		IL_0a16: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0a1b: box [System.Runtime]System.Double
+		IL_0a20: stloc.s 75
+		IL_0a22: ldloc.s 22
+		IL_0a24: ldc.r8 2147483647
+		IL_0a2d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0a32: castclass [System.Runtime]System.String
+		IL_0a37: stloc.s 77
+		IL_0a39: ldc.r8 2147483647
+		IL_0a42: box [System.Runtime]System.Double
+		IL_0a47: ldloc.s 22
+		IL_0a49: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0a4e: stloc.s 67
+		IL_0a50: ldloc.s 67
+		IL_0a52: box [System.Runtime]System.Boolean
+		IL_0a57: stloc.s 76
+		IL_0a59: ldloc.s 65
+		IL_0a5b: ldloc.s 75
+		IL_0a5d: ldloc.s 77
+		IL_0a5f: ldloc.s 76
+		IL_0a61: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0a66: pop
+		IL_0a67: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0a6c: stloc.s 65
+		IL_0a6e: ldloc.s 22
+		IL_0a70: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
+		IL_0a75: stloc.s 70
+		IL_0a77: ldloc.s 22
+		IL_0a79: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0a7e: box [System.Runtime]System.Double
+		IL_0a83: stloc.s 75
+		IL_0a85: ldc.r8 2147483647
+		IL_0a8e: box [System.Runtime]System.Double
+		IL_0a93: ldloc.s 22
+		IL_0a95: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0a9a: stloc.s 67
+		IL_0a9c: ldloc.s 67
+		IL_0a9e: box [System.Runtime]System.Boolean
+		IL_0aa3: stloc.s 76
+		IL_0aa5: ldloc.s 65
+		IL_0aa7: ldloc.s 70
+		IL_0aa9: ldloc.s 75
+		IL_0aab: ldloc.s 76
+		IL_0aad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0ab2: pop
+		IL_0ab3: ldc.i4.0
+		IL_0ab4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0ab9: stloc.s 23
+		IL_0abb: ldloc.s 23
+		IL_0abd: ldc.r8 4294967295
+		IL_0ac6: ldc.i4.1
+		IL_0ac7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
 		.try
 		{
-			IL_0aa2: nop
-			IL_0aa3: ldloc.s 23
-			IL_0aa5: ldstr "ordinary"
-			IL_0aaa: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0aaf: pop
-			IL_0ab0: leave IL_0b32
+			IL_0acc: nop
+			IL_0acd: ldloc.s 23
+			IL_0acf: ldstr "ordinary"
+			IL_0ad4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0ad9: pop
+			IL_0ada: leave IL_0b5c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0ab5: stloc.s 24
-			IL_0ab7: ldloc.s 24
-			IL_0ab9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0abe: dup
-			IL_0abf: brtrue IL_0ad5
+			IL_0adf: stloc.s 24
+			IL_0ae1: ldloc.s 24
+			IL_0ae3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0ae8: dup
+			IL_0ae9: brtrue IL_0aff
 
-			IL_0ac4: pop
-			IL_0ac5: ldloc.s 24
-			IL_0ac7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0acc: dup
-			IL_0acd: brtrue IL_0ae1
+			IL_0aee: pop
+			IL_0aef: ldloc.s 24
+			IL_0af1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0af6: dup
+			IL_0af7: brtrue IL_0b0b
 
-			IL_0ad2: pop
-			IL_0ad3: rethrow
+			IL_0afc: pop
+			IL_0afd: rethrow
 
-			IL_0ad5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0ada: stloc.s 25
-			IL_0adc: br IL_0ae3
+			IL_0aff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b04: stloc.s 25
+			IL_0b06: br IL_0b0d
 
-			IL_0ae1: stloc.s 25
+			IL_0b0b: stloc.s 25
 
-			IL_0ae3: ldloc.s 25
-			IL_0ae5: stloc.s 26
-			IL_0ae7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0aec: stloc.s 65
-			IL_0aee: volatile.
-			IL_0af0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0af5: brfalse IL_0b0b
+			IL_0b0d: ldloc.s 25
+			IL_0b0f: stloc.s 26
+			IL_0b11: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b16: stloc.s 65
+			IL_0b18: volatile.
+			IL_0b1a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0b1f: brfalse IL_0b35
 
-			IL_0afa: ldloc.s 26
-			IL_0afc: ldstr "name"
-			IL_0b01: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b06: br IL_0b21
+			IL_0b24: ldloc.s 26
+			IL_0b26: ldstr "name"
+			IL_0b2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b30: br IL_0b4b
 
-			IL_0b0b: ldloc.s 26
-			IL_0b0d: ldstr "name"
-			IL_0b12: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:360"
-			IL_0b17: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0b1c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0b35: ldloc.s 26
+			IL_0b37: ldstr "name"
+			IL_0b3c: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:360"
+			IL_0b41: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0b46: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0b21: stloc.s 70
-			IL_0b23: ldloc.s 65
-			IL_0b25: ldloc.s 70
-			IL_0b27: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b2c: pop
-			IL_0b2d: leave IL_0b32
+			IL_0b4b: stloc.s 70
+			IL_0b4d: ldloc.s 65
+			IL_0b4f: ldloc.s 70
+			IL_0b51: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b56: pop
+			IL_0b57: leave IL_0b5c
 		} // end handler
 
-		IL_0b32: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b37: stloc.s 65
-		IL_0b39: ldloc.s 23
-		IL_0b3b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0b40: box [System.Runtime]System.Double
-		IL_0b45: stloc.s 75
-		IL_0b47: ldloc.s 23
-		IL_0b49: ldc.r8 4294967295
-		IL_0b52: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0b57: stloc.s 70
-		IL_0b59: ldloc.s 65
-		IL_0b5b: ldloc.s 75
-		IL_0b5d: ldloc.s 70
-		IL_0b5f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0b64: pop
-		IL_0b65: ldc.i4.1
-		IL_0b66: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0b6b: dup
-		IL_0b6c: ldc.r8 1
-		IL_0b75: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0b7a: stloc.s 27
-		IL_0b7c: ldloc.s 27
-		IL_0b7e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_0b83: pop
-		IL_0b84: ldloc.s 27
-		IL_0b86: ldc.r8 0.0
-		IL_0b8f: ldc.r8 2
-		IL_0b98: ldc.i4.1
-		IL_0b99: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0b5c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b61: stloc.s 65
+		IL_0b63: ldloc.s 23
+		IL_0b65: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0b6a: box [System.Runtime]System.Double
+		IL_0b6f: stloc.s 75
+		IL_0b71: ldloc.s 23
+		IL_0b73: ldc.r8 4294967295
+		IL_0b7c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0b81: stloc.s 70
+		IL_0b83: ldloc.s 65
+		IL_0b85: ldloc.s 75
+		IL_0b87: ldloc.s 70
+		IL_0b89: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0b8e: pop
+		IL_0b8f: ldc.i4.1
+		IL_0b90: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0b95: dup
+		IL_0b96: ldc.r8 1
+		IL_0b9f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0ba4: stloc.s 27
+		IL_0ba6: ldloc.s 27
+		IL_0ba8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0bad: pop
+		IL_0bae: ldloc.s 27
+		IL_0bb0: ldc.r8 0.0
+		IL_0bb9: ldc.r8 2
+		IL_0bc2: ldc.i4.1
+		IL_0bc3: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
 		.try
 		{
-			IL_0b9e: nop
-			IL_0b9f: ldloc.s 27
-			IL_0ba1: ldc.r8 1
-			IL_0baa: ldc.r8 3
-			IL_0bb3: ldc.i4.1
-			IL_0bb4: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_0bb9: leave IL_0c3b
+			IL_0bc8: nop
+			IL_0bc9: ldloc.s 27
+			IL_0bcb: ldc.r8 1
+			IL_0bd4: ldc.r8 3
+			IL_0bdd: ldc.i4.1
+			IL_0bde: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_0be3: leave IL_0c65
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0bbe: stloc.s 28
-			IL_0bc0: ldloc.s 28
-			IL_0bc2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0bc7: dup
-			IL_0bc8: brtrue IL_0bde
+			IL_0be8: stloc.s 28
+			IL_0bea: ldloc.s 28
+			IL_0bec: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0bf1: dup
+			IL_0bf2: brtrue IL_0c08
 
-			IL_0bcd: pop
-			IL_0bce: ldloc.s 28
-			IL_0bd0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0bd5: dup
-			IL_0bd6: brtrue IL_0bea
+			IL_0bf7: pop
+			IL_0bf8: ldloc.s 28
+			IL_0bfa: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0bff: dup
+			IL_0c00: brtrue IL_0c14
 
-			IL_0bdb: pop
-			IL_0bdc: rethrow
+			IL_0c05: pop
+			IL_0c06: rethrow
 
-			IL_0bde: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0be3: stloc.s 29
-			IL_0be5: br IL_0bec
+			IL_0c08: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0c0d: stloc.s 29
+			IL_0c0f: br IL_0c16
 
-			IL_0bea: stloc.s 29
+			IL_0c14: stloc.s 29
 
-			IL_0bec: ldloc.s 29
-			IL_0bee: stloc.s 30
-			IL_0bf0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0bf5: stloc.s 65
-			IL_0bf7: volatile.
-			IL_0bf9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0bfe: brfalse IL_0c14
+			IL_0c16: ldloc.s 29
+			IL_0c18: stloc.s 30
+			IL_0c1a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c1f: stloc.s 65
+			IL_0c21: volatile.
+			IL_0c23: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0c28: brfalse IL_0c3e
 
-			IL_0c03: ldloc.s 30
-			IL_0c05: ldstr "name"
-			IL_0c0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c0f: br IL_0c2a
+			IL_0c2d: ldloc.s 30
+			IL_0c2f: ldstr "name"
+			IL_0c34: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c39: br IL_0c54
 
-			IL_0c14: ldloc.s 30
-			IL_0c16: ldstr "name"
-			IL_0c1b: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:400"
-			IL_0c20: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0c25: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0c3e: ldloc.s 30
+			IL_0c40: ldstr "name"
+			IL_0c45: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:400"
+			IL_0c4a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0c4f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0c2a: stloc.s 70
-			IL_0c2c: ldloc.s 65
-			IL_0c2e: ldloc.s 70
-			IL_0c30: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0c35: pop
-			IL_0c36: leave IL_0c3b
+			IL_0c54: stloc.s 70
+			IL_0c56: ldloc.s 65
+			IL_0c58: ldloc.s 70
+			IL_0c5a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c5f: pop
+			IL_0c60: leave IL_0c65
 		} // end handler
 
-		IL_0c3b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0c40: stloc.s 65
-		IL_0c42: ldloc.s 27
-		IL_0c44: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0c49: box [System.Runtime]System.Double
-		IL_0c4e: stloc.s 75
-		IL_0c50: ldloc.s 27
-		IL_0c52: ldc.r8 0.0
-		IL_0c5b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0c60: stloc.s 70
-		IL_0c62: ldc.r8 1
-		IL_0c6b: box [System.Runtime]System.Double
-		IL_0c70: ldloc.s 27
-		IL_0c72: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0c77: stloc.s 67
-		IL_0c79: ldloc.s 67
-		IL_0c7b: box [System.Runtime]System.Boolean
-		IL_0c80: stloc.s 76
-		IL_0c82: ldloc.s 65
-		IL_0c84: ldloc.s 75
-		IL_0c86: ldloc.s 70
-		IL_0c88: ldloc.s 76
-		IL_0c8a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0c8f: pop
-		IL_0c90: ldc.i4.3
-		IL_0c91: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0c96: dup
-		IL_0c97: ldc.r8 1
-		IL_0ca0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0ca5: dup
-		IL_0ca6: ldc.r8 2
-		IL_0caf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0cb4: dup
-		IL_0cb5: ldc.r8 3
-		IL_0cbe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0cc3: stloc.s 31
-		IL_0cc5: ldloc.s 31
-		IL_0cc7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::seal(object)
-		IL_0ccc: pop
+		IL_0c65: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0c6a: stloc.s 65
+		IL_0c6c: ldloc.s 27
+		IL_0c6e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0c73: box [System.Runtime]System.Double
+		IL_0c78: stloc.s 75
+		IL_0c7a: ldloc.s 27
+		IL_0c7c: ldc.r8 0.0
+		IL_0c85: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0c8a: stloc.s 70
+		IL_0c8c: ldc.r8 1
+		IL_0c95: box [System.Runtime]System.Double
+		IL_0c9a: ldloc.s 27
+		IL_0c9c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0ca1: stloc.s 67
+		IL_0ca3: ldloc.s 67
+		IL_0ca5: box [System.Runtime]System.Boolean
+		IL_0caa: stloc.s 76
+		IL_0cac: ldloc.s 65
+		IL_0cae: ldloc.s 75
+		IL_0cb0: ldloc.s 70
+		IL_0cb2: ldloc.s 76
+		IL_0cb4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0cb9: pop
+		IL_0cba: ldc.i4.3
+		IL_0cbb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0cc0: dup
+		IL_0cc1: ldc.r8 1
+		IL_0cca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0ccf: dup
+		IL_0cd0: ldc.r8 2
+		IL_0cd9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0cde: dup
+		IL_0cdf: ldc.r8 3
+		IL_0ce8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0ced: stloc.s 31
+		IL_0cef: ldloc.s 31
+		IL_0cf1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::seal(object)
+		IL_0cf6: pop
 		.try
 		{
-			IL_0ccd: nop
-			IL_0cce: ldloc.s 31
-			IL_0cd0: ldc.r8 1
-			IL_0cd9: ldc.i4.1
-			IL_0cda: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-			IL_0cdf: leave IL_0d61
+			IL_0cf7: nop
+			IL_0cf8: ldloc.s 31
+			IL_0cfa: ldc.r8 1
+			IL_0d03: ldc.i4.1
+			IL_0d04: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+			IL_0d09: leave IL_0d8b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0ce4: stloc.s 32
-			IL_0ce6: ldloc.s 32
-			IL_0ce8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0ced: dup
-			IL_0cee: brtrue IL_0d04
+			IL_0d0e: stloc.s 32
+			IL_0d10: ldloc.s 32
+			IL_0d12: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0d17: dup
+			IL_0d18: brtrue IL_0d2e
 
-			IL_0cf3: pop
-			IL_0cf4: ldloc.s 32
-			IL_0cf6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0cfb: dup
-			IL_0cfc: brtrue IL_0d10
+			IL_0d1d: pop
+			IL_0d1e: ldloc.s 32
+			IL_0d20: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0d25: dup
+			IL_0d26: brtrue IL_0d3a
 
-			IL_0d01: pop
-			IL_0d02: rethrow
+			IL_0d2b: pop
+			IL_0d2c: rethrow
 
-			IL_0d04: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0d09: stloc.s 33
-			IL_0d0b: br IL_0d12
+			IL_0d2e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0d33: stloc.s 33
+			IL_0d35: br IL_0d3c
 
-			IL_0d10: stloc.s 33
+			IL_0d3a: stloc.s 33
 
-			IL_0d12: ldloc.s 33
-			IL_0d14: stloc.s 34
-			IL_0d16: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0d1b: stloc.s 65
-			IL_0d1d: volatile.
-			IL_0d1f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0d24: brfalse IL_0d3a
+			IL_0d3c: ldloc.s 33
+			IL_0d3e: stloc.s 34
+			IL_0d40: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0d45: stloc.s 65
+			IL_0d47: volatile.
+			IL_0d49: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0d4e: brfalse IL_0d64
 
-			IL_0d29: ldloc.s 34
-			IL_0d2b: ldstr "name"
-			IL_0d30: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d35: br IL_0d50
+			IL_0d53: ldloc.s 34
+			IL_0d55: ldstr "name"
+			IL_0d5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d5f: br IL_0d7a
 
-			IL_0d3a: ldloc.s 34
-			IL_0d3c: ldstr "name"
-			IL_0d41: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:442"
-			IL_0d46: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0d4b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0d64: ldloc.s 34
+			IL_0d66: ldstr "name"
+			IL_0d6b: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:442"
+			IL_0d70: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0d75: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0d50: stloc.s 70
-			IL_0d52: ldloc.s 65
-			IL_0d54: ldloc.s 70
-			IL_0d56: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0d5b: pop
-			IL_0d5c: leave IL_0d61
+			IL_0d7a: stloc.s 70
+			IL_0d7c: ldloc.s 65
+			IL_0d7e: ldloc.s 70
+			IL_0d80: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0d85: pop
+			IL_0d86: leave IL_0d8b
 		} // end handler
 
-		IL_0d61: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0d66: stloc.s 65
-		IL_0d68: ldloc.s 31
-		IL_0d6a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
-		IL_0d6f: box [System.Runtime]System.Boolean
-		IL_0d74: stloc.s 76
-		IL_0d76: ldloc.s 31
-		IL_0d78: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0d7d: box [System.Runtime]System.Double
-		IL_0d82: stloc.s 75
-		IL_0d84: ldc.r8 2
-		IL_0d8d: box [System.Runtime]System.Double
+		IL_0d8b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0d90: stloc.s 65
 		IL_0d92: ldloc.s 31
-		IL_0d94: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_0d99: stloc.s 67
-		IL_0d9b: ldloc.s 67
-		IL_0d9d: box [System.Runtime]System.Boolean
-		IL_0da2: stloc.s 68
-		IL_0da4: ldloc.s 65
-		IL_0da6: ldloc.s 76
-		IL_0da8: ldloc.s 75
-		IL_0daa: ldloc.s 68
-		IL_0dac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0db1: pop
-		IL_0db2: ldc.i4.1
-		IL_0db3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0db8: dup
-		IL_0db9: ldc.r8 5
-		IL_0dc2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0dc7: stloc.s 35
-		IL_0dc9: ldloc.s 35
-		IL_0dcb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_0dd0: pop
+		IL_0d94: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
+		IL_0d99: box [System.Runtime]System.Boolean
+		IL_0d9e: stloc.s 76
+		IL_0da0: ldloc.s 31
+		IL_0da2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0da7: box [System.Runtime]System.Double
+		IL_0dac: stloc.s 75
+		IL_0dae: ldc.r8 2
+		IL_0db7: box [System.Runtime]System.Double
+		IL_0dbc: ldloc.s 31
+		IL_0dbe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0dc3: stloc.s 67
+		IL_0dc5: ldloc.s 67
+		IL_0dc7: box [System.Runtime]System.Boolean
+		IL_0dcc: stloc.s 68
+		IL_0dce: ldloc.s 65
+		IL_0dd0: ldloc.s 76
+		IL_0dd2: ldloc.s 75
+		IL_0dd4: ldloc.s 68
+		IL_0dd6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0ddb: pop
+		IL_0ddc: ldc.i4.1
+		IL_0ddd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0de2: dup
+		IL_0de3: ldc.r8 5
+		IL_0dec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0df1: stloc.s 35
+		IL_0df3: ldloc.s 35
+		IL_0df5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_0dfa: pop
 		.try
 		{
-			IL_0dd1: nop
-			IL_0dd2: ldloc.s 35
-			IL_0dd4: ldc.r8 0.0
-			IL_0ddd: ldc.r8 6
-			IL_0de6: ldc.i4.1
-			IL_0de7: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_0dec: leave IL_0e6e
+			IL_0dfb: nop
+			IL_0dfc: ldloc.s 35
+			IL_0dfe: ldc.r8 0.0
+			IL_0e07: ldc.r8 6
+			IL_0e10: ldc.i4.1
+			IL_0e11: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_0e16: leave IL_0e98
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0df1: stloc.s 36
-			IL_0df3: ldloc.s 36
-			IL_0df5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0dfa: dup
-			IL_0dfb: brtrue IL_0e11
+			IL_0e1b: stloc.s 36
+			IL_0e1d: ldloc.s 36
+			IL_0e1f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0e24: dup
+			IL_0e25: brtrue IL_0e3b
 
-			IL_0e00: pop
-			IL_0e01: ldloc.s 36
-			IL_0e03: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0e08: dup
-			IL_0e09: brtrue IL_0e1d
+			IL_0e2a: pop
+			IL_0e2b: ldloc.s 36
+			IL_0e2d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0e32: dup
+			IL_0e33: brtrue IL_0e47
 
-			IL_0e0e: pop
-			IL_0e0f: rethrow
+			IL_0e38: pop
+			IL_0e39: rethrow
 
-			IL_0e11: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0e16: stloc.s 37
-			IL_0e18: br IL_0e1f
+			IL_0e3b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0e40: stloc.s 37
+			IL_0e42: br IL_0e49
 
-			IL_0e1d: stloc.s 37
+			IL_0e47: stloc.s 37
 
-			IL_0e1f: ldloc.s 37
-			IL_0e21: stloc.s 38
-			IL_0e23: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0e28: stloc.s 65
-			IL_0e2a: volatile.
-			IL_0e2c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_0e31: brfalse IL_0e47
+			IL_0e49: ldloc.s 37
+			IL_0e4b: stloc.s 38
+			IL_0e4d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0e52: stloc.s 65
+			IL_0e54: volatile.
+			IL_0e56: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0e5b: brfalse IL_0e71
 
-			IL_0e36: ldloc.s 38
-			IL_0e38: ldstr "name"
-			IL_0e3d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e42: br IL_0e5d
+			IL_0e60: ldloc.s 38
+			IL_0e62: ldstr "name"
+			IL_0e67: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e6c: br IL_0e87
 
-			IL_0e47: ldloc.s 38
-			IL_0e49: ldstr "name"
-			IL_0e4e: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:482"
-			IL_0e53: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_0e58: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0e71: ldloc.s 38
+			IL_0e73: ldstr "name"
+			IL_0e78: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:482"
+			IL_0e7d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0e82: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e5d: stloc.s 70
-			IL_0e5f: ldloc.s 65
-			IL_0e61: ldloc.s 70
-			IL_0e63: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0e68: pop
-			IL_0e69: leave IL_0e6e
+			IL_0e87: stloc.s 70
+			IL_0e89: ldloc.s 65
+			IL_0e8b: ldloc.s 70
+			IL_0e8d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0e92: pop
+			IL_0e93: leave IL_0e98
 		} // end handler
 		.try
 		{
-			IL_0e6e: nop
-			IL_0e6f: ldloc.s 35
-			IL_0e71: ldc.r8 0.0
-			IL_0e7a: ldc.i4.1
-			IL_0e7b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-			IL_0e80: leave IL_0f02
+			IL_0e98: nop
+			IL_0e99: ldloc.s 35
+			IL_0e9b: ldc.r8 0.0
+			IL_0ea4: ldc.i4.1
+			IL_0ea5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+			IL_0eaa: leave IL_0f2c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0e85: stloc.s 39
-			IL_0e87: ldloc.s 39
-			IL_0e89: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0e8e: dup
-			IL_0e8f: brtrue IL_0ea5
+			IL_0eaf: stloc.s 39
+			IL_0eb1: ldloc.s 39
+			IL_0eb3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0eb8: dup
+			IL_0eb9: brtrue IL_0ecf
 
-			IL_0e94: pop
-			IL_0e95: ldloc.s 39
-			IL_0e97: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0e9c: dup
-			IL_0e9d: brtrue IL_0eb1
+			IL_0ebe: pop
+			IL_0ebf: ldloc.s 39
+			IL_0ec1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0ec6: dup
+			IL_0ec7: brtrue IL_0edb
 
-			IL_0ea2: pop
-			IL_0ea3: rethrow
+			IL_0ecc: pop
+			IL_0ecd: rethrow
 
-			IL_0ea5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0eaa: stloc.s 40
-			IL_0eac: br IL_0eb3
+			IL_0ecf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0ed4: stloc.s 40
+			IL_0ed6: br IL_0edd
 
-			IL_0eb1: stloc.s 40
+			IL_0edb: stloc.s 40
 
-			IL_0eb3: ldloc.s 40
-			IL_0eb5: stloc.s 41
-			IL_0eb7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0ebc: stloc.s 65
-			IL_0ebe: volatile.
-			IL_0ec0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0ec5: brfalse IL_0edb
+			IL_0edd: ldloc.s 40
+			IL_0edf: stloc.s 41
+			IL_0ee1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0ee6: stloc.s 65
+			IL_0ee8: volatile.
+			IL_0eea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0eef: brfalse IL_0f05
 
-			IL_0eca: ldloc.s 41
-			IL_0ecc: ldstr "name"
-			IL_0ed1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ed6: br IL_0ef1
+			IL_0ef4: ldloc.s 41
+			IL_0ef6: ldstr "name"
+			IL_0efb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f00: br IL_0f1b
 
-			IL_0edb: ldloc.s 41
-			IL_0edd: ldstr "name"
-			IL_0ee2: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:505"
-			IL_0ee7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0eec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0f05: ldloc.s 41
+			IL_0f07: ldstr "name"
+			IL_0f0c: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:505"
+			IL_0f11: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0f16: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0ef1: stloc.s 70
-			IL_0ef3: ldloc.s 65
-			IL_0ef5: ldloc.s 70
-			IL_0ef7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0efc: pop
-			IL_0efd: leave IL_0f02
+			IL_0f1b: stloc.s 70
+			IL_0f1d: ldloc.s 65
+			IL_0f1f: ldloc.s 70
+			IL_0f21: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0f26: pop
+			IL_0f27: leave IL_0f2c
 		} // end handler
 		.try
 		{
-			IL_0f02: nop
-			IL_0f03: ldloc.s 35
-			IL_0f05: ldc.r8 7
-			IL_0f0e: box [System.Runtime]System.Double
-			IL_0f13: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0f18: pop
-			IL_0f19: leave IL_0f9b
+			IL_0f2c: nop
+			IL_0f2d: ldloc.s 35
+			IL_0f2f: ldc.r8 7
+			IL_0f38: box [System.Runtime]System.Double
+			IL_0f3d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0f42: pop
+			IL_0f43: leave IL_0fc5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0f1e: stloc.s 42
-			IL_0f20: ldloc.s 42
-			IL_0f22: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0f27: dup
-			IL_0f28: brtrue IL_0f3e
+			IL_0f48: stloc.s 42
+			IL_0f4a: ldloc.s 42
+			IL_0f4c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0f51: dup
+			IL_0f52: brtrue IL_0f68
 
-			IL_0f2d: pop
-			IL_0f2e: ldloc.s 42
-			IL_0f30: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0f35: dup
-			IL_0f36: brtrue IL_0f4a
+			IL_0f57: pop
+			IL_0f58: ldloc.s 42
+			IL_0f5a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0f5f: dup
+			IL_0f60: brtrue IL_0f74
 
-			IL_0f3b: pop
-			IL_0f3c: rethrow
+			IL_0f65: pop
+			IL_0f66: rethrow
 
-			IL_0f3e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0f43: stloc.s 43
-			IL_0f45: br IL_0f4c
+			IL_0f68: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0f6d: stloc.s 43
+			IL_0f6f: br IL_0f76
 
-			IL_0f4a: stloc.s 43
+			IL_0f74: stloc.s 43
 
-			IL_0f4c: ldloc.s 43
-			IL_0f4e: stloc.s 44
-			IL_0f50: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0f55: stloc.s 65
-			IL_0f57: volatile.
-			IL_0f59: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_0f5e: brfalse IL_0f74
+			IL_0f76: ldloc.s 43
+			IL_0f78: stloc.s 44
+			IL_0f7a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0f7f: stloc.s 65
+			IL_0f81: volatile.
+			IL_0f83: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0f88: brfalse IL_0f9e
 
-			IL_0f63: ldloc.s 44
-			IL_0f65: ldstr "name"
-			IL_0f6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f6f: br IL_0f8a
+			IL_0f8d: ldloc.s 44
+			IL_0f8f: ldstr "name"
+			IL_0f94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f99: br IL_0fb4
 
-			IL_0f74: ldloc.s 44
-			IL_0f76: ldstr "name"
-			IL_0f7b: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:528"
-			IL_0f80: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_0f85: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0f9e: ldloc.s 44
+			IL_0fa0: ldstr "name"
+			IL_0fa5: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:528"
+			IL_0faa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0faf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f8a: stloc.s 70
-			IL_0f8c: ldloc.s 65
-			IL_0f8e: ldloc.s 70
-			IL_0f90: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0f95: pop
-			IL_0f96: leave IL_0f9b
+			IL_0fb4: stloc.s 70
+			IL_0fb6: ldloc.s 65
+			IL_0fb8: ldloc.s 70
+			IL_0fba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0fbf: pop
+			IL_0fc0: leave IL_0fc5
 		} // end handler
 		.try
 		{
-			IL_0f9b: nop
-			IL_0f9c: ldloc.s 35
-			IL_0f9e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
-			IL_0fa3: pop
-			IL_0fa4: leave IL_1026
+			IL_0fc5: nop
+			IL_0fc6: ldloc.s 35
+			IL_0fc8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::'pop'()
+			IL_0fcd: pop
+			IL_0fce: leave IL_1050
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0fa9: stloc.s 45
-			IL_0fab: ldloc.s 45
-			IL_0fad: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0fb2: dup
-			IL_0fb3: brtrue IL_0fc9
+			IL_0fd3: stloc.s 45
+			IL_0fd5: ldloc.s 45
+			IL_0fd7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0fdc: dup
+			IL_0fdd: brtrue IL_0ff3
 
-			IL_0fb8: pop
-			IL_0fb9: ldloc.s 45
-			IL_0fbb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0fc0: dup
-			IL_0fc1: brtrue IL_0fd5
+			IL_0fe2: pop
+			IL_0fe3: ldloc.s 45
+			IL_0fe5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0fea: dup
+			IL_0feb: brtrue IL_0fff
 
-			IL_0fc6: pop
-			IL_0fc7: rethrow
+			IL_0ff0: pop
+			IL_0ff1: rethrow
 
-			IL_0fc9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0fce: stloc.s 46
-			IL_0fd0: br IL_0fd7
+			IL_0ff3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0ff8: stloc.s 46
+			IL_0ffa: br IL_1001
 
-			IL_0fd5: stloc.s 46
+			IL_0fff: stloc.s 46
 
-			IL_0fd7: ldloc.s 46
-			IL_0fd9: stloc.s 47
-			IL_0fdb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0fe0: stloc.s 65
-			IL_0fe2: volatile.
-			IL_0fe4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_0fe9: brfalse IL_0fff
+			IL_1001: ldloc.s 46
+			IL_1003: stloc.s 47
+			IL_1005: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_100a: stloc.s 65
+			IL_100c: volatile.
+			IL_100e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_1013: brfalse IL_1029
 
-			IL_0fee: ldloc.s 47
-			IL_0ff0: ldstr "name"
-			IL_0ff5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ffa: br IL_1015
+			IL_1018: ldloc.s 47
+			IL_101a: ldstr "name"
+			IL_101f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1024: br IL_103f
 
-			IL_0fff: ldloc.s 47
-			IL_1001: ldstr "name"
-			IL_1006: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:549"
-			IL_100b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_1010: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1029: ldloc.s 47
+			IL_102b: ldstr "name"
+			IL_1030: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:549"
+			IL_1035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_103a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1015: stloc.s 70
-			IL_1017: ldloc.s 65
-			IL_1019: ldloc.s 70
-			IL_101b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1020: pop
-			IL_1021: leave IL_1026
+			IL_103f: stloc.s 70
+			IL_1041: ldloc.s 65
+			IL_1043: ldloc.s 70
+			IL_1045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_104a: pop
+			IL_104b: leave IL_1050
 		} // end handler
 
-		IL_1026: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_102b: stloc.s 65
-		IL_102d: ldloc.s 35
-		IL_102f: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_1034: box [System.Runtime]System.Boolean
-		IL_1039: stloc.s 68
-		IL_103b: ldloc.s 35
-		IL_103d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_1042: box [System.Runtime]System.Double
-		IL_1047: stloc.s 75
-		IL_1049: ldloc.s 35
-		IL_104b: ldc.r8 0.0
-		IL_1054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_1059: stloc.s 70
-		IL_105b: ldloc.s 65
-		IL_105d: ldloc.s 68
-		IL_105f: ldloc.s 75
-		IL_1061: ldloc.s 70
-		IL_1063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_1068: pop
-		IL_1069: ldc.i4.0
-		IL_106a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_106f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_1074: stloc.s 48
+		IL_1050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_1055: stloc.s 65
+		IL_1057: ldloc.s 35
+		IL_1059: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_105e: box [System.Runtime]System.Boolean
+		IL_1063: stloc.s 68
+		IL_1065: ldloc.s 35
+		IL_1067: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_106c: box [System.Runtime]System.Double
+		IL_1071: stloc.s 75
+		IL_1073: ldloc.s 35
+		IL_1075: ldc.r8 0.0
+		IL_107e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_1083: stloc.s 70
+		IL_1085: ldloc.s 65
+		IL_1087: ldloc.s 68
+		IL_1089: ldloc.s 75
+		IL_108b: ldloc.s 70
+		IL_108d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_1092: pop
+		IL_1093: ldc.i4.0
+		IL_1094: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_1099: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_109e: stloc.s 48
 		.try
 		{
-			IL_1076: nop
-			IL_1077: ldloc.s 48
-			IL_1079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_107e: volatile.
-			IL_1080: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_1085: brfalse IL_1099
+			IL_10a0: nop
+			IL_10a1: ldloc.s 48
+			IL_10a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_10a8: volatile.
+			IL_10aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_10af: brfalse IL_10c3
 
-			IL_108a: ldstr "push"
-			IL_108f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_1094: br IL_10ad
+			IL_10b4: ldstr "push"
+			IL_10b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_10be: br IL_10d7
 
-			IL_1099: ldstr "push"
-			IL_109e: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:573"
-			IL_10a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_10a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_10c3: ldstr "push"
+			IL_10c8: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:573"
+			IL_10cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_10d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_10ad: pop
-			IL_10ae: leave IL_1130
+			IL_10d7: pop
+			IL_10d8: leave IL_115a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_10b3: stloc.s 49
-			IL_10b5: ldloc.s 49
-			IL_10b7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_10bc: dup
-			IL_10bd: brtrue IL_10d3
+			IL_10dd: stloc.s 49
+			IL_10df: ldloc.s 49
+			IL_10e1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_10e6: dup
+			IL_10e7: brtrue IL_10fd
 
-			IL_10c2: pop
-			IL_10c3: ldloc.s 49
-			IL_10c5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_10ca: dup
-			IL_10cb: brtrue IL_10df
+			IL_10ec: pop
+			IL_10ed: ldloc.s 49
+			IL_10ef: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_10f4: dup
+			IL_10f5: brtrue IL_1109
 
-			IL_10d0: pop
-			IL_10d1: rethrow
+			IL_10fa: pop
+			IL_10fb: rethrow
 
-			IL_10d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_10d8: stloc.s 50
-			IL_10da: br IL_10e1
+			IL_10fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_1102: stloc.s 50
+			IL_1104: br IL_110b
 
-			IL_10df: stloc.s 50
+			IL_1109: stloc.s 50
 
-			IL_10e1: ldloc.s 50
-			IL_10e3: stloc.s 51
-			IL_10e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_10ea: stloc.s 65
-			IL_10ec: volatile.
-			IL_10ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_10f3: brfalse IL_1109
+			IL_110b: ldloc.s 50
+			IL_110d: stloc.s 51
+			IL_110f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1114: stloc.s 65
+			IL_1116: volatile.
+			IL_1118: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_111d: brfalse IL_1133
 
-			IL_10f8: ldloc.s 51
-			IL_10fa: ldstr "name"
-			IL_10ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1104: br IL_111f
+			IL_1122: ldloc.s 51
+			IL_1124: ldstr "name"
+			IL_1129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_112e: br IL_1149
 
-			IL_1109: ldloc.s 51
-			IL_110b: ldstr "name"
-			IL_1110: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:584"
-			IL_1115: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_111a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1133: ldloc.s 51
+			IL_1135: ldstr "name"
+			IL_113a: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:584"
+			IL_113f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_1144: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_111f: stloc.s 70
-			IL_1121: ldloc.s 65
-			IL_1123: ldloc.s 70
-			IL_1125: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_112a: pop
-			IL_112b: leave IL_1130
+			IL_1149: stloc.s 70
+			IL_114b: ldloc.s 65
+			IL_114d: ldloc.s 70
+			IL_114f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_1154: pop
+			IL_1155: leave IL_115a
 		} // end handler
 
-		IL_1130: nop
-		IL_1131: ldc.i4.2
-		IL_1132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_1137: dup
-		IL_1138: ldc.r8 1
-		IL_1141: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1146: dup
-		IL_1147: ldc.r8 2
-		IL_1150: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1155: stloc.s 52
-		IL_1157: ldloc.1
-		IL_1158: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_115d: ldloc.s 52
-		IL_115f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1164: pop
-		IL_1165: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_116a: stloc.s 65
-		IL_116c: ldloc.s 52
-		IL_116e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_1173: box [System.Runtime]System.Double
-		IL_1178: stloc.s 75
-		IL_117a: ldloc.s 65
-		IL_117c: ldloc.s 75
-		IL_117e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_1183: pop
-		IL_1184: ldc.i4.2
-		IL_1185: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_118a: dup
-		IL_118b: ldc.r8 1
-		IL_1194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1199: dup
-		IL_119a: ldc.r8 2
-		IL_11a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_11a8: stloc.s 53
-		IL_11aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_11af: stloc.s 74
-		IL_11b1: ldloc.s 53
-		IL_11b3: ldloc.s 74
-		IL_11b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_11ba: stloc.s 54
-		IL_11bc: ldloc.s 54
-		IL_11be: ldstr "length"
-		IL_11c3: ldc.r8 1
-		IL_11cc: ldc.i4.1
-		IL_11cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_11d2: pop
-		IL_11d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_11d8: stloc.s 65
-		IL_11da: ldloc.s 53
-		IL_11dc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_11e1: box [System.Runtime]System.Double
-		IL_11e6: stloc.s 75
-		IL_11e8: ldc.r8 1
-		IL_11f1: box [System.Runtime]System.Double
-		IL_11f6: ldloc.s 53
-		IL_11f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_11fd: stloc.s 67
-		IL_11ff: ldloc.s 67
-		IL_1201: box [System.Runtime]System.Boolean
-		IL_1206: stloc.s 68
-		IL_1208: ldloc.s 65
-		IL_120a: ldloc.s 75
-		IL_120c: ldloc.s 68
-		IL_120e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_1213: pop
-		IL_1214: ldc.i4.3
-		IL_1215: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_121a: dup
-		IL_121b: ldc.r8 0.0
-		IL_1224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1229: dup
-		IL_122a: ldc.r8 1
-		IL_1233: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1238: dup
-		IL_1239: ldc.r8 2
-		IL_1242: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_1247: stloc.s 55
-		IL_1249: ldloc.s 55
-		IL_124b: ldstr "2"
-		IL_1250: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_1255: dup
-		IL_1256: ldstr "configurable"
-		IL_125b: ldc.i4.0
-		IL_125c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_1261: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_1266: pop
-		IL_1267: ldloc.s 55
-		IL_1269: ldc.r8 1
-		IL_1272: box [System.Runtime]System.Double
-		IL_1277: ldc.r8 1
-		IL_1280: box [System.Runtime]System.Double
-		IL_1285: ldc.r8 9
-		IL_128e: box [System.Runtime]System.Double
-		IL_1293: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
-		IL_1298: stloc.s 56
-		IL_129a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_129f: stloc.s 65
-		IL_12a1: ldloc.s 55
-		IL_12a3: ldc.i4.1
-		IL_12a4: newarr [System.Runtime]System.Object
-		IL_12a9: dup
-		IL_12aa: ldc.i4.0
-		IL_12ab: ldstr ","
-		IL_12b0: stelem.ref
-		IL_12b1: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_12b6: stloc.s 77
-		IL_12b8: ldloc.s 56
-		IL_12ba: ldc.i4.1
-		IL_12bb: newarr [System.Runtime]System.Object
-		IL_12c0: dup
-		IL_12c1: ldc.i4.0
-		IL_12c2: ldstr ","
-		IL_12c7: stelem.ref
-		IL_12c8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_12cd: stloc.s 78
-		IL_12cf: ldloc.s 65
-		IL_12d1: ldloc.s 77
-		IL_12d3: ldloc.s 78
-		IL_12d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_12da: pop
-		IL_12db: ldc.i4.0
-		IL_12dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_12e1: stloc.s 57
-		IL_12e3: ldloc.s 57
-		IL_12e5: ldc.r8 3
-		IL_12ee: ldc.i4.1
-		IL_12ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-		IL_12f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_12f9: stloc.s 65
-		IL_12fb: ldloc.s 57
-		IL_12fd: ldstr "x"
-		IL_1302: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::unshift(object)
-		IL_1307: stloc.s 79
-		IL_1309: ldloc.s 79
-		IL_130b: box [System.Runtime]System.Double
-		IL_1310: stloc.s 75
-		IL_1312: ldloc.s 57
-		IL_1314: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_1319: box [System.Runtime]System.Double
-		IL_131e: stloc.s 80
-		IL_1320: ldc.r8 0.0
-		IL_1329: box [System.Runtime]System.Double
-		IL_132e: ldloc.s 57
-		IL_1330: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_1335: stloc.s 67
-		IL_1337: ldloc.s 67
-		IL_1339: box [System.Runtime]System.Boolean
-		IL_133e: stloc.s 68
-		IL_1340: ldc.r8 3
-		IL_1349: box [System.Runtime]System.Double
-		IL_134e: ldloc.s 57
-		IL_1350: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_1355: stloc.s 67
-		IL_1357: ldloc.s 67
-		IL_1359: box [System.Runtime]System.Boolean
-		IL_135e: stloc.s 76
-		IL_1360: ldloc.s 65
-		IL_1362: ldc.i4.4
-		IL_1363: newarr [System.Runtime]System.Object
-		IL_1368: dup
-		IL_1369: ldc.i4.0
-		IL_136a: ldloc.s 75
-		IL_136c: stelem.ref
-		IL_136d: dup
-		IL_136e: ldc.i4.1
-		IL_136f: ldloc.s 80
-		IL_1371: stelem.ref
-		IL_1372: dup
-		IL_1373: ldc.i4.2
-		IL_1374: ldloc.s 68
-		IL_1376: stelem.ref
-		IL_1377: dup
-		IL_1378: ldc.i4.3
-		IL_1379: ldloc.s 76
-		IL_137b: stelem.ref
-		IL_137c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_1381: pop
-		IL_1382: ldloc.0
-		IL_1383: ldc.r8 0.0
-		IL_138c: box [System.Runtime]System.Double
-		IL_1391: stfld object Modules.Array_Exotic_Property_Descriptors/Scope::keyConversions
-		IL_1396: ldc.i4.1
-		IL_1397: newarr [System.Runtime]System.Object
+		IL_115a: nop
+		IL_115b: ldc.i4.2
+		IL_115c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_1161: dup
+		IL_1162: ldc.r8 1
+		IL_116b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_1170: dup
+		IL_1171: ldc.r8 2
+		IL_117a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_117f: stloc.s 52
+		IL_1181: ldloc.1
+		IL_1182: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1187: ldloc.s 52
+		IL_1189: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_118e: pop
+		IL_118f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_1194: stloc.s 65
+		IL_1196: ldloc.s 52
+		IL_1198: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_119d: box [System.Runtime]System.Double
+		IL_11a2: stloc.s 75
+		IL_11a4: ldloc.s 65
+		IL_11a6: ldloc.s 75
+		IL_11a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_11ad: pop
+		IL_11ae: ldc.i4.2
+		IL_11af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_11b4: dup
+		IL_11b5: ldc.r8 1
+		IL_11be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_11c3: dup
+		IL_11c4: ldc.r8 2
+		IL_11cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_11d2: stloc.s 53
+		IL_11d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_11d9: stloc.s 74
+		IL_11db: ldloc.s 53
+		IL_11dd: ldloc.s 74
+		IL_11df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_11e4: stloc.s 54
+		IL_11e6: ldloc.s 54
+		IL_11e8: ldstr "length"
+		IL_11ed: ldc.r8 1
+		IL_11f6: ldc.i4.1
+		IL_11f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_11fc: pop
+		IL_11fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_1202: stloc.s 65
+		IL_1204: ldloc.s 53
+		IL_1206: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_120b: box [System.Runtime]System.Double
+		IL_1210: stloc.s 75
+		IL_1212: ldc.r8 1
+		IL_121b: box [System.Runtime]System.Double
+		IL_1220: ldloc.s 53
+		IL_1222: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_1227: stloc.s 67
+		IL_1229: ldloc.s 67
+		IL_122b: box [System.Runtime]System.Boolean
+		IL_1230: stloc.s 68
+		IL_1232: ldloc.s 65
+		IL_1234: ldloc.s 75
+		IL_1236: ldloc.s 68
+		IL_1238: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_123d: pop
+		IL_123e: ldc.i4.3
+		IL_123f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_1244: dup
+		IL_1245: ldc.r8 0.0
+		IL_124e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_1253: dup
+		IL_1254: ldc.r8 1
+		IL_125d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_1262: dup
+		IL_1263: ldc.r8 2
+		IL_126c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_1271: stloc.s 55
+		IL_1273: ldloc.s 55
+		IL_1275: ldstr "2"
+		IL_127a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_127f: dup
+		IL_1280: ldstr "configurable"
+		IL_1285: ldc.i4.0
+		IL_1286: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_128b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_1290: pop
+		IL_1291: ldloc.s 55
+		IL_1293: ldc.r8 1
+		IL_129c: box [System.Runtime]System.Double
+		IL_12a1: ldc.r8 1
+		IL_12aa: box [System.Runtime]System.Double
+		IL_12af: ldc.r8 9
+		IL_12b8: box [System.Runtime]System.Double
+		IL_12bd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
+		IL_12c2: stloc.s 56
+		IL_12c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_12c9: stloc.s 65
+		IL_12cb: ldloc.s 55
+		IL_12cd: ldc.i4.1
+		IL_12ce: newarr [System.Runtime]System.Object
+		IL_12d3: dup
+		IL_12d4: ldc.i4.0
+		IL_12d5: ldstr ","
+		IL_12da: stelem.ref
+		IL_12db: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_12e0: stloc.s 77
+		IL_12e2: ldloc.s 56
+		IL_12e4: ldc.i4.1
+		IL_12e5: newarr [System.Runtime]System.Object
+		IL_12ea: dup
+		IL_12eb: ldc.i4.0
+		IL_12ec: ldstr ","
+		IL_12f1: stelem.ref
+		IL_12f2: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_12f7: stloc.s 78
+		IL_12f9: ldloc.s 65
+		IL_12fb: ldloc.s 77
+		IL_12fd: ldloc.s 78
+		IL_12ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_1304: pop
+		IL_1305: ldc.i4.0
+		IL_1306: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_130b: stloc.s 57
+		IL_130d: ldloc.s 57
+		IL_130f: ldc.r8 3
+		IL_1318: ldc.i4.1
+		IL_1319: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+		IL_131e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_1323: stloc.s 65
+		IL_1325: ldloc.s 57
+		IL_1327: ldstr "x"
+		IL_132c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::unshift(object)
+		IL_1331: stloc.s 79
+		IL_1333: ldloc.s 79
+		IL_1335: box [System.Runtime]System.Double
+		IL_133a: stloc.s 75
+		IL_133c: ldloc.s 57
+		IL_133e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_1343: box [System.Runtime]System.Double
+		IL_1348: stloc.s 80
+		IL_134a: ldc.r8 0.0
+		IL_1353: box [System.Runtime]System.Double
+		IL_1358: ldloc.s 57
+		IL_135a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_135f: stloc.s 67
+		IL_1361: ldloc.s 67
+		IL_1363: box [System.Runtime]System.Boolean
+		IL_1368: stloc.s 68
+		IL_136a: ldc.r8 3
+		IL_1373: box [System.Runtime]System.Double
+		IL_1378: ldloc.s 57
+		IL_137a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_137f: stloc.s 67
+		IL_1381: ldloc.s 67
+		IL_1383: box [System.Runtime]System.Boolean
+		IL_1388: stloc.s 76
+		IL_138a: ldloc.s 65
+		IL_138c: ldc.i4.4
+		IL_138d: newarr [System.Runtime]System.Object
+		IL_1392: dup
+		IL_1393: ldc.i4.0
+		IL_1394: ldloc.s 75
+		IL_1396: stelem.ref
+		IL_1397: dup
+		IL_1398: ldc.i4.1
+		IL_1399: ldloc.s 80
+		IL_139b: stelem.ref
 		IL_139c: dup
-		IL_139d: ldc.i4.0
-		IL_139e: ldloc.0
-		IL_139f: stelem.ref
-		IL_13a0: stloc.s 64
-		IL_13a2: ldloc.s 64
-		IL_13a4: ldc.i4.0
-		IL_13a5: ldelem.ref
-		IL_13a6: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_13ab: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
-		IL_13b0: ldc.i4.0
-		IL_13b1: conv.r8
-		IL_13b2: ldstr ""
-		IL_13b7: ldc.i4.0
-		IL_13b8: ldc.i4.1
-		IL_13b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_13be: stloc.s 81
-		IL_13c0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_13c5: dup
-		IL_13c6: ldstr "toString"
-		IL_13cb: ldloc.s 81
-		IL_13cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_13d2: stloc.s 58
+		IL_139d: ldc.i4.2
+		IL_139e: ldloc.s 68
+		IL_13a0: stelem.ref
+		IL_13a1: dup
+		IL_13a2: ldc.i4.3
+		IL_13a3: ldloc.s 76
+		IL_13a5: stelem.ref
+		IL_13a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_13ab: pop
+		IL_13ac: ldloc.0
+		IL_13ad: ldc.r8 0.0
+		IL_13b6: box [System.Runtime]System.Double
+		IL_13bb: stfld object Modules.Array_Exotic_Property_Descriptors/Scope::keyConversions
+		IL_13c0: ldc.i4.1
+		IL_13c1: newarr [System.Runtime]System.Object
+		IL_13c6: dup
+		IL_13c7: ldc.i4.0
+		IL_13c8: ldloc.0
+		IL_13c9: stelem.ref
+		IL_13ca: stloc.s 64
+		IL_13cc: ldloc.s 64
+		IL_13ce: ldc.i4.0
+		IL_13cf: ldelem.ref
+		IL_13d0: castclass Modules.Array_Exotic_Property_Descriptors/Scope
+		IL_13d5: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
+		IL_13da: ldc.i4.0
+		IL_13db: conv.r8
+		IL_13dc: ldstr ""
+		IL_13e1: ldc.i4.0
+		IL_13e2: ldc.i4.1
+		IL_13e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_13e8: stloc.s 81
+		IL_13ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_13ef: dup
+		IL_13f0: ldstr "toString"
+		IL_13f5: ldloc.s 81
+		IL_13f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_13fc: stloc.s 58
 		.try
 		{
-			IL_13d4: nop
-			IL_13d5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_13da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-			IL_13df: ldloc.s 58
-			IL_13e1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_13e6: dup
-			IL_13e7: ldstr "value"
-			IL_13ec: ldc.r8 1
-			IL_13f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_13fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_13ff: pop
-			IL_1400: leave IL_148c
+			IL_13fe: nop
+			IL_13ff: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_1404: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+			IL_1409: ldloc.s 58
+			IL_140b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_1410: dup
+			IL_1411: ldstr "value"
+			IL_1416: ldc.r8 1
+			IL_141f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_1424: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_1429: pop
+			IL_142a: leave IL_14b6
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_1405: stloc.s 59
-			IL_1407: ldloc.s 59
-			IL_1409: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_140e: dup
-			IL_140f: brtrue IL_1425
+			IL_142f: stloc.s 59
+			IL_1431: ldloc.s 59
+			IL_1433: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_1438: dup
+			IL_1439: brtrue IL_144f
 
-			IL_1414: pop
-			IL_1415: ldloc.s 59
-			IL_1417: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_141c: dup
-			IL_141d: brtrue IL_1431
+			IL_143e: pop
+			IL_143f: ldloc.s 59
+			IL_1441: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_1446: dup
+			IL_1447: brtrue IL_145b
 
-			IL_1422: pop
-			IL_1423: rethrow
+			IL_144c: pop
+			IL_144d: rethrow
 
-			IL_1425: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_142a: stloc.s 60
-			IL_142c: br IL_1433
+			IL_144f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_1454: stloc.s 60
+			IL_1456: br IL_145d
 
-			IL_1431: stloc.s 60
+			IL_145b: stloc.s 60
 
-			IL_1433: ldloc.s 60
-			IL_1435: stloc.s 61
-			IL_1437: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_143c: stloc.s 65
-			IL_143e: volatile.
-			IL_1440: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_1445: brfalse IL_145b
+			IL_145d: ldloc.s 60
+			IL_145f: stloc.s 61
+			IL_1461: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1466: stloc.s 65
+			IL_1468: volatile.
+			IL_146a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_146f: brfalse IL_1485
 
-			IL_144a: ldloc.s 61
-			IL_144c: ldstr "name"
-			IL_1451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1456: br IL_1471
+			IL_1474: ldloc.s 61
+			IL_1476: ldstr "name"
+			IL_147b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1480: br IL_149b
 
-			IL_145b: ldloc.s 61
-			IL_145d: ldstr "name"
-			IL_1462: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:704"
-			IL_1467: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_146c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1485: ldloc.s 61
+			IL_1487: ldstr "name"
+			IL_148c: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:704"
+			IL_1491: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_1496: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1471: stloc.s 70
-			IL_1473: ldloc.0
-			IL_1474: ldfld object Modules.Array_Exotic_Property_Descriptors/Scope::keyConversions
-			IL_1479: stloc.s 71
-			IL_147b: ldloc.s 65
-			IL_147d: ldloc.s 70
-			IL_147f: ldloc.s 71
-			IL_1481: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_1486: pop
-			IL_1487: leave IL_148c
+			IL_149b: stloc.s 70
+			IL_149d: ldloc.0
+			IL_149e: ldfld object Modules.Array_Exotic_Property_Descriptors/Scope::keyConversions
+			IL_14a3: stloc.s 71
+			IL_14a5: ldloc.s 65
+			IL_14a7: ldloc.s 70
+			IL_14a9: ldloc.s 71
+			IL_14ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_14b0: pop
+			IL_14b1: leave IL_14b6
 		} // end handler
 
-		IL_148c: ldc.i4.0
-		IL_148d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_1492: stloc.s 62
-		IL_1494: ldloc.s 62
-		IL_1496: ldstr "01"
-		IL_149b: ldstr "ordinary"
-		IL_14a0: ldc.i4.1
-		IL_14a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_14a6: pop
-		IL_14a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_14ac: stloc.s 65
-		IL_14ae: ldloc.s 62
-		IL_14b0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_14b5: box [System.Runtime]System.Double
-		IL_14ba: stloc.s 80
-		IL_14bc: volatile.
-		IL_14be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_14c3: brfalse IL_14d9
+		IL_14b6: ldc.i4.0
+		IL_14b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_14bc: stloc.s 62
+		IL_14be: ldloc.s 62
+		IL_14c0: ldstr "01"
+		IL_14c5: ldstr "ordinary"
+		IL_14ca: ldc.i4.1
+		IL_14cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_14d0: pop
+		IL_14d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_14d6: stloc.s 65
+		IL_14d8: ldloc.s 62
+		IL_14da: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_14df: box [System.Runtime]System.Double
+		IL_14e4: stloc.s 80
+		IL_14e6: volatile.
+		IL_14e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_14ed: brfalse IL_1503
 
-		IL_14c8: ldloc.s 62
-		IL_14ca: ldstr "01"
-		IL_14cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_14d4: br IL_14ef
+		IL_14f2: ldloc.s 62
+		IL_14f4: ldstr "01"
+		IL_14f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_14fe: br IL_1519
 
-		IL_14d9: ldloc.s 62
-		IL_14db: ldstr "01"
-		IL_14e0: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:723"
-		IL_14e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_14ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1503: ldloc.s 62
+		IL_1505: ldstr "01"
+		IL_150a: ldstr "Array_Exotic_Property_Descriptors:Modules.Array_Exotic_Property_Descriptors:__js_module_init__:723"
+		IL_150f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_1514: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_14ef: stloc.s 71
-		IL_14f1: ldloc.s 65
-		IL_14f3: ldloc.s 80
-		IL_14f5: ldloc.s 71
-		IL_14f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_14fc: pop
-		IL_14fd: ldnull
-		IL_14fe: stloc.s 63
-		IL_1500: ret
+		IL_1519: stloc.s 71
+		IL_151b: ldloc.s 65
+		IL_151d: ldloc.s 80
+		IL_151f: ldloc.s 71
+		IL_1521: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_1526: pop
+		IL_1527: ldnull
+		IL_1528: stloc.s 63
+		IL_152a: ret
 	} // end of method Array_Exotic_Property_Descriptors::__js_module_init__
 
 } // end of class Modules.Array_Exotic_Property_Descriptors
@@ -3177,6 +3189,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_24
 	.field assembly static int32 __jroc_dynamicLookup_25
 	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ExplicitReceiverAbi.verified.txt
@@ -1488,7 +1488,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 4653 (0x122d)
+		// Code size: 4848 (0x12f0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_ExplicitReceiverAbi/Scope,
@@ -1979,976 +1979,1036 @@
 		IL_05dc: ldc.r8 3
 		IL_05e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_05ea: stloc.s 13
-		IL_05ec: ldstr "call"
-		IL_05f1: ldloc.s 13
-		IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05f8: stloc.s 12
-		IL_05fa: ldloc.s 11
-		IL_05fc: ldloc.s 12
-		IL_05fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0603: pop
-		IL_0604: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0609: stloc.s 11
-		IL_060b: ldstr "Array"
-		IL_0610: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0615: volatile.
-		IL_0617: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_061c: brfalse IL_0630
+		IL_05ec: volatile.
+		IL_05ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_05f3: brfalse IL_0609
 
-		IL_0621: ldstr "prototype"
-		IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_062b: br IL_0644
+		IL_05f8: ldstr "call"
+		IL_05fd: ldloc.s 13
+		IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0604: br IL_061f
 
-		IL_0630: ldstr "prototype"
-		IL_0635: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:121"
-		IL_063a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_063f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0609: ldstr "call"
+		IL_060e: ldloc.s 13
+		IL_0610: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:114"
+		IL_0615: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0644: stloc.s 12
-		IL_0646: volatile.
-		IL_0648: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_064d: brfalse IL_0663
+		IL_061f: stloc.s 12
+		IL_0621: ldloc.s 11
+		IL_0623: ldloc.s 12
+		IL_0625: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_062a: pop
+		IL_062b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0630: stloc.s 11
+		IL_0632: ldstr "Array"
+		IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_063c: volatile.
+		IL_063e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0643: brfalse IL_0657
 
-		IL_0652: ldloc.s 12
-		IL_0654: ldstr "join"
-		IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_065e: br IL_0679
+		IL_0648: ldstr "prototype"
+		IL_064d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0652: br IL_066b
 
-		IL_0663: ldloc.s 12
-		IL_0665: ldstr "join"
-		IL_066a: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:123"
-		IL_066f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0657: ldstr "prototype"
+		IL_065c: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:121"
+		IL_0661: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0679: stloc.s 12
-		IL_067b: ldloc.s 12
-		IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0682: ldc.i4.2
-		IL_0683: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0688: dup
-		IL_0689: ldc.r8 1
-		IL_0692: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0697: dup
-		IL_0698: ldc.r8 2
-		IL_06a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_06a6: stloc.s 13
-		IL_06a8: ldstr "call"
-		IL_06ad: ldloc.s 13
-		IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06b4: stloc.s 12
-		IL_06b6: ldloc.s 11
-		IL_06b8: ldloc.s 12
-		IL_06ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06bf: pop
-		IL_06c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06c5: stloc.s 11
-		IL_06c7: ldstr "Array"
-		IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06d1: volatile.
-		IL_06d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_06d8: brfalse IL_06ec
+		IL_066b: stloc.s 12
+		IL_066d: volatile.
+		IL_066f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0674: brfalse IL_068a
 
-		IL_06dd: ldstr "prototype"
-		IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06e7: br IL_0700
+		IL_0679: ldloc.s 12
+		IL_067b: ldstr "join"
+		IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0685: br IL_06a0
 
-		IL_06ec: ldstr "prototype"
-		IL_06f1: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:135"
-		IL_06f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_068a: ldloc.s 12
+		IL_068c: ldstr "join"
+		IL_0691: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:123"
+		IL_0696: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0700: stloc.s 12
-		IL_0702: volatile.
-		IL_0704: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0709: brfalse IL_071f
+		IL_06a0: stloc.s 12
+		IL_06a2: ldloc.s 12
+		IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06a9: ldc.i4.2
+		IL_06aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_06af: dup
+		IL_06b0: ldc.r8 1
+		IL_06b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_06be: dup
+		IL_06bf: ldc.r8 2
+		IL_06c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_06cd: stloc.s 13
+		IL_06cf: volatile.
+		IL_06d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_06d6: brfalse IL_06ec
 
-		IL_070e: ldloc.s 12
-		IL_0710: ldstr "join"
-		IL_0715: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_071a: br IL_0735
+		IL_06db: ldstr "call"
+		IL_06e0: ldloc.s 13
+		IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06e7: br IL_0702
 
-		IL_071f: ldloc.s 12
-		IL_0721: ldstr "join"
-		IL_0726: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:137"
-		IL_072b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06ec: ldstr "call"
+		IL_06f1: ldloc.s 13
+		IL_06f3: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:128"
+		IL_06f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0735: stloc.s 12
-		IL_0737: ldloc.s 12
-		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_073e: ldc.i4.2
-		IL_073f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0744: dup
-		IL_0745: ldc.r8 1
-		IL_074e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0753: dup
-		IL_0754: ldc.r8 2
-		IL_075d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0762: stloc.s 13
-		IL_0764: ldstr "call"
-		IL_0769: ldloc.s 13
-		IL_076b: ldnull
-		IL_076c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0771: stloc.s 12
-		IL_0773: ldloc.s 11
-		IL_0775: ldloc.s 12
-		IL_0777: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_077c: pop
-		IL_077d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0782: stloc.s 11
-		IL_0784: ldstr "Array"
-		IL_0789: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_078e: volatile.
-		IL_0790: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0795: brfalse IL_07a9
+		IL_0702: stloc.s 12
+		IL_0704: ldloc.s 11
+		IL_0706: ldloc.s 12
+		IL_0708: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_070d: pop
+		IL_070e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0713: stloc.s 11
+		IL_0715: ldstr "Array"
+		IL_071a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_071f: volatile.
+		IL_0721: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0726: brfalse IL_073a
 
-		IL_079a: ldstr "prototype"
-		IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07a4: br IL_07bd
+		IL_072b: ldstr "prototype"
+		IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0735: br IL_074e
 
-		IL_07a9: ldstr "prototype"
-		IL_07ae: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:150"
-		IL_07b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_073a: ldstr "prototype"
+		IL_073f: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:135"
+		IL_0744: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07bd: stloc.s 12
-		IL_07bf: volatile.
-		IL_07c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_07c6: brfalse IL_07dc
+		IL_074e: stloc.s 12
+		IL_0750: volatile.
+		IL_0752: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0757: brfalse IL_076d
 
-		IL_07cb: ldloc.s 12
-		IL_07cd: ldstr "at"
-		IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07d7: br IL_07f2
+		IL_075c: ldloc.s 12
+		IL_075e: ldstr "join"
+		IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0768: br IL_0783
 
-		IL_07dc: ldloc.s 12
-		IL_07de: ldstr "at"
-		IL_07e3: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:152"
-		IL_07e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_076d: ldloc.s 12
+		IL_076f: ldstr "join"
+		IL_0774: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:137"
+		IL_0779: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_077e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07f2: stloc.s 12
-		IL_07f4: ldloc.s 12
-		IL_07f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07fb: ldc.i4.3
-		IL_07fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0801: dup
-		IL_0802: ldc.r8 1
-		IL_080b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0810: dup
-		IL_0811: ldc.r8 2
-		IL_081a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_081f: dup
-		IL_0820: ldc.r8 3
-		IL_0829: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_082e: stloc.s 13
-		IL_0830: ldstr "call"
-		IL_0835: ldloc.s 13
-		IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_083c: stloc.s 12
-		IL_083e: ldloc.s 11
-		IL_0840: ldloc.s 12
-		IL_0842: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0847: pop
-		IL_0848: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_084d: stloc.s 11
-		IL_084f: ldstr "Array"
-		IL_0854: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0859: volatile.
-		IL_085b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0860: brfalse IL_0874
+		IL_0783: stloc.s 12
+		IL_0785: ldloc.s 12
+		IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_078c: ldc.i4.2
+		IL_078d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0792: dup
+		IL_0793: ldc.r8 1
+		IL_079c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_07a1: dup
+		IL_07a2: ldc.r8 2
+		IL_07ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_07b0: stloc.s 13
+		IL_07b2: ldstr "call"
+		IL_07b7: ldloc.s 13
+		IL_07b9: ldnull
+		IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_07bf: stloc.s 12
+		IL_07c1: ldloc.s 11
+		IL_07c3: ldloc.s 12
+		IL_07c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07ca: pop
+		IL_07cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07d0: stloc.s 11
+		IL_07d2: ldstr "Array"
+		IL_07d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07dc: volatile.
+		IL_07de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_07e3: brfalse IL_07f7
 
-		IL_0865: ldstr "prototype"
-		IL_086a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_086f: br IL_0888
+		IL_07e8: ldstr "prototype"
+		IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07f2: br IL_080b
 
-		IL_0874: ldstr "prototype"
-		IL_0879: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:165"
-		IL_087e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07f7: ldstr "prototype"
+		IL_07fc: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:150"
+		IL_0801: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0806: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0888: stloc.s 12
-		IL_088a: volatile.
-		IL_088c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0891: brfalse IL_08a7
+		IL_080b: stloc.s 12
+		IL_080d: volatile.
+		IL_080f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0814: brfalse IL_082a
 
-		IL_0896: ldloc.s 12
-		IL_0898: ldstr "at"
-		IL_089d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08a2: br IL_08bd
+		IL_0819: ldloc.s 12
+		IL_081b: ldstr "at"
+		IL_0820: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0825: br IL_0840
 
-		IL_08a7: ldloc.s 12
-		IL_08a9: ldstr "at"
-		IL_08ae: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:167"
-		IL_08b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_082a: ldloc.s 12
+		IL_082c: ldstr "at"
+		IL_0831: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:152"
+		IL_0836: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_083b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_08bd: stloc.s 12
-		IL_08bf: ldloc.s 12
-		IL_08c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08c6: ldc.i4.3
-		IL_08c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_08cc: dup
-		IL_08cd: ldc.r8 1
-		IL_08d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_08db: dup
-		IL_08dc: ldc.r8 2
-		IL_08e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_08ea: dup
-		IL_08eb: ldc.r8 3
-		IL_08f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_08f9: stloc.s 13
-		IL_08fb: ldstr "call"
-		IL_0900: ldloc.s 13
-		IL_0902: ldnull
-		IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0908: stloc.s 12
-		IL_090a: ldloc.s 11
-		IL_090c: ldloc.s 12
-		IL_090e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0913: pop
-		IL_0914: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0919: stloc.s 11
-		IL_091b: ldstr "Array"
-		IL_0920: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0925: volatile.
-		IL_0927: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_092c: brfalse IL_0940
+		IL_0840: stloc.s 12
+		IL_0842: ldloc.s 12
+		IL_0844: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0849: ldc.i4.3
+		IL_084a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_084f: dup
+		IL_0850: ldc.r8 1
+		IL_0859: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_085e: dup
+		IL_085f: ldc.r8 2
+		IL_0868: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_086d: dup
+		IL_086e: ldc.r8 3
+		IL_0877: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_087c: stloc.s 13
+		IL_087e: volatile.
+		IL_0880: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0885: brfalse IL_089b
 
-		IL_0931: ldstr "prototype"
-		IL_0936: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_093b: br IL_0954
+		IL_088a: ldstr "call"
+		IL_088f: ldloc.s 13
+		IL_0891: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0896: br IL_08b1
 
-		IL_0940: ldstr "prototype"
-		IL_0945: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:181"
-		IL_094a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_094f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_089b: ldstr "call"
+		IL_08a0: ldloc.s 13
+		IL_08a2: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:158"
+		IL_08a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_08ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0954: stloc.s 12
-		IL_0956: volatile.
-		IL_0958: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_095d: brfalse IL_0973
+		IL_08b1: stloc.s 12
+		IL_08b3: ldloc.s 11
+		IL_08b5: ldloc.s 12
+		IL_08b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08bc: pop
+		IL_08bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08c2: stloc.s 11
+		IL_08c4: ldstr "Array"
+		IL_08c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08ce: volatile.
+		IL_08d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_08d5: brfalse IL_08e9
 
-		IL_0962: ldloc.s 12
-		IL_0964: ldstr "indexOf"
-		IL_0969: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_096e: br IL_0989
+		IL_08da: ldstr "prototype"
+		IL_08df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08e4: br IL_08fd
 
-		IL_0973: ldloc.s 12
-		IL_0975: ldstr "indexOf"
-		IL_097a: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:183"
-		IL_097f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0984: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_08e9: ldstr "prototype"
+		IL_08ee: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:165"
+		IL_08f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_08f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0989: stloc.s 12
-		IL_098b: ldloc.s 12
-		IL_098d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0992: ldc.i4.2
-		IL_0993: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0998: dup
-		IL_0999: ldnull
-		IL_099a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_099f: dup
-		IL_09a0: ldc.r8 2
-		IL_09a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_09ae: stloc.s 13
-		IL_09b0: ldstr "call"
-		IL_09b5: ldloc.s 13
-		IL_09b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_09bc: stloc.s 12
-		IL_09be: ldloc.s 11
-		IL_09c0: ldloc.s 12
-		IL_09c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_09c7: pop
-		IL_09c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09cd: stloc.s 11
-		IL_09cf: ldstr "Array"
-		IL_09d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_09d9: volatile.
-		IL_09db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_09e0: brfalse IL_09f4
+		IL_08fd: stloc.s 12
+		IL_08ff: volatile.
+		IL_0901: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0906: brfalse IL_091c
 
-		IL_09e5: ldstr "prototype"
-		IL_09ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09ef: br IL_0a08
+		IL_090b: ldloc.s 12
+		IL_090d: ldstr "at"
+		IL_0912: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0917: br IL_0932
 
-		IL_09f4: ldstr "prototype"
-		IL_09f9: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:195"
-		IL_09fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_091c: ldloc.s 12
+		IL_091e: ldstr "at"
+		IL_0923: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:167"
+		IL_0928: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_092d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a08: stloc.s 12
-		IL_0a0a: volatile.
-		IL_0a0c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0a11: brfalse IL_0a27
+		IL_0932: stloc.s 12
+		IL_0934: ldloc.s 12
+		IL_0936: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_093b: ldc.i4.3
+		IL_093c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0941: dup
+		IL_0942: ldc.r8 1
+		IL_094b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0950: dup
+		IL_0951: ldc.r8 2
+		IL_095a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_095f: dup
+		IL_0960: ldc.r8 3
+		IL_0969: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_096e: stloc.s 13
+		IL_0970: ldstr "call"
+		IL_0975: ldloc.s 13
+		IL_0977: ldnull
+		IL_0978: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_097d: stloc.s 12
+		IL_097f: ldloc.s 11
+		IL_0981: ldloc.s 12
+		IL_0983: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0988: pop
+		IL_0989: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_098e: stloc.s 11
+		IL_0990: ldstr "Array"
+		IL_0995: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_099a: volatile.
+		IL_099c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_09a1: brfalse IL_09b5
 
-		IL_0a16: ldloc.s 12
-		IL_0a18: ldstr "indexOf"
-		IL_0a1d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a22: br IL_0a3d
+		IL_09a6: ldstr "prototype"
+		IL_09ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09b0: br IL_09c9
 
-		IL_0a27: ldloc.s 12
-		IL_0a29: ldstr "indexOf"
-		IL_0a2e: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:197"
-		IL_0a33: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0a38: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09b5: ldstr "prototype"
+		IL_09ba: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:181"
+		IL_09bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_09c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a3d: stloc.s 12
-		IL_0a3f: ldloc.s 12
-		IL_0a41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0a46: ldc.i4.2
-		IL_0a47: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0a4c: dup
-		IL_0a4d: ldnull
-		IL_0a4e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0a53: dup
-		IL_0a54: ldc.r8 2
-		IL_0a5d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0a62: stloc.s 13
-		IL_0a64: ldstr "call"
-		IL_0a69: ldloc.s 13
-		IL_0a6b: ldnull
-		IL_0a6c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0a71: stloc.s 12
-		IL_0a73: ldloc.s 11
-		IL_0a75: ldloc.s 12
-		IL_0a77: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0a7c: pop
-		IL_0a7d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0a82: stloc.s 11
-		IL_0a84: ldstr "Array"
-		IL_0a89: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0a8e: volatile.
-		IL_0a90: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0a95: brfalse IL_0aa9
+		IL_09c9: stloc.s 12
+		IL_09cb: volatile.
+		IL_09cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_09d2: brfalse IL_09e8
 
-		IL_0a9a: ldstr "prototype"
-		IL_0a9f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0aa4: br IL_0abd
+		IL_09d7: ldloc.s 12
+		IL_09d9: ldstr "indexOf"
+		IL_09de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09e3: br IL_09fe
 
-		IL_0aa9: ldstr "prototype"
-		IL_0aae: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:210"
-		IL_0ab3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0ab8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09e8: ldloc.s 12
+		IL_09ea: ldstr "indexOf"
+		IL_09ef: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:183"
+		IL_09f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_09f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0abd: stloc.s 12
-		IL_0abf: volatile.
-		IL_0ac1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0ac6: brfalse IL_0adc
+		IL_09fe: stloc.s 12
+		IL_0a00: ldloc.s 12
+		IL_0a02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a07: ldc.i4.2
+		IL_0a08: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0a0d: dup
+		IL_0a0e: ldnull
+		IL_0a0f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0a14: dup
+		IL_0a15: ldc.r8 2
+		IL_0a1e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0a23: stloc.s 13
+		IL_0a25: volatile.
+		IL_0a27: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0a2c: brfalse IL_0a42
 
-		IL_0acb: ldloc.s 12
-		IL_0acd: ldstr "values"
-		IL_0ad2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ad7: br IL_0af2
+		IL_0a31: ldstr "call"
+		IL_0a36: ldloc.s 13
+		IL_0a38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a3d: br IL_0a58
 
-		IL_0adc: ldloc.s 12
-		IL_0ade: ldstr "values"
-		IL_0ae3: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:212"
-		IL_0ae8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0aed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0a42: ldstr "call"
+		IL_0a47: ldloc.s 13
+		IL_0a49: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:188"
+		IL_0a4e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0a53: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0af2: stloc.s 12
-		IL_0af4: ldstr "Array"
-		IL_0af9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0afe: volatile.
-		IL_0b00: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0b05: brfalse IL_0b19
+		IL_0a58: stloc.s 12
+		IL_0a5a: ldloc.s 11
+		IL_0a5c: ldloc.s 12
+		IL_0a5e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0a63: pop
+		IL_0a64: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0a69: stloc.s 11
+		IL_0a6b: ldstr "Array"
+		IL_0a70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a75: volatile.
+		IL_0a77: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0a7c: brfalse IL_0a90
 
-		IL_0b0a: ldstr "prototype"
-		IL_0b0f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b14: br IL_0b2d
+		IL_0a81: ldstr "prototype"
+		IL_0a86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a8b: br IL_0aa4
 
-		IL_0b19: ldstr "prototype"
-		IL_0b1e: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:216"
-		IL_0b23: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0b28: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0a90: ldstr "prototype"
+		IL_0a95: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:195"
+		IL_0a9a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0a9f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0b2d: stloc.s 21
-		IL_0b2f: ldstr "iterator"
-		IL_0b34: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0b39: stloc.s 22
-		IL_0b3b: ldloc.s 21
-		IL_0b3d: ldloc.s 22
-		IL_0b3f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0b44: stloc.s 22
-		IL_0b46: ldloc.s 12
-		IL_0b48: ldloc.s 22
-		IL_0b4a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0b4f: stloc.s 23
-		IL_0b51: ldloc.s 23
-		IL_0b53: box [System.Runtime]System.Boolean
-		IL_0b58: stloc.s 24
-		IL_0b5a: ldloc.s 11
-		IL_0b5c: ldloc.s 24
-		IL_0b5e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0b63: pop
-		IL_0b64: ldc.i4.2
-		IL_0b65: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0b6a: dup
-		IL_0b6b: ldc.r8 1
-		IL_0b74: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0b79: dup
-		IL_0b7a: ldc.r8 2
-		IL_0b83: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0b88: stloc.2
-		IL_0b89: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b8e: stloc.s 11
-		IL_0b90: ldloc.2
-		IL_0b91: ldc.i4.3
-		IL_0b92: newarr [System.Runtime]System.Object
-		IL_0b97: dup
-		IL_0b98: ldc.i4.0
-		IL_0b99: ldc.r8 3
-		IL_0ba2: box [System.Runtime]System.Double
-		IL_0ba7: stelem.ref
-		IL_0ba8: dup
-		IL_0ba9: ldc.i4.1
-		IL_0baa: ldc.r8 4
-		IL_0bb3: box [System.Runtime]System.Double
-		IL_0bb8: stelem.ref
-		IL_0bb9: dup
-		IL_0bba: ldc.i4.2
-		IL_0bbb: ldc.r8 5
-		IL_0bc4: box [System.Runtime]System.Double
-		IL_0bc9: stelem.ref
-		IL_0bca: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object[])
-		IL_0bcf: stloc.s 19
-		IL_0bd1: ldloc.s 19
-		IL_0bd3: box [System.Runtime]System.Double
-		IL_0bd8: stloc.s 20
-		IL_0bda: ldloc.s 11
-		IL_0bdc: ldloc.s 20
-		IL_0bde: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0be3: pop
-		IL_0be4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0be9: stloc.s 11
-		IL_0beb: ldloc.2
-		IL_0bec: ldc.i4.1
-		IL_0bed: newarr [System.Runtime]System.Object
-		IL_0bf2: dup
-		IL_0bf3: ldc.i4.0
-		IL_0bf4: ldstr ","
-		IL_0bf9: stelem.ref
-		IL_0bfa: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0bff: stloc.s 25
-		IL_0c01: ldloc.s 11
-		IL_0c03: ldloc.s 25
-		IL_0c05: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0c0a: pop
-		IL_0c0b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0c10: stloc.s 11
-		IL_0c12: ldstr "Array"
-		IL_0c17: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0c1c: volatile.
-		IL_0c1e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0c23: brfalse IL_0c37
+		IL_0aa4: stloc.s 12
+		IL_0aa6: volatile.
+		IL_0aa8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0aad: brfalse IL_0ac3
 
-		IL_0c28: ldstr "prototype"
-		IL_0c2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c32: br IL_0c4b
+		IL_0ab2: ldloc.s 12
+		IL_0ab4: ldstr "indexOf"
+		IL_0ab9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0abe: br IL_0ad9
 
-		IL_0c37: ldstr "prototype"
-		IL_0c3c: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:249"
-		IL_0c41: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0c46: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ac3: ldloc.s 12
+		IL_0ac5: ldstr "indexOf"
+		IL_0aca: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:197"
+		IL_0acf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0ad4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0c4b: stloc.s 22
-		IL_0c4d: volatile.
-		IL_0c4f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0c54: brfalse IL_0c6a
+		IL_0ad9: stloc.s 12
+		IL_0adb: ldloc.s 12
+		IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0ae2: ldc.i4.2
+		IL_0ae3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0ae8: dup
+		IL_0ae9: ldnull
+		IL_0aea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0aef: dup
+		IL_0af0: ldc.r8 2
+		IL_0af9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0afe: stloc.s 13
+		IL_0b00: ldstr "call"
+		IL_0b05: ldloc.s 13
+		IL_0b07: ldnull
+		IL_0b08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0b0d: stloc.s 12
+		IL_0b0f: ldloc.s 11
+		IL_0b11: ldloc.s 12
+		IL_0b13: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b18: pop
+		IL_0b19: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b1e: stloc.s 11
+		IL_0b20: ldstr "Array"
+		IL_0b25: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b2a: volatile.
+		IL_0b2c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0b31: brfalse IL_0b45
 
-		IL_0c59: ldloc.s 22
-		IL_0c5b: ldstr "reduce"
-		IL_0c60: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c65: br IL_0c80
+		IL_0b36: ldstr "prototype"
+		IL_0b3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b40: br IL_0b59
 
-		IL_0c6a: ldloc.s 22
-		IL_0c6c: ldstr "reduce"
-		IL_0c71: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:251"
-		IL_0c76: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0c7b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0b45: ldstr "prototype"
+		IL_0b4a: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:210"
+		IL_0b4f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0b54: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0c80: stloc.s 22
-		IL_0c82: ldloc.s 22
-		IL_0c84: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0c89: stloc.s 22
-		IL_0c8b: ldc.i4.3
-		IL_0c8c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0c91: dup
-		IL_0c92: ldc.r8 1
-		IL_0c9b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0ca0: dup
-		IL_0ca1: ldc.r8 2
-		IL_0caa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0caf: dup
-		IL_0cb0: ldc.r8 3
-		IL_0cb9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0cbe: stloc.s 13
-		IL_0cc0: ldc.i4.1
-		IL_0cc1: newarr [System.Runtime]System.Object
-		IL_0cc6: dup
-		IL_0cc7: ldc.i4.0
-		IL_0cc8: ldloc.0
-		IL_0cc9: stelem.ref
-		IL_0cca: stloc.s 14
-		IL_0ccc: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L32C51/FunctionObject::.ctor()
-		IL_0cd1: ldc.i4.2
-		IL_0cd2: conv.r8
-		IL_0cd3: ldstr ""
-		IL_0cd8: ldc.i4.0
-		IL_0cd9: ldc.i4.1
-		IL_0cda: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L32C51/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0cdf: stloc.s 26
-		IL_0ce1: ldloc.s 22
-		IL_0ce3: ldstr "call"
-		IL_0ce8: ldloc.s 13
-		IL_0cea: ldloc.s 26
-		IL_0cec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0cf1: stloc.s 22
-		IL_0cf3: ldloc.s 11
+		IL_0b59: stloc.s 12
+		IL_0b5b: volatile.
+		IL_0b5d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0b62: brfalse IL_0b78
+
+		IL_0b67: ldloc.s 12
+		IL_0b69: ldstr "values"
+		IL_0b6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b73: br IL_0b8e
+
+		IL_0b78: ldloc.s 12
+		IL_0b7a: ldstr "values"
+		IL_0b7f: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:212"
+		IL_0b84: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0b89: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0b8e: stloc.s 12
+		IL_0b90: ldstr "Array"
+		IL_0b95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b9a: volatile.
+		IL_0b9c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0ba1: brfalse IL_0bb5
+
+		IL_0ba6: ldstr "prototype"
+		IL_0bab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0bb0: br IL_0bc9
+
+		IL_0bb5: ldstr "prototype"
+		IL_0bba: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:216"
+		IL_0bbf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0bc4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0bc9: stloc.s 21
+		IL_0bcb: ldstr "iterator"
+		IL_0bd0: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0bd5: stloc.s 22
+		IL_0bd7: ldloc.s 21
+		IL_0bd9: ldloc.s 22
+		IL_0bdb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0be0: stloc.s 22
+		IL_0be2: ldloc.s 12
+		IL_0be4: ldloc.s 22
+		IL_0be6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0beb: stloc.s 23
+		IL_0bed: ldloc.s 23
+		IL_0bef: box [System.Runtime]System.Boolean
+		IL_0bf4: stloc.s 24
+		IL_0bf6: ldloc.s 11
+		IL_0bf8: ldloc.s 24
+		IL_0bfa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0bff: pop
+		IL_0c00: ldc.i4.2
+		IL_0c01: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0c06: dup
+		IL_0c07: ldc.r8 1
+		IL_0c10: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0c15: dup
+		IL_0c16: ldc.r8 2
+		IL_0c1f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0c24: stloc.2
+		IL_0c25: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0c2a: stloc.s 11
+		IL_0c2c: ldloc.2
+		IL_0c2d: ldc.i4.3
+		IL_0c2e: newarr [System.Runtime]System.Object
+		IL_0c33: dup
+		IL_0c34: ldc.i4.0
+		IL_0c35: ldc.r8 3
+		IL_0c3e: box [System.Runtime]System.Double
+		IL_0c43: stelem.ref
+		IL_0c44: dup
+		IL_0c45: ldc.i4.1
+		IL_0c46: ldc.r8 4
+		IL_0c4f: box [System.Runtime]System.Double
+		IL_0c54: stelem.ref
+		IL_0c55: dup
+		IL_0c56: ldc.i4.2
+		IL_0c57: ldc.r8 5
+		IL_0c60: box [System.Runtime]System.Double
+		IL_0c65: stelem.ref
+		IL_0c66: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object[])
+		IL_0c6b: stloc.s 19
+		IL_0c6d: ldloc.s 19
+		IL_0c6f: box [System.Runtime]System.Double
+		IL_0c74: stloc.s 20
+		IL_0c76: ldloc.s 11
+		IL_0c78: ldloc.s 20
+		IL_0c7a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0c7f: pop
+		IL_0c80: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0c85: stloc.s 11
+		IL_0c87: ldloc.2
+		IL_0c88: ldc.i4.1
+		IL_0c89: newarr [System.Runtime]System.Object
+		IL_0c8e: dup
+		IL_0c8f: ldc.i4.0
+		IL_0c90: ldstr ","
+		IL_0c95: stelem.ref
+		IL_0c96: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0c9b: stloc.s 25
+		IL_0c9d: ldloc.s 11
+		IL_0c9f: ldloc.s 25
+		IL_0ca1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0ca6: pop
+		IL_0ca7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0cac: stloc.s 11
+		IL_0cae: ldstr "Array"
+		IL_0cb3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0cb8: volatile.
+		IL_0cba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0cbf: brfalse IL_0cd3
+
+		IL_0cc4: ldstr "prototype"
+		IL_0cc9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0cce: br IL_0ce7
+
+		IL_0cd3: ldstr "prototype"
+		IL_0cd8: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:249"
+		IL_0cdd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0ce2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0ce7: stloc.s 22
+		IL_0ce9: volatile.
+		IL_0ceb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0cf0: brfalse IL_0d06
+
 		IL_0cf5: ldloc.s 22
-		IL_0cf7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0cfc: pop
-		IL_0cfd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0d02: stloc.s 11
-		IL_0d04: ldstr "Array"
-		IL_0d09: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0d0e: volatile.
-		IL_0d10: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0d15: brfalse IL_0d29
+		IL_0cf7: ldstr "reduce"
+		IL_0cfc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d01: br IL_0d1c
 
-		IL_0d1a: ldstr "prototype"
-		IL_0d1f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0d24: br IL_0d3d
+		IL_0d06: ldloc.s 22
+		IL_0d08: ldstr "reduce"
+		IL_0d0d: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:251"
+		IL_0d12: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0d17: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0d29: ldstr "prototype"
-		IL_0d2e: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:266"
-		IL_0d33: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0d38: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0d1c: stloc.s 22
+		IL_0d1e: ldloc.s 22
+		IL_0d20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0d25: stloc.s 22
+		IL_0d27: ldc.i4.3
+		IL_0d28: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0d2d: dup
+		IL_0d2e: ldc.r8 1
+		IL_0d37: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0d3c: dup
+		IL_0d3d: ldc.r8 2
+		IL_0d46: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0d4b: dup
+		IL_0d4c: ldc.r8 3
+		IL_0d55: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0d5a: stloc.s 13
+		IL_0d5c: ldc.i4.1
+		IL_0d5d: newarr [System.Runtime]System.Object
+		IL_0d62: dup
+		IL_0d63: ldc.i4.0
+		IL_0d64: ldloc.0
+		IL_0d65: stelem.ref
+		IL_0d66: stloc.s 14
+		IL_0d68: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L32C51/FunctionObject::.ctor()
+		IL_0d6d: ldc.i4.2
+		IL_0d6e: conv.r8
+		IL_0d6f: ldstr ""
+		IL_0d74: ldc.i4.0
+		IL_0d75: ldc.i4.1
+		IL_0d76: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L32C51/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d7b: stloc.s 26
+		IL_0d7d: ldloc.s 22
+		IL_0d7f: ldstr "call"
+		IL_0d84: ldloc.s 13
+		IL_0d86: ldloc.s 26
+		IL_0d88: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0d8d: stloc.s 22
+		IL_0d8f: ldloc.s 11
+		IL_0d91: ldloc.s 22
+		IL_0d93: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0d98: pop
+		IL_0d99: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0d9e: stloc.s 11
+		IL_0da0: ldstr "Array"
+		IL_0da5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0daa: volatile.
+		IL_0dac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0db1: brfalse IL_0dc5
 
-		IL_0d3d: stloc.s 22
-		IL_0d3f: volatile.
-		IL_0d41: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0d46: brfalse IL_0d5c
+		IL_0db6: ldstr "prototype"
+		IL_0dbb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0dc0: br IL_0dd9
 
-		IL_0d4b: ldloc.s 22
-		IL_0d4d: ldstr "reduce"
-		IL_0d52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0d57: br IL_0d72
+		IL_0dc5: ldstr "prototype"
+		IL_0dca: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:266"
+		IL_0dcf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0dd4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0d5c: ldloc.s 22
-		IL_0d5e: ldstr "reduce"
-		IL_0d63: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:268"
-		IL_0d68: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0d6d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0dd9: stloc.s 22
+		IL_0ddb: volatile.
+		IL_0ddd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_0de2: brfalse IL_0df8
 
-		IL_0d72: stloc.s 22
-		IL_0d74: ldloc.s 22
-		IL_0d76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0d7b: stloc.s 22
-		IL_0d7d: ldc.i4.3
-		IL_0d7e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0d83: dup
-		IL_0d84: ldc.r8 1
-		IL_0d8d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0d92: dup
-		IL_0d93: ldc.r8 2
-		IL_0d9c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0da1: dup
-		IL_0da2: ldc.r8 3
-		IL_0dab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0db0: stloc.s 13
-		IL_0db2: ldc.i4.1
-		IL_0db3: newarr [System.Runtime]System.Object
-		IL_0db8: dup
-		IL_0db9: ldc.i4.0
-		IL_0dba: ldloc.0
-		IL_0dbb: stelem.ref
-		IL_0dbc: stloc.s 14
-		IL_0dbe: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L33C51/FunctionObject::.ctor()
-		IL_0dc3: ldc.i4.2
-		IL_0dc4: conv.r8
-		IL_0dc5: ldstr ""
-		IL_0dca: ldc.i4.0
-		IL_0dcb: ldc.i4.1
-		IL_0dcc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L33C51/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0dd1: stloc.s 27
-		IL_0dd3: ldloc.s 22
-		IL_0dd5: ldstr "call"
-		IL_0dda: ldloc.s 13
-		IL_0ddc: ldloc.s 27
-		IL_0dde: ldc.r8 10
-		IL_0de7: box [System.Runtime]System.Double
-		IL_0dec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0df1: stloc.s 22
-		IL_0df3: ldloc.s 11
-		IL_0df5: ldloc.s 22
-		IL_0df7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0dfc: pop
+		IL_0de7: ldloc.s 22
+		IL_0de9: ldstr "reduce"
+		IL_0dee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0df3: br IL_0e0e
+
+		IL_0df8: ldloc.s 22
+		IL_0dfa: ldstr "reduce"
+		IL_0dff: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:268"
+		IL_0e04: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_0e09: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0e0e: stloc.s 22
+		IL_0e10: ldloc.s 22
+		IL_0e12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0e17: stloc.s 22
+		IL_0e19: ldc.i4.3
+		IL_0e1a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0e1f: dup
+		IL_0e20: ldc.r8 1
+		IL_0e29: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0e2e: dup
+		IL_0e2f: ldc.r8 2
+		IL_0e38: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0e3d: dup
+		IL_0e3e: ldc.r8 3
+		IL_0e47: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0e4c: stloc.s 13
+		IL_0e4e: ldc.i4.1
+		IL_0e4f: newarr [System.Runtime]System.Object
+		IL_0e54: dup
+		IL_0e55: ldc.i4.0
+		IL_0e56: ldloc.0
+		IL_0e57: stelem.ref
+		IL_0e58: stloc.s 14
+		IL_0e5a: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L33C51/FunctionObject::.ctor()
+		IL_0e5f: ldc.i4.2
+		IL_0e60: conv.r8
+		IL_0e61: ldstr ""
+		IL_0e66: ldc.i4.0
+		IL_0e67: ldc.i4.1
+		IL_0e68: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L33C51/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e6d: stloc.s 27
+		IL_0e6f: ldloc.s 22
+		IL_0e71: ldstr "call"
+		IL_0e76: ldloc.s 13
+		IL_0e78: ldloc.s 27
+		IL_0e7a: ldc.r8 10
+		IL_0e83: box [System.Runtime]System.Double
+		IL_0e88: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0e8d: stloc.s 22
+		IL_0e8f: ldloc.s 11
+		IL_0e91: ldloc.s 22
+		IL_0e93: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0e98: pop
 		.try
 		{
-			IL_0dfd: nop
-			IL_0dfe: ldstr "Array"
-			IL_0e03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0e08: volatile.
-			IL_0e0a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_0e0f: brfalse IL_0e23
+			IL_0e99: nop
+			IL_0e9a: ldstr "Array"
+			IL_0e9f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ea4: volatile.
+			IL_0ea6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0eab: brfalse IL_0ebf
 
-			IL_0e14: ldstr "prototype"
-			IL_0e19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e1e: br IL_0e37
+			IL_0eb0: ldstr "prototype"
+			IL_0eb5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0eba: br IL_0ed3
 
-			IL_0e23: ldstr "prototype"
-			IL_0e28: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:287"
-			IL_0e2d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_0e32: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0ebf: ldstr "prototype"
+			IL_0ec4: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:287"
+			IL_0ec9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0ece: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e37: stloc.s 22
-			IL_0e39: volatile.
-			IL_0e3b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_0e40: brfalse IL_0e56
+			IL_0ed3: stloc.s 22
+			IL_0ed5: volatile.
+			IL_0ed7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_0edc: brfalse IL_0ef2
 
-			IL_0e45: ldloc.s 22
-			IL_0e47: ldstr "reduce"
-			IL_0e4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e51: br IL_0e6c
+			IL_0ee1: ldloc.s 22
+			IL_0ee3: ldstr "reduce"
+			IL_0ee8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0eed: br IL_0f08
 
-			IL_0e56: ldloc.s 22
-			IL_0e58: ldstr "reduce"
-			IL_0e5d: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:289"
-			IL_0e62: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_0e67: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0ef2: ldloc.s 22
+			IL_0ef4: ldstr "reduce"
+			IL_0ef9: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:289"
+			IL_0efe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_0f03: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e6c: stloc.s 22
-			IL_0e6e: ldloc.s 22
-			IL_0e70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0e75: stloc.s 22
-			IL_0e77: ldc.i4.1
-			IL_0e78: newarr [System.Runtime]System.Object
-			IL_0e7d: dup
-			IL_0e7e: ldc.i4.0
-			IL_0e7f: ldloc.0
-			IL_0e80: stelem.ref
-			IL_0e81: stloc.s 14
-			IL_0e83: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L37C38/FunctionObject::.ctor()
-			IL_0e88: ldc.i4.0
-			IL_0e89: conv.r8
-			IL_0e8a: ldstr ""
-			IL_0e8f: ldc.i4.0
-			IL_0e90: ldc.i4.1
-			IL_0e91: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L37C38/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0e96: stloc.s 28
-			IL_0e98: ldloc.s 22
-			IL_0e9a: ldstr "call"
-			IL_0e9f: ldc.i4.0
-			IL_0ea0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0ea5: ldloc.s 28
-			IL_0ea7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0eac: pop
-			IL_0ead: leave IL_0f1b
+			IL_0f08: stloc.s 22
+			IL_0f0a: ldloc.s 22
+			IL_0f0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0f11: stloc.s 22
+			IL_0f13: ldc.i4.1
+			IL_0f14: newarr [System.Runtime]System.Object
+			IL_0f19: dup
+			IL_0f1a: ldc.i4.0
+			IL_0f1b: ldloc.0
+			IL_0f1c: stelem.ref
+			IL_0f1d: stloc.s 14
+			IL_0f1f: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L37C38/FunctionObject::.ctor()
+			IL_0f24: ldc.i4.0
+			IL_0f25: conv.r8
+			IL_0f26: ldstr ""
+			IL_0f2b: ldc.i4.0
+			IL_0f2c: ldc.i4.1
+			IL_0f2d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L37C38/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0f32: stloc.s 28
+			IL_0f34: ldloc.s 22
+			IL_0f36: ldstr "call"
+			IL_0f3b: ldc.i4.0
+			IL_0f3c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0f41: ldloc.s 28
+			IL_0f43: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0f48: pop
+			IL_0f49: leave IL_0fb7
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0eb2: stloc.3
-			IL_0eb3: ldloc.3
-			IL_0eb4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0eb9: dup
-			IL_0eba: brtrue IL_0ecf
+			IL_0f4e: stloc.3
+			IL_0f4f: ldloc.3
+			IL_0f50: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0f55: dup
+			IL_0f56: brtrue IL_0f6b
 
-			IL_0ebf: pop
-			IL_0ec0: ldloc.3
-			IL_0ec1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0ec6: dup
-			IL_0ec7: brtrue IL_0edb
+			IL_0f5b: pop
+			IL_0f5c: ldloc.3
+			IL_0f5d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0f62: dup
+			IL_0f63: brtrue IL_0f77
 
-			IL_0ecc: pop
-			IL_0ecd: rethrow
+			IL_0f68: pop
+			IL_0f69: rethrow
 
-			IL_0ecf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0ed4: stloc.s 4
-			IL_0ed6: br IL_0edd
+			IL_0f6b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0f70: stloc.s 4
+			IL_0f72: br IL_0f79
 
-			IL_0edb: stloc.s 4
+			IL_0f77: stloc.s 4
 
-			IL_0edd: ldloc.s 4
-			IL_0edf: stloc.s 5
-			IL_0ee1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0ee6: stloc.s 11
-			IL_0ee8: ldloc.s 5
-			IL_0eea: stloc.s 22
-			IL_0eec: ldstr "TypeError"
-			IL_0ef1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ef6: stloc.s 12
-			IL_0ef8: ldloc.s 22
-			IL_0efa: ldloc.s 12
-			IL_0efc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0f01: stloc.s 23
-			IL_0f03: ldloc.s 23
-			IL_0f05: box [System.Runtime]System.Boolean
-			IL_0f0a: stloc.s 24
-			IL_0f0c: ldloc.s 11
-			IL_0f0e: ldloc.s 24
-			IL_0f10: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0f15: pop
-			IL_0f16: leave IL_0f1b
+			IL_0f79: ldloc.s 4
+			IL_0f7b: stloc.s 5
+			IL_0f7d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0f82: stloc.s 11
+			IL_0f84: ldloc.s 5
+			IL_0f86: stloc.s 22
+			IL_0f88: ldstr "TypeError"
+			IL_0f8d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0f92: stloc.s 12
+			IL_0f94: ldloc.s 22
+			IL_0f96: ldloc.s 12
+			IL_0f98: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0f9d: stloc.s 23
+			IL_0f9f: ldloc.s 23
+			IL_0fa1: box [System.Runtime]System.Boolean
+			IL_0fa6: stloc.s 24
+			IL_0fa8: ldloc.s 11
+			IL_0faa: ldloc.s 24
+			IL_0fac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0fb1: pop
+			IL_0fb2: leave IL_0fb7
 		} // end handler
 		.try
 		{
-			IL_0f1b: nop
-			IL_0f1c: ldstr "Array"
-			IL_0f21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0f26: volatile.
-			IL_0f28: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-			IL_0f2d: brfalse IL_0f41
+			IL_0fb7: nop
+			IL_0fb8: ldstr "Array"
+			IL_0fbd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0fc2: volatile.
+			IL_0fc4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_0fc9: brfalse IL_0fdd
 
-			IL_0f32: ldstr "prototype"
-			IL_0f37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f3c: br IL_0f55
+			IL_0fce: ldstr "prototype"
+			IL_0fd3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fd8: br IL_0ff1
 
-			IL_0f41: ldstr "prototype"
-			IL_0f46: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:322"
-			IL_0f4b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-			IL_0f50: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0fdd: ldstr "prototype"
+			IL_0fe2: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:322"
+			IL_0fe7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_0fec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f55: stloc.s 12
-			IL_0f57: volatile.
-			IL_0f59: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-			IL_0f5e: brfalse IL_0f74
+			IL_0ff1: stloc.s 12
+			IL_0ff3: volatile.
+			IL_0ff5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_0ffa: brfalse IL_1010
 
-			IL_0f63: ldloc.s 12
-			IL_0f65: ldstr "every"
-			IL_0f6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f6f: br IL_0f8a
+			IL_0fff: ldloc.s 12
+			IL_1001: ldstr "every"
+			IL_1006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_100b: br IL_1026
 
-			IL_0f74: ldloc.s 12
-			IL_0f76: ldstr "every"
-			IL_0f7b: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:324"
-			IL_0f80: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-			IL_0f85: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1010: ldloc.s 12
+			IL_1012: ldstr "every"
+			IL_1017: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:324"
+			IL_101c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_1021: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f8a: stloc.s 12
-			IL_0f8c: ldloc.s 12
-			IL_0f8e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0f93: stloc.s 12
-			IL_0f95: ldc.i4.1
-			IL_0f96: newarr [System.Runtime]System.Object
-			IL_0f9b: dup
-			IL_0f9c: ldc.i4.0
-			IL_0f9d: ldloc.0
-			IL_0f9e: stelem.ref
-			IL_0f9f: stloc.s 14
-			IL_0fa1: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L43C42/FunctionObject::.ctor()
-			IL_0fa6: ldc.i4.0
-			IL_0fa7: conv.r8
-			IL_0fa8: ldstr ""
-			IL_0fad: ldc.i4.0
-			IL_0fae: ldc.i4.1
-			IL_0faf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L43C42/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0fb4: stloc.s 29
-			IL_0fb6: ldloc.s 12
-			IL_0fb8: ldstr "call"
-			IL_0fbd: ldnull
-			IL_0fbe: ldloc.s 29
-			IL_0fc0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0fc5: pop
-			IL_0fc6: leave IL_1037
+			IL_1026: stloc.s 12
+			IL_1028: ldloc.s 12
+			IL_102a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_102f: stloc.s 12
+			IL_1031: ldc.i4.1
+			IL_1032: newarr [System.Runtime]System.Object
+			IL_1037: dup
+			IL_1038: ldc.i4.0
+			IL_1039: ldloc.0
+			IL_103a: stelem.ref
+			IL_103b: stloc.s 14
+			IL_103d: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L43C42/FunctionObject::.ctor()
+			IL_1042: ldc.i4.0
+			IL_1043: conv.r8
+			IL_1044: ldstr ""
+			IL_1049: ldc.i4.0
+			IL_104a: ldc.i4.1
+			IL_104b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L43C42/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_1050: stloc.s 29
+			IL_1052: ldloc.s 12
+			IL_1054: ldstr "call"
+			IL_1059: ldnull
+			IL_105a: ldloc.s 29
+			IL_105c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_1061: pop
+			IL_1062: leave IL_10d3
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0fcb: stloc.s 6
-			IL_0fcd: ldloc.s 6
-			IL_0fcf: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0fd4: dup
-			IL_0fd5: brtrue IL_0feb
+			IL_1067: stloc.s 6
+			IL_1069: ldloc.s 6
+			IL_106b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_1070: dup
+			IL_1071: brtrue IL_1087
 
-			IL_0fda: pop
-			IL_0fdb: ldloc.s 6
-			IL_0fdd: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0fe2: dup
-			IL_0fe3: brtrue IL_0ff7
+			IL_1076: pop
+			IL_1077: ldloc.s 6
+			IL_1079: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_107e: dup
+			IL_107f: brtrue IL_1093
 
-			IL_0fe8: pop
-			IL_0fe9: rethrow
+			IL_1084: pop
+			IL_1085: rethrow
 
-			IL_0feb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0ff0: stloc.s 7
-			IL_0ff2: br IL_0ff9
+			IL_1087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_108c: stloc.s 7
+			IL_108e: br IL_1095
 
-			IL_0ff7: stloc.s 7
+			IL_1093: stloc.s 7
 
-			IL_0ff9: ldloc.s 7
-			IL_0ffb: stloc.s 8
-			IL_0ffd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1002: stloc.s 11
-			IL_1004: ldloc.s 8
-			IL_1006: stloc.s 12
-			IL_1008: ldstr "TypeError"
-			IL_100d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1012: stloc.s 22
-			IL_1014: ldloc.s 12
-			IL_1016: ldloc.s 22
-			IL_1018: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_101d: stloc.s 23
-			IL_101f: ldloc.s 23
-			IL_1021: box [System.Runtime]System.Boolean
-			IL_1026: stloc.s 24
-			IL_1028: ldloc.s 11
-			IL_102a: ldloc.s 24
-			IL_102c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1031: pop
-			IL_1032: leave IL_1037
+			IL_1095: ldloc.s 7
+			IL_1097: stloc.s 8
+			IL_1099: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_109e: stloc.s 11
+			IL_10a0: ldloc.s 8
+			IL_10a2: stloc.s 12
+			IL_10a4: ldstr "TypeError"
+			IL_10a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_10ae: stloc.s 22
+			IL_10b0: ldloc.s 12
+			IL_10b2: ldloc.s 22
+			IL_10b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_10b9: stloc.s 23
+			IL_10bb: ldloc.s 23
+			IL_10bd: box [System.Runtime]System.Boolean
+			IL_10c2: stloc.s 24
+			IL_10c4: ldloc.s 11
+			IL_10c6: ldloc.s 24
+			IL_10c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_10cd: pop
+			IL_10ce: leave IL_10d3
 		} // end handler
 
-		IL_1037: ldstr "Array"
-		IL_103c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_1041: volatile.
-		IL_1043: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_1048: brfalse IL_105c
+		IL_10d3: ldstr "Array"
+		IL_10d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_10dd: volatile.
+		IL_10df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_10e4: brfalse IL_10f8
 
-		IL_104d: ldstr "prototype"
-		IL_1052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1057: br IL_1070
+		IL_10e9: ldstr "prototype"
+		IL_10ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_10f3: br IL_110c
 
-		IL_105c: ldstr "prototype"
-		IL_1061: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:353"
-		IL_1066: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_106b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_10f8: ldstr "prototype"
+		IL_10fd: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:353"
+		IL_1102: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_1107: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1070: stloc.s 22
-		IL_1072: volatile.
-		IL_1074: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_1079: brfalse IL_108f
+		IL_110c: stloc.s 22
+		IL_110e: volatile.
+		IL_1110: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_1115: brfalse IL_112b
 
-		IL_107e: ldloc.s 22
-		IL_1080: ldstr "join"
-		IL_1085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_108a: br IL_10a5
+		IL_111a: ldloc.s 22
+		IL_111c: ldstr "join"
+		IL_1121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1126: br IL_1141
 
-		IL_108f: ldloc.s 22
-		IL_1091: ldstr "join"
-		IL_1096: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:355"
-		IL_109b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_10a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_112b: ldloc.s 22
+		IL_112d: ldstr "join"
+		IL_1132: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:355"
+		IL_1137: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_113c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_10a5: stloc.s 9
-		IL_10a7: ldstr "Array"
-		IL_10ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_10b1: volatile.
-		IL_10b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_10b8: brfalse IL_10cc
+		IL_1141: stloc.s 9
+		IL_1143: ldstr "Array"
+		IL_1148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_114d: volatile.
+		IL_114f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_1154: brfalse IL_1168
 
-		IL_10bd: ldstr "prototype"
-		IL_10c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_10c7: br IL_10e0
+		IL_1159: ldstr "prototype"
+		IL_115e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1163: br IL_117c
 
-		IL_10cc: ldstr "prototype"
-		IL_10d1: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:361"
-		IL_10d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_10db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1168: ldstr "prototype"
+		IL_116d: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:361"
+		IL_1172: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_1177: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_10e0: stloc.s 22
-		IL_10e2: ldc.i4.1
-		IL_10e3: newarr [System.Runtime]System.Object
-		IL_10e8: dup
-		IL_10e9: ldc.i4.0
-		IL_10ea: ldloc.0
-		IL_10eb: stelem.ref
-		IL_10ec: stloc.s 14
-		IL_10ee: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L54C23/FunctionObject::.ctor()
-		IL_10f3: ldc.i4.0
-		IL_10f4: conv.r8
-		IL_10f5: ldstr ""
-		IL_10fa: ldc.i4.0
-		IL_10fb: ldc.i4.1
-		IL_10fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L54C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1101: stloc.s 30
-		IL_1103: ldloc.s 22
-		IL_1105: ldstr "join"
-		IL_110a: ldloc.s 30
-		IL_110c: ldc.i4.1
-		IL_110d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_1112: pop
-		IL_1113: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_1118: stloc.s 11
-		IL_111a: ldstr "Array"
-		IL_111f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_1124: volatile.
-		IL_1126: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-		IL_112b: brfalse IL_113f
+		IL_117c: stloc.s 22
+		IL_117e: ldc.i4.1
+		IL_117f: newarr [System.Runtime]System.Object
+		IL_1184: dup
+		IL_1185: ldc.i4.0
+		IL_1186: ldloc.0
+		IL_1187: stelem.ref
+		IL_1188: stloc.s 14
+		IL_118a: newobj instance void Modules.Array_ExplicitReceiverAbi/FunctionExpression_L54C23/FunctionObject::.ctor()
+		IL_118f: ldc.i4.0
+		IL_1190: conv.r8
+		IL_1191: ldstr ""
+		IL_1196: ldc.i4.0
+		IL_1197: ldc.i4.1
+		IL_1198: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ExplicitReceiverAbi/FunctionExpression_L54C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_119d: stloc.s 30
+		IL_119f: ldloc.s 22
+		IL_11a1: ldstr "join"
+		IL_11a6: ldloc.s 30
+		IL_11a8: ldc.i4.1
+		IL_11a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_11ae: pop
+		IL_11af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_11b4: stloc.s 11
+		IL_11b6: ldstr "Array"
+		IL_11bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_11c0: volatile.
+		IL_11c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+		IL_11c7: brfalse IL_11db
 
-		IL_1130: ldstr "prototype"
-		IL_1135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_113a: br IL_1153
+		IL_11cc: ldstr "prototype"
+		IL_11d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_11d6: br IL_11ef
 
-		IL_113f: ldstr "prototype"
-		IL_1144: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:371"
-		IL_1149: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-		IL_114e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_11db: ldstr "prototype"
+		IL_11e0: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:371"
+		IL_11e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+		IL_11ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1153: stloc.s 22
-		IL_1155: volatile.
-		IL_1157: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-		IL_115c: brfalse IL_1172
+		IL_11ef: stloc.s 22
+		IL_11f1: volatile.
+		IL_11f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+		IL_11f8: brfalse IL_120e
 
-		IL_1161: ldloc.s 22
-		IL_1163: ldstr "join"
-		IL_1168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_116d: br IL_1188
+		IL_11fd: ldloc.s 22
+		IL_11ff: ldstr "join"
+		IL_1204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1209: br IL_1224
 
-		IL_1172: ldloc.s 22
-		IL_1174: ldstr "join"
-		IL_1179: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:373"
-		IL_117e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-		IL_1183: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_120e: ldloc.s 22
+		IL_1210: ldstr "join"
+		IL_1215: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:373"
+		IL_121a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+		IL_121f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1188: stloc.s 22
-		IL_118a: ldloc.s 22
-		IL_118c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_1191: ldc.i4.3
-		IL_1192: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_1197: dup
-		IL_1198: ldc.r8 1
-		IL_11a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_11a6: dup
-		IL_11a7: ldc.r8 2
-		IL_11b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_11b5: dup
-		IL_11b6: ldc.r8 3
-		IL_11bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_11c4: stloc.s 13
-		IL_11c6: ldstr "call"
-		IL_11cb: ldloc.s 13
-		IL_11cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_11d2: stloc.s 22
-		IL_11d4: ldloc.s 11
-		IL_11d6: ldloc.s 22
-		IL_11d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_11dd: pop
-		IL_11de: ldstr "Array"
-		IL_11e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_11e8: volatile.
-		IL_11ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-		IL_11ef: brfalse IL_1203
+		IL_1224: stloc.s 22
+		IL_1226: ldloc.s 22
+		IL_1228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_122d: ldc.i4.3
+		IL_122e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_1233: dup
+		IL_1234: ldc.r8 1
+		IL_123d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_1242: dup
+		IL_1243: ldc.r8 2
+		IL_124c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_1251: dup
+		IL_1252: ldc.r8 3
+		IL_125b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_1260: stloc.s 13
+		IL_1262: volatile.
+		IL_1264: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+		IL_1269: brfalse IL_127f
 
-		IL_11f4: ldstr "prototype"
-		IL_11f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_11fe: br IL_1217
+		IL_126e: ldstr "call"
+		IL_1273: ldloc.s 13
+		IL_1275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_127a: br IL_1295
 
-		IL_1203: ldstr "prototype"
-		IL_1208: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:385"
-		IL_120d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-		IL_1212: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_127f: ldstr "call"
+		IL_1284: ldloc.s 13
+		IL_1286: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:379"
+		IL_128b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+		IL_1290: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_1217: stloc.s 22
-		IL_1219: ldloc.s 22
-		IL_121b: ldstr "join"
-		IL_1220: ldloc.s 9
-		IL_1222: ldc.i4.1
-		IL_1223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_1228: pop
-		IL_1229: ldnull
-		IL_122a: stloc.s 10
-		IL_122c: ret
+		IL_1295: stloc.s 22
+		IL_1297: ldloc.s 11
+		IL_1299: ldloc.s 22
+		IL_129b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_12a0: pop
+		IL_12a1: ldstr "Array"
+		IL_12a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_12ab: volatile.
+		IL_12ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+		IL_12b2: brfalse IL_12c6
+
+		IL_12b7: ldstr "prototype"
+		IL_12bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_12c1: br IL_12da
+
+		IL_12c6: ldstr "prototype"
+		IL_12cb: ldstr "Array_ExplicitReceiverAbi:Modules.Array_ExplicitReceiverAbi:__js_module_init__:385"
+		IL_12d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+		IL_12d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_12da: stloc.s 22
+		IL_12dc: ldloc.s 22
+		IL_12de: ldstr "join"
+		IL_12e3: ldloc.s 9
+		IL_12e5: ldc.i4.1
+		IL_12e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_12eb: pop
+		IL_12ec: ldnull
+		IL_12ed: stloc.s 10
+		IL_12ef: ret
 	} // end of method Array_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.Array_ExplicitReceiverAbi
@@ -3021,6 +3081,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_41
 	.field assembly static int32 __jroc_dynamicLookup_42
 	.field assembly static int32 __jroc_dynamicLookup_43
+	.field assembly static int32 __jroc_dynamicLookup_44
+	.field assembly static int32 __jroc_dynamicLookup_45
+	.field assembly static int32 __jroc_dynamicLookup_46
+	.field assembly static int32 __jroc_dynamicLookup_47
+	.field assembly static int32 __jroc_dynamicLookup_48
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Iterator_Methods.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Iterator_Methods.verified.txt
@@ -552,7 +552,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1866 (0x74a)
+		// Code size: 1943 (0x797)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Array_Iterator_Methods/Scope,
@@ -756,415 +756,439 @@
 		IL_0254: stloc.s 19
 		IL_0256: ldloc.s 19
 		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025d: ldstr "call"
-		IL_0262: ldloc.1
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0268: stloc.s 5
-		IL_026a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_026f: stloc.s 17
-		IL_0271: ldloc.s 5
-		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0278: volatile.
-		IL_027a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_027f: brfalse IL_0293
+		IL_025d: volatile.
+		IL_025f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0264: brfalse IL_0279
 
-		IL_0284: ldstr "next"
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_028e: br IL_02a7
+		IL_0269: ldstr "call"
+		IL_026e: ldloc.1
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0274: br IL_028e
 
-		IL_0293: ldstr "next"
-		IL_0298: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:97"
-		IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0279: ldstr "call"
+		IL_027e: ldloc.1
+		IL_027f: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:92"
+		IL_0284: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02a7: stloc.s 19
-		IL_02a9: volatile.
-		IL_02ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_02b0: brfalse IL_02c6
+		IL_028e: stloc.s 5
+		IL_0290: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0295: stloc.s 17
+		IL_0297: ldloc.s 5
+		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029e: volatile.
+		IL_02a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02a5: brfalse IL_02b9
 
-		IL_02b5: ldloc.s 19
-		IL_02b7: ldstr "value"
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02c1: br IL_02dc
+		IL_02aa: ldstr "next"
+		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02b4: br IL_02cd
 
-		IL_02c6: ldloc.s 19
-		IL_02c8: ldstr "value"
-		IL_02cd: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:99"
-		IL_02d2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02b9: ldstr "next"
+		IL_02be: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:97"
+		IL_02c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_02dc: stloc.s 19
-		IL_02de: ldloc.s 17
-		IL_02e0: ldloc.s 19
-		IL_02e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02e7: pop
-		IL_02e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ed: stloc.s 17
-		IL_02ef: ldloc.s 5
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f6: volatile.
-		IL_02f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_02fd: brfalse IL_0311
+		IL_02cd: stloc.s 19
+		IL_02cf: volatile.
+		IL_02d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02d6: brfalse IL_02ec
 
-		IL_0302: ldstr "next"
-		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_030c: br IL_0325
+		IL_02db: ldloc.s 19
+		IL_02dd: ldstr "value"
+		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02e7: br IL_0302
 
-		IL_0311: ldstr "next"
-		IL_0316: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:104"
-		IL_031b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_02ec: ldloc.s 19
+		IL_02ee: ldstr "value"
+		IL_02f3: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:99"
+		IL_02f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0325: stloc.s 19
-		IL_0327: volatile.
-		IL_0329: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_032e: brfalse IL_0344
+		IL_0302: stloc.s 19
+		IL_0304: ldloc.s 17
+		IL_0306: ldloc.s 19
+		IL_0308: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_030d: pop
+		IL_030e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0313: stloc.s 17
+		IL_0315: ldloc.s 5
+		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_031c: volatile.
+		IL_031e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0323: brfalse IL_0337
 
-		IL_0333: ldloc.s 19
-		IL_0335: ldstr "value"
-		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_033f: br IL_035a
+		IL_0328: ldstr "next"
+		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0332: br IL_034b
 
-		IL_0344: ldloc.s 19
-		IL_0346: ldstr "value"
-		IL_034b: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:106"
-		IL_0350: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0337: ldstr "next"
+		IL_033c: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:104"
+		IL_0341: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_035a: stloc.s 19
-		IL_035c: ldloc.s 17
-		IL_035e: ldloc.s 19
-		IL_0360: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0365: pop
-		IL_0366: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_036b: stloc.s 17
-		IL_036d: ldloc.s 5
-		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0374: volatile.
-		IL_0376: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_037b: brfalse IL_038f
+		IL_034b: stloc.s 19
+		IL_034d: volatile.
+		IL_034f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0354: brfalse IL_036a
 
-		IL_0380: ldstr "next"
-		IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_038a: br IL_03a3
+		IL_0359: ldloc.s 19
+		IL_035b: ldstr "value"
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0365: br IL_0380
 
-		IL_038f: ldstr "next"
-		IL_0394: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:111"
-		IL_0399: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_036a: ldloc.s 19
+		IL_036c: ldstr "value"
+		IL_0371: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:106"
+		IL_0376: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03a3: stloc.s 19
-		IL_03a5: volatile.
-		IL_03a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_03ac: brfalse IL_03c2
+		IL_0380: stloc.s 19
+		IL_0382: ldloc.s 17
+		IL_0384: ldloc.s 19
+		IL_0386: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_038b: pop
+		IL_038c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0391: stloc.s 17
+		IL_0393: ldloc.s 5
+		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_039a: volatile.
+		IL_039c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_03a1: brfalse IL_03b5
 
-		IL_03b1: ldloc.s 19
-		IL_03b3: ldstr "done"
-		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03bd: br IL_03d8
+		IL_03a6: ldstr "next"
+		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_03b0: br IL_03c9
 
-		IL_03c2: ldloc.s 19
-		IL_03c4: ldstr "done"
-		IL_03c9: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:113"
-		IL_03ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03b5: ldstr "next"
+		IL_03ba: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:111"
+		IL_03bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_03d8: stloc.s 19
-		IL_03da: ldloc.s 17
-		IL_03dc: ldloc.s 19
-		IL_03de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03e3: pop
-		IL_03e4: ldc.i4.1
-		IL_03e5: newarr [System.Runtime]System.Object
-		IL_03ea: dup
-		IL_03eb: ldc.i4.0
-		IL_03ec: ldc.r8 2
-		IL_03f5: box [System.Runtime]System.Double
-		IL_03fa: stelem.ref
-		IL_03fb: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
-		IL_0400: stloc.s 6
-		IL_0402: ldloc.s 6
-		IL_0404: ldc.r8 1
-		IL_040d: ldstr "x"
-		IL_0412: ldc.i4.1
-		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_0418: pop
-		IL_0419: ldloc.s 6
-		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0420: volatile.
-		IL_0422: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0427: brfalse IL_043b
+		IL_03c9: stloc.s 19
+		IL_03cb: volatile.
+		IL_03cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_03d2: brfalse IL_03e8
 
-		IL_042c: ldstr "values"
-		IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0436: br IL_044f
+		IL_03d7: ldloc.s 19
+		IL_03d9: ldstr "done"
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03e3: br IL_03fe
 
-		IL_043b: ldstr "values"
-		IL_0440: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:126"
-		IL_0445: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_03e8: ldloc.s 19
+		IL_03ea: ldstr "done"
+		IL_03ef: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:113"
+		IL_03f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_044f: stloc.s 19
-		IL_0451: ldloc.s 19
-		IL_0453: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0458: stloc.s 7
-		IL_045a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_045f: stloc.s 17
-		IL_0461: ldloc.s 7
-		IL_0463: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0468: box [System.Runtime]System.Double
-		IL_046d: stloc.s 18
-		IL_046f: ldloc.s 17
-		IL_0471: ldloc.s 18
-		IL_0473: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0478: pop
-		IL_0479: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_047e: stloc.s 17
-		IL_0480: ldloc.s 7
-		IL_0482: ldc.r8 0.0
-		IL_048b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0490: stloc.s 19
-		IL_0492: ldloc.s 19
-		IL_0494: ldnull
-		IL_0495: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_049a: stloc.s 20
-		IL_049c: ldloc.s 20
-		IL_049e: box [System.Runtime]System.Boolean
-		IL_04a3: stloc.s 21
-		IL_04a5: ldloc.s 17
-		IL_04a7: ldloc.s 21
-		IL_04a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ae: pop
-		IL_04af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04b4: stloc.s 17
-		IL_04b6: ldloc.s 7
-		IL_04b8: ldc.r8 1
-		IL_04c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_04c6: stloc.s 19
-		IL_04c8: ldloc.s 17
-		IL_04ca: ldloc.s 19
-		IL_04cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04d1: pop
-		IL_04d2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04d7: dup
-		IL_04d8: ldstr "0"
-		IL_04dd: ldstr "a"
-		IL_04e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_04e7: dup
-		IL_04e8: ldstr "1"
-		IL_04ed: ldstr "b"
-		IL_04f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_04f7: dup
-		IL_04f8: ldstr "length"
-		IL_04fd: ldc.r8 2
-		IL_0506: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_050b: stloc.s 8
-		IL_050d: ldstr "Array"
-		IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0517: volatile.
-		IL_0519: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_051e: brfalse IL_0532
+		IL_03fe: stloc.s 19
+		IL_0400: ldloc.s 17
+		IL_0402: ldloc.s 19
+		IL_0404: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0409: pop
+		IL_040a: ldc.i4.1
+		IL_040b: newarr [System.Runtime]System.Object
+		IL_0410: dup
+		IL_0411: ldc.i4.0
+		IL_0412: ldc.r8 2
+		IL_041b: box [System.Runtime]System.Double
+		IL_0420: stelem.ref
+		IL_0421: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
+		IL_0426: stloc.s 6
+		IL_0428: ldloc.s 6
+		IL_042a: ldc.r8 1
+		IL_0433: ldstr "x"
+		IL_0438: ldc.i4.1
+		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_043e: pop
+		IL_043f: ldloc.s 6
+		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0446: volatile.
+		IL_0448: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_044d: brfalse IL_0461
 
-		IL_0523: ldstr "prototype"
-		IL_0528: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_052d: br IL_0546
+		IL_0452: ldstr "values"
+		IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_045c: br IL_0475
 
-		IL_0532: ldstr "prototype"
-		IL_0537: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:157"
-		IL_053c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0461: ldstr "values"
+		IL_0466: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:126"
+		IL_046b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0546: stloc.s 19
-		IL_0548: volatile.
-		IL_054a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_054f: brfalse IL_0565
+		IL_0475: stloc.s 19
+		IL_0477: ldloc.s 19
+		IL_0479: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_047e: stloc.s 7
+		IL_0480: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0485: stloc.s 17
+		IL_0487: ldloc.s 7
+		IL_0489: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_048e: box [System.Runtime]System.Double
+		IL_0493: stloc.s 18
+		IL_0495: ldloc.s 17
+		IL_0497: ldloc.s 18
+		IL_0499: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_049e: pop
+		IL_049f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04a4: stloc.s 17
+		IL_04a6: ldloc.s 7
+		IL_04a8: ldc.r8 0.0
+		IL_04b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_04b6: stloc.s 19
+		IL_04b8: ldloc.s 19
+		IL_04ba: ldnull
+		IL_04bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04c0: stloc.s 20
+		IL_04c2: ldloc.s 20
+		IL_04c4: box [System.Runtime]System.Boolean
+		IL_04c9: stloc.s 21
+		IL_04cb: ldloc.s 17
+		IL_04cd: ldloc.s 21
+		IL_04cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04d4: pop
+		IL_04d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04da: stloc.s 17
+		IL_04dc: ldloc.s 7
+		IL_04de: ldc.r8 1
+		IL_04e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_04ec: stloc.s 19
+		IL_04ee: ldloc.s 17
+		IL_04f0: ldloc.s 19
+		IL_04f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04f7: pop
+		IL_04f8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04fd: dup
+		IL_04fe: ldstr "0"
+		IL_0503: ldstr "a"
+		IL_0508: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_050d: dup
+		IL_050e: ldstr "1"
+		IL_0513: ldstr "b"
+		IL_0518: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_051d: dup
+		IL_051e: ldstr "length"
+		IL_0523: ldc.r8 2
+		IL_052c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0531: stloc.s 8
+		IL_0533: ldstr "Array"
+		IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_053d: volatile.
+		IL_053f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0544: brfalse IL_0558
 
-		IL_0554: ldloc.s 19
-		IL_0556: ldstr "values"
-		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0560: br IL_057b
+		IL_0549: ldstr "prototype"
+		IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0553: br IL_056c
 
-		IL_0565: ldloc.s 19
-		IL_0567: ldstr "values"
-		IL_056c: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:159"
-		IL_0571: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0558: ldstr "prototype"
+		IL_055d: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:157"
+		IL_0562: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_057b: stloc.s 19
-		IL_057d: ldloc.s 19
-		IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0584: ldstr "call"
-		IL_0589: ldloc.s 8
-		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0590: stloc.s 19
-		IL_0592: ldloc.s 19
-		IL_0594: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0599: stloc.s 9
-		IL_059b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05a0: stloc.s 17
-		IL_05a2: ldloc.s 9
-		IL_05a4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_05a9: box [System.Runtime]System.Double
-		IL_05ae: stloc.s 18
-		IL_05b0: ldloc.s 17
-		IL_05b2: ldloc.s 18
-		IL_05b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05b9: pop
-		IL_05ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05bf: stloc.s 17
-		IL_05c1: ldloc.s 9
-		IL_05c3: ldc.r8 0.0
-		IL_05cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_05d1: stloc.s 19
-		IL_05d3: ldloc.s 17
-		IL_05d5: ldloc.s 19
-		IL_05d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05dc: pop
-		IL_05dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05e2: stloc.s 17
-		IL_05e4: ldloc.s 9
-		IL_05e6: ldc.r8 1
-		IL_05ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_05f4: stloc.s 19
-		IL_05f6: ldloc.s 17
-		IL_05f8: ldloc.s 19
-		IL_05fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05ff: pop
-		IL_0600: ldc.i4.2
-		IL_0601: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0606: dup
-		IL_0607: ldc.r8 1
-		IL_0610: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0615: dup
-		IL_0616: ldc.r8 2
-		IL_061f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0624: stloc.s 10
-		IL_0626: ldstr "iterator"
-		IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0630: stloc.s 19
-		IL_0632: ldc.i4.1
-		IL_0633: newarr [System.Runtime]System.Object
-		IL_0638: dup
-		IL_0639: ldc.i4.0
-		IL_063a: ldloc.0
-		IL_063b: stelem.ref
-		IL_063c: stloc.s 22
-		IL_063e: ldloc.s 22
-		IL_0640: ldc.i4.0
-		IL_0641: ldelem.ref
-		IL_0642: castclass Modules.Array_Iterator_Methods/Scope
-		IL_0647: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject::.ctor(class Modules.Array_Iterator_Methods/Scope)
-		IL_064c: ldc.i4.0
-		IL_064d: conv.r8
-		IL_064e: ldstr ""
-		IL_0653: ldc.i4.0
-		IL_0654: ldc.i4.1
-		IL_0655: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_065a: stloc.s 23
-		IL_065c: ldloc.s 10
-		IL_065e: ldloc.s 19
-		IL_0660: ldloc.s 23
-		IL_0662: ldc.i4.1
-		IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_0668: pop
-		IL_0669: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_066e: stloc.s 17
-		IL_0670: ldc.i4.0
-		IL_0671: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0676: stloc.s 24
-		IL_0678: ldloc.s 24
-		IL_067a: ldloc.s 10
-		IL_067c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_0681: ldloc.s 24
-		IL_0683: ldc.i4.1
-		IL_0684: newarr [System.Runtime]System.Object
-		IL_0689: dup
-		IL_068a: ldc.i4.0
-		IL_068b: ldstr ","
-		IL_0690: stelem.ref
-		IL_0691: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0696: stloc.s 25
-		IL_0698: ldloc.s 17
-		IL_069a: ldloc.s 25
-		IL_069c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06a1: pop
-		IL_06a2: ldc.i4.0
-		IL_06a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_06a8: stloc.s 11
-		IL_06aa: ldloc.s 10
-		IL_06ac: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-		IL_06b1: stloc.s 12
-		IL_06b3: ldc.i4.0
-		IL_06b4: stloc.s 13
-		IL_06b6: ldc.i4.0
-		IL_06b7: stloc.s 14
+		IL_056c: stloc.s 19
+		IL_056e: volatile.
+		IL_0570: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0575: brfalse IL_058b
+
+		IL_057a: ldloc.s 19
+		IL_057c: ldstr "values"
+		IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0586: br IL_05a1
+
+		IL_058b: ldloc.s 19
+		IL_058d: ldstr "values"
+		IL_0592: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:159"
+		IL_0597: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05a1: stloc.s 19
+		IL_05a3: ldloc.s 19
+		IL_05a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05aa: volatile.
+		IL_05ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_05b1: brfalse IL_05c7
+
+		IL_05b6: ldstr "call"
+		IL_05bb: ldloc.s 8
+		IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05c2: br IL_05dd
+
+		IL_05c7: ldstr "call"
+		IL_05cc: ldloc.s 8
+		IL_05ce: ldstr "Array_Iterator_Methods:Modules.Array_Iterator_Methods:__js_module_init__:161"
+		IL_05d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_05dd: stloc.s 19
+		IL_05df: ldloc.s 19
+		IL_05e1: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_05e6: stloc.s 9
+		IL_05e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05ed: stloc.s 17
+		IL_05ef: ldloc.s 9
+		IL_05f1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_05f6: box [System.Runtime]System.Double
+		IL_05fb: stloc.s 18
+		IL_05fd: ldloc.s 17
+		IL_05ff: ldloc.s 18
+		IL_0601: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0606: pop
+		IL_0607: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_060c: stloc.s 17
+		IL_060e: ldloc.s 9
+		IL_0610: ldc.r8 0.0
+		IL_0619: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_061e: stloc.s 19
+		IL_0620: ldloc.s 17
+		IL_0622: ldloc.s 19
+		IL_0624: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0629: pop
+		IL_062a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_062f: stloc.s 17
+		IL_0631: ldloc.s 9
+		IL_0633: ldc.r8 1
+		IL_063c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0641: stloc.s 19
+		IL_0643: ldloc.s 17
+		IL_0645: ldloc.s 19
+		IL_0647: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_064c: pop
+		IL_064d: ldc.i4.2
+		IL_064e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0653: dup
+		IL_0654: ldc.r8 1
+		IL_065d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0662: dup
+		IL_0663: ldc.r8 2
+		IL_066c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0671: stloc.s 10
+		IL_0673: ldstr "iterator"
+		IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_067d: stloc.s 19
+		IL_067f: ldc.i4.1
+		IL_0680: newarr [System.Runtime]System.Object
+		IL_0685: dup
+		IL_0686: ldc.i4.0
+		IL_0687: ldloc.0
+		IL_0688: stelem.ref
+		IL_0689: stloc.s 22
+		IL_068b: ldloc.s 22
+		IL_068d: ldc.i4.0
+		IL_068e: ldelem.ref
+		IL_068f: castclass Modules.Array_Iterator_Methods/Scope
+		IL_0694: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject::.ctor(class Modules.Array_Iterator_Methods/Scope)
+		IL_0699: ldc.i4.0
+		IL_069a: conv.r8
+		IL_069b: ldstr ""
+		IL_06a0: ldc.i4.0
+		IL_06a1: ldc.i4.1
+		IL_06a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06a7: stloc.s 23
+		IL_06a9: ldloc.s 10
+		IL_06ab: ldloc.s 19
+		IL_06ad: ldloc.s 23
+		IL_06af: ldc.i4.1
+		IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_06b5: pop
+		IL_06b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06bb: stloc.s 17
+		IL_06bd: ldc.i4.0
+		IL_06be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_06c3: stloc.s 24
+		IL_06c5: ldloc.s 24
+		IL_06c7: ldloc.s 10
+		IL_06c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_06ce: ldloc.s 24
+		IL_06d0: ldc.i4.1
+		IL_06d1: newarr [System.Runtime]System.Object
+		IL_06d6: dup
+		IL_06d7: ldc.i4.0
+		IL_06d8: ldstr ","
+		IL_06dd: stelem.ref
+		IL_06de: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_06e3: stloc.s 25
+		IL_06e5: ldloc.s 17
+		IL_06e7: ldloc.s 25
+		IL_06e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06ee: pop
+		IL_06ef: ldc.i4.0
+		IL_06f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_06f5: stloc.s 11
+		IL_06f7: ldloc.s 10
+		IL_06f9: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_06fe: stloc.s 12
+		IL_0700: ldc.i4.0
+		IL_0701: stloc.s 13
+		IL_0703: ldc.i4.0
+		IL_0704: stloc.s 14
 		.try
 		{
-			// loop start (head: IL_06b9)
-				IL_06b9: ldc.i4.1
-				IL_06ba: stloc.s 13
-				IL_06bc: ldloc.s 12
-				IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-				IL_06c3: stloc.s 19
-				IL_06c5: ldloc.s 19
-				IL_06c7: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-				IL_06cc: stloc.s 20
-				IL_06ce: ldloc.s 20
-				IL_06d0: brtrue IL_0703
+			// loop start (head: IL_0706)
+				IL_0706: ldc.i4.1
+				IL_0707: stloc.s 13
+				IL_0709: ldloc.s 12
+				IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+				IL_0710: stloc.s 19
+				IL_0712: ldloc.s 19
+				IL_0714: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+				IL_0719: stloc.s 20
+				IL_071b: ldloc.s 20
+				IL_071d: brtrue IL_0750
 
-				IL_06d5: ldloc.s 19
-				IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-				IL_06dc: stloc.s 19
-				IL_06de: ldc.i4.0
-				IL_06df: stloc.s 13
-				IL_06e1: ldloc.s 19
-				IL_06e3: stloc.s 15
-				IL_06e5: ldloc.s 11
-				IL_06e7: ldloc.s 15
-				IL_06e9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_06ee: pop
-				IL_06ef: br IL_06b9
+				IL_0722: ldloc.s 19
+				IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+				IL_0729: stloc.s 19
+				IL_072b: ldc.i4.0
+				IL_072c: stloc.s 13
+				IL_072e: ldloc.s 19
+				IL_0730: stloc.s 15
+				IL_0732: ldloc.s 11
+				IL_0734: ldloc.s 15
+				IL_0736: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_073b: pop
+				IL_073c: br IL_0706
 			// end loop
-			IL_06f4: ldloc.s 12
-			IL_06f6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-			IL_06fb: ldc.i4.1
-			IL_06fc: stloc.s 14
-			IL_06fe: leave IL_0721
+			IL_0741: ldloc.s 12
+			IL_0743: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+			IL_0748: ldc.i4.1
+			IL_0749: stloc.s 14
+			IL_074b: leave IL_076e
 
-			IL_0703: ldc.i4.1
-			IL_0704: stloc.s 13
-			IL_0706: leave IL_0721
+			IL_0750: ldc.i4.1
+			IL_0751: stloc.s 13
+			IL_0753: leave IL_076e
 		} // end .try
 		finally
 		{
-			IL_070b: ldloc.s 13
-			IL_070d: brtrue IL_0720
+			IL_0758: ldloc.s 13
+			IL_075a: brtrue IL_076d
 
-			IL_0712: ldloc.s 14
-			IL_0714: brtrue IL_0720
+			IL_075f: ldloc.s 14
+			IL_0761: brtrue IL_076d
 
-			IL_0719: ldloc.s 12
-			IL_071b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+			IL_0766: ldloc.s 12
+			IL_0768: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-			IL_0720: endfinally
+			IL_076d: endfinally
 		} // end handler
 
-		IL_0721: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0726: stloc.s 17
-		IL_0728: ldloc.s 11
-		IL_072a: ldc.i4.1
-		IL_072b: newarr [System.Runtime]System.Object
-		IL_0730: dup
-		IL_0731: ldc.i4.0
-		IL_0732: ldstr ","
-		IL_0737: stelem.ref
-		IL_0738: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_073d: stloc.s 25
-		IL_073f: ldloc.s 17
-		IL_0741: ldloc.s 25
-		IL_0743: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0748: pop
-		IL_0749: ret
+		IL_076e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0773: stloc.s 17
+		IL_0775: ldloc.s 11
+		IL_0777: ldc.i4.1
+		IL_0778: newarr [System.Runtime]System.Object
+		IL_077d: dup
+		IL_077e: ldc.i4.0
+		IL_077f: ldstr ","
+		IL_0784: stelem.ref
+		IL_0785: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_078a: stloc.s 25
+		IL_078c: ldloc.s 17
+		IL_078e: ldloc.s 25
+		IL_0790: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0795: pop
+		IL_0796: ret
 	} // end of method Array_Iterator_Methods::__js_module_init__
 
 } // end of class Modules.Array_Iterator_Methods
@@ -1204,6 +1228,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
@@ -303,7 +303,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1896 (0x768)
+		// Code size: 2104 (0x838)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Array_JsObject_NamedProperties/Scope,
@@ -450,485 +450,546 @@
 		IL_0174: ldloc.1
 		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017f: ldstr "join"
-		IL_0184: ldstr ","
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018e: stloc.s 13
-		IL_0190: ldloc.s 12
-		IL_0192: ldloc.s 13
-		IL_0194: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0199: pop
-		IL_019a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_019f: stloc.s 12
-		IL_01a1: ldloc.1
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ac: ldstr "join"
-		IL_01b1: ldstr ","
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bb: stloc.s 13
-		IL_01bd: ldloc.s 12
-		IL_01bf: ldloc.s 13
-		IL_01c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01c6: pop
-		IL_01c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01cc: stloc.s 12
-		IL_01ce: ldloc.1
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertySymbols(object)
-		IL_01d4: volatile.
-		IL_01d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01db: brfalse IL_01ef
+		IL_017f: volatile.
+		IL_0181: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0186: brfalse IL_019f
 
-		IL_01e0: ldstr "length"
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ea: br IL_0203
+		IL_018b: ldstr "join"
+		IL_0190: ldstr ","
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019a: br IL_01b8
 
-		IL_01ef: ldstr "length"
-		IL_01f4: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:71"
-		IL_01f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_019f: ldstr "join"
+		IL_01a4: ldstr ","
+		IL_01a9: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:58"
+		IL_01ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0203: stloc.s 13
-		IL_0205: ldloc.s 12
-		IL_0207: ldloc.s 13
-		IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_020e: pop
-		IL_020f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0214: stloc.s 12
-		IL_0216: ldloc.1
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_021c: stloc.s 13
-		IL_021e: ldstr "Array"
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b8: stloc.s 13
+		IL_01ba: ldloc.s 12
+		IL_01bc: ldloc.s 13
+		IL_01be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c3: pop
+		IL_01c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c9: stloc.s 12
+		IL_01cb: ldloc.1
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d6: volatile.
+		IL_01d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01dd: brfalse IL_01f6
+
+		IL_01e2: ldstr "join"
+		IL_01e7: ldstr ","
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f1: br IL_020f
+
+		IL_01f6: ldstr "join"
+		IL_01fb: ldstr ","
+		IL_0200: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:65"
+		IL_0205: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_020f: stloc.s 13
+		IL_0211: ldloc.s 12
+		IL_0213: ldloc.s 13
+		IL_0215: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_021a: pop
+		IL_021b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0220: stloc.s 12
+		IL_0222: ldloc.1
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertySymbols(object)
 		IL_0228: volatile.
-		IL_022a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_022a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 		IL_022f: brfalse IL_0243
 
-		IL_0234: ldstr "prototype"
+		IL_0234: ldstr "length"
 		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_023e: br IL_0257
 
-		IL_0243: ldstr "prototype"
-		IL_0248: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:79"
-		IL_024d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0243: ldstr "length"
+		IL_0248: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:71"
+		IL_024d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0257: stloc.s 19
-		IL_0259: ldloc.s 13
-		IL_025b: ldloc.s 19
-		IL_025d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0262: stloc.s 15
-		IL_0264: ldloc.s 15
-		IL_0266: box [System.Runtime]System.Boolean
-		IL_026b: stloc.s 18
-		IL_026d: ldloc.s 12
-		IL_026f: ldloc.s 18
-		IL_0271: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0276: pop
-		IL_0277: ldc.i4.0
-		IL_0278: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_027d: stloc.3
-		IL_027e: ldloc.1
-		IL_027f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::EnumerateObjectProperties(object)
-		IL_0284: stloc.s 4
-		// loop start (head: IL_0286)
-			IL_0286: ldloc.s 4
-			IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-			IL_028d: stloc.s 19
-			IL_028f: ldloc.s 19
-			IL_0291: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-			IL_0296: stloc.s 15
-			IL_0298: ldloc.s 15
-			IL_029a: brtrue IL_02ba
+		IL_0257: stloc.s 13
+		IL_0259: ldloc.s 12
+		IL_025b: ldloc.s 13
+		IL_025d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0262: pop
+		IL_0263: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0268: stloc.s 12
+		IL_026a: ldloc.1
+		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0270: stloc.s 13
+		IL_0272: ldstr "Array"
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_027c: volatile.
+		IL_027e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0283: brfalse IL_0297
 
-			IL_029f: ldloc.s 19
-			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-			IL_02a6: stloc.s 19
-			IL_02a8: ldloc.s 19
-			IL_02aa: stloc.s 5
-			IL_02ac: ldloc.3
-			IL_02ad: ldloc.s 5
-			IL_02af: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_02b4: pop
-			IL_02b5: br IL_0286
+		IL_0288: ldstr "prototype"
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0292: br IL_02ab
+
+		IL_0297: ldstr "prototype"
+		IL_029c: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:79"
+		IL_02a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02ab: stloc.s 19
+		IL_02ad: ldloc.s 13
+		IL_02af: ldloc.s 19
+		IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02b6: stloc.s 15
+		IL_02b8: ldloc.s 15
+		IL_02ba: box [System.Runtime]System.Boolean
+		IL_02bf: stloc.s 18
+		IL_02c1: ldloc.s 12
+		IL_02c3: ldloc.s 18
+		IL_02c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ca: pop
+		IL_02cb: ldc.i4.0
+		IL_02cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02d1: stloc.3
+		IL_02d2: ldloc.1
+		IL_02d3: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::EnumerateObjectProperties(object)
+		IL_02d8: stloc.s 4
+		// loop start (head: IL_02da)
+			IL_02da: ldloc.s 4
+			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+			IL_02e1: stloc.s 19
+			IL_02e3: ldloc.s 19
+			IL_02e5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+			IL_02ea: stloc.s 15
+			IL_02ec: ldloc.s 15
+			IL_02ee: brtrue IL_030e
+
+			IL_02f3: ldloc.s 19
+			IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+			IL_02fa: stloc.s 19
+			IL_02fc: ldloc.s 19
+			IL_02fe: stloc.s 5
+			IL_0300: ldloc.3
+			IL_0301: ldloc.s 5
+			IL_0303: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0308: pop
+			IL_0309: br IL_02da
 		// end loop
 
-		IL_02ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02bf: stloc.s 12
-		IL_02c1: ldloc.3
-		IL_02c2: ldc.i4.1
-		IL_02c3: newarr [System.Runtime]System.Object
-		IL_02c8: dup
-		IL_02c9: ldc.i4.0
-		IL_02ca: ldstr ","
-		IL_02cf: stelem.ref
-		IL_02d0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_02d5: stloc.s 20
-		IL_02d7: ldloc.s 12
-		IL_02d9: ldloc.s 20
-		IL_02db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02e0: pop
-		IL_02e1: ldloc.1
-		IL_02e2: ldstr "hidden"
-		IL_02e7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02ec: dup
-		IL_02ed: ldstr "value"
-		IL_02f2: ldstr "descriptor"
-		IL_02f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02fc: dup
-		IL_02fd: ldstr "enumerable"
-		IL_0302: ldc.i4.0
-		IL_0303: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0308: dup
-		IL_0309: ldstr "configurable"
-		IL_030e: ldc.i4.1
-		IL_030f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0319: pop
-		IL_031a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_031f: stloc.s 12
-		IL_0321: volatile.
-		IL_0323: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0328: brfalse IL_033d
+		IL_030e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0313: stloc.s 12
+		IL_0315: ldloc.3
+		IL_0316: ldc.i4.1
+		IL_0317: newarr [System.Runtime]System.Object
+		IL_031c: dup
+		IL_031d: ldc.i4.0
+		IL_031e: ldstr ","
+		IL_0323: stelem.ref
+		IL_0324: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0329: stloc.s 20
+		IL_032b: ldloc.s 12
+		IL_032d: ldloc.s 20
+		IL_032f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0334: pop
+		IL_0335: ldloc.1
+		IL_0336: ldstr "hidden"
+		IL_033b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0340: dup
+		IL_0341: ldstr "value"
+		IL_0346: ldstr "descriptor"
+		IL_034b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0350: dup
+		IL_0351: ldstr "enumerable"
+		IL_0356: ldc.i4.0
+		IL_0357: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_035c: dup
+		IL_035d: ldstr "configurable"
+		IL_0362: ldc.i4.1
+		IL_0363: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_036d: pop
+		IL_036e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0373: stloc.s 12
+		IL_0375: volatile.
+		IL_0377: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_037c: brfalse IL_0391
 
-		IL_032d: ldloc.1
-		IL_032e: ldstr "hidden"
-		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0338: br IL_0352
+		IL_0381: ldloc.1
+		IL_0382: ldstr "hidden"
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_038c: br IL_03a6
 
-		IL_033d: ldloc.1
-		IL_033e: ldstr "hidden"
-		IL_0343: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:115"
-		IL_0348: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0391: ldloc.1
+		IL_0392: ldstr "hidden"
+		IL_0397: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:115"
+		IL_039c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0352: stloc.s 19
-		IL_0354: ldloc.s 12
-		IL_0356: ldloc.s 19
-		IL_0358: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_035d: pop
-		IL_035e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0363: stloc.s 12
-		IL_0365: ldloc.1
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0370: ldstr "join"
-		IL_0375: ldstr ","
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_037f: stloc.s 19
-		IL_0381: ldloc.s 12
-		IL_0383: ldloc.s 19
-		IL_0385: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_038a: pop
-		IL_038b: ldloc.1
-		IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0391: stloc.s 6
-		IL_0393: ldloc.1
-		IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0399: dup
-		IL_039a: ldstr "inherited"
-		IL_039f: ldstr "prototype"
-		IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_03ae: pop
-		IL_03af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03b4: stloc.s 12
-		IL_03b6: volatile.
-		IL_03b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03bd: brfalse IL_03d2
+		IL_03a6: stloc.s 19
+		IL_03a8: ldloc.s 12
+		IL_03aa: ldloc.s 19
+		IL_03ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03b1: pop
+		IL_03b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03b7: stloc.s 12
+		IL_03b9: ldloc.1
+		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c4: volatile.
+		IL_03c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_03cb: brfalse IL_03e4
 
-		IL_03c2: ldloc.1
-		IL_03c3: ldstr "inherited"
-		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03cd: br IL_03e7
+		IL_03d0: ldstr "join"
+		IL_03d5: ldstr ","
+		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03df: br IL_03fd
 
-		IL_03d2: ldloc.1
-		IL_03d3: ldstr "inherited"
-		IL_03d8: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:134"
-		IL_03dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03e4: ldstr "join"
+		IL_03e9: ldstr ","
+		IL_03ee: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:122"
+		IL_03f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03e7: stloc.s 19
-		IL_03e9: ldloc.s 12
-		IL_03eb: ldloc.s 19
-		IL_03ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03f2: pop
-		IL_03f3: ldloc.1
-		IL_03f4: ldloc.s 6
-		IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_03fb: pop
-		IL_03fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0401: stloc.s 21
-		IL_0403: ldloc.1
-		IL_0404: ldloc.s 21
-		IL_0406: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_040b: stloc.s 7
-		IL_040d: ldloc.s 7
-		IL_040f: ldstr "viaProxy"
-		IL_0414: ldstr "proxy"
-		IL_0419: ldc.i4.0
-		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_041f: pop
-		IL_0420: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0425: stloc.s 12
-		IL_0427: volatile.
-		IL_0429: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_042e: brfalse IL_0443
+		IL_03fd: stloc.s 19
+		IL_03ff: ldloc.s 12
+		IL_0401: ldloc.s 19
+		IL_0403: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0408: pop
+		IL_0409: ldloc.1
+		IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_040f: stloc.s 6
+		IL_0411: ldloc.1
+		IL_0412: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0417: dup
+		IL_0418: ldstr "inherited"
+		IL_041d: ldstr "prototype"
+		IL_0422: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_042c: pop
+		IL_042d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0432: stloc.s 12
+		IL_0434: volatile.
+		IL_0436: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_043b: brfalse IL_0450
 
-		IL_0433: ldloc.1
-		IL_0434: ldstr "viaProxy"
-		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_043e: br IL_0458
+		IL_0440: ldloc.1
+		IL_0441: ldstr "inherited"
+		IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_044b: br IL_0465
 
-		IL_0443: ldloc.1
-		IL_0444: ldstr "viaProxy"
-		IL_0449: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:149"
-		IL_044e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0450: ldloc.1
+		IL_0451: ldstr "inherited"
+		IL_0456: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:134"
+		IL_045b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0458: stloc.s 19
-		IL_045a: ldloc.s 12
-		IL_045c: ldloc.s 19
-		IL_045e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0463: pop
-		IL_0464: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakMap::.ctor()
-		IL_0469: stloc.s 8
-		IL_046b: ldloc.s 8
-		IL_046d: ldstr "set"
-		IL_0472: ldloc.1
-		IL_0473: ldstr "identity"
-		IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_047d: pop
-		IL_047e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0483: stloc.s 12
-		IL_0485: ldloc.s 8
-		IL_0487: ldstr "get"
-		IL_048c: ldloc.1
-		IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0492: stloc.s 19
-		IL_0494: ldloc.s 12
-		IL_0496: ldloc.s 19
-		IL_0498: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0465: stloc.s 19
+		IL_0467: ldloc.s 12
+		IL_0469: ldloc.s 19
+		IL_046b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0470: pop
+		IL_0471: ldloc.1
+		IL_0472: ldloc.s 6
+		IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0479: pop
+		IL_047a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_047f: stloc.s 21
+		IL_0481: ldloc.1
+		IL_0482: ldloc.s 21
+		IL_0484: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0489: stloc.s 7
+		IL_048b: ldloc.s 7
+		IL_048d: ldstr "viaProxy"
+		IL_0492: ldstr "proxy"
+		IL_0497: ldc.i4.0
+		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
 		IL_049d: pop
 		IL_049e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_04a3: stloc.s 12
-		IL_04a5: ldloc.1
-		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_04ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b0: ldstr "join"
-		IL_04b5: ldstr ","
-		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04bf: stloc.s 19
-		IL_04c1: ldloc.s 12
-		IL_04c3: ldloc.s 19
-		IL_04c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ca: pop
-		IL_04cb: ldloc.1
-		IL_04cc: ldstr "custom"
-		IL_04d1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
-		IL_04d6: stloc.s 15
-		IL_04d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04dd: stloc.s 12
-		IL_04df: volatile.
-		IL_04e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_04e6: brfalse IL_04fb
+		IL_04a5: volatile.
+		IL_04a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_04ac: brfalse IL_04c1
 
-		IL_04eb: ldloc.1
-		IL_04ec: ldstr "custom"
-		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04f6: br IL_0510
+		IL_04b1: ldloc.1
+		IL_04b2: ldstr "viaProxy"
+		IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04bc: br IL_04d6
 
-		IL_04fb: ldloc.1
-		IL_04fc: ldstr "custom"
-		IL_0501: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:175"
-		IL_0506: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04c1: ldloc.1
+		IL_04c2: ldstr "viaProxy"
+		IL_04c7: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:149"
+		IL_04cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0510: stloc.s 19
-		IL_0512: ldloc.s 12
-		IL_0514: ldloc.s 19
-		IL_0516: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_051b: pop
-		IL_051c: ldloc.1
-		IL_051d: ldc.r8 5
-		IL_0526: ldstr "sparse"
-		IL_052b: ldc.i4.0
-		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_0531: pop
-		IL_0532: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0537: stloc.s 12
-		IL_0539: ldloc.1
-		IL_053a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_053f: box [System.Runtime]System.Double
-		IL_0544: stloc.s 14
-		IL_0546: ldloc.1
-		IL_0547: ldc.r8 5
-		IL_0550: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0555: stloc.s 19
-		IL_0557: ldc.r8 4
-		IL_0560: box [System.Runtime]System.Double
-		IL_0565: ldloc.1
-		IL_0566: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_056b: stloc.s 15
-		IL_056d: ldloc.s 15
-		IL_056f: box [System.Runtime]System.Boolean
-		IL_0574: stloc.s 18
-		IL_0576: ldloc.s 12
-		IL_0578: ldloc.s 14
-		IL_057a: ldloc.s 19
-		IL_057c: ldloc.s 18
-		IL_057e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0583: pop
-		IL_0584: ldloc.1
-		IL_0585: ldc.r8 2
-		IL_058e: ldc.i4.0
-		IL_058f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-		IL_0594: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0599: stloc.s 12
+		IL_04d6: stloc.s 19
+		IL_04d8: ldloc.s 12
+		IL_04da: ldloc.s 19
+		IL_04dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04e1: pop
+		IL_04e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakMap::.ctor()
+		IL_04e7: stloc.s 8
+		IL_04e9: ldloc.s 8
+		IL_04eb: ldstr "set"
+		IL_04f0: ldloc.1
+		IL_04f1: ldstr "identity"
+		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04fb: pop
+		IL_04fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0501: stloc.s 12
+		IL_0503: volatile.
+		IL_0505: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_050a: brfalse IL_0521
+
+		IL_050f: ldloc.s 8
+		IL_0511: ldstr "get"
+		IL_0516: ldloc.1
+		IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_051c: br IL_0538
+
+		IL_0521: ldloc.s 8
+		IL_0523: ldstr "get"
+		IL_0528: ldloc.1
+		IL_0529: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:159"
+		IL_052e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0538: stloc.s 19
+		IL_053a: ldloc.s 12
+		IL_053c: ldloc.s 19
+		IL_053e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0543: pop
+		IL_0544: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0549: stloc.s 12
+		IL_054b: ldloc.1
+		IL_054c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0556: volatile.
+		IL_0558: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_055d: brfalse IL_0576
+
+		IL_0562: ldstr "join"
+		IL_0567: ldstr ","
+		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0571: br IL_058f
+
+		IL_0576: ldstr "join"
+		IL_057b: ldstr ","
+		IL_0580: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:166"
+		IL_0585: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_058f: stloc.s 19
+		IL_0591: ldloc.s 12
+		IL_0593: ldloc.s 19
+		IL_0595: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_059a: pop
 		IL_059b: ldloc.1
-		IL_059c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_05a1: box [System.Runtime]System.Double
-		IL_05a6: stloc.s 14
-		IL_05a8: ldc.r8 2
-		IL_05b1: box [System.Runtime]System.Double
-		IL_05b6: ldloc.1
-		IL_05b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05bc: stloc.s 15
-		IL_05be: ldloc.s 15
-		IL_05c0: box [System.Runtime]System.Boolean
-		IL_05c5: stloc.s 18
-		IL_05c7: ldc.r8 5
-		IL_05d0: box [System.Runtime]System.Double
-		IL_05d5: ldloc.1
-		IL_05d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05db: stloc.s 15
-		IL_05dd: ldloc.s 15
-		IL_05df: box [System.Runtime]System.Boolean
-		IL_05e4: stloc.s 17
-		IL_05e6: ldloc.s 12
-		IL_05e8: ldloc.s 14
-		IL_05ea: ldloc.s 18
-		IL_05ec: ldloc.s 17
-		IL_05ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_05f3: pop
-		IL_05f4: ldc.i4.1
-		IL_05f5: newarr [System.Runtime]System.Object
-		IL_05fa: dup
+		IL_059c: ldstr "custom"
+		IL_05a1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
+		IL_05a6: stloc.s 15
+		IL_05a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05ad: stloc.s 12
+		IL_05af: volatile.
+		IL_05b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_05b6: brfalse IL_05cb
+
+		IL_05bb: ldloc.1
+		IL_05bc: ldstr "custom"
+		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05c6: br IL_05e0
+
+		IL_05cb: ldloc.1
+		IL_05cc: ldstr "custom"
+		IL_05d1: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:175"
+		IL_05d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05e0: stloc.s 19
+		IL_05e2: ldloc.s 12
+		IL_05e4: ldloc.s 19
+		IL_05e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05eb: pop
+		IL_05ec: ldloc.1
+		IL_05ed: ldc.r8 5
+		IL_05f6: ldstr "sparse"
 		IL_05fb: ldc.i4.0
-		IL_05fc: ldloc.0
-		IL_05fd: stelem.ref
-		IL_05fe: stloc.s 22
-		IL_0600: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
-		IL_0605: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_060a: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
-		IL_060f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0614: stloc.s 23
-		IL_0616: ldloc.s 22
-		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentLexicalSuperReceiver()
-		IL_061d: ldc.i4.1
-		IL_061e: newarr [System.Runtime]System.Object
-		IL_0623: dup
-		IL_0624: ldc.i4.0
-		IL_0625: ldloc.0
-		IL_0626: stelem.ref
-		IL_0627: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
-		IL_062c: ldloc.s 23
-		IL_062e: ldloc.s 22
-		IL_0630: ldc.i4.0
-		IL_0631: conv.r8
-		IL_0632: ldc.i4.0
-		IL_0633: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0638: castclass Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject
-		IL_063d: stloc.s 24
-		IL_063f: ldstr "Array"
-		IL_0644: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0649: stloc.s 19
-		IL_064b: ldloc.s 24
-		IL_064d: ldloc.s 19
-		IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0654: stloc.s 19
-		IL_0656: ldloc.s 19
-		IL_0658: stloc.s 9
-		IL_065a: ldc.i4.0
-		IL_065b: newarr [System.Runtime]System.Object
-		IL_0660: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0665: ldloc.s 9
-		IL_0667: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_066c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0671: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray::.ctor()
-		IL_0676: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_067b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0680: dup
-		IL_0681: ldloc.s 9
-		IL_0683: ldstr "prototype"
-		IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_068d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0692: stloc.s 10
-		IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0699: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_069e: stloc.s 10
-		IL_06a0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_06a5: ldloc.s 10
-		IL_06a7: ldc.r8 1
-		IL_06b0: ldc.r8 42
-		IL_06b9: ldc.i4.0
-		IL_06ba: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_06bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06c4: stloc.s 12
-		IL_06c6: volatile.
-		IL_06c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_06cd: brfalse IL_06e3
+		IL_05fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0601: pop
+		IL_0602: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0607: stloc.s 12
+		IL_0609: ldloc.1
+		IL_060a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_060f: box [System.Runtime]System.Double
+		IL_0614: stloc.s 14
+		IL_0616: ldloc.1
+		IL_0617: ldc.r8 5
+		IL_0620: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0625: stloc.s 19
+		IL_0627: ldc.r8 4
+		IL_0630: box [System.Runtime]System.Double
+		IL_0635: ldloc.1
+		IL_0636: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_063b: stloc.s 15
+		IL_063d: ldloc.s 15
+		IL_063f: box [System.Runtime]System.Boolean
+		IL_0644: stloc.s 18
+		IL_0646: ldloc.s 12
+		IL_0648: ldloc.s 14
+		IL_064a: ldloc.s 19
+		IL_064c: ldloc.s 18
+		IL_064e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0653: pop
+		IL_0654: ldloc.1
+		IL_0655: ldc.r8 2
+		IL_065e: ldc.i4.0
+		IL_065f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+		IL_0664: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0669: stloc.s 12
+		IL_066b: ldloc.1
+		IL_066c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0671: box [System.Runtime]System.Double
+		IL_0676: stloc.s 14
+		IL_0678: ldc.r8 2
+		IL_0681: box [System.Runtime]System.Double
+		IL_0686: ldloc.1
+		IL_0687: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_068c: stloc.s 15
+		IL_068e: ldloc.s 15
+		IL_0690: box [System.Runtime]System.Boolean
+		IL_0695: stloc.s 18
+		IL_0697: ldc.r8 5
+		IL_06a0: box [System.Runtime]System.Double
+		IL_06a5: ldloc.1
+		IL_06a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_06ab: stloc.s 15
+		IL_06ad: ldloc.s 15
+		IL_06af: box [System.Runtime]System.Boolean
+		IL_06b4: stloc.s 17
+		IL_06b6: ldloc.s 12
+		IL_06b8: ldloc.s 14
+		IL_06ba: ldloc.s 18
+		IL_06bc: ldloc.s 17
+		IL_06be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_06c3: pop
+		IL_06c4: ldc.i4.1
+		IL_06c5: newarr [System.Runtime]System.Object
+		IL_06ca: dup
+		IL_06cb: ldc.i4.0
+		IL_06cc: ldloc.0
+		IL_06cd: stelem.ref
+		IL_06ce: stloc.s 22
+		IL_06d0: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
+		IL_06d5: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_06da: ldtoken Modules.Array_JsObject_NamedProperties/DerivedArray
+		IL_06df: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_06e4: stloc.s 23
+		IL_06e6: ldloc.s 22
+		IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentLexicalSuperReceiver()
+		IL_06ed: ldc.i4.1
+		IL_06ee: newarr [System.Runtime]System.Object
+		IL_06f3: dup
+		IL_06f4: ldc.i4.0
+		IL_06f5: ldloc.0
+		IL_06f6: stelem.ref
+		IL_06f7: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_06fc: ldloc.s 23
+		IL_06fe: ldloc.s 22
+		IL_0700: ldc.i4.0
+		IL_0701: conv.r8
+		IL_0702: ldc.i4.0
+		IL_0703: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0708: castclass Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject
+		IL_070d: stloc.s 24
+		IL_070f: ldstr "Array"
+		IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0719: stloc.s 19
+		IL_071b: ldloc.s 24
+		IL_071d: ldloc.s 19
+		IL_071f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_0724: stloc.s 19
+		IL_0726: ldloc.s 19
+		IL_0728: stloc.s 9
+		IL_072a: ldc.i4.0
+		IL_072b: newarr [System.Runtime]System.Object
+		IL_0730: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0735: ldloc.s 9
+		IL_0737: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_073c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_0741: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray::.ctor()
+		IL_0746: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_074b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0750: dup
+		IL_0751: ldloc.s 9
+		IL_0753: ldstr "prototype"
+		IL_0758: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_075d: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0762: stloc.s 10
+		IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0769: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_076e: stloc.s 10
+		IL_0770: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0775: ldloc.s 10
+		IL_0777: ldc.r8 1
+		IL_0780: ldc.r8 42
+		IL_0789: ldc.i4.0
+		IL_078a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_078f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0794: stloc.s 12
+		IL_0796: volatile.
+		IL_0798: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_079d: brfalse IL_07b3
 
-		IL_06d2: ldloc.s 10
-		IL_06d4: ldstr "length"
-		IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06de: br IL_06f9
+		IL_07a2: ldloc.s 10
+		IL_07a4: ldstr "length"
+		IL_07a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07ae: br IL_07c9
 
-		IL_06e3: ldloc.s 10
-		IL_06e5: ldstr "length"
-		IL_06ea: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:228"
-		IL_06ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07b3: ldloc.s 10
+		IL_07b5: ldstr "length"
+		IL_07ba: ldstr "Array_JsObject_NamedProperties:Modules.Array_JsObject_NamedProperties:__js_module_init__:228"
+		IL_07bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06f9: stloc.s 19
-		IL_06fb: ldloc.s 10
-		IL_06fd: ldc.r8 1
-		IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_070b: stloc.s 13
-		IL_070d: ldloc.s 12
-		IL_070f: ldloc.s 19
-		IL_0711: ldloc.s 13
-		IL_0713: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0718: pop
-		IL_0719: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_071e: stloc.s 12
-		IL_0720: ldloc.1
-		IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0726: stloc.s 13
-		IL_0728: ldloc.s 12
-		IL_072a: ldloc.s 13
-		IL_072c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0731: pop
-		IL_0732: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0737: stloc.s 12
-		IL_0739: ldloc.s 12
-		IL_073b: ldloc.1
-		IL_073c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0741: pop
-		IL_0742: ldloc.1
-		IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_0748: pop
-		IL_0749: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_074e: stloc.s 12
-		IL_0750: ldloc.1
-		IL_0751: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0756: box [System.Runtime]System.Boolean
-		IL_075b: stloc.s 17
-		IL_075d: ldloc.s 12
-		IL_075f: ldloc.s 17
-		IL_0761: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0766: pop
-		IL_0767: ret
+		IL_07c9: stloc.s 19
+		IL_07cb: ldloc.s 10
+		IL_07cd: ldc.r8 1
+		IL_07d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_07db: stloc.s 13
+		IL_07dd: ldloc.s 12
+		IL_07df: ldloc.s 19
+		IL_07e1: ldloc.s 13
+		IL_07e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_07e8: pop
+		IL_07e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07ee: stloc.s 12
+		IL_07f0: ldloc.1
+		IL_07f1: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_07f6: stloc.s 13
+		IL_07f8: ldloc.s 12
+		IL_07fa: ldloc.s 13
+		IL_07fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0801: pop
+		IL_0802: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0807: stloc.s 12
+		IL_0809: ldloc.s 12
+		IL_080b: ldloc.1
+		IL_080c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0811: pop
+		IL_0812: ldloc.1
+		IL_0813: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0818: pop
+		IL_0819: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_081e: stloc.s 12
+		IL_0820: ldloc.1
+		IL_0821: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0826: box [System.Runtime]System.Boolean
+		IL_082b: stloc.s 17
+		IL_082d: ldloc.s 12
+		IL_082f: ldloc.s 17
+		IL_0831: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0836: pop
+		IL_0837: ret
 	} // end of method Array_JsObject_NamedProperties::__js_module_init__
 
 } // end of class Modules.Array_JsObject_NamedProperties
@@ -966,6 +1027,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -224,7 +224,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 32 (0x20)
+				// Code size: 70 (0x46)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -236,12 +236,24 @@
 				IL_0003: castclass Modules.Array_Map_NestedParam/outer/Scope
 				IL_0008: ldfld object Modules.Array_Map_NestedParam/outer/Scope::arr
 				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0012: ldstr "map"
-				IL_0017: ldarg.2
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001d: stloc.0
-				IL_001e: ldloc.0
-				IL_001f: ret
+				IL_0012: volatile.
+				IL_0014: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+				IL_0019: brfalse IL_002e
+
+				IL_001e: ldstr "map"
+				IL_0023: ldarg.2
+				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0029: br IL_0043
+
+				IL_002e: ldstr "map"
+				IL_0033: ldarg.2
+				IL_0034: ldstr "Array_Map_NestedParam:<TwoPhaseDummy_M5>:__js_call__:4"
+				IL_0039: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+				IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0043: stloc.0
+				IL_0044: ldloc.0
+				IL_0045: ret
 			} // end of method inner::__js_call__
 
 		} // end of class inner
@@ -352,7 +364,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 				IL_0007: brfalse IL_001c
 
 				IL_000c: ldarg.1
@@ -363,7 +375,7 @@
 				IL_001c: ldarg.1
 				IL_001d: ldstr "length"
 				IL_0022: ldstr "Array_Map_NestedParam:<TwoPhaseDummy_M6>:__js_call__:2"
-				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0031: stloc.0
@@ -799,6 +811,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_NumericStorage_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_NumericStorage_Basic.verified.txt
@@ -183,7 +183,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 848 (0x350)
+		// Code size: 890 (0x37a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_NumericStorage_Basic/Scope,
@@ -423,64 +423,76 @@
 		IL_027f: stloc.s 14
 		IL_0281: ldloc.s 6
 		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0288: ldstr "join"
-		IL_028d: ldstr ","
-		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0297: stloc.s 11
-		IL_0299: ldloc.s 6
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_02a0: volatile.
-		IL_02a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_02a7: brfalse IL_02bb
+		IL_0288: volatile.
+		IL_028a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_028f: brfalse IL_02a8
 
-		IL_02ac: ldstr "length"
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b6: br IL_02cf
+		IL_0294: ldstr "join"
+		IL_0299: ldstr ","
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a3: br IL_02c1
 
-		IL_02bb: ldstr "length"
-		IL_02c0: ldstr "Array_NumericStorage_Basic:Modules.Array_NumericStorage_Basic:__js_module_init__:113"
-		IL_02c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02a8: ldstr "join"
+		IL_02ad: ldstr ","
+		IL_02b2: ldstr "Array_NumericStorage_Basic:Modules.Array_NumericStorage_Basic:__js_module_init__:110"
+		IL_02b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02cf: stloc.s 13
-		IL_02d1: ldloc.s 14
-		IL_02d3: ldloc.s 11
-		IL_02d5: ldloc.s 13
-		IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02dc: pop
-		IL_02dd: ldc.i4.0
-		IL_02de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02e3: stloc.s 8
-		IL_02e5: ldloc.s 8
-		IL_02e7: ldc.r8 0.0
-		IL_02f0: box [System.Runtime]System.Double
-		IL_02f5: ldc.r8 0.0
-		IL_02fe: box [System.Runtime]System.Double
-		IL_0303: ldc.r8 9
-		IL_030c: box [System.Runtime]System.Double
-		IL_0311: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
-		IL_0316: pop
-		IL_0317: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_031c: stloc.s 14
-		IL_031e: ldloc.s 8
-		IL_0320: ldc.i4.1
-		IL_0321: newarr [System.Runtime]System.Object
-		IL_0326: dup
-		IL_0327: ldc.i4.0
-		IL_0328: ldstr ","
-		IL_032d: stelem.ref
-		IL_032e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0333: stloc.s 20
-		IL_0335: ldloc.s 8
-		IL_0337: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_033c: box [System.Runtime]System.Double
-		IL_0341: stloc.s 17
-		IL_0343: ldloc.s 14
-		IL_0345: ldloc.s 20
-		IL_0347: ldloc.s 17
-		IL_0349: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_034e: pop
-		IL_034f: ret
+		IL_02c1: stloc.s 11
+		IL_02c3: ldloc.s 6
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_02ca: volatile.
+		IL_02cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_02d1: brfalse IL_02e5
+
+		IL_02d6: ldstr "length"
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02e0: br IL_02f9
+
+		IL_02e5: ldstr "length"
+		IL_02ea: ldstr "Array_NumericStorage_Basic:Modules.Array_NumericStorage_Basic:__js_module_init__:113"
+		IL_02ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02f9: stloc.s 13
+		IL_02fb: ldloc.s 14
+		IL_02fd: ldloc.s 11
+		IL_02ff: ldloc.s 13
+		IL_0301: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0306: pop
+		IL_0307: ldc.i4.0
+		IL_0308: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_030d: stloc.s 8
+		IL_030f: ldloc.s 8
+		IL_0311: ldc.r8 0.0
+		IL_031a: box [System.Runtime]System.Double
+		IL_031f: ldc.r8 0.0
+		IL_0328: box [System.Runtime]System.Double
+		IL_032d: ldc.r8 9
+		IL_0336: box [System.Runtime]System.Double
+		IL_033b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::splice(object, object, object)
+		IL_0340: pop
+		IL_0341: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0346: stloc.s 14
+		IL_0348: ldloc.s 8
+		IL_034a: ldc.i4.1
+		IL_034b: newarr [System.Runtime]System.Object
+		IL_0350: dup
+		IL_0351: ldc.i4.0
+		IL_0352: ldstr ","
+		IL_0357: stelem.ref
+		IL_0358: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_035d: stloc.s 20
+		IL_035f: ldloc.s 8
+		IL_0361: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0366: box [System.Runtime]System.Double
+		IL_036b: stloc.s 17
+		IL_036d: ldloc.s 14
+		IL_036f: ldloc.s 20
+		IL_0371: ldloc.s 17
+		IL_0373: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0378: pop
+		IL_0379: ret
 	} // end of method Array_NumericStorage_Basic::__js_module_init__
 
 } // end of class Modules.Array_NumericStorage_Basic
@@ -511,6 +523,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethod_InferredThisLengthAndIndex.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethod_InferredThisLengthAndIndex.verified.txt
@@ -538,7 +538,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 51 (0x33)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] bool
@@ -550,17 +550,29 @@
 			IL_000f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0014: stloc.0
 			IL_0015: ldloc.0
-			IL_0016: brfalse IL_0031
+			IL_0016: brfalse IL_005b
 
 			IL_001b: ldarg.1
 			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0021: ldstr "push"
-			IL_0026: ldstr "c"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0030: pop
+			IL_0021: volatile.
+			IL_0023: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0028: brfalse IL_0041
 
-			IL_0031: ldnull
-			IL_0032: ret
+			IL_002d: ldstr "push"
+			IL_0032: ldstr "c"
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_003c: br IL_005a
+
+			IL_0041: ldstr "push"
+			IL_0046: ldstr "c"
+			IL_004b: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:<TwoPhaseDummy_M5>:__js_call__:10"
+			IL_0050: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_005a: pop
+
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method FunctionExpression_L15C32::__js_call__
 
 	} // end of class FunctionExpression_L15C32
@@ -903,7 +915,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1263 (0x4ef)
+		// Code size: 1423 (0x58f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope,
@@ -1005,330 +1017,379 @@
 		IL_00c5: ldc.i4.1
 		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L15C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00cb: stloc.s 12
-		IL_00cd: ldloc.1
-		IL_00ce: ldstr "scanPhaseTwo"
-		IL_00d3: ldloc.s 12
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00da: stloc.s 8
-		IL_00dc: ldloc.s 11
-		IL_00de: ldloc.s 8
-		IL_00e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e5: pop
-		IL_00e6: ldc.i4.1
-		IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00ec: dup
-		IL_00ed: ldstr "unused"
-		IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_00f7: stloc.2
-		IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00fd: stloc.s 13
-		IL_00ff: ldloc.s 13
-		IL_0101: ldstr "configurable"
-		IL_0106: ldc.i4.1
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
-		IL_010c: pop
-		IL_010d: ldc.i4.1
-		IL_010e: newarr [System.Runtime]System.Object
-		IL_0113: dup
-		IL_0114: ldc.i4.0
-		IL_0115: ldloc.0
-		IL_0116: stelem.ref
-		IL_0117: stloc.s 9
-		IL_0119: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject::.ctor()
-		IL_011e: ldc.i4.0
-		IL_011f: conv.r8
-		IL_0120: ldstr ""
-		IL_0125: ldc.i4.0
-		IL_0126: ldc.i4.1
-		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_012c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject>(!!0)
-		IL_0131: stloc.s 14
-		IL_0133: ldloc.s 13
-		IL_0135: ldstr "get"
-		IL_013a: ldloc.s 14
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0141: pop
-		IL_0142: ldloc.2
-		IL_0143: ldstr "0"
-		IL_0148: ldloc.s 13
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_014f: pop
-		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0155: stloc.s 11
-		IL_0157: volatile.
-		IL_0159: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_015e: brfalse IL_0173
+		IL_00cd: volatile.
+		IL_00cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00d4: brfalse IL_00eb
 
-		IL_0163: ldloc.2
-		IL_0164: ldstr "scanPhaseTwo"
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_016e: br IL_0188
+		IL_00d9: ldloc.1
+		IL_00da: ldstr "scanPhaseTwo"
+		IL_00df: ldloc.s 12
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e6: br IL_0102
 
-		IL_0173: ldloc.2
-		IL_0174: ldstr "scanPhaseTwo"
-		IL_0179: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:42"
-		IL_017e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_00eb: ldloc.1
+		IL_00ec: ldstr "scanPhaseTwo"
+		IL_00f1: ldloc.s 12
+		IL_00f3: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:23"
+		IL_00f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0188: stloc.s 8
-		IL_018a: ldloc.s 11
-		IL_018c: ldloc.s 8
-		IL_018e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0193: pop
-		IL_0194: ldc.i4.0
-		IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_019a: stloc.3
-		IL_019b: ldloc.3
-		IL_019c: ldc.r8 2
-		IL_01a5: ldc.i4.1
-		IL_01a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
-		IL_01ab: ldstr "Array"
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01b5: volatile.
-		IL_01b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01bc: brfalse IL_01d0
+		IL_0102: stloc.s 8
+		IL_0104: ldloc.s 11
+		IL_0106: ldloc.s 8
+		IL_0108: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010d: pop
+		IL_010e: ldc.i4.1
+		IL_010f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0114: dup
+		IL_0115: ldstr "unused"
+		IL_011a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_011f: stloc.2
+		IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0125: stloc.s 13
+		IL_0127: ldloc.s 13
+		IL_0129: ldstr "configurable"
+		IL_012e: ldc.i4.1
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+		IL_0134: pop
+		IL_0135: ldc.i4.1
+		IL_0136: newarr [System.Runtime]System.Object
+		IL_013b: dup
+		IL_013c: ldc.i4.0
+		IL_013d: ldloc.0
+		IL_013e: stelem.ref
+		IL_013f: stloc.s 9
+		IL_0141: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject::.ctor()
+		IL_0146: ldc.i4.0
+		IL_0147: conv.r8
+		IL_0148: ldstr ""
+		IL_014d: ldc.i4.0
+		IL_014e: ldc.i4.1
+		IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject>(!!0)
+		IL_0159: stloc.s 14
+		IL_015b: ldloc.s 13
+		IL_015d: ldstr "get"
+		IL_0162: ldloc.s 14
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0169: pop
+		IL_016a: ldloc.2
+		IL_016b: ldstr "0"
+		IL_0170: ldloc.s 13
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0177: pop
+		IL_0178: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017d: stloc.s 11
+		IL_017f: volatile.
+		IL_0181: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0186: brfalse IL_019b
 
-		IL_01c1: ldstr "prototype"
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01cb: br IL_01e4
+		IL_018b: ldloc.2
+		IL_018c: ldstr "scanPhaseTwo"
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0196: br IL_01b0
 
-		IL_01d0: ldstr "prototype"
-		IL_01d5: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:55"
-		IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_019b: ldloc.2
+		IL_019c: ldstr "scanPhaseTwo"
+		IL_01a1: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:42"
+		IL_01a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_01e4: stloc.s 8
-		IL_01e6: ldloc.s 8
-		IL_01e8: ldc.r8 1
-		IL_01f1: ldstr "prototype"
-		IL_01f6: ldc.i4.1
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_01fc: pop
-		IL_01fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0202: stloc.s 11
-		IL_0204: volatile.
-		IL_0206: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_020b: brfalse IL_0220
+		IL_01b0: stloc.s 8
+		IL_01b2: ldloc.s 11
+		IL_01b4: ldloc.s 8
+		IL_01b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01bb: pop
+		IL_01bc: ldc.i4.0
+		IL_01bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01c2: stloc.3
+		IL_01c3: ldloc.3
+		IL_01c4: ldc.r8 2
+		IL_01cd: ldc.i4.1
+		IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+		IL_01d3: ldstr "Array"
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01dd: volatile.
+		IL_01df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01e4: brfalse IL_01f8
 
-		IL_0210: ldloc.3
-		IL_0211: ldstr "scanPhaseTwo"
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_021b: br IL_0235
+		IL_01e9: ldstr "prototype"
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f3: br IL_020c
 
-		IL_0220: ldloc.3
-		IL_0221: ldstr "scanPhaseTwo"
-		IL_0226: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:61"
-		IL_022b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01f8: ldstr "prototype"
+		IL_01fd: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:55"
+		IL_0202: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0235: stloc.s 8
-		IL_0237: ldloc.s 11
-		IL_0239: ldloc.s 8
-		IL_023b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0240: pop
-		IL_0241: ldstr "Array"
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_024b: volatile.
-		IL_024d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0252: brfalse IL_0266
+		IL_020c: stloc.s 8
+		IL_020e: ldloc.s 8
+		IL_0210: ldc.r8 1
+		IL_0219: ldstr "prototype"
+		IL_021e: ldc.i4.1
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0224: pop
+		IL_0225: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_022a: stloc.s 11
+		IL_022c: volatile.
+		IL_022e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0233: brfalse IL_0248
 
-		IL_0257: ldstr "prototype"
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0261: br IL_027a
+		IL_0238: ldloc.3
+		IL_0239: ldstr "scanPhaseTwo"
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0243: br IL_025d
 
-		IL_0266: ldstr "prototype"
-		IL_026b: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:67"
-		IL_0270: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0248: ldloc.3
+		IL_0249: ldstr "scanPhaseTwo"
+		IL_024e: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:61"
+		IL_0253: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_027a: stloc.s 8
-		IL_027c: ldloc.s 8
-		IL_027e: ldc.r8 1
-		IL_0287: box [System.Runtime]System.Double
-		IL_028c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
-		IL_0291: stloc.s 15
-		IL_0293: ldstr "Array"
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_029d: volatile.
-		IL_029f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_02a4: brfalse IL_02b8
+		IL_025d: stloc.s 8
+		IL_025f: ldloc.s 11
+		IL_0261: ldloc.s 8
+		IL_0263: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0268: pop
+		IL_0269: ldstr "Array"
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0273: volatile.
+		IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_027a: brfalse IL_028e
 
-		IL_02a9: ldstr "prototype"
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b3: br IL_02cc
+		IL_027f: ldstr "prototype"
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0289: br IL_02a2
 
-		IL_02b8: ldstr "prototype"
-		IL_02bd: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:76"
-		IL_02c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_028e: ldstr "prototype"
+		IL_0293: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:67"
+		IL_0298: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02cc: stloc.s 8
-		IL_02ce: volatile.
-		IL_02d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02d5: brfalse IL_02eb
+		IL_02a2: stloc.s 8
+		IL_02a4: ldloc.s 8
+		IL_02a6: ldc.r8 1
+		IL_02af: box [System.Runtime]System.Double
+		IL_02b4: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
+		IL_02b9: stloc.s 15
+		IL_02bb: ldstr "Array"
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c5: volatile.
+		IL_02c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02cc: brfalse IL_02e0
 
-		IL_02da: ldloc.s 8
-		IL_02dc: ldstr "scanPhaseTwo"
-		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e6: br IL_0301
+		IL_02d1: ldstr "prototype"
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02db: br IL_02f4
 
-		IL_02eb: ldloc.s 8
-		IL_02ed: ldstr "scanPhaseTwo"
-		IL_02f2: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:78"
-		IL_02f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02e0: ldstr "prototype"
+		IL_02e5: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:76"
+		IL_02ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0301: stloc.s 4
-		IL_0303: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0308: stloc.s 11
-		IL_030a: ldloc.s 4
-		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0316: dup
-		IL_0317: ldstr "0"
-		IL_031c: ldstr "ordinary"
-		IL_0321: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0326: dup
-		IL_0327: ldstr "length"
-		IL_032c: ldc.r8 1
-		IL_0335: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_033a: stloc.s 13
-		IL_033c: ldstr "call"
-		IL_0341: ldloc.s 13
-		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0348: stloc.s 8
-		IL_034a: ldloc.s 11
-		IL_034c: ldloc.s 8
-		IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0353: pop
-		IL_0354: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0359: dup
-		IL_035a: ldstr "0"
-		IL_035f: ldstr "proxy"
-		IL_0364: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0369: dup
-		IL_036a: ldstr "length"
-		IL_036f: ldc.r8 1
-		IL_0378: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_037d: stloc.s 13
-		IL_037f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0384: stloc.s 16
-		IL_0386: ldc.i4.1
-		IL_0387: newarr [System.Runtime]System.Object
-		IL_038c: dup
-		IL_038d: ldc.i4.0
-		IL_038e: ldloc.0
-		IL_038f: stelem.ref
-		IL_0390: stloc.s 9
-		IL_0392: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject::.ctor()
-		IL_0397: ldc.i4.2
-		IL_0398: conv.r8
-		IL_0399: ldstr ""
-		IL_039e: ldc.i4.0
-		IL_039f: ldc.i4.1
-		IL_03a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject>(!!0)
-		IL_03aa: stloc.s 17
-		IL_03ac: ldloc.s 16
-		IL_03ae: ldstr "get"
-		IL_03b3: ldloc.s 17
-		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_03ba: pop
-		IL_03bb: ldloc.s 13
-		IL_03bd: ldloc.s 16
-		IL_03bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_03c4: stloc.s 5
-		IL_03c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03cb: stloc.s 11
-		IL_03cd: ldloc.s 4
-		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d4: ldstr "call"
-		IL_03d9: ldloc.s 5
-		IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03e0: stloc.s 8
-		IL_03e2: ldloc.s 11
-		IL_03e4: ldloc.s 8
-		IL_03e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03eb: pop
-		IL_03ec: ldc.i4.1
-		IL_03ed: newarr [System.Runtime]System.Object
-		IL_03f2: dup
-		IL_03f3: ldc.i4.0
-		IL_03f4: ldloc.0
-		IL_03f5: stelem.ref
-		IL_03f6: stloc.s 9
-		IL_03f8: ldtoken Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray
-		IL_03fd: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0402: ldtoken Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray
-		IL_0407: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_040c: stloc.s 18
-		IL_040e: ldloc.s 9
-		IL_0410: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray/FunctionObject::.ctor(object[])
-		IL_0415: ldloc.s 18
-		IL_0417: ldloc.s 9
-		IL_0419: ldc.i4.0
-		IL_041a: conv.r8
-		IL_041b: ldc.i4.0
-		IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0421: castclass Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray/FunctionObject
-		IL_0426: stloc.s 19
-		IL_0428: ldstr "Array"
-		IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0432: stloc.s 8
-		IL_0434: ldloc.s 19
-		IL_0436: ldloc.s 8
-		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_043d: stloc.s 8
-		IL_043f: ldloc.s 8
-		IL_0441: stloc.s 6
-		IL_0443: ldc.i4.0
-		IL_0444: newarr [System.Runtime]System.Object
-		IL_0449: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_044e: ldloc.s 6
-		IL_0450: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_0455: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_045a: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray::.ctor()
-		IL_045f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_0464: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0469: dup
-		IL_046a: ldloc.s 6
-		IL_046c: ldstr "prototype"
-		IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0476: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_047b: stloc.s 7
-		IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_0487: stloc.s 7
-		IL_0489: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_048e: ldloc.s 7
-		IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0495: ldstr "push"
-		IL_049a: ldstr "subclass"
-		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04a4: pop
-		IL_04a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04aa: stloc.s 11
-		IL_04ac: ldloc.s 7
-		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b3: volatile.
-		IL_04b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_04ba: brfalse IL_04ce
+		IL_02f4: stloc.s 8
+		IL_02f6: volatile.
+		IL_02f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02fd: brfalse IL_0313
 
-		IL_04bf: ldstr "scanPhaseTwo"
-		IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_04c9: br IL_04e2
+		IL_0302: ldloc.s 8
+		IL_0304: ldstr "scanPhaseTwo"
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_030e: br IL_0329
 
-		IL_04ce: ldstr "scanPhaseTwo"
-		IL_04d3: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:123"
-		IL_04d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0313: ldloc.s 8
+		IL_0315: ldstr "scanPhaseTwo"
+		IL_031a: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:78"
+		IL_031f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04e2: stloc.s 8
-		IL_04e4: ldloc.s 11
-		IL_04e6: ldloc.s 8
-		IL_04e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ed: pop
-		IL_04ee: ret
+		IL_0329: stloc.s 4
+		IL_032b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0330: stloc.s 11
+		IL_0332: ldloc.s 4
+		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0339: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_033e: dup
+		IL_033f: ldstr "0"
+		IL_0344: ldstr "ordinary"
+		IL_0349: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_034e: dup
+		IL_034f: ldstr "length"
+		IL_0354: ldc.r8 1
+		IL_035d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0362: stloc.s 13
+		IL_0364: volatile.
+		IL_0366: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_036b: brfalse IL_0381
+
+		IL_0370: ldstr "call"
+		IL_0375: ldloc.s 13
+		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_037c: br IL_0397
+
+		IL_0381: ldstr "call"
+		IL_0386: ldloc.s 13
+		IL_0388: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:86"
+		IL_038d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0397: stloc.s 8
+		IL_0399: ldloc.s 11
+		IL_039b: ldloc.s 8
+		IL_039d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03a2: pop
+		IL_03a3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03a8: dup
+		IL_03a9: ldstr "0"
+		IL_03ae: ldstr "proxy"
+		IL_03b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03b8: dup
+		IL_03b9: ldstr "length"
+		IL_03be: ldc.r8 1
+		IL_03c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03cc: stloc.s 13
+		IL_03ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03d3: stloc.s 16
+		IL_03d5: ldc.i4.1
+		IL_03d6: newarr [System.Runtime]System.Object
+		IL_03db: dup
+		IL_03dc: ldc.i4.0
+		IL_03dd: ldloc.0
+		IL_03de: stelem.ref
+		IL_03df: stloc.s 9
+		IL_03e1: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject::.ctor()
+		IL_03e6: ldc.i4.2
+		IL_03e7: conv.r8
+		IL_03e8: ldstr ""
+		IL_03ed: ldc.i4.0
+		IL_03ee: ldc.i4.1
+		IL_03ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject>(!!0)
+		IL_03f9: stloc.s 17
+		IL_03fb: ldloc.s 16
+		IL_03fd: ldstr "get"
+		IL_0402: ldloc.s 17
+		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0409: pop
+		IL_040a: ldloc.s 13
+		IL_040c: ldloc.s 16
+		IL_040e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0413: stloc.s 5
+		IL_0415: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_041a: stloc.s 11
+		IL_041c: ldloc.s 4
+		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0423: volatile.
+		IL_0425: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_042a: brfalse IL_0440
+
+		IL_042f: ldstr "call"
+		IL_0434: ldloc.s 5
+		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_043b: br IL_0456
+
+		IL_0440: ldstr "call"
+		IL_0445: ldloc.s 5
+		IL_0447: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:102"
+		IL_044c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0456: stloc.s 8
+		IL_0458: ldloc.s 11
+		IL_045a: ldloc.s 8
+		IL_045c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0461: pop
+		IL_0462: ldc.i4.1
+		IL_0463: newarr [System.Runtime]System.Object
+		IL_0468: dup
+		IL_0469: ldc.i4.0
+		IL_046a: ldloc.0
+		IL_046b: stelem.ref
+		IL_046c: stloc.s 9
+		IL_046e: ldtoken Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray
+		IL_0473: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0478: ldtoken Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray
+		IL_047d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0482: stloc.s 18
+		IL_0484: ldloc.s 9
+		IL_0486: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray/FunctionObject::.ctor(object[])
+		IL_048b: ldloc.s 18
+		IL_048d: ldloc.s 9
+		IL_048f: ldc.i4.0
+		IL_0490: conv.r8
+		IL_0491: ldc.i4.0
+		IL_0492: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0497: castclass Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray/FunctionObject
+		IL_049c: stloc.s 19
+		IL_049e: ldstr "Array"
+		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04a8: stloc.s 8
+		IL_04aa: ldloc.s 19
+		IL_04ac: ldloc.s 8
+		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_04b3: stloc.s 8
+		IL_04b5: ldloc.s 8
+		IL_04b7: stloc.s 6
+		IL_04b9: ldc.i4.0
+		IL_04ba: newarr [System.Runtime]System.Object
+		IL_04bf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_04c4: ldloc.s 6
+		IL_04c6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_04cb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_04d0: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray::.ctor()
+		IL_04d5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_04da: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_04df: dup
+		IL_04e0: ldloc.s 6
+		IL_04e2: ldstr "prototype"
+		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_04ec: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_04f1: stloc.s 7
+		IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_04f8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_04fd: stloc.s 7
+		IL_04ff: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0504: ldloc.s 7
+		IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_050b: volatile.
+		IL_050d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0512: brfalse IL_052b
+
+		IL_0517: ldstr "push"
+		IL_051c: ldstr "subclass"
+		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0526: br IL_0544
+
+		IL_052b: ldstr "push"
+		IL_0530: ldstr "subclass"
+		IL_0535: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:119"
+		IL_053a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0544: pop
+		IL_0545: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_054a: stloc.s 11
+		IL_054c: ldloc.s 7
+		IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0553: volatile.
+		IL_0555: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_055a: brfalse IL_056e
+
+		IL_055f: ldstr "scanPhaseTwo"
+		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0569: br IL_0582
+
+		IL_056e: ldstr "scanPhaseTwo"
+		IL_0573: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:123"
+		IL_0578: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0582: stloc.s 8
+		IL_0584: ldloc.s 11
+		IL_0586: ldloc.s 8
+		IL_0588: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_058d: pop
+		IL_058e: ret
 	} // end of method Array_PrototypeMethod_InferredThisLengthAndIndex::__js_module_init__
 
 } // end of class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex
@@ -1366,6 +1427,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
@@ -1298,7 +1298,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3044 (0xbe4)
+		// Code size: 3120 (0xc30)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope,
@@ -1382,948 +1382,972 @@
 			IL_0090: stloc.s 22
 			IL_0092: ldloc.s 22
 			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0099: ldstr "call"
-			IL_009e: ldloc.1
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a4: pop
-			IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00aa: stloc.s 23
-			IL_00ac: ldloc.s 23
-			IL_00ae: ldstr "no-throw"
-			IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00b8: pop
-			IL_00b9: leave IL_0135
+			IL_0099: volatile.
+			IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_00a0: brfalse IL_00b5
+
+			IL_00a5: ldstr "call"
+			IL_00aa: ldloc.1
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b0: br IL_00ca
+
+			IL_00b5: ldstr "call"
+			IL_00ba: ldloc.1
+			IL_00bb: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:18"
+			IL_00c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00ca: pop
+			IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00d0: stloc.s 23
+			IL_00d2: ldloc.s 23
+			IL_00d4: ldstr "no-throw"
+			IL_00d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00de: pop
+			IL_00df: leave IL_015b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00be: stloc.2
-			IL_00bf: ldloc.2
-			IL_00c0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00c5: dup
-			IL_00c6: brtrue IL_00db
+			IL_00e4: stloc.2
+			IL_00e5: ldloc.2
+			IL_00e6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00eb: dup
+			IL_00ec: brtrue IL_0101
 
-			IL_00cb: pop
-			IL_00cc: ldloc.2
-			IL_00cd: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00d2: dup
-			IL_00d3: brtrue IL_00e6
+			IL_00f1: pop
+			IL_00f2: ldloc.2
+			IL_00f3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00f8: dup
+			IL_00f9: brtrue IL_010c
 
-			IL_00d8: pop
-			IL_00d9: rethrow
+			IL_00fe: pop
+			IL_00ff: rethrow
 
-			IL_00db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00e0: stloc.3
-			IL_00e1: br IL_00e7
+			IL_0101: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0106: stloc.3
+			IL_0107: br IL_010d
 
-			IL_00e6: stloc.3
+			IL_010c: stloc.3
 
-			IL_00e7: ldloc.3
-			IL_00e8: stloc.s 4
-			IL_00ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00ef: stloc.s 23
-			IL_00f1: volatile.
-			IL_00f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_00f8: brfalse IL_010e
+			IL_010d: ldloc.3
+			IL_010e: stloc.s 4
+			IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0115: stloc.s 23
+			IL_0117: volatile.
+			IL_0119: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_011e: brfalse IL_0134
 
-			IL_00fd: ldloc.s 4
-			IL_00ff: ldstr "name"
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0109: br IL_0124
+			IL_0123: ldloc.s 4
+			IL_0125: ldstr "name"
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012f: br IL_014a
 
-			IL_010e: ldloc.s 4
-			IL_0110: ldstr "name"
-			IL_0115: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:33"
-			IL_011a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0134: ldloc.s 4
+			IL_0136: ldstr "name"
+			IL_013b: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:33"
+			IL_0140: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0124: stloc.s 22
-			IL_0126: ldloc.s 23
-			IL_0128: ldloc.s 22
-			IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_012f: pop
-			IL_0130: leave IL_0135
+			IL_014a: stloc.s 22
+			IL_014c: ldloc.s 23
+			IL_014e: ldloc.s 22
+			IL_0150: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0155: pop
+			IL_0156: leave IL_015b
 		} // end handler
 		.try
 		{
-			IL_0135: nop
-			IL_0136: ldstr "Array"
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0140: volatile.
-			IL_0142: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_0147: brfalse IL_015b
+			IL_015b: nop
+			IL_015c: ldstr "Array"
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0166: volatile.
+			IL_0168: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_016d: brfalse IL_0181
 
-			IL_014c: ldstr "prototype"
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0156: br IL_016f
+			IL_0172: ldstr "prototype"
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017c: br IL_0195
 
-			IL_015b: ldstr "prototype"
-			IL_0160: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:46"
-			IL_0165: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0181: ldstr "prototype"
+			IL_0186: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:46"
+			IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_016f: stloc.s 22
-			IL_0171: volatile.
-			IL_0173: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_0178: brfalse IL_018e
+			IL_0195: stloc.s 22
+			IL_0197: volatile.
+			IL_0199: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_019e: brfalse IL_01b4
 
-			IL_017d: ldloc.s 22
-			IL_017f: ldstr "reduceRight"
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0189: br IL_01a4
+			IL_01a3: ldloc.s 22
+			IL_01a5: ldstr "reduceRight"
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01af: br IL_01ca
 
-			IL_018e: ldloc.s 22
-			IL_0190: ldstr "reduceRight"
-			IL_0195: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:48"
-			IL_019a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01b4: ldloc.s 22
+			IL_01b6: ldstr "reduceRight"
+			IL_01bb: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:48"
+			IL_01c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01a4: stloc.s 22
-			IL_01a6: ldloc.s 22
-			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ad: ldstr "call"
-			IL_01b2: ldloc.1
-			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01b8: pop
-			IL_01b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01be: stloc.s 23
-			IL_01c0: ldloc.s 23
-			IL_01c2: ldstr "no-throw"
-			IL_01c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01cc: pop
-			IL_01cd: leave IL_024f
+			IL_01ca: stloc.s 22
+			IL_01cc: ldloc.s 22
+			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d3: volatile.
+			IL_01d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_01da: brfalse IL_01ef
+
+			IL_01df: ldstr "call"
+			IL_01e4: ldloc.1
+			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ea: br IL_0204
+
+			IL_01ef: ldstr "call"
+			IL_01f4: ldloc.1
+			IL_01f5: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:50"
+			IL_01fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0204: pop
+			IL_0205: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_020a: stloc.s 23
+			IL_020c: ldloc.s 23
+			IL_020e: ldstr "no-throw"
+			IL_0213: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0218: pop
+			IL_0219: leave IL_029b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01d2: stloc.s 5
-			IL_01d4: ldloc.s 5
-			IL_01d6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01db: dup
-			IL_01dc: brtrue IL_01f2
+			IL_021e: stloc.s 5
+			IL_0220: ldloc.s 5
+			IL_0222: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0227: dup
+			IL_0228: brtrue IL_023e
 
-			IL_01e1: pop
-			IL_01e2: ldloc.s 5
-			IL_01e4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01e9: dup
-			IL_01ea: brtrue IL_01fe
+			IL_022d: pop
+			IL_022e: ldloc.s 5
+			IL_0230: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0235: dup
+			IL_0236: brtrue IL_024a
 
-			IL_01ef: pop
-			IL_01f0: rethrow
+			IL_023b: pop
+			IL_023c: rethrow
 
-			IL_01f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_01f7: stloc.s 6
-			IL_01f9: br IL_0200
+			IL_023e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0243: stloc.s 6
+			IL_0245: br IL_024c
 
-			IL_01fe: stloc.s 6
+			IL_024a: stloc.s 6
 
-			IL_0200: ldloc.s 6
-			IL_0202: stloc.s 7
-			IL_0204: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0209: stloc.s 23
-			IL_020b: volatile.
-			IL_020d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_0212: brfalse IL_0228
+			IL_024c: ldloc.s 6
+			IL_024e: stloc.s 7
+			IL_0250: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0255: stloc.s 23
+			IL_0257: volatile.
+			IL_0259: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_025e: brfalse IL_0274
 
-			IL_0217: ldloc.s 7
-			IL_0219: ldstr "name"
-			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0223: br IL_023e
+			IL_0263: ldloc.s 7
+			IL_0265: ldstr "name"
+			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026f: br IL_028a
 
-			IL_0228: ldloc.s 7
-			IL_022a: ldstr "name"
-			IL_022f: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:65"
-			IL_0234: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0274: ldloc.s 7
+			IL_0276: ldstr "name"
+			IL_027b: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:65"
+			IL_0280: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_023e: stloc.s 22
-			IL_0240: ldloc.s 23
-			IL_0242: ldloc.s 22
-			IL_0244: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0249: pop
-			IL_024a: leave IL_024f
+			IL_028a: stloc.s 22
+			IL_028c: ldloc.s 23
+			IL_028e: ldloc.s 22
+			IL_0290: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0295: pop
+			IL_0296: leave IL_029b
 		} // end handler
 
-		IL_024f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0254: dup
-		IL_0255: ldstr "length"
-		IL_025a: ldc.r8 3
-		IL_0263: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0268: dup
-		IL_0269: ldstr "1"
-		IL_026e: ldstr "b"
-		IL_0273: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0278: stloc.s 8
-		IL_027a: ldloc.0
-		IL_027b: ldc.r8 0.0
-		IL_0284: box [System.Runtime]System.Double
-		IL_0289: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_028e: ldstr "Array"
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0298: volatile.
-		IL_029a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_029f: brfalse IL_02b3
+		IL_029b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02a0: dup
+		IL_02a1: ldstr "length"
+		IL_02a6: ldc.r8 3
+		IL_02af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_02b4: dup
+		IL_02b5: ldstr "1"
+		IL_02ba: ldstr "b"
+		IL_02bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02c4: stloc.s 8
+		IL_02c6: ldloc.0
+		IL_02c7: ldc.r8 0.0
+		IL_02d0: box [System.Runtime]System.Double
+		IL_02d5: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_02da: ldstr "Array"
+		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02e4: volatile.
+		IL_02e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_02eb: brfalse IL_02ff
 
-		IL_02a4: ldstr "prototype"
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ae: br IL_02c7
+		IL_02f0: ldstr "prototype"
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02fa: br IL_0313
 
-		IL_02b3: ldstr "prototype"
-		IL_02b8: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:84"
-		IL_02bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02ff: ldstr "prototype"
+		IL_0304: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:84"
+		IL_0309: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02c7: stloc.s 22
-		IL_02c9: volatile.
-		IL_02cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_02d0: brfalse IL_02e6
+		IL_0313: stloc.s 22
+		IL_0315: volatile.
+		IL_0317: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_031c: brfalse IL_0332
 
-		IL_02d5: ldloc.s 22
-		IL_02d7: ldstr "reduce"
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e1: br IL_02fc
+		IL_0321: ldloc.s 22
+		IL_0323: ldstr "reduce"
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_032d: br IL_0348
 
-		IL_02e6: ldloc.s 22
-		IL_02e8: ldstr "reduce"
-		IL_02ed: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:86"
-		IL_02f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0332: ldloc.s 22
+		IL_0334: ldstr "reduce"
+		IL_0339: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:86"
+		IL_033e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02fc: stloc.s 22
-		IL_02fe: ldloc.s 22
-		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0305: stloc.s 22
-		IL_0307: ldc.i4.1
-		IL_0308: newarr [System.Runtime]System.Object
-		IL_030d: dup
-		IL_030e: ldc.i4.0
-		IL_030f: ldloc.0
-		IL_0310: stelem.ref
-		IL_0311: stloc.s 24
-		IL_0313: ldloc.s 24
-		IL_0315: ldc.i4.0
-		IL_0316: ldelem.ref
-		IL_0317: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_031c: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
-		IL_0321: ldc.i4.2
-		IL_0322: conv.r8
-		IL_0323: ldstr ""
-		IL_0328: ldc.i4.0
-		IL_0329: ldc.i4.1
-		IL_032a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_032f: stloc.s 25
-		IL_0331: ldloc.s 22
-		IL_0333: ldstr "call"
-		IL_0338: ldloc.s 8
-		IL_033a: ldloc.s 25
-		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0341: stloc.s 9
-		IL_0343: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0348: stloc.s 23
-		IL_034a: ldloc.s 23
-		IL_034c: ldloc.s 9
-		IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0353: pop
-		IL_0354: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0359: stloc.s 23
+		IL_0348: stloc.s 22
+		IL_034a: ldloc.s 22
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0351: stloc.s 22
+		IL_0353: ldc.i4.1
+		IL_0354: newarr [System.Runtime]System.Object
+		IL_0359: dup
+		IL_035a: ldc.i4.0
 		IL_035b: ldloc.0
-		IL_035c: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_0361: stloc.s 22
-		IL_0363: ldloc.s 23
-		IL_0365: ldloc.s 22
-		IL_0367: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_036c: pop
-		IL_036d: ldloc.0
-		IL_036e: ldc.r8 0.0
-		IL_0377: box [System.Runtime]System.Double
-		IL_037c: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_0381: ldstr "Array"
-		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_038b: volatile.
-		IL_038d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0392: brfalse IL_03a6
+		IL_035c: stelem.ref
+		IL_035d: stloc.s 24
+		IL_035f: ldloc.s 24
+		IL_0361: ldc.i4.0
+		IL_0362: ldelem.ref
+		IL_0363: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
+		IL_0368: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_036d: ldc.i4.2
+		IL_036e: conv.r8
+		IL_036f: ldstr ""
+		IL_0374: ldc.i4.0
+		IL_0375: ldc.i4.1
+		IL_0376: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_037b: stloc.s 25
+		IL_037d: ldloc.s 22
+		IL_037f: ldstr "call"
+		IL_0384: ldloc.s 8
+		IL_0386: ldloc.s 25
+		IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_038d: stloc.s 9
+		IL_038f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0394: stloc.s 23
+		IL_0396: ldloc.s 23
+		IL_0398: ldloc.s 9
+		IL_039a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_039f: pop
+		IL_03a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a5: stloc.s 23
+		IL_03a7: ldloc.0
+		IL_03a8: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_03ad: stloc.s 22
+		IL_03af: ldloc.s 23
+		IL_03b1: ldloc.s 22
+		IL_03b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03b8: pop
+		IL_03b9: ldloc.0
+		IL_03ba: ldc.r8 0.0
+		IL_03c3: box [System.Runtime]System.Double
+		IL_03c8: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_03cd: ldstr "Array"
+		IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03d7: volatile.
+		IL_03d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_03de: brfalse IL_03f2
 
-		IL_0397: ldstr "prototype"
-		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03a1: br IL_03ba
+		IL_03e3: ldstr "prototype"
+		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ed: br IL_0406
 
-		IL_03a6: ldstr "prototype"
-		IL_03ab: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:107"
-		IL_03b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03f2: ldstr "prototype"
+		IL_03f7: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:107"
+		IL_03fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03ba: stloc.s 22
-		IL_03bc: volatile.
-		IL_03be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_03c3: brfalse IL_03d9
+		IL_0406: stloc.s 22
+		IL_0408: volatile.
+		IL_040a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_040f: brfalse IL_0425
 
-		IL_03c8: ldloc.s 22
-		IL_03ca: ldstr "reduce"
-		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d4: br IL_03ef
+		IL_0414: ldloc.s 22
+		IL_0416: ldstr "reduce"
+		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0420: br IL_043b
 
-		IL_03d9: ldloc.s 22
-		IL_03db: ldstr "reduce"
-		IL_03e0: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:109"
-		IL_03e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0425: ldloc.s 22
+		IL_0427: ldstr "reduce"
+		IL_042c: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:109"
+		IL_0431: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03ef: stloc.s 22
-		IL_03f1: ldloc.s 22
-		IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03f8: stloc.s 22
-		IL_03fa: ldc.i4.1
-		IL_03fb: newarr [System.Runtime]System.Object
-		IL_0400: dup
-		IL_0401: ldc.i4.0
-		IL_0402: ldloc.0
-		IL_0403: stelem.ref
-		IL_0404: stloc.s 24
-		IL_0406: ldloc.s 24
-		IL_0408: ldc.i4.0
-		IL_0409: ldelem.ref
-		IL_040a: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_040f: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
-		IL_0414: ldc.i4.2
-		IL_0415: conv.r8
-		IL_0416: ldstr ""
-		IL_041b: ldc.i4.0
-		IL_041c: ldc.i4.1
-		IL_041d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0422: stloc.s 26
-		IL_0424: ldloc.s 22
-		IL_0426: ldstr "call"
-		IL_042b: ldloc.s 8
-		IL_042d: ldloc.s 26
-		IL_042f: ldstr ""
-		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0439: stloc.s 10
-		IL_043b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0440: stloc.s 23
-		IL_0442: ldloc.s 23
-		IL_0444: ldloc.s 10
-		IL_0446: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_044b: pop
-		IL_044c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0451: stloc.s 23
-		IL_0453: ldloc.0
-		IL_0454: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_0459: stloc.s 22
-		IL_045b: ldloc.s 23
-		IL_045d: ldloc.s 22
-		IL_045f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0464: pop
-		IL_0465: ldloc.0
-		IL_0466: ldc.r8 0.0
-		IL_046f: box [System.Runtime]System.Double
-		IL_0474: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_0479: ldstr "Array"
-		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0483: volatile.
-		IL_0485: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_048a: brfalse IL_049e
+		IL_043b: stloc.s 22
+		IL_043d: ldloc.s 22
+		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0444: stloc.s 22
+		IL_0446: ldc.i4.1
+		IL_0447: newarr [System.Runtime]System.Object
+		IL_044c: dup
+		IL_044d: ldc.i4.0
+		IL_044e: ldloc.0
+		IL_044f: stelem.ref
+		IL_0450: stloc.s 24
+		IL_0452: ldloc.s 24
+		IL_0454: ldc.i4.0
+		IL_0455: ldelem.ref
+		IL_0456: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
+		IL_045b: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_0460: ldc.i4.2
+		IL_0461: conv.r8
+		IL_0462: ldstr ""
+		IL_0467: ldc.i4.0
+		IL_0468: ldc.i4.1
+		IL_0469: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_046e: stloc.s 26
+		IL_0470: ldloc.s 22
+		IL_0472: ldstr "call"
+		IL_0477: ldloc.s 8
+		IL_0479: ldloc.s 26
+		IL_047b: ldstr ""
+		IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0485: stloc.s 10
+		IL_0487: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_048c: stloc.s 23
+		IL_048e: ldloc.s 23
+		IL_0490: ldloc.s 10
+		IL_0492: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0497: pop
+		IL_0498: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_049d: stloc.s 23
+		IL_049f: ldloc.0
+		IL_04a0: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_04a5: stloc.s 22
+		IL_04a7: ldloc.s 23
+		IL_04a9: ldloc.s 22
+		IL_04ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04b0: pop
+		IL_04b1: ldloc.0
+		IL_04b2: ldc.r8 0.0
+		IL_04bb: box [System.Runtime]System.Double
+		IL_04c0: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_04c5: ldstr "Array"
+		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04cf: volatile.
+		IL_04d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_04d6: brfalse IL_04ea
 
-		IL_048f: ldstr "prototype"
-		IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0499: br IL_04b2
+		IL_04db: ldstr "prototype"
+		IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04e5: br IL_04fe
 
-		IL_049e: ldstr "prototype"
-		IL_04a3: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:131"
-		IL_04a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04ea: ldstr "prototype"
+		IL_04ef: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:131"
+		IL_04f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04b2: stloc.s 22
-		IL_04b4: volatile.
-		IL_04b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_04bb: brfalse IL_04d1
+		IL_04fe: stloc.s 22
+		IL_0500: volatile.
+		IL_0502: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0507: brfalse IL_051d
 
-		IL_04c0: ldloc.s 22
-		IL_04c2: ldstr "reduceRight"
-		IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04cc: br IL_04e7
+		IL_050c: ldloc.s 22
+		IL_050e: ldstr "reduceRight"
+		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0518: br IL_0533
 
-		IL_04d1: ldloc.s 22
-		IL_04d3: ldstr "reduceRight"
-		IL_04d8: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:133"
-		IL_04dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_051d: ldloc.s 22
+		IL_051f: ldstr "reduceRight"
+		IL_0524: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:133"
+		IL_0529: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04e7: stloc.s 22
-		IL_04e9: ldloc.s 22
-		IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04f0: stloc.s 22
-		IL_04f2: ldc.i4.1
-		IL_04f3: newarr [System.Runtime]System.Object
-		IL_04f8: dup
-		IL_04f9: ldc.i4.0
-		IL_04fa: ldloc.0
-		IL_04fb: stelem.ref
-		IL_04fc: stloc.s 24
-		IL_04fe: ldloc.s 24
-		IL_0500: ldc.i4.0
-		IL_0501: ldelem.ref
-		IL_0502: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_0507: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
-		IL_050c: ldc.i4.2
-		IL_050d: conv.r8
-		IL_050e: ldstr ""
-		IL_0513: ldc.i4.0
-		IL_0514: ldc.i4.1
-		IL_0515: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_051a: stloc.s 27
-		IL_051c: ldloc.s 22
-		IL_051e: ldstr "call"
-		IL_0523: ldloc.s 8
-		IL_0525: ldloc.s 27
-		IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_052c: stloc.s 11
-		IL_052e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0533: stloc.s 23
-		IL_0535: ldloc.s 23
-		IL_0537: ldloc.s 11
-		IL_0539: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_053e: pop
-		IL_053f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0544: stloc.s 23
+		IL_0533: stloc.s 22
+		IL_0535: ldloc.s 22
+		IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_053c: stloc.s 22
+		IL_053e: ldc.i4.1
+		IL_053f: newarr [System.Runtime]System.Object
+		IL_0544: dup
+		IL_0545: ldc.i4.0
 		IL_0546: ldloc.0
-		IL_0547: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_054c: stloc.s 22
-		IL_054e: ldloc.s 23
-		IL_0550: ldloc.s 22
-		IL_0552: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0557: pop
-		IL_0558: ldloc.0
-		IL_0559: ldc.r8 0.0
-		IL_0562: box [System.Runtime]System.Double
-		IL_0567: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_056c: ldstr "Array"
-		IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0576: volatile.
-		IL_0578: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_057d: brfalse IL_0591
+		IL_0547: stelem.ref
+		IL_0548: stloc.s 24
+		IL_054a: ldloc.s 24
+		IL_054c: ldc.i4.0
+		IL_054d: ldelem.ref
+		IL_054e: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
+		IL_0553: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_0558: ldc.i4.2
+		IL_0559: conv.r8
+		IL_055a: ldstr ""
+		IL_055f: ldc.i4.0
+		IL_0560: ldc.i4.1
+		IL_0561: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0566: stloc.s 27
+		IL_0568: ldloc.s 22
+		IL_056a: ldstr "call"
+		IL_056f: ldloc.s 8
+		IL_0571: ldloc.s 27
+		IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0578: stloc.s 11
+		IL_057a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_057f: stloc.s 23
+		IL_0581: ldloc.s 23
+		IL_0583: ldloc.s 11
+		IL_0585: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_058a: pop
+		IL_058b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0590: stloc.s 23
+		IL_0592: ldloc.0
+		IL_0593: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_0598: stloc.s 22
+		IL_059a: ldloc.s 23
+		IL_059c: ldloc.s 22
+		IL_059e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05a3: pop
+		IL_05a4: ldloc.0
+		IL_05a5: ldc.r8 0.0
+		IL_05ae: box [System.Runtime]System.Double
+		IL_05b3: stfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_05b8: ldstr "Array"
+		IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05c2: volatile.
+		IL_05c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_05c9: brfalse IL_05dd
 
-		IL_0582: ldstr "prototype"
-		IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_058c: br IL_05a5
+		IL_05ce: ldstr "prototype"
+		IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05d8: br IL_05f1
 
-		IL_0591: ldstr "prototype"
-		IL_0596: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:154"
-		IL_059b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05dd: ldstr "prototype"
+		IL_05e2: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:154"
+		IL_05e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05a5: stloc.s 22
-		IL_05a7: volatile.
-		IL_05a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_05ae: brfalse IL_05c4
+		IL_05f1: stloc.s 22
+		IL_05f3: volatile.
+		IL_05f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_05fa: brfalse IL_0610
 
-		IL_05b3: ldloc.s 22
-		IL_05b5: ldstr "reduceRight"
-		IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05bf: br IL_05da
+		IL_05ff: ldloc.s 22
+		IL_0601: ldstr "reduceRight"
+		IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_060b: br IL_0626
 
-		IL_05c4: ldloc.s 22
-		IL_05c6: ldstr "reduceRight"
-		IL_05cb: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:156"
-		IL_05d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0610: ldloc.s 22
+		IL_0612: ldstr "reduceRight"
+		IL_0617: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:156"
+		IL_061c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05da: stloc.s 22
-		IL_05dc: ldloc.s 22
-		IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05e3: stloc.s 22
-		IL_05e5: ldc.i4.1
-		IL_05e6: newarr [System.Runtime]System.Object
-		IL_05eb: dup
-		IL_05ec: ldc.i4.0
-		IL_05ed: ldloc.0
-		IL_05ee: stelem.ref
-		IL_05ef: stloc.s 24
-		IL_05f1: ldloc.s 24
-		IL_05f3: ldc.i4.0
-		IL_05f4: ldelem.ref
-		IL_05f5: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_05fa: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
-		IL_05ff: ldc.i4.2
-		IL_0600: conv.r8
-		IL_0601: ldstr ""
-		IL_0606: ldc.i4.0
-		IL_0607: ldc.i4.1
-		IL_0608: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_060d: stloc.s 28
-		IL_060f: ldloc.s 22
-		IL_0611: ldstr "call"
-		IL_0616: ldloc.s 8
-		IL_0618: ldloc.s 28
-		IL_061a: ldstr ""
-		IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0624: stloc.s 12
-		IL_0626: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_062b: stloc.s 23
-		IL_062d: ldloc.s 23
-		IL_062f: ldloc.s 12
-		IL_0631: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0636: pop
-		IL_0637: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_063c: stloc.s 23
-		IL_063e: ldloc.0
-		IL_063f: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
-		IL_0644: stloc.s 22
-		IL_0646: ldloc.s 23
-		IL_0648: ldloc.s 22
-		IL_064a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_064f: pop
-		IL_0650: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0655: dup
-		IL_0656: ldstr "length"
-		IL_065b: ldc.r8 2
-		IL_0664: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0669: stloc.s 13
+		IL_0626: stloc.s 22
+		IL_0628: ldloc.s 22
+		IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_062f: stloc.s 22
+		IL_0631: ldc.i4.1
+		IL_0632: newarr [System.Runtime]System.Object
+		IL_0637: dup
+		IL_0638: ldc.i4.0
+		IL_0639: ldloc.0
+		IL_063a: stelem.ref
+		IL_063b: stloc.s 24
+		IL_063d: ldloc.s 24
+		IL_063f: ldc.i4.0
+		IL_0640: ldelem.ref
+		IL_0641: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
+		IL_0646: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_064b: ldc.i4.2
+		IL_064c: conv.r8
+		IL_064d: ldstr ""
+		IL_0652: ldc.i4.0
+		IL_0653: ldc.i4.1
+		IL_0654: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0659: stloc.s 28
+		IL_065b: ldloc.s 22
+		IL_065d: ldstr "call"
+		IL_0662: ldloc.s 8
+		IL_0664: ldloc.s 28
+		IL_0666: ldstr ""
+		IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0670: stloc.s 12
+		IL_0672: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0677: stloc.s 23
+		IL_0679: ldloc.s 23
+		IL_067b: ldloc.s 12
+		IL_067d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0682: pop
+		IL_0683: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0688: stloc.s 23
+		IL_068a: ldloc.0
+		IL_068b: ldfld object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope::calls
+		IL_0690: stloc.s 22
+		IL_0692: ldloc.s 23
+		IL_0694: ldloc.s 22
+		IL_0696: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_069b: pop
+		IL_069c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_06a1: dup
+		IL_06a2: ldstr "length"
+		IL_06a7: ldc.r8 2
+		IL_06b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_06b5: stloc.s 13
 		.try
 		{
-			IL_066b: nop
-			IL_066c: ldstr "Array"
-			IL_0671: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0676: volatile.
-			IL_0678: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_067d: brfalse IL_0691
+			IL_06b7: nop
+			IL_06b8: ldstr "Array"
+			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06c2: volatile.
+			IL_06c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_06c9: brfalse IL_06dd
 
-			IL_0682: ldstr "prototype"
-			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_068c: br IL_06a5
+			IL_06ce: ldstr "prototype"
+			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06d8: br IL_06f1
 
-			IL_0691: ldstr "prototype"
-			IL_0696: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:181"
-			IL_069b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_06a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06dd: ldstr "prototype"
+			IL_06e2: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:181"
+			IL_06e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06a5: stloc.s 22
-			IL_06a7: volatile.
-			IL_06a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_06ae: brfalse IL_06c4
+			IL_06f1: stloc.s 22
+			IL_06f3: volatile.
+			IL_06f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_06fa: brfalse IL_0710
 
-			IL_06b3: ldloc.s 22
-			IL_06b5: ldstr "reduce"
-			IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06bf: br IL_06da
+			IL_06ff: ldloc.s 22
+			IL_0701: ldstr "reduce"
+			IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_070b: br IL_0726
 
-			IL_06c4: ldloc.s 22
-			IL_06c6: ldstr "reduce"
-			IL_06cb: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:183"
-			IL_06d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0710: ldloc.s 22
+			IL_0712: ldstr "reduce"
+			IL_0717: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:183"
+			IL_071c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06da: stloc.s 22
-			IL_06dc: ldloc.s 22
-			IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06e3: stloc.s 22
-			IL_06e5: ldc.i4.1
-			IL_06e6: newarr [System.Runtime]System.Object
-			IL_06eb: dup
-			IL_06ec: ldc.i4.0
-			IL_06ed: ldloc.0
-			IL_06ee: stelem.ref
-			IL_06ef: stloc.s 24
-			IL_06f1: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject::.ctor()
-			IL_06f6: ldc.i4.2
-			IL_06f7: conv.r8
-			IL_06f8: ldstr ""
-			IL_06fd: ldc.i4.0
-			IL_06fe: ldc.i4.1
-			IL_06ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0704: stloc.s 29
-			IL_0706: ldloc.s 22
-			IL_0708: ldstr "call"
-			IL_070d: ldloc.s 13
-			IL_070f: ldloc.s 29
-			IL_0711: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0716: pop
-			IL_0717: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_071c: stloc.s 23
-			IL_071e: ldloc.s 23
-			IL_0720: ldstr "no-throw"
-			IL_0725: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_072a: pop
-			IL_072b: leave IL_07ad
+			IL_0726: stloc.s 22
+			IL_0728: ldloc.s 22
+			IL_072a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_072f: stloc.s 22
+			IL_0731: ldc.i4.1
+			IL_0732: newarr [System.Runtime]System.Object
+			IL_0737: dup
+			IL_0738: ldc.i4.0
+			IL_0739: ldloc.0
+			IL_073a: stelem.ref
+			IL_073b: stloc.s 24
+			IL_073d: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject::.ctor()
+			IL_0742: ldc.i4.2
+			IL_0743: conv.r8
+			IL_0744: ldstr ""
+			IL_0749: ldc.i4.0
+			IL_074a: ldc.i4.1
+			IL_074b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0750: stloc.s 29
+			IL_0752: ldloc.s 22
+			IL_0754: ldstr "call"
+			IL_0759: ldloc.s 13
+			IL_075b: ldloc.s 29
+			IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0762: pop
+			IL_0763: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0768: stloc.s 23
+			IL_076a: ldloc.s 23
+			IL_076c: ldstr "no-throw"
+			IL_0771: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0776: pop
+			IL_0777: leave IL_07f9
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0730: stloc.s 14
-			IL_0732: ldloc.s 14
-			IL_0734: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0739: dup
-			IL_073a: brtrue IL_0750
+			IL_077c: stloc.s 14
+			IL_077e: ldloc.s 14
+			IL_0780: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0785: dup
+			IL_0786: brtrue IL_079c
 
-			IL_073f: pop
-			IL_0740: ldloc.s 14
-			IL_0742: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0747: dup
-			IL_0748: brtrue IL_075c
+			IL_078b: pop
+			IL_078c: ldloc.s 14
+			IL_078e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0793: dup
+			IL_0794: brtrue IL_07a8
 
-			IL_074d: pop
-			IL_074e: rethrow
+			IL_0799: pop
+			IL_079a: rethrow
 
-			IL_0750: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0755: stloc.s 15
-			IL_0757: br IL_075e
+			IL_079c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07a1: stloc.s 15
+			IL_07a3: br IL_07aa
 
-			IL_075c: stloc.s 15
+			IL_07a8: stloc.s 15
 
-			IL_075e: ldloc.s 15
-			IL_0760: stloc.s 16
-			IL_0762: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0767: stloc.s 23
-			IL_0769: volatile.
-			IL_076b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_0770: brfalse IL_0786
+			IL_07aa: ldloc.s 15
+			IL_07ac: stloc.s 16
+			IL_07ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07b3: stloc.s 23
+			IL_07b5: volatile.
+			IL_07b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_07bc: brfalse IL_07d2
 
-			IL_0775: ldloc.s 16
-			IL_0777: ldstr "name"
-			IL_077c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0781: br IL_079c
+			IL_07c1: ldloc.s 16
+			IL_07c3: ldstr "name"
+			IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07cd: br IL_07e8
 
-			IL_0786: ldloc.s 16
-			IL_0788: ldstr "name"
-			IL_078d: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:202"
-			IL_0792: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_0797: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07d2: ldloc.s 16
+			IL_07d4: ldstr "name"
+			IL_07d9: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:202"
+			IL_07de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_07e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_079c: stloc.s 22
-			IL_079e: ldloc.s 23
-			IL_07a0: ldloc.s 22
-			IL_07a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_07a7: pop
-			IL_07a8: leave IL_07ad
+			IL_07e8: stloc.s 22
+			IL_07ea: ldloc.s 23
+			IL_07ec: ldloc.s 22
+			IL_07ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07f3: pop
+			IL_07f4: leave IL_07f9
 		} // end handler
 		.try
 		{
-			IL_07ad: nop
-			IL_07ae: ldstr "Array"
-			IL_07b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07b8: volatile.
-			IL_07ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_07bf: brfalse IL_07d3
+			IL_07f9: nop
+			IL_07fa: ldstr "Array"
+			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0804: volatile.
+			IL_0806: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_080b: brfalse IL_081f
 
-			IL_07c4: ldstr "prototype"
-			IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07ce: br IL_07e7
+			IL_0810: ldstr "prototype"
+			IL_0815: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_081a: br IL_0833
 
-			IL_07d3: ldstr "prototype"
-			IL_07d8: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:215"
-			IL_07dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_081f: ldstr "prototype"
+			IL_0824: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:215"
+			IL_0829: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_082e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07e7: stloc.s 22
-			IL_07e9: volatile.
-			IL_07eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_07f0: brfalse IL_0806
+			IL_0833: stloc.s 22
+			IL_0835: volatile.
+			IL_0837: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_083c: brfalse IL_0852
 
-			IL_07f5: ldloc.s 22
-			IL_07f7: ldstr "reduceRight"
-			IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0801: br IL_081c
+			IL_0841: ldloc.s 22
+			IL_0843: ldstr "reduceRight"
+			IL_0848: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_084d: br IL_0868
 
-			IL_0806: ldloc.s 22
-			IL_0808: ldstr "reduceRight"
-			IL_080d: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:217"
-			IL_0812: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0852: ldloc.s 22
+			IL_0854: ldstr "reduceRight"
+			IL_0859: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:217"
+			IL_085e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0863: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_081c: stloc.s 22
-			IL_081e: ldloc.s 22
-			IL_0820: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0825: stloc.s 22
-			IL_0827: ldc.i4.1
-			IL_0828: newarr [System.Runtime]System.Object
-			IL_082d: dup
-			IL_082e: ldc.i4.0
-			IL_082f: ldloc.0
-			IL_0830: stelem.ref
-			IL_0831: stloc.s 24
-			IL_0833: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject::.ctor()
-			IL_0838: ldc.i4.2
-			IL_0839: conv.r8
-			IL_083a: ldstr ""
-			IL_083f: ldc.i4.0
-			IL_0840: ldc.i4.1
-			IL_0841: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0846: stloc.s 30
-			IL_0848: ldloc.s 22
-			IL_084a: ldstr "call"
-			IL_084f: ldloc.s 13
-			IL_0851: ldloc.s 30
-			IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0858: pop
-			IL_0859: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_085e: stloc.s 23
-			IL_0860: ldloc.s 23
-			IL_0862: ldstr "no-throw"
-			IL_0867: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_086c: pop
-			IL_086d: leave IL_08ef
+			IL_0868: stloc.s 22
+			IL_086a: ldloc.s 22
+			IL_086c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0871: stloc.s 22
+			IL_0873: ldc.i4.1
+			IL_0874: newarr [System.Runtime]System.Object
+			IL_0879: dup
+			IL_087a: ldc.i4.0
+			IL_087b: ldloc.0
+			IL_087c: stelem.ref
+			IL_087d: stloc.s 24
+			IL_087f: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject::.ctor()
+			IL_0884: ldc.i4.2
+			IL_0885: conv.r8
+			IL_0886: ldstr ""
+			IL_088b: ldc.i4.0
+			IL_088c: ldc.i4.1
+			IL_088d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0892: stloc.s 30
+			IL_0894: ldloc.s 22
+			IL_0896: ldstr "call"
+			IL_089b: ldloc.s 13
+			IL_089d: ldloc.s 30
+			IL_089f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_08a4: pop
+			IL_08a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08aa: stloc.s 23
+			IL_08ac: ldloc.s 23
+			IL_08ae: ldstr "no-throw"
+			IL_08b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_08b8: pop
+			IL_08b9: leave IL_093b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0872: stloc.s 17
-			IL_0874: ldloc.s 17
-			IL_0876: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_087b: dup
-			IL_087c: brtrue IL_0892
+			IL_08be: stloc.s 17
+			IL_08c0: ldloc.s 17
+			IL_08c2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_08c7: dup
+			IL_08c8: brtrue IL_08de
 
-			IL_0881: pop
-			IL_0882: ldloc.s 17
-			IL_0884: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0889: dup
-			IL_088a: brtrue IL_089e
+			IL_08cd: pop
+			IL_08ce: ldloc.s 17
+			IL_08d0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_08d5: dup
+			IL_08d6: brtrue IL_08ea
 
-			IL_088f: pop
-			IL_0890: rethrow
+			IL_08db: pop
+			IL_08dc: rethrow
 
-			IL_0892: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0897: stloc.s 18
-			IL_0899: br IL_08a0
+			IL_08de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_08e3: stloc.s 18
+			IL_08e5: br IL_08ec
 
-			IL_089e: stloc.s 18
+			IL_08ea: stloc.s 18
 
-			IL_08a0: ldloc.s 18
-			IL_08a2: stloc.s 19
-			IL_08a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08a9: stloc.s 23
-			IL_08ab: volatile.
-			IL_08ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_08b2: brfalse IL_08c8
+			IL_08ec: ldloc.s 18
+			IL_08ee: stloc.s 19
+			IL_08f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08f5: stloc.s 23
+			IL_08f7: volatile.
+			IL_08f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_08fe: brfalse IL_0914
 
-			IL_08b7: ldloc.s 19
-			IL_08b9: ldstr "name"
-			IL_08be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08c3: br IL_08de
+			IL_0903: ldloc.s 19
+			IL_0905: ldstr "name"
+			IL_090a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_090f: br IL_092a
 
-			IL_08c8: ldloc.s 19
-			IL_08ca: ldstr "name"
-			IL_08cf: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:236"
-			IL_08d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_08d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0914: ldloc.s 19
+			IL_0916: ldstr "name"
+			IL_091b: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:236"
+			IL_0920: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08de: stloc.s 22
-			IL_08e0: ldloc.s 23
-			IL_08e2: ldloc.s 22
-			IL_08e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08e9: pop
-			IL_08ea: leave IL_08ef
+			IL_092a: stloc.s 22
+			IL_092c: ldloc.s 23
+			IL_092e: ldloc.s 22
+			IL_0930: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0935: pop
+			IL_0936: leave IL_093b
 		} // end handler
 
-		IL_08ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_08f4: dup
-		IL_08f5: ldstr "0"
-		IL_08fa: ldstr "a"
-		IL_08ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0904: dup
-		IL_0905: ldstr "1"
-		IL_090a: ldstr "b"
-		IL_090f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0914: dup
-		IL_0915: ldstr "length"
-		IL_091a: ldc.r8 2
-		IL_0923: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0928: stloc.s 20
-		IL_092a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_092f: stloc.s 23
-		IL_0931: ldstr "Array"
-		IL_0936: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_093b: volatile.
-		IL_093d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0942: brfalse IL_0956
+		IL_093b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0940: dup
+		IL_0941: ldstr "0"
+		IL_0946: ldstr "a"
+		IL_094b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0950: dup
+		IL_0951: ldstr "1"
+		IL_0956: ldstr "b"
+		IL_095b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0960: dup
+		IL_0961: ldstr "length"
+		IL_0966: ldc.r8 2
+		IL_096f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0974: stloc.s 20
+		IL_0976: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_097b: stloc.s 23
+		IL_097d: ldstr "Array"
+		IL_0982: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0987: volatile.
+		IL_0989: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_098e: brfalse IL_09a2
 
-		IL_0947: ldstr "prototype"
-		IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0951: br IL_096a
+		IL_0993: ldstr "prototype"
+		IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_099d: br IL_09b6
 
-		IL_0956: ldstr "prototype"
-		IL_095b: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:253"
-		IL_0960: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0965: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09a2: ldstr "prototype"
+		IL_09a7: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:253"
+		IL_09ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_09b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_096a: stloc.s 22
-		IL_096c: volatile.
-		IL_096e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0973: brfalse IL_0989
+		IL_09b6: stloc.s 22
+		IL_09b8: volatile.
+		IL_09ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_09bf: brfalse IL_09d5
 
-		IL_0978: ldloc.s 22
-		IL_097a: ldstr "indexOf"
-		IL_097f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0984: br IL_099f
+		IL_09c4: ldloc.s 22
+		IL_09c6: ldstr "indexOf"
+		IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09d0: br IL_09eb
 
-		IL_0989: ldloc.s 22
-		IL_098b: ldstr "indexOf"
-		IL_0990: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:255"
-		IL_0995: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_099a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09d5: ldloc.s 22
+		IL_09d7: ldstr "indexOf"
+		IL_09dc: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:255"
+		IL_09e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_09e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_099f: stloc.s 22
-		IL_09a1: ldloc.s 22
-		IL_09a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_09a8: ldstr "call"
-		IL_09ad: ldloc.s 20
-		IL_09af: ldstr "b"
-		IL_09b4: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_09bd: box [System.Runtime]System.Double
-		IL_09c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_09c7: stloc.s 22
-		IL_09c9: ldloc.s 23
-		IL_09cb: ldloc.s 22
-		IL_09cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_09d2: pop
-		IL_09d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09d8: stloc.s 23
-		IL_09da: ldstr "Array"
-		IL_09df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_09e4: volatile.
-		IL_09e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_09eb: brfalse IL_09ff
-
-		IL_09f0: ldstr "prototype"
-		IL_09f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09fa: br IL_0a13
-
-		IL_09ff: ldstr "prototype"
-		IL_0a04: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:267"
-		IL_0a09: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0a0e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
+		IL_09eb: stloc.s 22
+		IL_09ed: ldloc.s 22
+		IL_09ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_09f4: ldstr "call"
+		IL_09f9: ldloc.s 20
+		IL_09fb: ldstr "b"
+		IL_0a00: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_0a09: box [System.Runtime]System.Double
+		IL_0a0e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
 		IL_0a13: stloc.s 22
-		IL_0a15: volatile.
-		IL_0a17: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0a1c: brfalse IL_0a32
+		IL_0a15: ldloc.s 23
+		IL_0a17: ldloc.s 22
+		IL_0a19: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0a1e: pop
+		IL_0a1f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0a24: stloc.s 23
+		IL_0a26: ldstr "Array"
+		IL_0a2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a30: volatile.
+		IL_0a32: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0a37: brfalse IL_0a4b
 
-		IL_0a21: ldloc.s 22
-		IL_0a23: ldstr "indexOf"
-		IL_0a28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a2d: br IL_0a48
+		IL_0a3c: ldstr "prototype"
+		IL_0a41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a46: br IL_0a5f
 
-		IL_0a32: ldloc.s 22
-		IL_0a34: ldstr "indexOf"
-		IL_0a39: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:269"
-		IL_0a3e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0a43: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0a4b: ldstr "prototype"
+		IL_0a50: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:267"
+		IL_0a55: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a48: stloc.s 22
-		IL_0a4a: ldloc.s 22
-		IL_0a4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0a51: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_0a5a: neg
-		IL_0a5b: stloc.s 31
-		IL_0a5d: ldloc.s 31
-		IL_0a5f: box [System.Runtime]System.Double
-		IL_0a64: stloc.s 32
-		IL_0a66: ldstr "call"
-		IL_0a6b: ldloc.s 20
-		IL_0a6d: ldstr "b"
-		IL_0a72: ldloc.s 32
-		IL_0a74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0a79: stloc.s 22
-		IL_0a7b: ldloc.s 23
-		IL_0a7d: ldloc.s 22
-		IL_0a7f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0a84: pop
-		IL_0a85: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0a8a: stloc.s 23
-		IL_0a8c: ldstr "Array"
-		IL_0a91: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0a96: volatile.
-		IL_0a98: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0a9d: brfalse IL_0ab1
+		IL_0a5f: stloc.s 22
+		IL_0a61: volatile.
+		IL_0a63: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0a68: brfalse IL_0a7e
 
-		IL_0aa2: ldstr "prototype"
-		IL_0aa7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0aac: br IL_0ac5
+		IL_0a6d: ldloc.s 22
+		IL_0a6f: ldstr "indexOf"
+		IL_0a74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a79: br IL_0a94
 
-		IL_0ab1: ldstr "prototype"
-		IL_0ab6: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:282"
-		IL_0abb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0ac0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0a7e: ldloc.s 22
+		IL_0a80: ldstr "indexOf"
+		IL_0a85: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:269"
+		IL_0a8a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0a8f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
+		IL_0a94: stloc.s 22
+		IL_0a96: ldloc.s 22
+		IL_0a98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a9d: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_0aa6: neg
+		IL_0aa7: stloc.s 31
+		IL_0aa9: ldloc.s 31
+		IL_0aab: box [System.Runtime]System.Double
+		IL_0ab0: stloc.s 32
+		IL_0ab2: ldstr "call"
+		IL_0ab7: ldloc.s 20
+		IL_0ab9: ldstr "b"
+		IL_0abe: ldloc.s 32
+		IL_0ac0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
 		IL_0ac5: stloc.s 22
-		IL_0ac7: volatile.
-		IL_0ac9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0ace: brfalse IL_0ae4
+		IL_0ac7: ldloc.s 23
+		IL_0ac9: ldloc.s 22
+		IL_0acb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0ad0: pop
+		IL_0ad1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ad6: stloc.s 23
+		IL_0ad8: ldstr "Array"
+		IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0ae2: volatile.
+		IL_0ae4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0ae9: brfalse IL_0afd
 
-		IL_0ad3: ldloc.s 22
-		IL_0ad5: ldstr "indexOf"
-		IL_0ada: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0adf: br IL_0afa
+		IL_0aee: ldstr "prototype"
+		IL_0af3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0af8: br IL_0b11
 
-		IL_0ae4: ldloc.s 22
-		IL_0ae6: ldstr "indexOf"
-		IL_0aeb: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:284"
-		IL_0af0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0af5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0afd: ldstr "prototype"
+		IL_0b02: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:282"
+		IL_0b07: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0b0c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0afa: stloc.s 22
-		IL_0afc: ldloc.s 22
-		IL_0afe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b03: ldstr "call"
-		IL_0b08: ldloc.s 20
-		IL_0b0a: ldstr "b"
-		IL_0b0f: ldc.r8 9999999999
-		IL_0b18: box [System.Runtime]System.Double
-		IL_0b1d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0b22: stloc.s 22
-		IL_0b24: ldloc.s 23
-		IL_0b26: ldloc.s 22
-		IL_0b28: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0b2d: pop
-		IL_0b2e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b33: stloc.s 23
-		IL_0b35: ldstr "Array"
-		IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b3f: volatile.
-		IL_0b41: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0b46: brfalse IL_0b5a
+		IL_0b11: stloc.s 22
+		IL_0b13: volatile.
+		IL_0b15: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0b1a: brfalse IL_0b30
 
-		IL_0b4b: ldstr "prototype"
-		IL_0b50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b55: br IL_0b6e
+		IL_0b1f: ldloc.s 22
+		IL_0b21: ldstr "indexOf"
+		IL_0b26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b2b: br IL_0b46
 
-		IL_0b5a: ldstr "prototype"
-		IL_0b5f: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:296"
-		IL_0b64: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0b69: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0b30: ldloc.s 22
+		IL_0b32: ldstr "indexOf"
+		IL_0b37: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:284"
+		IL_0b3c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0b41: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
+		IL_0b46: stloc.s 22
+		IL_0b48: ldloc.s 22
+		IL_0b4a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b4f: ldstr "call"
+		IL_0b54: ldloc.s 20
+		IL_0b56: ldstr "b"
+		IL_0b5b: ldc.r8 9999999999
+		IL_0b64: box [System.Runtime]System.Double
+		IL_0b69: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
 		IL_0b6e: stloc.s 22
-		IL_0b70: volatile.
-		IL_0b72: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0b77: brfalse IL_0b8d
+		IL_0b70: ldloc.s 23
+		IL_0b72: ldloc.s 22
+		IL_0b74: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b79: pop
+		IL_0b7a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b7f: stloc.s 23
+		IL_0b81: ldstr "Array"
+		IL_0b86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b8b: volatile.
+		IL_0b8d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0b92: brfalse IL_0ba6
 
-		IL_0b7c: ldloc.s 22
-		IL_0b7e: ldstr "indexOf"
-		IL_0b83: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b88: br IL_0ba3
+		IL_0b97: ldstr "prototype"
+		IL_0b9c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ba1: br IL_0bba
 
-		IL_0b8d: ldloc.s 22
-		IL_0b8f: ldstr "indexOf"
-		IL_0b94: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:298"
-		IL_0b99: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0b9e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ba6: ldstr "prototype"
+		IL_0bab: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:296"
+		IL_0bb0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0bb5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0ba3: stloc.s 22
-		IL_0ba5: ldloc.s 22
-		IL_0ba7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0bac: ldc.r8 9999999999
-		IL_0bb5: neg
-		IL_0bb6: stloc.s 31
-		IL_0bb8: ldloc.s 31
-		IL_0bba: box [System.Runtime]System.Double
-		IL_0bbf: stloc.s 32
-		IL_0bc1: ldstr "call"
-		IL_0bc6: ldloc.s 20
-		IL_0bc8: ldstr "b"
-		IL_0bcd: ldloc.s 32
-		IL_0bcf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0bd4: stloc.s 22
-		IL_0bd6: ldloc.s 23
-		IL_0bd8: ldloc.s 22
-		IL_0bda: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0bdf: pop
-		IL_0be0: ldnull
-		IL_0be1: stloc.s 21
-		IL_0be3: ret
+		IL_0bba: stloc.s 22
+		IL_0bbc: volatile.
+		IL_0bbe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0bc3: brfalse IL_0bd9
+
+		IL_0bc8: ldloc.s 22
+		IL_0bca: ldstr "indexOf"
+		IL_0bcf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0bd4: br IL_0bef
+
+		IL_0bd9: ldloc.s 22
+		IL_0bdb: ldstr "indexOf"
+		IL_0be0: ldstr "Array_PrototypeMethods_ArrayLike_EdgeCases:Modules.Array_PrototypeMethods_ArrayLike_EdgeCases:__js_module_init__:298"
+		IL_0be5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0bea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0bef: stloc.s 22
+		IL_0bf1: ldloc.s 22
+		IL_0bf3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0bf8: ldc.r8 9999999999
+		IL_0c01: neg
+		IL_0c02: stloc.s 31
+		IL_0c04: ldloc.s 31
+		IL_0c06: box [System.Runtime]System.Double
+		IL_0c0b: stloc.s 32
+		IL_0c0d: ldstr "call"
+		IL_0c12: ldloc.s 20
+		IL_0c14: ldstr "b"
+		IL_0c19: ldloc.s 32
+		IL_0c1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0c20: stloc.s 22
+		IL_0c22: ldloc.s 23
+		IL_0c24: ldloc.s 22
+		IL_0c26: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0c2b: pop
+		IL_0c2c: ldnull
+		IL_0c2d: stloc.s 21
+		IL_0c2f: ret
 	} // end of method Array_PrototypeMethods_ArrayLike_EdgeCases::__js_module_init__
 
 } // end of class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases
@@ -2381,6 +2405,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_31
 	.field assembly static int32 __jroc_dynamicLookup_32
 	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
+	.field assembly static int32 __jroc_dynamicLookup_35
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
@@ -242,7 +242,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 140 (0x8c)
+			// Code size: 220 (0xdc)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -256,46 +256,70 @@
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0010: ldstr "indexOf"
-			IL_0015: ldarg.2
-			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001b: stloc.0
-			IL_001c: ldloc.0
-			IL_001d: stloc.1
-			IL_001e: ldc.r8 1
-			IL_0027: neg
-			IL_0028: stloc.2
-			IL_0029: ldloc.2
-			IL_002a: box [System.Runtime]System.Double
-			IL_002f: stloc.3
-			IL_0030: ldloc.1
-			IL_0031: ldloc.3
-			IL_0032: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0037: stloc.s 4
-			IL_0039: ldloc.s 4
-			IL_003b: brfalse IL_006a
+			IL_0010: volatile.
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0017: brfalse IL_002c
 
-			IL_0040: ldarg.1
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0050: ldstr "splice"
-			IL_0055: ldloc.0
-			IL_0056: ldc.r8 1
-			IL_005f: box [System.Runtime]System.Double
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0069: pop
+			IL_001c: ldstr "indexOf"
+			IL_0021: ldarg.2
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0027: br IL_0041
 
-			IL_006a: ldarg.1
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007a: ldstr "join"
-			IL_007f: ldstr ","
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0089: stloc.1
-			IL_008a: ldloc.1
-			IL_008b: ret
+			IL_002c: ldstr "indexOf"
+			IL_0031: ldarg.2
+			IL_0032: ldstr "Array_Prototype_CustomMethod_Dispatch:<TwoPhaseDummy_M4>:__js_call__:4"
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0041: stloc.0
+			IL_0042: ldloc.0
+			IL_0043: stloc.1
+			IL_0044: ldc.r8 1
+			IL_004d: neg
+			IL_004e: stloc.2
+			IL_004f: ldloc.2
+			IL_0050: box [System.Runtime]System.Double
+			IL_0055: stloc.3
+			IL_0056: ldloc.1
+			IL_0057: ldloc.3
+			IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_005d: stloc.s 4
+			IL_005f: ldloc.s 4
+			IL_0061: brfalse IL_0090
+
+			IL_0066: ldarg.1
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0076: ldstr "splice"
+			IL_007b: ldloc.0
+			IL_007c: ldc.r8 1
+			IL_0085: box [System.Runtime]System.Double
+			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_008f: pop
+
+			IL_0090: ldarg.1
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a0: volatile.
+			IL_00a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00a7: brfalse IL_00c0
+
+			IL_00ac: ldstr "join"
+			IL_00b1: ldstr ","
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00bb: br IL_00d9
+
+			IL_00c0: ldstr "join"
+			IL_00c5: ldstr ","
+			IL_00ca: ldstr "Array_Prototype_CustomMethod_Dispatch:<TwoPhaseDummy_M4>:__js_call__:24"
+			IL_00cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00d9: stloc.1
+			IL_00da: ldloc.1
+			IL_00db: ret
 		} // end of method FunctionExpression_L3C34::__js_call__
 
 	} // end of class FunctionExpression_L3C34
@@ -331,7 +355,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 246 (0xf6)
+		// Code size: 298 (0x12a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Prototype_CustomMethod_Dispatch/Scope,
@@ -397,32 +421,46 @@
 		IL_00a3: stloc.1
 		IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00a9: stloc.s 5
-		IL_00ab: ldloc.1
-		IL_00ac: ldstr "removeGraphNode"
-		IL_00b1: ldc.r8 2
-		IL_00ba: box [System.Runtime]System.Double
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c4: stloc.2
-		IL_00c5: ldloc.s 5
-		IL_00c7: ldloc.2
-		IL_00c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cd: pop
-		IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d3: stloc.s 5
+		IL_00ab: volatile.
+		IL_00ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00b2: brfalse IL_00d5
+
+		IL_00b7: ldloc.1
+		IL_00b8: ldstr "removeGraphNode"
+		IL_00bd: ldc.r8 2
+		IL_00c6: box [System.Runtime]System.Double
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d0: br IL_00f8
+
 		IL_00d5: ldloc.1
-		IL_00d6: ldc.i4.1
-		IL_00d7: newarr [System.Runtime]System.Object
-		IL_00dc: dup
-		IL_00dd: ldc.i4.0
-		IL_00de: ldstr ","
-		IL_00e3: stelem.ref
-		IL_00e4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00e9: stloc.s 6
-		IL_00eb: ldloc.s 5
-		IL_00ed: ldloc.s 6
-		IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f4: pop
-		IL_00f5: ret
+		IL_00d6: ldstr "removeGraphNode"
+		IL_00db: ldc.r8 2
+		IL_00e4: box [System.Runtime]System.Double
+		IL_00e9: ldstr "Array_Prototype_CustomMethod_Dispatch:Modules.Array_Prototype_CustomMethod_Dispatch:__js_module_init__:23"
+		IL_00ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f8: stloc.2
+		IL_00f9: ldloc.s 5
+		IL_00fb: ldloc.2
+		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0101: pop
+		IL_0102: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0107: stloc.s 5
+		IL_0109: ldloc.1
+		IL_010a: ldc.i4.1
+		IL_010b: newarr [System.Runtime]System.Object
+		IL_0110: dup
+		IL_0111: ldc.i4.0
+		IL_0112: ldstr ","
+		IL_0117: stelem.ref
+		IL_0118: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_011d: stloc.s 6
+		IL_011f: ldloc.s 5
+		IL_0121: ldloc.s 6
+		IL_0123: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0128: pop
+		IL_0129: ret
 	} // end of method Array_Prototype_CustomMethod_Dispatch::__js_module_init__
 
 } // end of class Modules.Array_Prototype_CustomMethod_Dispatch
@@ -453,6 +491,9 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -914,7 +914,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1345 (0x541)
+		// Code size: 1396 (0x574)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_ReceiverCandidate_GuardedOverrides/Scope,
@@ -984,414 +984,427 @@
 		IL_006a: stloc.s 9
 		IL_006c: ldloc.3
 		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: ldstr "push"
-		IL_0077: ldc.r8 0.0
-		IL_0080: box [System.Runtime]System.Double
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: stloc.s 10
-		IL_008c: ldloc.s 9
-		IL_008e: ldloc.s 10
-		IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0095: pop
-		IL_0096: ldc.r8 0.0
-		IL_009f: stloc.s 4
-		// loop start (head: IL_00a1)
-			IL_00a1: ldloc.s 4
-			IL_00a3: stloc.s 11
-			IL_00a5: ldloc.s 11
-			IL_00a7: ldc.r8 1
-			IL_00b0: clt
-			IL_00b2: brfalse IL_0540
+		IL_0072: volatile.
+		IL_0074: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0079: brfalse IL_009b
 
-			IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00bc: stloc.s 9
-			IL_00be: ldloc.3
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c4: stloc.s 10
-			IL_00c6: ldc.i4.1
-			IL_00c7: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00cc: brfalse IL_0124
+		IL_007e: ldstr "push"
+		IL_0083: ldc.r8 0.0
+		IL_008c: box [System.Runtime]System.Double
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0096: br IL_00bd
 
-			IL_00d1: ldloc.s 10
-			IL_00d3: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_00d8: dup
-			IL_00d9: brfalse IL_0123
+		IL_009b: ldstr "push"
+		IL_00a0: ldc.r8 0.0
+		IL_00a9: box [System.Runtime]System.Double
+		IL_00ae: ldstr "Array_ReceiverCandidate_GuardedOverrides:Modules.Array_ReceiverCandidate_GuardedOverrides:__js_module_init__:25"
+		IL_00b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_00de: pop
-			IL_00df: ldloc.s 10
-			IL_00e1: ldstr "push"
-			IL_00e6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_00eb: brtrue IL_0124
+		IL_00bd: stloc.s 10
+		IL_00bf: ldloc.s 9
+		IL_00c1: ldloc.s 10
+		IL_00c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c8: pop
+		IL_00c9: ldc.r8 0.0
+		IL_00d2: stloc.s 4
+		// loop start (head: IL_00d4)
+			IL_00d4: ldloc.s 4
+			IL_00d6: stloc.s 11
+			IL_00d8: ldloc.s 11
+			IL_00da: ldc.r8 1
+			IL_00e3: clt
+			IL_00e5: brfalse IL_0573
 
-			IL_00f0: ldloc.s 10
-			IL_00f2: ldc.i4.1
-			IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00f8: brfalse IL_0124
+			IL_00ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ef: stloc.s 9
+			IL_00f1: ldloc.3
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f7: stloc.s 10
+			IL_00f9: ldc.i4.1
+			IL_00fa: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00ff: brfalse IL_0157
 
-			IL_00fd: ldloc.s 10
-			IL_00ff: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0104: ldc.r8 1
-			IL_010d: box [System.Runtime]System.Double
-			IL_0112: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0117: box [System.Runtime]System.Double
-			IL_011c: stloc.s 10
-			IL_011e: br IL_0140
+			IL_0104: ldloc.s 10
+			IL_0106: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_010b: dup
+			IL_010c: brfalse IL_0156
 
-			IL_0123: pop
+			IL_0111: pop
+			IL_0112: ldloc.s 10
+			IL_0114: ldstr "push"
+			IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_011e: brtrue IL_0157
 
-			IL_0124: ldloc.s 10
-			IL_0126: ldstr "push"
-			IL_012b: ldc.r8 1
-			IL_0134: box [System.Runtime]System.Double
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_013e: stloc.s 10
+			IL_0123: ldloc.s 10
+			IL_0125: ldc.i4.1
+			IL_0126: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_012b: brfalse IL_0157
 
-			IL_0140: ldloc.s 9
-			IL_0142: ldloc.s 10
-			IL_0144: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0149: pop
-			IL_014a: ldc.i4.1
-			IL_014b: newarr [System.Runtime]System.Object
-			IL_0150: dup
-			IL_0151: ldc.i4.0
-			IL_0152: ldloc.0
-			IL_0153: stelem.ref
-			IL_0154: stloc.s 7
-			IL_0156: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C20/FunctionObject::.ctor()
-			IL_015b: ldc.i4.1
-			IL_015c: conv.r8
-			IL_015d: ldstr ""
-			IL_0162: ldc.i4.0
-			IL_0163: ldc.i4.1
-			IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C20/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0169: stloc.s 12
-			IL_016b: ldloc.3
-			IL_016c: ldstr "push"
-			IL_0171: ldloc.s 12
-			IL_0173: ldc.i4.1
-			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0179: pop
-			IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_017f: stloc.s 9
-			IL_0181: ldloc.3
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0187: stloc.s 10
-			IL_0189: ldc.i4.1
-			IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_018f: brfalse IL_01e7
+			IL_0130: ldloc.s 10
+			IL_0132: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0137: ldc.r8 1
+			IL_0140: box [System.Runtime]System.Double
+			IL_0145: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_014a: box [System.Runtime]System.Double
+			IL_014f: stloc.s 10
+			IL_0151: br IL_0173
 
-			IL_0194: ldloc.s 10
-			IL_0196: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_019b: dup
-			IL_019c: brfalse IL_01e6
+			IL_0156: pop
 
-			IL_01a1: pop
-			IL_01a2: ldloc.s 10
-			IL_01a4: ldstr "push"
-			IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_01ae: brtrue IL_01e7
+			IL_0157: ldloc.s 10
+			IL_0159: ldstr "push"
+			IL_015e: ldc.r8 1
+			IL_0167: box [System.Runtime]System.Double
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0171: stloc.s 10
 
-			IL_01b3: ldloc.s 10
-			IL_01b5: ldc.i4.1
-			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_01bb: brfalse IL_01e7
+			IL_0173: ldloc.s 9
+			IL_0175: ldloc.s 10
+			IL_0177: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_017c: pop
+			IL_017d: ldc.i4.1
+			IL_017e: newarr [System.Runtime]System.Object
+			IL_0183: dup
+			IL_0184: ldc.i4.0
+			IL_0185: ldloc.0
+			IL_0186: stelem.ref
+			IL_0187: stloc.s 7
+			IL_0189: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C20/FunctionObject::.ctor()
+			IL_018e: ldc.i4.1
+			IL_018f: conv.r8
+			IL_0190: ldstr ""
+			IL_0195: ldc.i4.0
+			IL_0196: ldc.i4.1
+			IL_0197: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C20/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_019c: stloc.s 12
+			IL_019e: ldloc.3
+			IL_019f: ldstr "push"
+			IL_01a4: ldloc.s 12
+			IL_01a6: ldc.i4.1
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_01ac: pop
+			IL_01ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01b2: stloc.s 9
+			IL_01b4: ldloc.3
+			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ba: stloc.s 10
+			IL_01bc: ldc.i4.1
+			IL_01bd: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01c2: brfalse IL_021a
 
-			IL_01c0: ldloc.s 10
-			IL_01c2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01c7: ldc.r8 2
-			IL_01d0: box [System.Runtime]System.Double
-			IL_01d5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_01da: box [System.Runtime]System.Double
-			IL_01df: stloc.s 10
-			IL_01e1: br IL_0203
+			IL_01c7: ldloc.s 10
+			IL_01c9: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01ce: dup
+			IL_01cf: brfalse IL_0219
 
-			IL_01e6: pop
+			IL_01d4: pop
+			IL_01d5: ldloc.s 10
+			IL_01d7: ldstr "push"
+			IL_01dc: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_01e1: brtrue IL_021a
 
-			IL_01e7: ldloc.s 10
-			IL_01e9: ldstr "push"
-			IL_01ee: ldc.r8 2
-			IL_01f7: box [System.Runtime]System.Double
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0201: stloc.s 10
+			IL_01e6: ldloc.s 10
+			IL_01e8: ldc.i4.1
+			IL_01e9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01ee: brfalse IL_021a
 
-			IL_0203: ldloc.s 9
-			IL_0205: ldloc.s 10
-			IL_0207: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_020c: pop
-			IL_020d: ldloc.3
-			IL_020e: ldstr "push"
-			IL_0213: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-			IL_0218: stloc.s 13
-			IL_021a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_021f: stloc.s 6
-			IL_0221: ldloc.s 6
-			IL_0223: ldstr "configurable"
-			IL_0228: ldc.i4.1
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
-			IL_022e: pop
-			IL_022f: ldc.i4.1
-			IL_0230: newarr [System.Runtime]System.Object
-			IL_0235: dup
-			IL_0236: ldc.i4.0
-			IL_0237: ldloc.0
-			IL_0238: stelem.ref
-			IL_0239: stloc.s 7
-			IL_023b: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject::.ctor()
-			IL_0240: ldc.i4.0
-			IL_0241: conv.r8
-			IL_0242: ldstr ""
-			IL_0247: ldc.i4.0
-			IL_0248: ldc.i4.1
-			IL_0249: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_024e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject>(!!0)
-			IL_0253: stloc.s 14
-			IL_0255: ldloc.s 6
-			IL_0257: ldstr "get"
-			IL_025c: ldloc.s 14
-			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0263: pop
-			IL_0264: ldloc.3
-			IL_0265: ldstr "push"
-			IL_026a: ldloc.s 6
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0271: pop
-			IL_0272: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0277: stloc.s 9
-			IL_0279: ldloc.3
-			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027f: stloc.s 10
-			IL_0281: ldc.i4.1
-			IL_0282: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0287: brfalse IL_02df
+			IL_01f3: ldloc.s 10
+			IL_01f5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01fa: ldc.r8 2
+			IL_0203: box [System.Runtime]System.Double
+			IL_0208: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_020d: box [System.Runtime]System.Double
+			IL_0212: stloc.s 10
+			IL_0214: br IL_0236
 
-			IL_028c: ldloc.s 10
-			IL_028e: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0293: dup
-			IL_0294: brfalse IL_02de
+			IL_0219: pop
 
-			IL_0299: pop
-			IL_029a: ldloc.s 10
-			IL_029c: ldstr "push"
-			IL_02a1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_02a6: brtrue IL_02df
+			IL_021a: ldloc.s 10
+			IL_021c: ldstr "push"
+			IL_0221: ldc.r8 2
+			IL_022a: box [System.Runtime]System.Double
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0234: stloc.s 10
 
-			IL_02ab: ldloc.s 10
-			IL_02ad: ldc.i4.1
-			IL_02ae: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_02b3: brfalse IL_02df
+			IL_0236: ldloc.s 9
+			IL_0238: ldloc.s 10
+			IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_023f: pop
+			IL_0240: ldloc.3
+			IL_0241: ldstr "push"
+			IL_0246: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_024b: stloc.s 13
+			IL_024d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0252: stloc.s 6
+			IL_0254: ldloc.s 6
+			IL_0256: ldstr "configurable"
+			IL_025b: ldc.i4.1
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+			IL_0261: pop
+			IL_0262: ldc.i4.1
+			IL_0263: newarr [System.Runtime]System.Object
+			IL_0268: dup
+			IL_0269: ldc.i4.0
+			IL_026a: ldloc.0
+			IL_026b: stelem.ref
+			IL_026c: stloc.s 7
+			IL_026e: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject::.ctor()
+			IL_0273: ldc.i4.0
+			IL_0274: conv.r8
+			IL_0275: ldstr ""
+			IL_027a: ldc.i4.0
+			IL_027b: ldc.i4.1
+			IL_027c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0281: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject>(!!0)
+			IL_0286: stloc.s 14
+			IL_0288: ldloc.s 6
+			IL_028a: ldstr "get"
+			IL_028f: ldloc.s 14
+			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0296: pop
+			IL_0297: ldloc.3
+			IL_0298: ldstr "push"
+			IL_029d: ldloc.s 6
+			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_02a4: pop
+			IL_02a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02aa: stloc.s 9
+			IL_02ac: ldloc.3
+			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02b2: stloc.s 10
+			IL_02b4: ldc.i4.1
+			IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_02ba: brfalse IL_0312
 
-			IL_02b8: ldloc.s 10
-			IL_02ba: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_02bf: ldc.r8 3
-			IL_02c8: box [System.Runtime]System.Double
-			IL_02cd: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_02d2: box [System.Runtime]System.Double
-			IL_02d7: stloc.s 10
-			IL_02d9: br IL_02fb
+			IL_02bf: ldloc.s 10
+			IL_02c1: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02c6: dup
+			IL_02c7: brfalse IL_0311
 
-			IL_02de: pop
+			IL_02cc: pop
+			IL_02cd: ldloc.s 10
+			IL_02cf: ldstr "push"
+			IL_02d4: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_02d9: brtrue IL_0312
 
-			IL_02df: ldloc.s 10
-			IL_02e1: ldstr "push"
-			IL_02e6: ldc.r8 3
-			IL_02ef: box [System.Runtime]System.Double
-			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02f9: stloc.s 10
+			IL_02de: ldloc.s 10
+			IL_02e0: ldc.i4.1
+			IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_02e6: brfalse IL_0312
 
-			IL_02fb: ldloc.s 9
-			IL_02fd: ldloc.s 10
-			IL_02ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0304: pop
-			IL_0305: ldloc.3
-			IL_0306: ldstr "push"
-			IL_030b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-			IL_0310: stloc.s 13
-			IL_0312: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0317: stloc.s 6
-			IL_0319: ldc.i4.1
-			IL_031a: newarr [System.Runtime]System.Object
-			IL_031f: dup
-			IL_0320: ldc.i4.0
-			IL_0321: ldloc.0
-			IL_0322: stelem.ref
-			IL_0323: stloc.s 7
-			IL_0325: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject::.ctor()
-			IL_032a: ldc.i4.1
-			IL_032b: conv.r8
-			IL_032c: ldstr ""
-			IL_0331: ldc.i4.0
-			IL_0332: ldc.i4.1
-			IL_0333: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0338: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject>(!!0)
-			IL_033d: stloc.s 15
-			IL_033f: ldloc.s 6
-			IL_0341: ldstr "push"
-			IL_0346: ldloc.s 15
-			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_034d: pop
-			IL_034e: ldloc.3
-			IL_034f: ldloc.s 6
-			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-			IL_0356: pop
-			IL_0357: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_035c: stloc.s 9
-			IL_035e: ldloc.3
-			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0364: stloc.s 10
-			IL_0366: ldc.i4.1
-			IL_0367: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_036c: brfalse IL_03c4
+			IL_02eb: ldloc.s 10
+			IL_02ed: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02f2: ldc.r8 3
+			IL_02fb: box [System.Runtime]System.Double
+			IL_0300: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0305: box [System.Runtime]System.Double
+			IL_030a: stloc.s 10
+			IL_030c: br IL_032e
 
-			IL_0371: ldloc.s 10
-			IL_0373: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0378: dup
-			IL_0379: brfalse IL_03c3
+			IL_0311: pop
 
-			IL_037e: pop
-			IL_037f: ldloc.s 10
-			IL_0381: ldstr "push"
-			IL_0386: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_038b: brtrue IL_03c4
+			IL_0312: ldloc.s 10
+			IL_0314: ldstr "push"
+			IL_0319: ldc.r8 3
+			IL_0322: box [System.Runtime]System.Double
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_032c: stloc.s 10
 
-			IL_0390: ldloc.s 10
-			IL_0392: ldc.i4.1
-			IL_0393: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0398: brfalse IL_03c4
+			IL_032e: ldloc.s 9
+			IL_0330: ldloc.s 10
+			IL_0332: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0337: pop
+			IL_0338: ldloc.3
+			IL_0339: ldstr "push"
+			IL_033e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_0343: stloc.s 13
+			IL_0345: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_034a: stloc.s 6
+			IL_034c: ldc.i4.1
+			IL_034d: newarr [System.Runtime]System.Object
+			IL_0352: dup
+			IL_0353: ldc.i4.0
+			IL_0354: ldloc.0
+			IL_0355: stelem.ref
+			IL_0356: stloc.s 7
+			IL_0358: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject::.ctor()
+			IL_035d: ldc.i4.1
+			IL_035e: conv.r8
+			IL_035f: ldstr ""
+			IL_0364: ldc.i4.0
+			IL_0365: ldc.i4.1
+			IL_0366: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_036b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject>(!!0)
+			IL_0370: stloc.s 15
+			IL_0372: ldloc.s 6
+			IL_0374: ldstr "push"
+			IL_0379: ldloc.s 15
+			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0380: pop
+			IL_0381: ldloc.3
+			IL_0382: ldloc.s 6
+			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_0389: pop
+			IL_038a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_038f: stloc.s 9
+			IL_0391: ldloc.3
+			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0397: stloc.s 10
+			IL_0399: ldc.i4.1
+			IL_039a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_039f: brfalse IL_03f7
 
-			IL_039d: ldloc.s 10
-			IL_039f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_03a4: ldc.r8 4
-			IL_03ad: box [System.Runtime]System.Double
-			IL_03b2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_03b7: box [System.Runtime]System.Double
-			IL_03bc: stloc.s 10
-			IL_03be: br IL_03e0
+			IL_03a4: ldloc.s 10
+			IL_03a6: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_03ab: dup
+			IL_03ac: brfalse IL_03f6
 
-			IL_03c3: pop
+			IL_03b1: pop
+			IL_03b2: ldloc.s 10
+			IL_03b4: ldstr "push"
+			IL_03b9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_03be: brtrue IL_03f7
 
-			IL_03c4: ldloc.s 10
-			IL_03c6: ldstr "push"
-			IL_03cb: ldc.r8 4
-			IL_03d4: box [System.Runtime]System.Double
-			IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03de: stloc.s 10
+			IL_03c3: ldloc.s 10
+			IL_03c5: ldc.i4.1
+			IL_03c6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_03cb: brfalse IL_03f7
 
-			IL_03e0: ldloc.s 9
-			IL_03e2: ldloc.s 10
-			IL_03e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03e9: pop
-			IL_03ea: ldstr "Array"
-			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03f4: volatile.
-			IL_03f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-			IL_03fb: brfalse IL_040f
+			IL_03d0: ldloc.s 10
+			IL_03d2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_03d7: ldc.r8 4
+			IL_03e0: box [System.Runtime]System.Double
+			IL_03e5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03ea: box [System.Runtime]System.Double
+			IL_03ef: stloc.s 10
+			IL_03f1: br IL_0413
 
-			IL_0400: ldstr "prototype"
-			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_040a: br IL_0423
+			IL_03f6: pop
 
-			IL_040f: ldstr "prototype"
-			IL_0414: ldstr "Array_ReceiverCandidate_GuardedOverrides:Modules.Array_ReceiverCandidate_GuardedOverrides:__js_module_init__:98"
-			IL_0419: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03f7: ldloc.s 10
+			IL_03f9: ldstr "push"
+			IL_03fe: ldc.r8 4
+			IL_0407: box [System.Runtime]System.Double
+			IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0411: stloc.s 10
 
-			IL_0423: stloc.s 10
-			IL_0425: ldloc.3
-			IL_0426: ldloc.s 10
-			IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-			IL_042d: pop
-			IL_042e: ldstr "Array"
-			IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0438: volatile.
-			IL_043a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-			IL_043f: brfalse IL_0453
+			IL_0413: ldloc.s 9
+			IL_0415: ldloc.s 10
+			IL_0417: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_041c: pop
+			IL_041d: ldstr "Array"
+			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0427: volatile.
+			IL_0429: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_042e: brfalse IL_0442
 
-			IL_0444: ldstr "prototype"
-			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_044e: br IL_0467
+			IL_0433: ldstr "prototype"
+			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_043d: br IL_0456
 
-			IL_0453: ldstr "prototype"
-			IL_0458: ldstr "Array_ReceiverCandidate_GuardedOverrides:Modules.Array_ReceiverCandidate_GuardedOverrides:__js_module_init__:104"
-			IL_045d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-			IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0442: ldstr "prototype"
+			IL_0447: ldstr "Array_ReceiverCandidate_GuardedOverrides:Modules.Array_ReceiverCandidate_GuardedOverrides:__js_module_init__:98"
+			IL_044c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0467: stloc.s 10
-			IL_0469: ldc.i4.1
-			IL_046a: newarr [System.Runtime]System.Object
-			IL_046f: dup
-			IL_0470: ldc.i4.0
-			IL_0471: ldloc.0
-			IL_0472: stelem.ref
-			IL_0473: stloc.s 7
-			IL_0475: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L39C27/FunctionObject::.ctor()
-			IL_047a: ldc.i4.1
-			IL_047b: conv.r8
-			IL_047c: ldstr ""
-			IL_0481: ldc.i4.0
-			IL_0482: ldc.i4.1
-			IL_0483: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L39C27/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0488: stloc.s 16
-			IL_048a: ldloc.s 10
-			IL_048c: ldstr "push"
-			IL_0491: ldloc.s 16
-			IL_0493: ldc.i4.1
-			IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0499: pop
-			IL_049a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_049f: stloc.s 9
-			IL_04a1: ldloc.3
-			IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04a7: stloc.s 10
-			IL_04a9: ldc.i4.1
-			IL_04aa: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_04af: brfalse IL_0507
+			IL_0456: stloc.s 10
+			IL_0458: ldloc.3
+			IL_0459: ldloc.s 10
+			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_0460: pop
+			IL_0461: ldstr "Array"
+			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_046b: volatile.
+			IL_046d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0472: brfalse IL_0486
 
-			IL_04b4: ldloc.s 10
-			IL_04b6: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_04bb: dup
-			IL_04bc: brfalse IL_0506
+			IL_0477: ldstr "prototype"
+			IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0481: br IL_049a
 
-			IL_04c1: pop
-			IL_04c2: ldloc.s 10
-			IL_04c4: ldstr "push"
-			IL_04c9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_04ce: brtrue IL_0507
+			IL_0486: ldstr "prototype"
+			IL_048b: ldstr "Array_ReceiverCandidate_GuardedOverrides:Modules.Array_ReceiverCandidate_GuardedOverrides:__js_module_init__:104"
+			IL_0490: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04d3: ldloc.s 10
-			IL_04d5: ldc.i4.1
-			IL_04d6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_04db: brfalse IL_0507
+			IL_049a: stloc.s 10
+			IL_049c: ldc.i4.1
+			IL_049d: newarr [System.Runtime]System.Object
+			IL_04a2: dup
+			IL_04a3: ldc.i4.0
+			IL_04a4: ldloc.0
+			IL_04a5: stelem.ref
+			IL_04a6: stloc.s 7
+			IL_04a8: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L39C27/FunctionObject::.ctor()
+			IL_04ad: ldc.i4.1
+			IL_04ae: conv.r8
+			IL_04af: ldstr ""
+			IL_04b4: ldc.i4.0
+			IL_04b5: ldc.i4.1
+			IL_04b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L39C27/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_04bb: stloc.s 16
+			IL_04bd: ldloc.s 10
+			IL_04bf: ldstr "push"
+			IL_04c4: ldloc.s 16
+			IL_04c6: ldc.i4.1
+			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_04cc: pop
+			IL_04cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04d2: stloc.s 9
+			IL_04d4: ldloc.3
+			IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04da: stloc.s 10
+			IL_04dc: ldc.i4.1
+			IL_04dd: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_04e2: brfalse IL_053a
 
-			IL_04e0: ldloc.s 10
-			IL_04e2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_04e7: ldc.r8 5
-			IL_04f0: box [System.Runtime]System.Double
-			IL_04f5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_04fa: box [System.Runtime]System.Double
-			IL_04ff: stloc.s 10
-			IL_0501: br IL_0523
+			IL_04e7: ldloc.s 10
+			IL_04e9: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_04ee: dup
+			IL_04ef: brfalse IL_0539
 
-			IL_0506: pop
+			IL_04f4: pop
+			IL_04f5: ldloc.s 10
+			IL_04f7: ldstr "push"
+			IL_04fc: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_0501: brtrue IL_053a
 
-			IL_0507: ldloc.s 10
-			IL_0509: ldstr "push"
-			IL_050e: ldc.r8 5
-			IL_0517: box [System.Runtime]System.Double
-			IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0521: stloc.s 10
+			IL_0506: ldloc.s 10
+			IL_0508: ldc.i4.1
+			IL_0509: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_050e: brfalse IL_053a
 
-			IL_0523: ldloc.s 9
-			IL_0525: ldloc.s 10
-			IL_0527: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_052c: pop
-			IL_052d: ldloc.s 4
-			IL_052f: ldc.r8 1
-			IL_0538: add
-			IL_0539: stloc.s 4
-			IL_053b: br IL_00a1
+			IL_0513: ldloc.s 10
+			IL_0515: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_051a: ldc.r8 5
+			IL_0523: box [System.Runtime]System.Double
+			IL_0528: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_052d: box [System.Runtime]System.Double
+			IL_0532: stloc.s 10
+			IL_0534: br IL_0556
+
+			IL_0539: pop
+
+			IL_053a: ldloc.s 10
+			IL_053c: ldstr "push"
+			IL_0541: ldc.r8 5
+			IL_054a: box [System.Runtime]System.Double
+			IL_054f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0554: stloc.s 10
+
+			IL_0556: ldloc.s 9
+			IL_0558: ldloc.s 10
+			IL_055a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_055f: pop
+			IL_0560: ldloc.s 4
+			IL_0562: ldc.r8 1
+			IL_056b: add
+			IL_056c: stloc.s 4
+			IL_056e: br IL_00d4
 		// end loop
 
-		IL_0540: ret
+		IL_0573: ret
 	} // end of method Array_ReceiverCandidate_GuardedOverrides::__js_module_init__
 
 } // end of class Modules.Array_ReceiverCandidate_GuardedOverrides
@@ -1423,6 +1436,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
@@ -388,7 +388,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 389 (0x185)
+		// Code size: 431 (0x1af)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope,
@@ -520,23 +520,35 @@
 		IL_014a: ldloc.0
 		IL_014b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::order
 		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0155: ldstr "join"
-		IL_015a: ldstr ","
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0164: stloc.s 6
-		IL_0166: ldloc.0
-		IL_0167: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::innerReadCount
-		IL_016c: stloc.s 9
-		IL_016e: ldloc.0
-		IL_016f: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::outerReadCount
-		IL_0174: stloc.s 10
-		IL_0176: ldloc.s 8
-		IL_0178: ldloc.s 6
-		IL_017a: ldloc.s 9
-		IL_017c: ldloc.s 10
-		IL_017e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0183: pop
-		IL_0184: ret
+		IL_0155: volatile.
+		IL_0157: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_015c: brfalse IL_0175
+
+		IL_0161: ldstr "join"
+		IL_0166: ldstr ","
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0170: br IL_018e
+
+		IL_0175: ldstr "join"
+		IL_017a: ldstr ","
+		IL_017f: ldstr "Array_StableLoadReceiver_EvaluationOrder:Modules.Array_StableLoadReceiver_EvaluationOrder:__js_module_init__:47"
+		IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_018e: stloc.s 6
+		IL_0190: ldloc.0
+		IL_0191: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::innerReadCount
+		IL_0196: stloc.s 9
+		IL_0198: ldloc.0
+		IL_0199: ldfld object Modules.Array_StableLoadReceiver_EvaluationOrder/Scope::outerReadCount
+		IL_019e: stloc.s 10
+		IL_01a0: ldloc.s 8
+		IL_01a2: ldloc.s 6
+		IL_01a4: ldloc.s 9
+		IL_01a6: ldloc.s 10
+		IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_01ad: pop
+		IL_01ae: ret
 	} // end of method Array_StableLoadReceiver_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.Array_StableLoadReceiver_EvaluationOrder
@@ -567,6 +579,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForOfIterableArrowCallback.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ForOfIterableArrowCallback.verified.txt
@@ -332,7 +332,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 198 (0xc6)
+			// Code size: 281 (0x119)
 			.maxstack 10
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -360,78 +360,103 @@
 			IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_ForOfIterableArrowCallback/ArrowFunction_L1C26/ArrowFunction_L2C48/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_ForOfIterableArrowCallback/ArrowFunction_L1C26/ArrowFunction_L2C48/FunctionObject>(!!0)
 			IL_002c: stloc.s 6
-			IL_002e: ldloc.s 4
-			IL_0030: ldstr "filter"
-			IL_0035: ldloc.s 6
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_003c: stloc.s 4
-			IL_003e: ldloc.s 4
-			IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_0045: stloc.0
-			IL_0046: ldc.i4.0
-			IL_0047: stloc.1
-			IL_0048: ldc.i4.0
-			IL_0049: stloc.2
+			IL_002e: volatile.
+			IL_0030: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0035: brfalse IL_004d
+
+			IL_003a: ldloc.s 4
+			IL_003c: ldstr "filter"
+			IL_0041: ldloc.s 6
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0048: br IL_0065
+
+			IL_004d: ldloc.s 4
+			IL_004f: ldstr "filter"
+			IL_0054: ldloc.s 6
+			IL_0056: ldstr "ArrowFunction_ForOfIterableArrowCallback:<TwoPhaseDummy_M4>:__js_call__:6"
+			IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0065: stloc.s 4
+			IL_0067: ldloc.s 4
+			IL_0069: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_006e: stloc.0
+			IL_006f: ldc.i4.0
+			IL_0070: stloc.1
+			IL_0071: ldc.i4.0
+			IL_0072: stloc.2
 			.try
 			{
-				// loop start (head: IL_004a)
-					IL_004a: ldc.i4.1
-					IL_004b: stloc.1
-					IL_004c: ldloc.0
-					IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_0052: stloc.s 4
-					IL_0054: ldloc.s 4
-					IL_0056: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_005b: stloc.s 7
-					IL_005d: ldloc.s 7
-					IL_005f: brtrue IL_008d
+				// loop start (head: IL_0073)
+					IL_0073: ldc.i4.1
+					IL_0074: stloc.1
+					IL_0075: ldloc.0
+					IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_007b: stloc.s 4
+					IL_007d: ldloc.s 4
+					IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_0084: stloc.s 7
+					IL_0086: ldloc.s 7
+					IL_0088: brtrue IL_00b6
 
-					IL_0064: ldloc.s 4
-					IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_006b: stloc.s 4
-					IL_006d: ldc.i4.0
-					IL_006e: stloc.1
-					IL_006f: ldloc.s 4
-					IL_0071: stloc.3
-					IL_0072: ldarg.1
-					IL_0073: ldloc.3
-					IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItemNonStrict(object, object)
-					IL_0079: stloc.s 7
-					IL_007b: br IL_004a
+					IL_008d: ldloc.s 4
+					IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_0094: stloc.s 4
+					IL_0096: ldc.i4.0
+					IL_0097: stloc.1
+					IL_0098: ldloc.s 4
+					IL_009a: stloc.3
+					IL_009b: ldarg.1
+					IL_009c: ldloc.3
+					IL_009d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItemNonStrict(object, object)
+					IL_00a2: stloc.s 7
+					IL_00a4: br IL_0073
 				// end loop
-				IL_0080: ldloc.0
-				IL_0081: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0086: ldc.i4.1
-				IL_0087: stloc.2
-				IL_0088: leave IL_00a7
+				IL_00a9: ldloc.0
+				IL_00aa: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_00af: ldc.i4.1
+				IL_00b0: stloc.2
+				IL_00b1: leave IL_00d0
 
-				IL_008d: ldc.i4.1
-				IL_008e: stloc.1
-				IL_008f: leave IL_00a7
+				IL_00b6: ldc.i4.1
+				IL_00b7: stloc.1
+				IL_00b8: leave IL_00d0
 			} // end .try
 			finally
 			{
-				IL_0094: ldloc.1
-				IL_0095: brtrue IL_00a6
+				IL_00bd: ldloc.1
+				IL_00be: brtrue IL_00cf
 
-				IL_009a: ldloc.2
-				IL_009b: brtrue IL_00a6
+				IL_00c3: ldloc.2
+				IL_00c4: brtrue IL_00cf
 
-				IL_00a0: ldloc.0
-				IL_00a1: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_00c9: ldloc.0
+				IL_00ca: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_00a6: endfinally
+				IL_00cf: endfinally
 			} // end handler
 
-			IL_00a7: ldarg.1
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b2: ldstr "join"
-			IL_00b7: ldstr ","
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c1: stloc.s 4
-			IL_00c3: ldloc.s 4
-			IL_00c5: ret
+			IL_00d0: ldarg.1
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00db: volatile.
+			IL_00dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00e2: brfalse IL_00fb
+
+			IL_00e7: ldstr "join"
+			IL_00ec: ldstr ","
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00f6: br IL_0114
+
+			IL_00fb: ldstr "join"
+			IL_0100: ldstr ","
+			IL_0105: ldstr "ArrowFunction_ForOfIterableArrowCallback:<TwoPhaseDummy_M4>:__js_call__:49"
+			IL_010a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0114: stloc.s 4
+			IL_0116: ldloc.s 4
+			IL_0118: ret
 		} // end of method ArrowFunction_L1C26::__js_call__
 
 	} // end of class ArrowFunction_L1C26
@@ -528,4 +553,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GeneratedFunctionObjectSurface.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GeneratedFunctionObjectSurface.verified.txt
@@ -224,7 +224,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 				IL_0007: brfalse IL_0026
 
 				IL_000c: ldarg.1
@@ -239,7 +239,7 @@
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0031: ldstr "base"
 				IL_0036: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:<TwoPhaseDummy_M5>:__js_call__:2"
-				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0045: stloc.0
@@ -502,7 +502,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 909 (0x38d)
+		// Code size: 949 (0x3b5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_GeneratedFunctionObjectSurface/Scope,
@@ -550,277 +550,290 @@
 		IL_0033: ldc.r8 10
 		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_0041: stloc.s 10
-		IL_0043: ldloc.1
-		IL_0044: ldstr "call"
-		IL_0049: ldloc.s 10
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0050: stloc.2
-		IL_0051: ldloc.2
-		IL_0052: stloc.3
-		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0058: stloc.s 11
-		IL_005a: ldloc.2
-		IL_005b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0060: stloc.s 12
-		IL_0062: ldloc.s 11
-		IL_0064: ldloc.s 12
-		IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006b: pop
-		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0071: stloc.s 11
-		IL_0073: ldloc.2
-		IL_0074: ldloc.3
-		IL_0075: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_007a: stloc.s 13
-		IL_007c: ldloc.s 13
-		IL_007e: box [System.Runtime]System.Boolean
-		IL_0083: stloc.s 14
-		IL_0085: ldloc.s 11
-		IL_0087: ldloc.s 14
-		IL_0089: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008e: pop
-		IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0094: stloc.s 11
-		IL_0096: volatile.
-		IL_0098: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_009d: brfalse IL_00b2
+		IL_0043: volatile.
+		IL_0045: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_004a: brfalse IL_0061
 
-		IL_00a2: ldloc.2
-		IL_00a3: ldstr "length"
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ad: br IL_00c7
+		IL_004f: ldloc.1
+		IL_0050: ldstr "call"
+		IL_0055: ldloc.s 10
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005c: br IL_0078
 
-		IL_00b2: ldloc.2
-		IL_00b3: ldstr "length"
-		IL_00b8: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:Modules.ArrowFunction_GeneratedFunctionObjectSurface:__js_module_init__:26"
-		IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0061: ldloc.1
+		IL_0062: ldstr "call"
+		IL_0067: ldloc.s 10
+		IL_0069: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:Modules.ArrowFunction_GeneratedFunctionObjectSurface:__js_module_init__:10"
+		IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00c7: stloc.s 15
-		IL_00c9: ldloc.s 11
-		IL_00cb: ldloc.s 15
-		IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d2: pop
-		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d8: stloc.s 11
-		IL_00da: volatile.
-		IL_00dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_00e1: brfalse IL_00f6
+		IL_0078: stloc.2
+		IL_0079: ldloc.2
+		IL_007a: stloc.3
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: stloc.s 11
+		IL_0082: ldloc.2
+		IL_0083: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0088: stloc.s 12
+		IL_008a: ldloc.s 11
+		IL_008c: ldloc.s 12
+		IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0093: pop
+		IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0099: stloc.s 11
+		IL_009b: ldloc.2
+		IL_009c: ldloc.3
+		IL_009d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00a2: stloc.s 13
+		IL_00a4: ldloc.s 13
+		IL_00a6: box [System.Runtime]System.Boolean
+		IL_00ab: stloc.s 14
+		IL_00ad: ldloc.s 11
+		IL_00af: ldloc.s 14
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b6: pop
+		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bc: stloc.s 11
+		IL_00be: volatile.
+		IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00c5: brfalse IL_00da
 
-		IL_00e6: ldloc.2
-		IL_00e7: ldstr "name"
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f1: br IL_010b
+		IL_00ca: ldloc.2
+		IL_00cb: ldstr "length"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d5: br IL_00ef
 
-		IL_00f6: ldloc.2
-		IL_00f7: ldstr "name"
-		IL_00fc: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:Modules.ArrowFunction_GeneratedFunctionObjectSurface:__js_module_init__:31"
-		IL_0101: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00da: ldloc.2
+		IL_00db: ldstr "length"
+		IL_00e0: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:Modules.ArrowFunction_GeneratedFunctionObjectSurface:__js_module_init__:26"
+		IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_010b: stloc.s 15
-		IL_010d: ldloc.s 15
-		IL_010f: ldstr ""
-		IL_0114: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0119: stloc.s 13
-		IL_011b: ldloc.s 13
-		IL_011d: box [System.Runtime]System.Boolean
-		IL_0122: stloc.s 14
-		IL_0124: ldloc.s 11
-		IL_0126: ldloc.s 14
-		IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012d: pop
-		IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0133: stloc.s 11
-		IL_0135: ldloc.2
-		IL_0136: ldstr "prototype"
-		IL_013b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0140: box [System.Runtime]System.Boolean
-		IL_0145: stloc.s 14
-		IL_0147: ldloc.s 11
-		IL_0149: ldloc.s 14
-		IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0150: pop
-		IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0156: stloc.s 11
-		IL_0158: ldloc.2
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0163: dup
-		IL_0164: ldstr "base"
-		IL_0169: ldc.r8 100
-		IL_0172: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0177: stloc.s 10
-		IL_0179: ldstr "call"
-		IL_017e: ldloc.s 10
-		IL_0180: ldc.r8 1
-		IL_0189: box [System.Runtime]System.Double
-		IL_018e: ldc.r8 2
-		IL_0197: box [System.Runtime]System.Double
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_01a1: stloc.s 15
-		IL_01a3: ldloc.s 11
-		IL_01a5: ldloc.s 15
-		IL_01a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ac: pop
-		IL_01ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b2: stloc.s 11
-		IL_01b4: ldloc.2
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ba: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01bf: dup
-		IL_01c0: ldstr "base"
-		IL_01c5: ldc.r8 100
-		IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_01d3: stloc.s 10
-		IL_01d5: ldc.i4.2
-		IL_01d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01db: dup
-		IL_01dc: ldc.r8 3
-		IL_01e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01ea: dup
-		IL_01eb: ldc.r8 4
-		IL_01f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01f9: stloc.s 16
-		IL_01fb: ldstr "apply"
-		IL_0200: ldloc.s 10
-		IL_0202: ldloc.s 16
-		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0209: stloc.s 15
-		IL_020b: ldloc.s 11
-		IL_020d: ldloc.s 15
-		IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0214: pop
-		IL_0215: ldloc.2
-		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0220: dup
-		IL_0221: ldstr "base"
-		IL_0226: ldc.r8 100
-		IL_022f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0234: stloc.s 10
-		IL_0236: ldstr "bind"
-		IL_023b: ldloc.s 10
-		IL_023d: ldc.r8 5
-		IL_0246: box [System.Runtime]System.Double
-		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0250: stloc.s 4
-		IL_0252: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0257: stloc.s 11
-		IL_0259: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_025e: stloc.s 9
-		IL_0260: ldloc.s 4
-		IL_0262: ldloc.s 9
-		IL_0264: ldc.r8 6
-		IL_026d: box [System.Runtime]System.Double
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0277: stloc.s 15
-		IL_0279: ldloc.s 11
-		IL_027b: ldloc.s 15
-		IL_027d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0282: pop
-		IL_0283: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0288: stloc.s 11
-		IL_028a: volatile.
-		IL_028c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0291: brfalse IL_02a7
+		IL_00ef: stloc.s 15
+		IL_00f1: ldloc.s 11
+		IL_00f3: ldloc.s 15
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fa: pop
+		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0100: stloc.s 11
+		IL_0102: volatile.
+		IL_0104: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0109: brfalse IL_011e
 
-		IL_0296: ldloc.s 4
-		IL_0298: ldstr "length"
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a2: br IL_02bd
+		IL_010e: ldloc.2
+		IL_010f: ldstr "name"
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0119: br IL_0133
 
-		IL_02a7: ldloc.s 4
-		IL_02a9: ldstr "length"
-		IL_02ae: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:Modules.ArrowFunction_GeneratedFunctionObjectSurface:__js_module_init__:81"
-		IL_02b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_011e: ldloc.2
+		IL_011f: ldstr "name"
+		IL_0124: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:Modules.ArrowFunction_GeneratedFunctionObjectSurface:__js_module_init__:31"
+		IL_0129: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02bd: stloc.s 15
-		IL_02bf: ldloc.s 11
-		IL_02c1: ldloc.s 15
-		IL_02c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c8: pop
-		IL_02c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ce: stloc.s 11
-		IL_02d0: volatile.
-		IL_02d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_02d7: brfalse IL_02ed
+		IL_0133: stloc.s 15
+		IL_0135: ldloc.s 15
+		IL_0137: ldstr ""
+		IL_013c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0141: stloc.s 13
+		IL_0143: ldloc.s 13
+		IL_0145: box [System.Runtime]System.Boolean
+		IL_014a: stloc.s 14
+		IL_014c: ldloc.s 11
+		IL_014e: ldloc.s 14
+		IL_0150: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0155: pop
+		IL_0156: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_015b: stloc.s 11
+		IL_015d: ldloc.2
+		IL_015e: ldstr "prototype"
+		IL_0163: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0168: box [System.Runtime]System.Boolean
+		IL_016d: stloc.s 14
+		IL_016f: ldloc.s 11
+		IL_0171: ldloc.s 14
+		IL_0173: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0178: pop
+		IL_0179: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017e: stloc.s 11
+		IL_0180: ldloc.2
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0186: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_018b: dup
+		IL_018c: ldstr "base"
+		IL_0191: ldc.r8 100
+		IL_019a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_019f: stloc.s 10
+		IL_01a1: ldstr "call"
+		IL_01a6: ldloc.s 10
+		IL_01a8: ldc.r8 1
+		IL_01b1: box [System.Runtime]System.Double
+		IL_01b6: ldc.r8 2
+		IL_01bf: box [System.Runtime]System.Double
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_01c9: stloc.s 15
+		IL_01cb: ldloc.s 11
+		IL_01cd: ldloc.s 15
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d4: pop
+		IL_01d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01da: stloc.s 11
+		IL_01dc: ldloc.2
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01e7: dup
+		IL_01e8: ldstr "base"
+		IL_01ed: ldc.r8 100
+		IL_01f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_01fb: stloc.s 10
+		IL_01fd: ldc.i4.2
+		IL_01fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0203: dup
+		IL_0204: ldc.r8 3
+		IL_020d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0212: dup
+		IL_0213: ldc.r8 4
+		IL_021c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0221: stloc.s 16
+		IL_0223: ldstr "apply"
+		IL_0228: ldloc.s 10
+		IL_022a: ldloc.s 16
+		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0231: stloc.s 15
+		IL_0233: ldloc.s 11
+		IL_0235: ldloc.s 15
+		IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_023c: pop
+		IL_023d: ldloc.2
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0243: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0248: dup
+		IL_0249: ldstr "base"
+		IL_024e: ldc.r8 100
+		IL_0257: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_025c: stloc.s 10
+		IL_025e: ldstr "bind"
+		IL_0263: ldloc.s 10
+		IL_0265: ldc.r8 5
+		IL_026e: box [System.Runtime]System.Double
+		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0278: stloc.s 4
+		IL_027a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_027f: stloc.s 11
+		IL_0281: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0286: stloc.s 9
+		IL_0288: ldloc.s 4
+		IL_028a: ldloc.s 9
+		IL_028c: ldc.r8 6
+		IL_0295: box [System.Runtime]System.Double
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_029f: stloc.s 15
+		IL_02a1: ldloc.s 11
+		IL_02a3: ldloc.s 15
+		IL_02a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02aa: pop
+		IL_02ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02b0: stloc.s 11
+		IL_02b2: volatile.
+		IL_02b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02b9: brfalse IL_02cf
 
-		IL_02dc: ldloc.s 4
-		IL_02de: ldstr "name"
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e8: br IL_0303
+		IL_02be: ldloc.s 4
+		IL_02c0: ldstr "length"
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ca: br IL_02e5
 
-		IL_02ed: ldloc.s 4
-		IL_02ef: ldstr "name"
-		IL_02f4: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:Modules.ArrowFunction_GeneratedFunctionObjectSurface:__js_module_init__:86"
-		IL_02f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02cf: ldloc.s 4
+		IL_02d1: ldstr "length"
+		IL_02d6: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:Modules.ArrowFunction_GeneratedFunctionObjectSurface:__js_module_init__:81"
+		IL_02db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0303: stloc.s 15
-		IL_0305: ldloc.s 11
-		IL_0307: ldloc.s 15
-		IL_0309: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_030e: pop
+		IL_02e5: stloc.s 15
+		IL_02e7: ldloc.s 11
+		IL_02e9: ldloc.s 15
+		IL_02eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02f0: pop
+		IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02f6: stloc.s 11
+		IL_02f8: volatile.
+		IL_02fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02ff: brfalse IL_0315
+
+		IL_0304: ldloc.s 4
+		IL_0306: ldstr "name"
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0310: br IL_032b
+
+		IL_0315: ldloc.s 4
+		IL_0317: ldstr "name"
+		IL_031c: ldstr "ArrowFunction_GeneratedFunctionObjectSurface:Modules.ArrowFunction_GeneratedFunctionObjectSurface:__js_module_init__:86"
+		IL_0321: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_032b: stloc.s 15
+		IL_032d: ldloc.s 11
+		IL_032f: ldloc.s 15
+		IL_0331: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0336: pop
 		.try
 		{
-			IL_030f: nop
-			IL_0310: ldloc.2
-			IL_0311: dup
-			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-			IL_0317: pop
-			IL_0318: leave IL_0389
+			IL_0337: nop
+			IL_0338: ldloc.2
+			IL_0339: dup
+			IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+			IL_033f: pop
+			IL_0340: leave IL_03b1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_031d: stloc.s 5
-			IL_031f: ldloc.s 5
-			IL_0321: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0326: dup
-			IL_0327: brtrue IL_033d
+			IL_0345: stloc.s 5
+			IL_0347: ldloc.s 5
+			IL_0349: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_034e: dup
+			IL_034f: brtrue IL_0365
 
-			IL_032c: pop
-			IL_032d: ldloc.s 5
-			IL_032f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0334: dup
-			IL_0335: brtrue IL_0349
+			IL_0354: pop
+			IL_0355: ldloc.s 5
+			IL_0357: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_035c: dup
+			IL_035d: brtrue IL_0371
 
-			IL_033a: pop
-			IL_033b: rethrow
+			IL_0362: pop
+			IL_0363: rethrow
 
-			IL_033d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0342: stloc.s 6
-			IL_0344: br IL_034b
+			IL_0365: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_036a: stloc.s 6
+			IL_036c: br IL_0373
 
-			IL_0349: stloc.s 6
+			IL_0371: stloc.s 6
 
-			IL_034b: ldloc.s 6
-			IL_034d: stloc.s 7
-			IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0354: stloc.s 11
-			IL_0356: ldloc.s 7
-			IL_0358: stloc.s 15
-			IL_035a: ldstr "TypeError"
-			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0364: stloc.s 17
-			IL_0366: ldloc.s 15
-			IL_0368: ldloc.s 17
-			IL_036a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_036f: stloc.s 13
-			IL_0371: ldloc.s 13
-			IL_0373: box [System.Runtime]System.Boolean
-			IL_0378: stloc.s 14
-			IL_037a: ldloc.s 11
-			IL_037c: ldloc.s 14
-			IL_037e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0383: pop
-			IL_0384: leave IL_0389
+			IL_0373: ldloc.s 6
+			IL_0375: stloc.s 7
+			IL_0377: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_037c: stloc.s 11
+			IL_037e: ldloc.s 7
+			IL_0380: stloc.s 15
+			IL_0382: ldstr "TypeError"
+			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_038c: stloc.s 17
+			IL_038e: ldloc.s 15
+			IL_0390: ldloc.s 17
+			IL_0392: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0397: stloc.s 13
+			IL_0399: ldloc.s 13
+			IL_039b: box [System.Runtime]System.Boolean
+			IL_03a0: stloc.s 14
+			IL_03a2: ldloc.s 11
+			IL_03a4: ldloc.s 14
+			IL_03a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03ab: pop
+			IL_03ac: leave IL_03b1
 		} // end handler
 
-		IL_0389: ldnull
-		IL_038a: stloc.s 8
-		IL_038c: ret
+		IL_03b1: ldnull
+		IL_03b2: stloc.s 8
+		IL_03b4: ret
 	} // end of method ArrowFunction_GeneratedFunctionObjectSurface::__js_module_init__
 
 } // end of class Modules.ArrowFunction_GeneratedFunctionObjectSurface
@@ -855,6 +868,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
@@ -1012,7 +1012,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 699 (0x2bb)
+		// Code size: 777 (0x309)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Scope,
@@ -1230,33 +1230,57 @@
 		IL_0251: ldc.r8 99
 		IL_025a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_025f: stloc.s 11
-		IL_0261: ldstr "call"
-		IL_0266: ldloc.s 11
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026d: stloc.s 6
-		IL_026f: ldloc.s 10
-		IL_0271: ldloc.s 6
-		IL_0273: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0278: pop
-		IL_0279: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_027e: stloc.s 10
-		IL_0280: ldloc.s 4
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0287: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_028c: dup
-		IL_028d: ldstr "value"
-		IL_0292: ldc.r8 99
-		IL_029b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_02a0: stloc.s 11
-		IL_02a2: ldstr "call"
-		IL_02a7: ldloc.s 11
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ae: stloc.s 6
-		IL_02b0: ldloc.s 10
-		IL_02b2: ldloc.s 6
-		IL_02b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b9: pop
-		IL_02ba: ret
+		IL_0261: volatile.
+		IL_0263: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0268: brfalse IL_027e
+
+		IL_026d: ldstr "call"
+		IL_0272: ldloc.s 11
+		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0279: br IL_0294
+
+		IL_027e: ldstr "call"
+		IL_0283: ldloc.s 11
+		IL_0285: ldstr "ArrowFunction_LexicalSuper_MethodAndConstructor:Modules.ArrowFunction_LexicalSuper_MethodAndConstructor:__js_module_init__:46"
+		IL_028a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0294: stloc.s 6
+		IL_0296: ldloc.s 10
+		IL_0298: ldloc.s 6
+		IL_029a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029f: pop
+		IL_02a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a5: stloc.s 10
+		IL_02a7: ldloc.s 4
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ae: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02b3: dup
+		IL_02b4: ldstr "value"
+		IL_02b9: ldc.r8 99
+		IL_02c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_02c7: stloc.s 11
+		IL_02c9: volatile.
+		IL_02cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_02d0: brfalse IL_02e6
+
+		IL_02d5: ldstr "call"
+		IL_02da: ldloc.s 11
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e1: br IL_02fc
+
+		IL_02e6: ldstr "call"
+		IL_02eb: ldloc.s 11
+		IL_02ed: ldstr "ArrowFunction_LexicalSuper_MethodAndConstructor:Modules.ArrowFunction_LexicalSuper_MethodAndConstructor:__js_module_init__:53"
+		IL_02f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02fc: stloc.s 6
+		IL_02fe: ldloc.s 10
+		IL_0300: ldloc.s 6
+		IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0307: pop
+		IL_0308: ret
 	} // end of method ArrowFunction_LexicalSuper_MethodAndConstructor::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor
@@ -1289,6 +1313,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_TopLevelCallback.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_TopLevelCallback.verified.txt
@@ -216,7 +216,7 @@
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
 			// Header size: 12
-			// Code size: 168 (0xa8)
+			// Code size: 248 (0xf8)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -255,34 +255,60 @@
 			IL_004e: ldloc.s 4
 			IL_0050: box [System.Runtime]System.Boolean
 			IL_0055: stloc.s 5
-			IL_0057: ldloc.2
-			IL_0058: ldstr "log"
-			IL_005d: ldloc.s 5
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0064: pop
-			IL_0065: ldstr "console"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0074: stloc.2
-			IL_0075: ldarg.0
-			IL_0076: ldfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::usurper
-			IL_007b: stloc.3
-			IL_007c: ldarg.2
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0087: ldloc.3
-			IL_0088: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_008d: stloc.s 4
-			IL_008f: ldloc.s 4
-			IL_0091: box [System.Runtime]System.Boolean
-			IL_0096: stloc.s 5
-			IL_0098: ldloc.2
-			IL_0099: ldstr "log"
-			IL_009e: ldloc.s 5
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a5: pop
-			IL_00a6: ldnull
-			IL_00a7: ret
+			IL_0057: volatile.
+			IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_005e: brfalse IL_0075
+
+			IL_0063: ldloc.2
+			IL_0064: ldstr "log"
+			IL_0069: ldloc.s 5
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0070: br IL_008c
+
+			IL_0075: ldloc.2
+			IL_0076: ldstr "log"
+			IL_007b: ldloc.s 5
+			IL_007d: ldstr "ArrowFunction_LexicalThis_TopLevelCallback:<TwoPhaseDummy_M4>:__js_call__:15"
+			IL_0082: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_008c: pop
+			IL_008d: ldstr "console"
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009c: stloc.2
+			IL_009d: ldarg.0
+			IL_009e: ldfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::usurper
+			IL_00a3: stloc.3
+			IL_00a4: ldarg.2
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_00af: ldloc.3
+			IL_00b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00b5: stloc.s 4
+			IL_00b7: ldloc.s 4
+			IL_00b9: box [System.Runtime]System.Boolean
+			IL_00be: stloc.s 5
+			IL_00c0: volatile.
+			IL_00c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_00c7: brfalse IL_00de
+
+			IL_00cc: ldloc.2
+			IL_00cd: ldstr "log"
+			IL_00d2: ldloc.s 5
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d9: br IL_00f5
+
+			IL_00de: ldloc.2
+			IL_00df: ldstr "log"
+			IL_00e4: ldloc.s 5
+			IL_00e6: ldstr "ArrowFunction_LexicalThis_TopLevelCallback:<TwoPhaseDummy_M4>:__js_call__:24"
+			IL_00eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00f5: pop
+			IL_00f6: ldnull
+			IL_00f7: ret
 		} // end of method ArrowFunction_L7C13::__js_call__
 
 	} // end of class ArrowFunction_L7C13
@@ -332,7 +358,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 340 (0x154)
+		// Code size: 380 (0x17c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope,
@@ -448,12 +474,25 @@
 		IL_013d: ldloc.0
 		IL_013e: ldfld object Modules.ArrowFunction_LexicalThis_TopLevelCallback/Scope::calls
 		IL_0143: stloc.s 6
-		IL_0145: ldloc.1
-		IL_0146: ldstr "log"
-		IL_014b: ldloc.s 6
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0152: pop
-		IL_0153: ret
+		IL_0145: volatile.
+		IL_0147: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_014c: brfalse IL_0163
+
+		IL_0151: ldloc.1
+		IL_0152: ldstr "log"
+		IL_0157: ldloc.s 6
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015e: br IL_017a
+
+		IL_0163: ldloc.1
+		IL_0164: ldstr "log"
+		IL_0169: ldloc.s 6
+		IL_016b: ldstr "ArrowFunction_LexicalThis_TopLevelCallback:Modules.ArrowFunction_LexicalThis_TopLevelCallback:__js_module_init__:49"
+		IL_0170: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_017a: pop
+		IL_017b: ret
 	} // end of method ArrowFunction_LexicalThis_TopLevelCallback::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_TopLevelCallback
@@ -478,4 +517,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
@@ -746,7 +746,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 304 (0x130)
+		// Code size: 345 (0x159)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ArrowFunction_LexicalThis/Scope,
@@ -846,18 +846,31 @@
 		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L23C16/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L23C16/FunctionObject>(!!0)
 		IL_010a: stloc.s 8
-		IL_010c: ldloc.s 7
-		IL_010e: ldstr "then"
-		IL_0113: ldloc.s 8
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011a: pop
-		IL_011b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0120: stloc.s 9
-		IL_0122: ldloc.s 9
-		IL_0124: ldstr "After calling async getter"
-		IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012e: pop
-		IL_012f: ret
+		IL_010c: volatile.
+		IL_010e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0113: brfalse IL_012b
+
+		IL_0118: ldloc.s 7
+		IL_011a: ldstr "then"
+		IL_011f: ldloc.s 8
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0126: br IL_0143
+
+		IL_012b: ldloc.s 7
+		IL_012d: ldstr "then"
+		IL_0132: ldloc.s 8
+		IL_0134: ldstr "Async_ArrowFunction_LexicalThis:Modules.Async_ArrowFunction_LexicalThis:__js_module_init__:25"
+		IL_0139: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0143: pop
+		IL_0144: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0149: stloc.s 9
+		IL_014b: ldloc.s 9
+		IL_014d: ldstr "After calling async getter"
+		IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0157: pop
+		IL_0158: ret
 	} // end of method Async_ArrowFunction_LexicalThis::__js_module_init__
 
 } // end of class Modules.Async_ArrowFunction_LexicalThis
@@ -888,6 +901,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_SimpleAwait.verified.txt
@@ -477,7 +477,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 151 (0x97)
+		// Code size: 192 (0xc0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ArrowFunction_SimpleAwait/Scope,
@@ -536,18 +536,31 @@
 		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ArrowFunction_SimpleAwait/ArrowFunction_L11C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ArrowFunction_SimpleAwait/ArrowFunction_L11C19/FunctionObject>(!!0)
 		IL_0071: stloc.s 5
-		IL_0073: ldloc.s 4
-		IL_0075: ldstr "then"
-		IL_007a: ldloc.s 5
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0087: stloc.s 6
-		IL_0089: ldloc.s 6
-		IL_008b: ldstr "After calling async arrow"
-		IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0095: pop
-		IL_0096: ret
+		IL_0073: volatile.
+		IL_0075: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_007a: brfalse IL_0092
+
+		IL_007f: ldloc.s 4
+		IL_0081: ldstr "then"
+		IL_0086: ldloc.s 5
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008d: br IL_00aa
+
+		IL_0092: ldloc.s 4
+		IL_0094: ldstr "then"
+		IL_0099: ldloc.s 5
+		IL_009b: ldstr "Async_ArrowFunction_SimpleAwait:Modules.Async_ArrowFunction_SimpleAwait:__js_module_init__:15"
+		IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00aa: pop
+		IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b0: stloc.s 6
+		IL_00b2: ldloc.s 6
+		IL_00b4: ldstr "After calling async arrow"
+		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00be: pop
+		IL_00bf: ret
 	} // end of method Async_ArrowFunction_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_ArrowFunction_SimpleAwait
@@ -572,4 +585,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
@@ -592,7 +592,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 209 (0xd1)
+			// Code size: 248 (0xf8)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -614,7 +614,7 @@
 			IL_0018: brfalse IL_0057
 
 			IL_001d: volatile.
-			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0024: brfalse IL_0039
 
 			IL_0029: ldarg.1
@@ -625,7 +625,7 @@
 			IL_0039: ldarg.1
 			IL_003a: ldstr "message"
 			IL_003f: ldstr "Async_Calls_Module_Function_Before_Await:<TwoPhaseDummy_M6>:__js_call__:9"
-			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004e: stloc.3
@@ -643,7 +643,7 @@
 			IL_0063: brfalse IL_00a1
 
 			IL_0068: volatile.
-			IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_006f: brfalse IL_0084
 
 			IL_0074: ldarg.1
@@ -654,7 +654,7 @@
 			IL_0084: ldarg.1
 			IL_0085: ldstr "message"
 			IL_008a: ldstr "Async_Calls_Module_Function_Before_Await:<TwoPhaseDummy_M6>:__js_call__:19"
-			IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0099: stloc.3
@@ -665,20 +665,33 @@
 			IL_00a1: ldarg.1
 			IL_00a2: stloc.0
 
-			IL_00a3: ldloc.1
-			IL_00a4: ldstr "error"
-			IL_00a9: ldloc.0
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00af: pop
-			IL_00b0: ldstr "process"
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ba: ldstr "exitCode"
-			IL_00bf: ldc.r8 1
-			IL_00c8: ldc.i4.1
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_00ce: pop
-			IL_00cf: ldnull
-			IL_00d0: ret
+			IL_00a3: volatile.
+			IL_00a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_00aa: brfalse IL_00c0
+
+			IL_00af: ldloc.1
+			IL_00b0: ldstr "error"
+			IL_00b5: ldloc.0
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00bb: br IL_00d6
+
+			IL_00c0: ldloc.1
+			IL_00c1: ldstr "error"
+			IL_00c6: ldloc.0
+			IL_00c7: ldstr "Async_Calls_Module_Function_Before_Await:<TwoPhaseDummy_M6>:__js_call__:26"
+			IL_00cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00d6: pop
+			IL_00d7: ldstr "process"
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00e1: ldstr "exitCode"
+			IL_00e6: ldc.r8 1
+			IL_00ef: ldc.i4.1
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_00f5: pop
+			IL_00f6: ldnull
+			IL_00f7: ret
 		} // end of method ArrowFunction_L13C14::__js_call__
 
 	} // end of class ArrowFunction_L13C14
@@ -724,7 +737,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 167 (0xa7)
+		// Code size: 208 (0xd0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_Calls_Module_Function_Before_Await/Scope,
@@ -802,12 +815,25 @@
 		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_Calls_Module_Function_Before_Await/ArrowFunction_L13C14/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_Calls_Module_Function_Before_Await/ArrowFunction_L13C14/FunctionObject>(!!0)
 		IL_0095: stloc.s 5
-		IL_0097: ldloc.s 4
-		IL_0099: ldstr "catch"
-		IL_009e: ldloc.s 5
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a5: pop
-		IL_00a6: ret
+		IL_0097: volatile.
+		IL_0099: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_009e: brfalse IL_00b6
+
+		IL_00a3: ldloc.s 4
+		IL_00a5: ldstr "catch"
+		IL_00aa: ldloc.s 5
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b1: br IL_00ce
+
+		IL_00b6: ldloc.s 4
+		IL_00b8: ldstr "catch"
+		IL_00bd: ldloc.s 5
+		IL_00bf: ldstr "Async_Calls_Module_Function_Before_Await:Modules.Async_Calls_Module_Function_Before_Await:__js_module_init__:17"
+		IL_00c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ce: pop
+		IL_00cf: ret
 	} // end of method Async_Calls_Module_Function_Before_Await::__js_module_init__
 
 } // end of class Modules.Async_Calls_Module_Function_Before_Await
@@ -839,6 +865,8 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
@@ -808,7 +808,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 469 (0x1d5)
+		// Code size: 510 (0x1fe)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_ClassMethod_CallsOtherAsync/Scope,
@@ -1014,12 +1014,25 @@
 		IL_01b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject>(!!0)
 		IL_01c3: stloc.s 8
-		IL_01c5: ldloc.s 7
-		IL_01c7: ldstr "then"
-		IL_01cc: ldloc.s 8
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d3: pop
-		IL_01d4: ret
+		IL_01c5: volatile.
+		IL_01c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01cc: brfalse IL_01e4
+
+		IL_01d1: ldloc.s 7
+		IL_01d3: ldstr "then"
+		IL_01d8: ldloc.s 8
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01df: br IL_01fc
+
+		IL_01e4: ldloc.s 7
+		IL_01e6: ldstr "then"
+		IL_01eb: ldloc.s 8
+		IL_01ed: ldstr "Async_ClassMethod_CallsOtherAsync:Modules.Async_ClassMethod_CallsOtherAsync:__js_module_init__:49"
+		IL_01f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01fc: pop
+		IL_01fd: ret
 	} // end of method Async_ClassMethod_CallsOtherAsync::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_CallsOtherAsync
@@ -1050,6 +1063,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
@@ -627,7 +627,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 409 (0x199)
+		// Code size: 450 (0x1c2)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_ClassMethod_MultipleAwaits/Scope,
@@ -795,12 +795,25 @@
 		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_MultipleAwaits/ArrowFunction_L12C34/FunctionObject>(!!0)
 		IL_0187: stloc.s 9
-		IL_0189: ldloc.s 8
-		IL_018b: ldstr "then"
-		IL_0190: ldloc.s 9
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0197: pop
-		IL_0198: ret
+		IL_0189: volatile.
+		IL_018b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0190: brfalse IL_01a8
+
+		IL_0195: ldloc.s 8
+		IL_0197: ldstr "then"
+		IL_019c: ldloc.s 9
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a3: br IL_01c0
+
+		IL_01a8: ldloc.s 8
+		IL_01aa: ldstr "then"
+		IL_01af: ldloc.s 9
+		IL_01b1: ldstr "Async_ClassMethod_MultipleAwaits:Modules.Async_ClassMethod_MultipleAwaits:__js_module_init__:38"
+		IL_01b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01c0: pop
+		IL_01c1: ret
 	} // end of method Async_ClassMethod_MultipleAwaits::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_MultipleAwaits
@@ -831,6 +844,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
@@ -567,7 +567,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 397 (0x18d)
+		// Code size: 438 (0x1b6)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_ClassMethod_SimpleAwait/Scope,
@@ -728,12 +728,25 @@
 		IL_0171: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject>(!!0)
 		IL_017b: stloc.s 8
-		IL_017d: ldloc.s 7
-		IL_017f: ldstr "then"
-		IL_0184: ldloc.s 8
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018b: pop
-		IL_018c: ret
+		IL_017d: volatile.
+		IL_017f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0184: brfalse IL_019c
+
+		IL_0189: ldloc.s 7
+		IL_018b: ldstr "then"
+		IL_0190: ldloc.s 8
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0197: br IL_01b4
+
+		IL_019c: ldloc.s 7
+		IL_019e: ldstr "then"
+		IL_01a3: ldloc.s 8
+		IL_01a5: ldstr "Async_ClassMethod_SimpleAwait:Modules.Async_ClassMethod_SimpleAwait:__js_module_init__:39"
+		IL_01aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01b4: pop
+		IL_01b5: ret
 	} // end of method Async_ClassMethod_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_SimpleAwait
@@ -764,6 +777,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
@@ -576,7 +576,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 369 (0x171)
+		// Code size: 410 (0x19a)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_ClassMethod_WithThis/Scope,
@@ -733,12 +733,25 @@
 		IL_0155: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_015a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject>(!!0)
 		IL_015f: stloc.s 8
-		IL_0161: ldloc.s 7
-		IL_0163: ldstr "then"
-		IL_0168: ldloc.s 8
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016f: pop
-		IL_0170: ret
+		IL_0161: volatile.
+		IL_0163: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0168: brfalse IL_0180
+
+		IL_016d: ldloc.s 7
+		IL_016f: ldstr "then"
+		IL_0174: ldloc.s 8
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017b: br IL_0198
+
+		IL_0180: ldloc.s 7
+		IL_0182: ldstr "then"
+		IL_0187: ldloc.s 8
+		IL_0189: ldstr "Async_ClassMethod_WithThis:Modules.Async_ClassMethod_WithThis:__js_module_init__:35"
+		IL_018e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0198: pop
+		IL_0199: ret
 	} // end of method Async_ClassMethod_WithThis::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_WithThis
@@ -769,6 +782,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_Array.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_Array.verified.txt
@@ -816,7 +816,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 116 (0x74)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_Array/Scope,
@@ -870,12 +870,25 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_Array/ArrowFunction_L15C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_Array/ArrowFunction_L15C13/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "then"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.3
+		IL_0072: ldstr "then"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.3
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Async_ForAwaitOf_Array:Modules.Async_ForAwaitOf_Array:__js_module_init__:13"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Async_ForAwaitOf_Array::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_Array
@@ -900,4 +913,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
@@ -1320,7 +1320,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 202 (0xca)
+		// Code size: 242 (0xf2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope,
@@ -1410,12 +1410,25 @@
 		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13/FunctionObject>(!!0)
 		IL_00b9: stloc.s 5
-		IL_00bb: ldloc.3
-		IL_00bc: ldstr "then"
-		IL_00c1: ldloc.s 5
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c8: pop
-		IL_00c9: ret
+		IL_00bb: volatile.
+		IL_00bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_00c2: brfalse IL_00d9
+
+		IL_00c7: ldloc.3
+		IL_00c8: ldstr "then"
+		IL_00cd: ldloc.s 5
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d4: br IL_00f0
+
+		IL_00d9: ldloc.3
+		IL_00da: ldstr "then"
+		IL_00df: ldloc.s 5
+		IL_00e1: ldstr "Async_ForAwaitOf_AsyncIterator_BreakCloses:Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses:__js_module_init__:21"
+		IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f0: pop
+		IL_00f1: ret
 	} // end of method Async_ForAwaitOf_AsyncIterator_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses
@@ -1440,4 +1453,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_15
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
@@ -1314,7 +1314,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 202 (0xca)
+		// Code size: 242 (0xf2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope,
@@ -1404,12 +1404,25 @@
 		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13/FunctionObject>(!!0)
 		IL_00b9: stloc.s 5
-		IL_00bb: ldloc.3
-		IL_00bc: ldstr "then"
-		IL_00c1: ldloc.s 5
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c8: pop
-		IL_00c9: ret
+		IL_00bb: volatile.
+		IL_00bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_00c2: brfalse IL_00d9
+
+		IL_00c7: ldloc.3
+		IL_00c8: ldstr "then"
+		IL_00cd: ldloc.s 5
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d4: br IL_00f0
+
+		IL_00d9: ldloc.3
+		IL_00da: ldstr "then"
+		IL_00df: ldloc.s 5
+		IL_00e1: ldstr "Async_ForAwaitOf_SyncIteratorFallback_BreakCloses:Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses:__js_module_init__:21"
+		IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f0: pop
+		IL_00f1: ret
 	} // end of method Async_ForAwaitOf_SyncIteratorFallback_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
@@ -1434,4 +1447,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_15
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_FunctionExpression_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_FunctionExpression_SimpleAwait.verified.txt
@@ -477,7 +477,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 151 (0x97)
+		// Code size: 192 (0xc0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_FunctionExpression_SimpleAwait/Scope,
@@ -536,18 +536,31 @@
 		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_FunctionExpression_SimpleAwait/ArrowFunction_L11C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_FunctionExpression_SimpleAwait/ArrowFunction_L11C18/FunctionObject>(!!0)
 		IL_0071: stloc.s 5
-		IL_0073: ldloc.s 4
-		IL_0075: ldstr "then"
-		IL_007a: ldloc.s 5
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0087: stloc.s 6
-		IL_0089: ldloc.s 6
-		IL_008b: ldstr "After calling async function expression"
-		IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0095: pop
-		IL_0096: ret
+		IL_0073: volatile.
+		IL_0075: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_007a: brfalse IL_0092
+
+		IL_007f: ldloc.s 4
+		IL_0081: ldstr "then"
+		IL_0086: ldloc.s 5
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008d: br IL_00aa
+
+		IL_0092: ldloc.s 4
+		IL_0094: ldstr "then"
+		IL_0099: ldloc.s 5
+		IL_009b: ldstr "Async_FunctionExpression_SimpleAwait:Modules.Async_FunctionExpression_SimpleAwait:__js_module_init__:15"
+		IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00aa: pop
+		IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b0: stloc.s 6
+		IL_00b2: ldloc.s 6
+		IL_00b4: ldstr "After calling async function expression"
+		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00be: pop
+		IL_00bf: ret
 	} // end of method Async_FunctionExpression_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_FunctionExpression_SimpleAwait
@@ -572,4 +585,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_GeneratedFunctionObject_Semantics.verified.txt
@@ -308,7 +308,7 @@
 			IL_00d8: ldfld object Modules.Async_GeneratedFunctionObject_Semantics/declared/Scope::_awaited1
 			IL_00dd: pop
 			IL_00de: volatile.
-			IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 			IL_00e5: brfalse IL_0103
 
 			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
@@ -321,7 +321,7 @@
 			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_010d: ldstr "base"
 			IL_0112: ldstr "Async_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M4>:__js_call__:9"
-			IL_0117: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0117: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0121: stloc.1
@@ -2312,7 +2312,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -2323,17 +2323,29 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.1
 			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000c: ldstr "join"
-			IL_0011: ldstr ","
-			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001b: stloc.1
-			IL_001c: ldloc.0
-			IL_001d: ldstr "results"
-			IL_0022: ldloc.1
-			IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0028: pop
-			IL_0029: ldnull
-			IL_002a: ret
+			IL_000c: volatile.
+			IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_0013: brfalse IL_002c
+
+			IL_0018: ldstr "join"
+			IL_001d: ldstr ","
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0027: br IL_0045
+
+			IL_002c: ldstr "join"
+			IL_0031: ldstr ","
+			IL_0036: ldstr "Async_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M14>:__js_call__:6"
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0045: stloc.1
+			IL_0046: ldloc.0
+			IL_0047: ldstr "results"
+			IL_004c: ldloc.1
+			IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0052: pop
+			IL_0053: ldnull
+			IL_0054: ret
 		} // end of method ArrowFunction_L104C9::__js_call__
 
 	} // end of class ArrowFunction_L104C9
@@ -2583,7 +2595,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -2594,7 +2606,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "message"
 			IL_0028: ldstr "Async_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M16>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -3162,7 +3174,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2411 (0x96b)
+		// Code size: 2712 (0xa98)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Async_GeneratedFunctionObject_Semantics/Scope,
@@ -3708,447 +3720,539 @@
 		IL_0524: box [System.Runtime]System.Double
 		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 		IL_052e: stloc.s 16
-		IL_0530: ldloc.s 8
-		IL_0532: ldstr "run"
-		IL_0537: ldc.r8 9
-		IL_0540: box [System.Runtime]System.Double
-		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_054a: stloc.s 17
-		IL_054c: nop
-		IL_054d: ldc.i4.1
-		IL_054e: newarr [System.Runtime]System.Object
-		IL_0553: dup
-		IL_0554: ldc.i4.0
-		IL_0555: ldloc.0
-		IL_0556: stelem.ref
-		IL_0557: stloc.s 39
-		IL_0559: ldloc.s 39
-		IL_055b: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L59C30/FunctionObject::.ctor(object[])
-		IL_0560: ldc.i4.0
-		IL_0561: conv.r8
-		IL_0562: ldstr ""
-		IL_0567: ldc.i4.0
-		IL_0568: ldc.i4.0
-		IL_0569: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L59C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_056e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L59C30/FunctionObject>(!!0)
-		IL_0573: stloc.s 56
-		IL_0575: ldloc.s 56
-		IL_0577: ldstr "arrowParameterReject"
-		IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0581: stloc.s 18
-		IL_0583: ldc.i4.1
-		IL_0584: newarr [System.Runtime]System.Object
-		IL_0589: dup
-		IL_058a: ldc.i4.0
-		IL_058b: ldloc.0
-		IL_058c: stelem.ref
-		IL_058d: stloc.s 39
-		IL_058f: ldloc.s 39
-		IL_0591: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject::.ctor(object[])
-		IL_0596: ldc.i4.0
-		IL_0597: conv.r8
-		IL_0598: ldstr ""
+		IL_0530: volatile.
+		IL_0532: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_0537: brfalse IL_055b
+
+		IL_053c: ldloc.s 8
+		IL_053e: ldstr "run"
+		IL_0543: ldc.r8 9
+		IL_054c: box [System.Runtime]System.Double
+		IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0556: br IL_057f
+
+		IL_055b: ldloc.s 8
+		IL_055d: ldstr "run"
+		IL_0562: ldc.r8 9
+		IL_056b: box [System.Runtime]System.Double
+		IL_0570: ldstr "Async_GeneratedFunctionObject_Semantics:Modules.Async_GeneratedFunctionObject_Semantics:__js_module_init__:142"
+		IL_0575: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_057f: stloc.s 17
+		IL_0581: nop
+		IL_0582: ldc.i4.1
+		IL_0583: newarr [System.Runtime]System.Object
+		IL_0588: dup
+		IL_0589: ldc.i4.0
+		IL_058a: ldloc.0
+		IL_058b: stelem.ref
+		IL_058c: stloc.s 39
+		IL_058e: ldloc.s 39
+		IL_0590: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L59C30/FunctionObject::.ctor(object[])
+		IL_0595: ldc.i4.0
+		IL_0596: conv.r8
+		IL_0597: ldstr ""
+		IL_059c: ldc.i4.0
 		IL_059d: ldc.i4.0
-		IL_059e: ldc.i4.0
-		IL_059f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject>(!!0)
-		IL_05a9: stloc.s 57
-		IL_05ab: ldloc.s 57
-		IL_05ad: ldstr "primitiveParameterReject"
-		IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_05b7: stloc.s 19
-		IL_05b9: ldc.i4.0
-		IL_05ba: stloc.s 20
-		IL_05bc: ldnull
-		IL_05bd: stloc.s 21
+		IL_059e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L59C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L59C30/FunctionObject>(!!0)
+		IL_05a8: stloc.s 56
+		IL_05aa: ldloc.s 56
+		IL_05ac: ldstr "arrowParameterReject"
+		IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_05b6: stloc.s 18
+		IL_05b8: ldc.i4.1
+		IL_05b9: newarr [System.Runtime]System.Object
+		IL_05be: dup
 		IL_05bf: ldc.i4.0
-		IL_05c0: stloc.s 22
-		IL_05c2: ldnull
-		IL_05c3: stloc.s 23
+		IL_05c0: ldloc.0
+		IL_05c1: stelem.ref
+		IL_05c2: stloc.s 39
+		IL_05c4: ldloc.s 39
+		IL_05c6: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject::.ctor(object[])
+		IL_05cb: ldc.i4.0
+		IL_05cc: conv.r8
+		IL_05cd: ldstr ""
+		IL_05d2: ldc.i4.0
+		IL_05d3: ldc.i4.0
+		IL_05d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject>(!!0)
+		IL_05de: stloc.s 57
+		IL_05e0: ldloc.s 57
+		IL_05e2: ldstr "primitiveParameterReject"
+		IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_05ec: stloc.s 19
+		IL_05ee: ldc.i4.0
+		IL_05ef: stloc.s 20
+		IL_05f1: ldnull
+		IL_05f2: stloc.s 21
+		IL_05f4: ldc.i4.0
+		IL_05f5: stloc.s 22
+		IL_05f7: ldnull
+		IL_05f8: stloc.s 23
 		.try
 		{
-			IL_05c5: nop
-			IL_05c6: ldloc.3
-			IL_05c7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_05d1: stloc.s 48
-			IL_05d3: ldloc.s 48
-			IL_05d5: stloc.s 21
-			IL_05d7: leave IL_0616
+			IL_05fa: nop
+			IL_05fb: ldloc.3
+			IL_05fc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0606: stloc.s 48
+			IL_0608: ldloc.s 48
+			IL_060a: stloc.s 21
+			IL_060c: leave IL_064b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_05dc: stloc.s 24
-			IL_05de: ldloc.s 24
-			IL_05e0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_05e5: dup
-			IL_05e6: brtrue IL_05fc
+			IL_0611: stloc.s 24
+			IL_0613: ldloc.s 24
+			IL_0615: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_061a: dup
+			IL_061b: brtrue IL_0631
 
-			IL_05eb: pop
-			IL_05ec: ldloc.s 24
-			IL_05ee: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_05f3: dup
-			IL_05f4: brtrue IL_0608
+			IL_0620: pop
+			IL_0621: ldloc.s 24
+			IL_0623: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0628: dup
+			IL_0629: brtrue IL_063d
 
-			IL_05f9: pop
-			IL_05fa: rethrow
+			IL_062e: pop
+			IL_062f: rethrow
 
-			IL_05fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0601: stloc.s 25
-			IL_0603: br IL_060a
+			IL_0631: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0636: stloc.s 25
+			IL_0638: br IL_063f
 
-			IL_0608: stloc.s 25
+			IL_063d: stloc.s 25
 
-			IL_060a: ldloc.s 25
-			IL_060c: stloc.s 26
-			IL_060e: ldc.i4.1
-			IL_060f: stloc.s 20
-			IL_0611: leave IL_0616
+			IL_063f: ldloc.s 25
+			IL_0641: stloc.s 26
+			IL_0643: ldc.i4.1
+			IL_0644: stloc.s 20
+			IL_0646: leave IL_064b
 		} // end handler
 		.try
 		{
-			IL_0616: nop
-			IL_0617: ldloc.s 18
-			IL_0619: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0623: stloc.s 48
-			IL_0625: ldloc.s 48
-			IL_0627: stloc.s 23
-			IL_0629: leave IL_0668
+			IL_064b: nop
+			IL_064c: ldloc.s 18
+			IL_064e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0658: stloc.s 48
+			IL_065a: ldloc.s 48
+			IL_065c: stloc.s 23
+			IL_065e: leave IL_069d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_062e: stloc.s 27
-			IL_0630: ldloc.s 27
-			IL_0632: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0637: dup
-			IL_0638: brtrue IL_064e
+			IL_0663: stloc.s 27
+			IL_0665: ldloc.s 27
+			IL_0667: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_066c: dup
+			IL_066d: brtrue IL_0683
 
-			IL_063d: pop
-			IL_063e: ldloc.s 27
-			IL_0640: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0645: dup
-			IL_0646: brtrue IL_065a
+			IL_0672: pop
+			IL_0673: ldloc.s 27
+			IL_0675: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_067a: dup
+			IL_067b: brtrue IL_068f
 
-			IL_064b: pop
-			IL_064c: rethrow
+			IL_0680: pop
+			IL_0681: rethrow
 
-			IL_064e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0653: stloc.s 28
-			IL_0655: br IL_065c
+			IL_0683: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0688: stloc.s 28
+			IL_068a: br IL_0691
 
-			IL_065a: stloc.s 28
+			IL_068f: stloc.s 28
 
-			IL_065c: ldloc.s 28
-			IL_065e: stloc.s 29
-			IL_0660: ldc.i4.1
-			IL_0661: stloc.s 22
-			IL_0663: leave IL_0668
+			IL_0691: ldloc.s 28
+			IL_0693: stloc.s 29
+			IL_0695: ldc.i4.1
+			IL_0696: stloc.s 22
+			IL_0698: leave IL_069d
 		} // end handler
 
-		IL_0668: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_066d: stloc.s 41
-		IL_066f: ldloc.s 20
-		IL_0671: box [System.Runtime]System.Boolean
-		IL_0676: stloc.s 53
-		IL_0678: ldloc.s 21
-		IL_067a: stloc.s 48
-		IL_067c: ldstr "Promise"
-		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0686: stloc.s 47
-		IL_0688: ldloc.s 48
-		IL_068a: ldloc.s 47
-		IL_068c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0691: stloc.s 49
-		IL_0693: ldloc.s 49
-		IL_0695: box [System.Runtime]System.Boolean
-		IL_069a: stloc.s 52
-		IL_069c: ldloc.s 22
-		IL_069e: box [System.Runtime]System.Boolean
-		IL_06a3: stloc.s 51
-		IL_06a5: ldloc.s 23
-		IL_06a7: stloc.s 47
-		IL_06a9: ldstr "Promise"
-		IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06b3: stloc.s 48
-		IL_06b5: ldloc.s 47
-		IL_06b7: ldloc.s 48
-		IL_06b9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_06be: stloc.s 49
-		IL_06c0: ldloc.s 49
-		IL_06c2: box [System.Runtime]System.Boolean
-		IL_06c7: stloc.s 50
-		IL_06c9: ldloc.s 41
-		IL_06cb: ldc.i4.5
-		IL_06cc: newarr [System.Runtime]System.Object
-		IL_06d1: dup
-		IL_06d2: ldc.i4.0
-		IL_06d3: ldstr "parameterSetup"
-		IL_06d8: stelem.ref
-		IL_06d9: dup
-		IL_06da: ldc.i4.1
-		IL_06db: ldloc.s 53
-		IL_06dd: stelem.ref
-		IL_06de: dup
-		IL_06df: ldc.i4.2
-		IL_06e0: ldloc.s 52
-		IL_06e2: stelem.ref
-		IL_06e3: dup
-		IL_06e4: ldc.i4.3
-		IL_06e5: ldloc.s 51
-		IL_06e7: stelem.ref
-		IL_06e8: dup
-		IL_06e9: ldc.i4.4
-		IL_06ea: ldloc.s 50
-		IL_06ec: stelem.ref
-		IL_06ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_06f2: pop
-		IL_06f3: ldloc.s 21
-		IL_06f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06fa: stloc.s 48
-		IL_06fc: ldc.i4.1
-		IL_06fd: newarr [System.Runtime]System.Object
-		IL_0702: dup
-		IL_0703: ldc.i4.0
-		IL_0704: ldloc.0
-		IL_0705: stelem.ref
-		IL_0706: stloc.s 39
-		IL_0708: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L86C51/FunctionObject::.ctor()
-		IL_070d: ldc.i4.1
-		IL_070e: conv.r8
-		IL_070f: ldstr ""
-		IL_0714: ldc.i4.0
-		IL_0715: ldc.i4.0
-		IL_0716: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L86C51/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_071b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L86C51/FunctionObject>(!!0)
-		IL_0720: stloc.s 58
-		IL_0722: ldloc.s 48
-		IL_0724: ldstr "catch"
-		IL_0729: ldloc.s 58
-		IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0730: stloc.s 30
-		IL_0732: ldloc.s 23
-		IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0739: stloc.s 48
-		IL_073b: ldc.i4.1
-		IL_073c: newarr [System.Runtime]System.Object
-		IL_0741: dup
-		IL_0742: ldc.i4.0
-		IL_0743: ldloc.0
-		IL_0744: stelem.ref
-		IL_0745: stloc.s 39
-		IL_0747: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L89C61/FunctionObject::.ctor()
-		IL_074c: ldc.i4.1
-		IL_074d: conv.r8
-		IL_074e: ldstr ""
-		IL_0753: ldc.i4.0
-		IL_0754: ldc.i4.0
-		IL_0755: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L89C61/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_075a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L89C61/FunctionObject>(!!0)
-		IL_075f: stloc.s 59
-		IL_0761: ldloc.s 48
-		IL_0763: ldstr "catch"
-		IL_0768: ldloc.s 59
-		IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_076f: stloc.s 31
-		IL_0771: ldloc.s 19
-		IL_0773: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0778: ldstr "call"
-		IL_077d: ldc.i4.0
-		IL_077e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0783: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0788: stloc.s 48
-		IL_078a: ldloc.s 48
-		IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0791: stloc.s 48
-		IL_0793: ldc.i4.1
-		IL_0794: newarr [System.Runtime]System.Object
-		IL_0799: dup
-		IL_079a: ldc.i4.0
-		IL_079b: ldloc.0
-		IL_079c: stelem.ref
-		IL_079d: stloc.s 39
-		IL_079f: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L93C12/FunctionObject::.ctor()
-		IL_07a4: ldc.i4.1
-		IL_07a5: conv.r8
-		IL_07a6: ldstr ""
-		IL_07ab: ldc.i4.0
-		IL_07ac: ldc.i4.0
-		IL_07ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L93C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L93C12/FunctionObject>(!!0)
-		IL_07b7: stloc.s 60
-		IL_07b9: ldloc.s 48
-		IL_07bb: ldstr "catch"
-		IL_07c0: ldloc.s 60
-		IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07c7: stloc.s 32
-		IL_07c9: ldc.i4.8
-		IL_07ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_07cf: dup
-		IL_07d0: ldloc.s 13
-		IL_07d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_07d7: dup
-		IL_07d8: ldloc.s 14
-		IL_07da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_07df: dup
-		IL_07e0: ldloc.s 15
-		IL_07e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_07e7: dup
-		IL_07e8: ldloc.s 16
-		IL_07ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_07ef: dup
-		IL_07f0: ldloc.s 17
-		IL_07f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_07f7: dup
-		IL_07f8: ldloc.s 30
-		IL_07fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_07ff: dup
-		IL_0800: ldloc.s 31
-		IL_0802: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0807: dup
-		IL_0808: ldloc.s 32
-		IL_080a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_080f: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::all(object)
-		IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0819: stloc.s 48
-		IL_081b: ldc.i4.1
-		IL_081c: newarr [System.Runtime]System.Object
-		IL_0821: dup
-		IL_0822: ldc.i4.0
-		IL_0823: ldloc.0
-		IL_0824: stelem.ref
-		IL_0825: stloc.s 39
-		IL_0827: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L104C9/FunctionObject::.ctor()
-		IL_082c: ldc.i4.1
-		IL_082d: conv.r8
-		IL_082e: ldstr ""
-		IL_0833: ldc.i4.0
-		IL_0834: ldc.i4.0
-		IL_0835: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L104C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_083a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L104C9/FunctionObject>(!!0)
-		IL_083f: stloc.s 61
-		IL_0841: ldloc.s 48
-		IL_0843: ldstr "then"
-		IL_0848: ldloc.s 61
-		IL_084a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_084f: pop
-		IL_0850: nop
-		IL_0851: ldc.i4.0
-		IL_0852: stloc.s 33
-		IL_0854: ldnull
-		IL_0855: stloc.s 34
-		.try
-		{
-			IL_0857: nop
-			IL_0858: ldloc.s 4
-			IL_085a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_085f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0864: stloc.s 48
-			IL_0866: ldloc.s 48
-			IL_0868: stloc.s 34
-			IL_086a: leave IL_08a9
-		} // end .try
-		catch [System.Runtime]System.Exception
-		{
-			IL_086f: stloc.s 35
-			IL_0871: ldloc.s 35
-			IL_0873: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0878: dup
-			IL_0879: brtrue IL_088f
+		IL_069d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06a2: stloc.s 41
+		IL_06a4: ldloc.s 20
+		IL_06a6: box [System.Runtime]System.Boolean
+		IL_06ab: stloc.s 53
+		IL_06ad: ldloc.s 21
+		IL_06af: stloc.s 48
+		IL_06b1: ldstr "Promise"
+		IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06bb: stloc.s 47
+		IL_06bd: ldloc.s 48
+		IL_06bf: ldloc.s 47
+		IL_06c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_06c6: stloc.s 49
+		IL_06c8: ldloc.s 49
+		IL_06ca: box [System.Runtime]System.Boolean
+		IL_06cf: stloc.s 52
+		IL_06d1: ldloc.s 22
+		IL_06d3: box [System.Runtime]System.Boolean
+		IL_06d8: stloc.s 51
+		IL_06da: ldloc.s 23
+		IL_06dc: stloc.s 47
+		IL_06de: ldstr "Promise"
+		IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06e8: stloc.s 48
+		IL_06ea: ldloc.s 47
+		IL_06ec: ldloc.s 48
+		IL_06ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_06f3: stloc.s 49
+		IL_06f5: ldloc.s 49
+		IL_06f7: box [System.Runtime]System.Boolean
+		IL_06fc: stloc.s 50
+		IL_06fe: ldloc.s 41
+		IL_0700: ldc.i4.5
+		IL_0701: newarr [System.Runtime]System.Object
+		IL_0706: dup
+		IL_0707: ldc.i4.0
+		IL_0708: ldstr "parameterSetup"
+		IL_070d: stelem.ref
+		IL_070e: dup
+		IL_070f: ldc.i4.1
+		IL_0710: ldloc.s 53
+		IL_0712: stelem.ref
+		IL_0713: dup
+		IL_0714: ldc.i4.2
+		IL_0715: ldloc.s 52
+		IL_0717: stelem.ref
+		IL_0718: dup
+		IL_0719: ldc.i4.3
+		IL_071a: ldloc.s 51
+		IL_071c: stelem.ref
+		IL_071d: dup
+		IL_071e: ldc.i4.4
+		IL_071f: ldloc.s 50
+		IL_0721: stelem.ref
+		IL_0722: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0727: pop
+		IL_0728: ldloc.s 21
+		IL_072a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_072f: stloc.s 48
+		IL_0731: ldc.i4.1
+		IL_0732: newarr [System.Runtime]System.Object
+		IL_0737: dup
+		IL_0738: ldc.i4.0
+		IL_0739: ldloc.0
+		IL_073a: stelem.ref
+		IL_073b: stloc.s 39
+		IL_073d: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L86C51/FunctionObject::.ctor()
+		IL_0742: ldc.i4.1
+		IL_0743: conv.r8
+		IL_0744: ldstr ""
+		IL_0749: ldc.i4.0
+		IL_074a: ldc.i4.0
+		IL_074b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L86C51/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0750: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L86C51/FunctionObject>(!!0)
+		IL_0755: stloc.s 58
+		IL_0757: volatile.
+		IL_0759: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_075e: brfalse IL_0776
 
-			IL_087e: pop
-			IL_087f: ldloc.s 35
-			IL_0881: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0886: dup
-			IL_0887: brtrue IL_089b
+		IL_0763: ldloc.s 48
+		IL_0765: ldstr "catch"
+		IL_076a: ldloc.s 58
+		IL_076c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0771: br IL_078e
 
-			IL_088c: pop
-			IL_088d: rethrow
+		IL_0776: ldloc.s 48
+		IL_0778: ldstr "catch"
+		IL_077d: ldloc.s 58
+		IL_077f: ldstr "Async_GeneratedFunctionObject_Semantics:Modules.Async_GeneratedFunctionObject_Semantics:__js_module_init__:235"
+		IL_0784: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_0789: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_088f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0894: stloc.s 36
-			IL_0896: br IL_089d
+		IL_078e: stloc.s 30
+		IL_0790: ldloc.s 23
+		IL_0792: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0797: stloc.s 48
+		IL_0799: ldc.i4.1
+		IL_079a: newarr [System.Runtime]System.Object
+		IL_079f: dup
+		IL_07a0: ldc.i4.0
+		IL_07a1: ldloc.0
+		IL_07a2: stelem.ref
+		IL_07a3: stloc.s 39
+		IL_07a5: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L89C61/FunctionObject::.ctor()
+		IL_07aa: ldc.i4.1
+		IL_07ab: conv.r8
+		IL_07ac: ldstr ""
+		IL_07b1: ldc.i4.0
+		IL_07b2: ldc.i4.0
+		IL_07b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L89C61/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L89C61/FunctionObject>(!!0)
+		IL_07bd: stloc.s 59
+		IL_07bf: volatile.
+		IL_07c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_07c6: brfalse IL_07de
 
-			IL_089b: stloc.s 36
+		IL_07cb: ldloc.s 48
+		IL_07cd: ldstr "catch"
+		IL_07d2: ldloc.s 59
+		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07d9: br IL_07f6
 
-			IL_089d: ldloc.s 36
-			IL_089f: stloc.s 37
-			IL_08a1: ldc.i4.1
-			IL_08a2: stloc.s 33
-			IL_08a4: leave IL_08a9
-		} // end handler
+		IL_07de: ldloc.s 48
+		IL_07e0: ldstr "catch"
+		IL_07e5: ldloc.s 59
+		IL_07e7: ldstr "Async_GeneratedFunctionObject_Semantics:Modules.Async_GeneratedFunctionObject_Semantics:__js_module_init__:241"
+		IL_07ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_07f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_08a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08ae: stloc.s 41
-		IL_08b0: ldloc.s 33
-		IL_08b2: box [System.Runtime]System.Boolean
-		IL_08b7: stloc.s 50
-		IL_08b9: ldloc.s 34
-		IL_08bb: stloc.s 48
-		IL_08bd: ldstr "Promise"
-		IL_08c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08c7: stloc.s 47
-		IL_08c9: ldloc.s 48
-		IL_08cb: ldloc.s 47
-		IL_08cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_08d2: stloc.s 49
-		IL_08d4: ldloc.s 49
-		IL_08d6: box [System.Runtime]System.Boolean
-		IL_08db: stloc.s 51
-		IL_08dd: ldloc.s 41
-		IL_08df: ldstr "syncThrow"
-		IL_08e4: ldloc.s 50
-		IL_08e6: ldloc.s 51
-		IL_08e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_08ed: pop
-		IL_08ee: ldloc.s 34
-		IL_08f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08f5: stloc.s 47
-		IL_08f7: ldc.i4.1
-		IL_08f8: newarr [System.Runtime]System.Object
-		IL_08fd: dup
-		IL_08fe: ldc.i4.0
-		IL_08ff: ldloc.0
-		IL_0900: stelem.ref
-		IL_0901: stloc.s 39
-		IL_0903: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L120C17/FunctionObject::.ctor()
-		IL_0908: ldc.i4.1
-		IL_0909: conv.r8
-		IL_090a: ldstr ""
+		IL_07f6: stloc.s 31
+		IL_07f8: ldloc.s 19
+		IL_07fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07ff: volatile.
+		IL_0801: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0806: brfalse IL_0820
+
+		IL_080b: ldstr "call"
+		IL_0810: ldc.i4.0
+		IL_0811: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0816: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_081b: br IL_083a
+
+		IL_0820: ldstr "call"
+		IL_0825: ldc.i4.0
+		IL_0826: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_082b: ldstr "Async_GeneratedFunctionObject_Semantics:Modules.Async_GeneratedFunctionObject_Semantics:__js_module_init__:247"
+		IL_0830: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_083a: stloc.s 48
+		IL_083c: ldloc.s 48
+		IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0843: stloc.s 48
+		IL_0845: ldc.i4.1
+		IL_0846: newarr [System.Runtime]System.Object
+		IL_084b: dup
+		IL_084c: ldc.i4.0
+		IL_084d: ldloc.0
+		IL_084e: stelem.ref
+		IL_084f: stloc.s 39
+		IL_0851: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L93C12/FunctionObject::.ctor()
+		IL_0856: ldc.i4.1
+		IL_0857: conv.r8
+		IL_0858: ldstr ""
+		IL_085d: ldc.i4.0
+		IL_085e: ldc.i4.0
+		IL_085f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L93C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0864: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L93C12/FunctionObject>(!!0)
+		IL_0869: stloc.s 60
+		IL_086b: volatile.
+		IL_086d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_0872: brfalse IL_088a
+
+		IL_0877: ldloc.s 48
+		IL_0879: ldstr "catch"
+		IL_087e: ldloc.s 60
+		IL_0880: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0885: br IL_08a2
+
+		IL_088a: ldloc.s 48
+		IL_088c: ldstr "catch"
+		IL_0891: ldloc.s 60
+		IL_0893: ldstr "Async_GeneratedFunctionObject_Semantics:Modules.Async_GeneratedFunctionObject_Semantics:__js_module_init__:251"
+		IL_0898: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_089d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_08a2: stloc.s 32
+		IL_08a4: ldc.i4.8
+		IL_08a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_08aa: dup
+		IL_08ab: ldloc.s 13
+		IL_08ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_08b2: dup
+		IL_08b3: ldloc.s 14
+		IL_08b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_08ba: dup
+		IL_08bb: ldloc.s 15
+		IL_08bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_08c2: dup
+		IL_08c3: ldloc.s 16
+		IL_08c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_08ca: dup
+		IL_08cb: ldloc.s 17
+		IL_08cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_08d2: dup
+		IL_08d3: ldloc.s 30
+		IL_08d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_08da: dup
+		IL_08db: ldloc.s 31
+		IL_08dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_08e2: dup
+		IL_08e3: ldloc.s 32
+		IL_08e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_08ea: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::all(object)
+		IL_08ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08f4: stloc.s 48
+		IL_08f6: ldc.i4.1
+		IL_08f7: newarr [System.Runtime]System.Object
+		IL_08fc: dup
+		IL_08fd: ldc.i4.0
+		IL_08fe: ldloc.0
+		IL_08ff: stelem.ref
+		IL_0900: stloc.s 39
+		IL_0902: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L104C9/FunctionObject::.ctor()
+		IL_0907: ldc.i4.1
+		IL_0908: conv.r8
+		IL_0909: ldstr ""
+		IL_090e: ldc.i4.0
 		IL_090f: ldc.i4.0
-		IL_0910: ldc.i4.0
-		IL_0911: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L120C17/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0916: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L120C17/FunctionObject>(!!0)
-		IL_091b: stloc.s 62
-		IL_091d: ldloc.s 47
-		IL_091f: ldstr "catch"
-		IL_0924: ldloc.s 62
-		IL_0926: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_092b: pop
-		IL_092c: nop
-		IL_092d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0932: stloc.s 41
-		IL_0934: ldnull
-		IL_0935: call object Modules.Async_GeneratedFunctionObject_Semantics/makeAsync::__js_call__(object)
-		IL_093a: stloc.s 47
-		IL_093c: ldnull
-		IL_093d: call object Modules.Async_GeneratedFunctionObject_Semantics/makeAsync::__js_call__(object)
-		IL_0942: stloc.s 48
-		IL_0944: ldloc.s 47
-		IL_0946: ldloc.s 48
-		IL_0948: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_094d: stloc.s 49
-		IL_094f: ldloc.s 49
-		IL_0951: box [System.Runtime]System.Boolean
-		IL_0956: stloc.s 51
-		IL_0958: ldloc.s 41
-		IL_095a: ldstr "identity"
-		IL_095f: ldloc.s 51
-		IL_0961: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0966: pop
-		IL_0967: ldnull
-		IL_0968: stloc.s 38
-		IL_096a: ret
+		IL_0910: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L104C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0915: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L104C9/FunctionObject>(!!0)
+		IL_091a: stloc.s 61
+		IL_091c: volatile.
+		IL_091e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_0923: brfalse IL_093b
+
+		IL_0928: ldloc.s 48
+		IL_092a: ldstr "then"
+		IL_092f: ldloc.s 61
+		IL_0931: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0936: br IL_0953
+
+		IL_093b: ldloc.s 48
+		IL_093d: ldstr "then"
+		IL_0942: ldloc.s 61
+		IL_0944: ldstr "Async_GeneratedFunctionObject_Semantics:Modules.Async_GeneratedFunctionObject_Semantics:__js_module_init__:259"
+		IL_0949: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_094e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0953: pop
+		IL_0954: nop
+		IL_0955: ldc.i4.0
+		IL_0956: stloc.s 33
+		IL_0958: ldnull
+		IL_0959: stloc.s 34
+		.try
+		{
+			IL_095b: nop
+			IL_095c: ldloc.s 4
+			IL_095e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0968: stloc.s 48
+			IL_096a: ldloc.s 48
+			IL_096c: stloc.s 34
+			IL_096e: leave IL_09ad
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_0973: stloc.s 35
+			IL_0975: ldloc.s 35
+			IL_0977: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_097c: dup
+			IL_097d: brtrue IL_0993
+
+			IL_0982: pop
+			IL_0983: ldloc.s 35
+			IL_0985: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_098a: dup
+			IL_098b: brtrue IL_099f
+
+			IL_0990: pop
+			IL_0991: rethrow
+
+			IL_0993: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0998: stloc.s 36
+			IL_099a: br IL_09a1
+
+			IL_099f: stloc.s 36
+
+			IL_09a1: ldloc.s 36
+			IL_09a3: stloc.s 37
+			IL_09a5: ldc.i4.1
+			IL_09a6: stloc.s 33
+			IL_09a8: leave IL_09ad
+		} // end handler
+
+		IL_09ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_09b2: stloc.s 41
+		IL_09b4: ldloc.s 33
+		IL_09b6: box [System.Runtime]System.Boolean
+		IL_09bb: stloc.s 50
+		IL_09bd: ldloc.s 34
+		IL_09bf: stloc.s 48
+		IL_09c1: ldstr "Promise"
+		IL_09c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_09cb: stloc.s 47
+		IL_09cd: ldloc.s 48
+		IL_09cf: ldloc.s 47
+		IL_09d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_09d6: stloc.s 49
+		IL_09d8: ldloc.s 49
+		IL_09da: box [System.Runtime]System.Boolean
+		IL_09df: stloc.s 51
+		IL_09e1: ldloc.s 41
+		IL_09e3: ldstr "syncThrow"
+		IL_09e8: ldloc.s 50
+		IL_09ea: ldloc.s 51
+		IL_09ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_09f1: pop
+		IL_09f2: ldloc.s 34
+		IL_09f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_09f9: stloc.s 47
+		IL_09fb: ldc.i4.1
+		IL_09fc: newarr [System.Runtime]System.Object
+		IL_0a01: dup
+		IL_0a02: ldc.i4.0
+		IL_0a03: ldloc.0
+		IL_0a04: stelem.ref
+		IL_0a05: stloc.s 39
+		IL_0a07: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L120C17/FunctionObject::.ctor()
+		IL_0a0c: ldc.i4.1
+		IL_0a0d: conv.r8
+		IL_0a0e: ldstr ""
+		IL_0a13: ldc.i4.0
+		IL_0a14: ldc.i4.0
+		IL_0a15: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L120C17/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a1a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L120C17/FunctionObject>(!!0)
+		IL_0a1f: stloc.s 62
+		IL_0a21: volatile.
+		IL_0a23: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_0a28: brfalse IL_0a40
+
+		IL_0a2d: ldloc.s 47
+		IL_0a2f: ldstr "catch"
+		IL_0a34: ldloc.s 62
+		IL_0a36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a3b: br IL_0a58
+
+		IL_0a40: ldloc.s 47
+		IL_0a42: ldstr "catch"
+		IL_0a47: ldloc.s 62
+		IL_0a49: ldstr "Async_GeneratedFunctionObject_Semantics:Modules.Async_GeneratedFunctionObject_Semantics:__js_module_init__:304"
+		IL_0a4e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_0a53: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0a58: pop
+		IL_0a59: nop
+		IL_0a5a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0a5f: stloc.s 41
+		IL_0a61: ldnull
+		IL_0a62: call object Modules.Async_GeneratedFunctionObject_Semantics/makeAsync::__js_call__(object)
+		IL_0a67: stloc.s 47
+		IL_0a69: ldnull
+		IL_0a6a: call object Modules.Async_GeneratedFunctionObject_Semantics/makeAsync::__js_call__(object)
+		IL_0a6f: stloc.s 48
+		IL_0a71: ldloc.s 47
+		IL_0a73: ldloc.s 48
+		IL_0a75: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0a7a: stloc.s 49
+		IL_0a7c: ldloc.s 49
+		IL_0a7e: box [System.Runtime]System.Boolean
+		IL_0a83: stloc.s 51
+		IL_0a85: ldloc.s 41
+		IL_0a87: ldstr "identity"
+		IL_0a8c: ldloc.s 51
+		IL_0a8e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0a93: pop
+		IL_0a94: ldnull
+		IL_0a95: stloc.s 38
+		IL_0a97: ret
 	} // end of method Async_GeneratedFunctionObject_Semantics::__js_module_init__
 
 } // end of class Modules.Async_GeneratedFunctionObject_Semantics
@@ -4187,6 +4291,14 @@
 	.field assembly static int32 __jroc_dynamicLookup_36
 	.field assembly static int32 __jroc_dynamicLookup_37
 	.field assembly static int32 __jroc_dynamicLookup_38
+	.field assembly static int32 __jroc_dynamicLookup_39
+	.field assembly static int32 __jroc_dynamicLookup_40
+	.field assembly static int32 __jroc_dynamicLookup_41
+	.field assembly static int32 __jroc_dynamicLookup_42
+	.field assembly static int32 __jroc_dynamicLookup_43
+	.field assembly static int32 __jroc_dynamicLookup_44
+	.field assembly static int32 __jroc_dynamicLookup_45
+	.field assembly static int32 __jroc_dynamicLookup_46
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
@@ -939,7 +939,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 666 (0x29a)
+		// Code size: 707 (0x2c3)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_Inheritance_SuperAsyncMethod/Scope,
@@ -1223,12 +1223,25 @@
 		IL_027e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0283: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject>(!!0)
 		IL_0288: stloc.s 7
-		IL_028a: ldloc.s 6
-		IL_028c: ldstr "then"
-		IL_0291: ldloc.s 7
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0298: pop
-		IL_0299: ret
+		IL_028a: volatile.
+		IL_028c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0291: brfalse IL_02a9
+
+		IL_0296: ldloc.s 6
+		IL_0298: ldstr "then"
+		IL_029d: ldloc.s 7
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a4: br IL_02c1
+
+		IL_02a9: ldloc.s 6
+		IL_02ab: ldstr "then"
+		IL_02b0: ldloc.s 7
+		IL_02b2: ldstr "Async_Inheritance_SuperAsyncMethod:Modules.Async_Inheritance_SuperAsyncMethod:__js_module_init__:57"
+		IL_02b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02c1: pop
+		IL_02c2: ret
 	} // end of method Async_Inheritance_SuperAsyncMethod::__js_module_init__
 
 } // end of class Modules.Async_Inheritance_SuperAsyncMethod
@@ -1260,6 +1273,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
@@ -855,7 +855,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 156 (0x9c)
+		// Code size: 197 (0xc5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_PendingPromiseAwait/Scope,
@@ -916,18 +916,31 @@
 		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_PendingPromiseAwait/ArrowFunction_L20C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_PendingPromiseAwait/ArrowFunction_L20C13/FunctionObject>(!!0)
 		IL_0078: stloc.s 5
-		IL_007a: ldloc.s 4
-		IL_007c: ldstr "then"
-		IL_0081: ldloc.s 5
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0088: pop
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008e: stloc.3
-		IL_008f: ldloc.3
-		IL_0090: ldstr "After calling async function"
-		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009a: pop
-		IL_009b: ret
+		IL_007a: volatile.
+		IL_007c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0081: brfalse IL_0099
+
+		IL_0086: ldloc.s 4
+		IL_0088: ldstr "then"
+		IL_008d: ldloc.s 5
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0094: br IL_00b1
+
+		IL_0099: ldloc.s 4
+		IL_009b: ldstr "then"
+		IL_00a0: ldloc.s 5
+		IL_00a2: ldstr "Async_PendingPromiseAwait:Modules.Async_PendingPromiseAwait:__js_module_init__:17"
+		IL_00a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00b1: pop
+		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b7: stloc.3
+		IL_00b8: ldloc.3
+		IL_00b9: ldstr "After calling async function"
+		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c3: pop
+		IL_00c4: ret
 	} // end of method Async_PendingPromiseAwait::__js_module_init__
 
 } // end of class Modules.Async_PendingPromiseAwait
@@ -952,4 +965,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_9
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
@@ -873,7 +873,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 140 (0x8c)
+		// Code size: 181 (0xb5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_RealSuspension_SetTimeout/Scope,
@@ -936,12 +936,25 @@
 		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12/FunctionObject>(!!0)
 		IL_007a: stloc.s 5
-		IL_007c: ldloc.s 4
-		IL_007e: ldstr "then"
-		IL_0083: ldloc.s 5
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: pop
-		IL_008b: ret
+		IL_007c: volatile.
+		IL_007e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0083: brfalse IL_009b
+
+		IL_0088: ldloc.s 4
+		IL_008a: ldstr "then"
+		IL_008f: ldloc.s 5
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0096: br IL_00b3
+
+		IL_009b: ldloc.s 4
+		IL_009d: ldstr "then"
+		IL_00a2: ldloc.s 5
+		IL_00a4: ldstr "Async_RealSuspension_SetTimeout:Modules.Async_RealSuspension_SetTimeout:__js_module_init__:17"
+		IL_00a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00b3: pop
+		IL_00b4: ret
 	} // end of method Async_RealSuspension_SetTimeout::__js_module_init__
 
 } // end of class Modules.Async_RealSuspension_SetTimeout
@@ -966,4 +979,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_7
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ReturnValue.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ReturnValue.verified.txt
@@ -341,7 +341,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 116 (0x74)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ReturnValue/Scope,
@@ -395,12 +395,25 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ReturnValue/ArrowFunction_L7C17/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ReturnValue/ArrowFunction_L7C17/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "then"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.3
+		IL_0072: ldstr "then"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.3
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Async_ReturnValue:Modules.Async_ReturnValue:__js_module_init__:13"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Async_ReturnValue::__js_module_init__
 
 } // end of class Modules.Async_ReturnValue
@@ -425,4 +438,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SimpleAwait.verified.txt
@@ -478,7 +478,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 116 (0x74)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_SimpleAwait/Scope,
@@ -532,12 +532,25 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_SimpleAwait/ArrowFunction_L10C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_SimpleAwait/ArrowFunction_L10C13/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "then"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.3
+		IL_0072: ldstr "then"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.3
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Async_SimpleAwait:Modules.Async_SimpleAwait:__js_module_init__:13"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Async_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_SimpleAwait
@@ -562,4 +575,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_StaticMethod_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_StaticMethod_SimpleAwait.verified.txt
@@ -182,7 +182,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -193,7 +193,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "value"
 			IL_0028: ldstr "Async_StaticMethod_SimpleAwait:<TwoPhaseDummy_M4>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -550,7 +550,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 338 (0x152)
+		// Code size: 379 (0x17b)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Async_StaticMethod_SimpleAwait/Scope,
@@ -696,12 +696,25 @@
 		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject>(!!0)
 		IL_0140: stloc.s 6
-		IL_0142: ldloc.s 5
-		IL_0144: ldstr "then"
-		IL_0149: ldloc.s 6
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0150: pop
-		IL_0151: ret
+		IL_0142: volatile.
+		IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0149: brfalse IL_0161
+
+		IL_014e: ldloc.s 5
+		IL_0150: ldstr "then"
+		IL_0155: ldloc.s 6
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015c: br IL_0179
+
+		IL_0161: ldloc.s 5
+		IL_0163: ldstr "then"
+		IL_0168: ldloc.s 6
+		IL_016a: ldstr "Async_StaticMethod_SimpleAwait:Modules.Async_StaticMethod_SimpleAwait:__js_module_init__:31"
+		IL_016f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0179: pop
+		IL_017a: ret
 	} // end of method Async_StaticMethod_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_StaticMethod_SimpleAwait
@@ -734,6 +747,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
@@ -742,7 +742,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 116 (0x74)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/Scope,
@@ -796,12 +796,25 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/ArrowFunction_L20C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/ArrowFunction_L20C13/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "then"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.3
+		IL_0072: ldstr "then"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.3
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Async_TryCatchFinally_AwaitInFinally_OnReject:Modules.Async_TryCatchFinally_AwaitInFinally_OnReject:__js_module_init__:13"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Async_TryCatchFinally_AwaitInFinally_OnReject::__js_module_init__
 
 } // end of class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject
@@ -826,4 +839,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
@@ -554,7 +554,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 136 (0x88)
+		// Code size: 176 (0xb0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryCatch_AwaitReject/Scope,
@@ -609,18 +609,31 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TryCatch_AwaitReject/ArrowFunction_L16C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryCatch_AwaitReject/ArrowFunction_L16C21/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "then"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0078: stloc.s 5
-		IL_007a: ldloc.s 5
-		IL_007c: ldstr "After calling async function"
-		IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0086: pop
-		IL_0087: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.3
+		IL_0072: ldstr "then"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.3
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Async_TryCatch_AwaitReject:Modules.Async_TryCatch_AwaitReject:__js_module_init__:13"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a0: stloc.s 5
+		IL_00a2: ldloc.s 5
+		IL_00a4: ldstr "After calling async function"
+		IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ae: pop
+		IL_00af: ret
 	} // end of method Async_TryCatch_AwaitReject::__js_module_init__
 
 } // end of class Modules.Async_TryCatch_AwaitReject
@@ -645,4 +658,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
@@ -699,7 +699,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 136 (0x88)
+		// Code size: 176 (0xb0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_AwaitInFinally_Normal/Scope,
@@ -754,18 +754,31 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TryFinally_AwaitInFinally_Normal/ArrowFunction_L18C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_AwaitInFinally_Normal/ArrowFunction_L18C13/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "then"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0078: stloc.s 5
-		IL_007a: ldloc.s 5
-		IL_007c: ldstr "after call"
-		IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0086: pop
-		IL_0087: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.3
+		IL_0072: ldstr "then"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.3
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Async_TryFinally_AwaitInFinally_Normal:Modules.Async_TryFinally_AwaitInFinally_Normal:__js_module_init__:13"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a0: stloc.s 5
+		IL_00a2: ldloc.s 5
+		IL_00a4: ldstr "after call"
+		IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ae: pop
+		IL_00af: ret
 	} // end of method Async_TryFinally_AwaitInFinally_Normal::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_AwaitInFinally_Normal
@@ -790,4 +803,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
@@ -702,7 +702,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 116 (0x74)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/Scope,
@@ -756,12 +756,25 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/ArrowFunction_L20C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/ArrowFunction_L20C13/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "then"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.3
+		IL_0072: ldstr "then"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.3
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Async_TryFinally_FinallyThrowOverridesOriginal:Modules.Async_TryFinally_FinallyThrowOverridesOriginal:__js_module_init__:13"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Async_TryFinally_FinallyThrowOverridesOriginal::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_FinallyThrowOverridesOriginal
@@ -786,4 +799,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
@@ -748,7 +748,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 116 (0x74)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_PreservesExceptionThroughAwait/Scope,
@@ -802,12 +802,25 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TryFinally_PreservesExceptionThroughAwait/ArrowFunction_L22C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_PreservesExceptionThroughAwait/ArrowFunction_L22C13/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "then"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.3
+		IL_0072: ldstr "then"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.3
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Async_TryFinally_PreservesExceptionThroughAwait:Modules.Async_TryFinally_PreservesExceptionThroughAwait:__js_module_init__:13"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Async_TryFinally_PreservesExceptionThroughAwait::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_PreservesExceptionThroughAwait
@@ -832,4 +845,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_ReturnPreservedThroughAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_ReturnPreservedThroughAwait.verified.txt
@@ -652,7 +652,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 116 (0x74)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_ReturnPreservedThroughAwait/Scope,
@@ -706,12 +706,25 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TryFinally_ReturnPreservedThroughAwait/ArrowFunction_L16C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_ReturnPreservedThroughAwait/ArrowFunction_L16C13/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldstr "then"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.3
+		IL_0072: ldstr "then"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.3
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Async_TryFinally_ReturnPreservedThroughAwait:Modules.Async_TryFinally_ReturnPreservedThroughAwait:__js_module_init__:13"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Async_TryFinally_ReturnPreservedThroughAwait::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_ReturnPreservedThroughAwait
@@ -736,4 +749,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ExplicitReceiverAbi.verified.txt
@@ -1042,7 +1042,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 2623 (0xa3f)
+			// Code size: 2745 (0xab9)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope,
@@ -1161,7 +1161,7 @@
 
 			IL_00c7: ldloc.0
 			IL_00c8: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00cd: switch (IL_00ee, IL_01ee, IL_035c, IL_04e6, IL_05a4, IL_072e, IL_07f5)
+			IL_00cd: switch (IL_00ee, IL_0216, IL_0384, IL_0537, IL_05f5, IL_07a8, IL_086f)
 
 			IL_00ee: ldarg.0
 			IL_00ef: ldc.i4.1
@@ -1219,921 +1219,960 @@
 			IL_0170: ldloc.s 10
 			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0177: stloc.s 10
-			IL_0179: ldloc.s 10
-			IL_017b: ldstr "call"
-			IL_0180: ldloc.2
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0186: stloc.s 10
-			IL_0188: ldloc.0
-			IL_0189: ldc.i4.1
-			IL_018a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_018f: ldloc.0
-			IL_0190: ldloc.s 10
-			IL_0192: ldarg.0
-			IL_0193: ldc.i4.1
-			IL_0194: ldloc.0
-			IL_0195: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_019a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_019f: ldloc.0
-			IL_01a0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01a5: dup
-			IL_01a6: ldc.i4.0
-			IL_01a7: ldloc.1
-			IL_01a8: stelem.ref
-			IL_01a9: dup
-			IL_01aa: ldc.i4.1
-			IL_01ab: ldloc.2
-			IL_01ac: stelem.ref
-			IL_01ad: dup
-			IL_01ae: ldc.i4.2
-			IL_01af: ldloc.3
-			IL_01b0: stelem.ref
-			IL_01b1: dup
-			IL_01b2: ldc.i4.3
-			IL_01b3: ldloc.s 4
-			IL_01b5: stelem.ref
-			IL_01b6: dup
-			IL_01b7: ldc.i4.4
-			IL_01b8: ldloc.s 5
-			IL_01ba: stelem.ref
-			IL_01bb: dup
-			IL_01bc: ldc.i4.5
-			IL_01bd: ldloc.s 6
-			IL_01bf: stelem.ref
-			IL_01c0: dup
-			IL_01c1: ldc.i4.6
-			IL_01c2: ldloc.s 7
-			IL_01c4: stelem.ref
-			IL_01c5: dup
-			IL_01c6: ldc.i4.7
-			IL_01c7: ldloc.s 8
-			IL_01c9: stelem.ref
-			IL_01ca: dup
-			IL_01cb: ldc.i4.8
-			IL_01cc: ldloc.s 9
-			IL_01ce: stelem.ref
-			IL_01cf: dup
-			IL_01d0: ldc.i4.s 9
-			IL_01d2: ldloc.s 10
+			IL_0179: volatile.
+			IL_017b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0180: brfalse IL_0197
+
+			IL_0185: ldloc.s 10
+			IL_0187: ldstr "call"
+			IL_018c: ldloc.2
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0192: br IL_01ae
+
+			IL_0197: ldloc.s 10
+			IL_0199: ldstr "call"
+			IL_019e: ldloc.2
+			IL_019f: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:16"
+			IL_01a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_01ae: stloc.s 10
+			IL_01b0: ldloc.0
+			IL_01b1: ldc.i4.1
+			IL_01b2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01b7: ldloc.0
+			IL_01b8: ldloc.s 10
+			IL_01ba: ldarg.0
+			IL_01bb: ldc.i4.1
+			IL_01bc: ldloc.0
+			IL_01bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_01c7: ldloc.0
+			IL_01c8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01cd: dup
+			IL_01ce: ldc.i4.0
+			IL_01cf: ldloc.1
+			IL_01d0: stelem.ref
+			IL_01d1: dup
+			IL_01d2: ldc.i4.1
+			IL_01d3: ldloc.2
 			IL_01d4: stelem.ref
 			IL_01d5: dup
-			IL_01d6: ldc.i4.s 10
-			IL_01d8: ldloc.s 11
-			IL_01da: stelem.ref
-			IL_01db: dup
-			IL_01dc: ldc.i4.s 11
-			IL_01de: ldloc.s 12
-			IL_01e0: stelem.ref
-			IL_01e1: pop
-			IL_01e2: ldloc.0
-			IL_01e3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01e8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01ed: ret
+			IL_01d6: ldc.i4.2
+			IL_01d7: ldloc.3
+			IL_01d8: stelem.ref
+			IL_01d9: dup
+			IL_01da: ldc.i4.3
+			IL_01db: ldloc.s 4
+			IL_01dd: stelem.ref
+			IL_01de: dup
+			IL_01df: ldc.i4.4
+			IL_01e0: ldloc.s 5
+			IL_01e2: stelem.ref
+			IL_01e3: dup
+			IL_01e4: ldc.i4.5
+			IL_01e5: ldloc.s 6
+			IL_01e7: stelem.ref
+			IL_01e8: dup
+			IL_01e9: ldc.i4.6
+			IL_01ea: ldloc.s 7
+			IL_01ec: stelem.ref
+			IL_01ed: dup
+			IL_01ee: ldc.i4.7
+			IL_01ef: ldloc.s 8
+			IL_01f1: stelem.ref
+			IL_01f2: dup
+			IL_01f3: ldc.i4.8
+			IL_01f4: ldloc.s 9
+			IL_01f6: stelem.ref
+			IL_01f7: dup
+			IL_01f8: ldc.i4.s 9
+			IL_01fa: ldloc.s 10
+			IL_01fc: stelem.ref
+			IL_01fd: dup
+			IL_01fe: ldc.i4.s 10
+			IL_0200: ldloc.s 11
+			IL_0202: stelem.ref
+			IL_0203: dup
+			IL_0204: ldc.i4.s 11
+			IL_0206: ldloc.s 12
+			IL_0208: stelem.ref
+			IL_0209: pop
+			IL_020a: ldloc.0
+			IL_020b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0210: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0215: ret
 
-			IL_01ee: ldloc.0
-			IL_01ef: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited1
-			IL_01f4: stloc.3
-			IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01fa: stloc.s 11
-			IL_01fc: volatile.
-			IL_01fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_0203: brfalse IL_0218
+			IL_0216: ldloc.0
+			IL_0217: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited1
+			IL_021c: stloc.3
+			IL_021d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0222: stloc.s 11
+			IL_0224: volatile.
+			IL_0226: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_022b: brfalse IL_0240
 
-			IL_0208: ldloc.3
-			IL_0209: ldstr "value"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0213: br IL_022d
+			IL_0230: ldloc.3
+			IL_0231: ldstr "value"
+			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023b: br IL_0255
 
-			IL_0218: ldloc.3
-			IL_0219: ldstr "value"
-			IL_021e: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:23"
-			IL_0223: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0240: ldloc.3
+			IL_0241: ldstr "value"
+			IL_0246: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:23"
+			IL_024b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_022d: stloc.s 10
-			IL_022f: ldloc.s 10
-			IL_0231: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0236: stloc.s 12
-			IL_0238: ldstr "r1: "
-			IL_023d: ldloc.s 12
-			IL_023f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0244: ldstr " done: "
-			IL_0249: call string [System.Runtime]System.String::Concat(string, string)
-			IL_024e: volatile.
-			IL_0250: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_0255: brfalse IL_026a
+			IL_0255: stloc.s 10
+			IL_0257: ldloc.s 10
+			IL_0259: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_025e: stloc.s 12
+			IL_0260: ldstr "r1: "
+			IL_0265: ldloc.s 12
+			IL_0267: call string [System.Runtime]System.String::Concat(string, string)
+			IL_026c: ldstr " done: "
+			IL_0271: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0276: volatile.
+			IL_0278: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_027d: brfalse IL_0292
 
-			IL_025a: ldloc.3
-			IL_025b: ldstr "done"
-			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0265: br IL_027f
+			IL_0282: ldloc.3
+			IL_0283: ldstr "done"
+			IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028d: br IL_02a7
 
-			IL_026a: ldloc.3
-			IL_026b: ldstr "done"
-			IL_0270: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:29"
-			IL_0275: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0292: ldloc.3
+			IL_0293: ldstr "done"
+			IL_0298: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:29"
+			IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_027f: stloc.s 10
-			IL_0281: ldloc.s 10
-			IL_0283: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0288: stloc.s 12
-			IL_028a: ldloc.s 12
-			IL_028c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0291: stloc.s 12
-			IL_0293: ldloc.s 11
-			IL_0295: ldloc.s 12
-			IL_0297: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_029c: pop
-			IL_029d: volatile.
-			IL_029f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_02a4: brfalse IL_02b9
+			IL_02a7: stloc.s 10
+			IL_02a9: ldloc.s 10
+			IL_02ab: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02b0: stloc.s 12
+			IL_02b2: ldloc.s 12
+			IL_02b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02b9: stloc.s 12
+			IL_02bb: ldloc.s 11
+			IL_02bd: ldloc.s 12
+			IL_02bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02c4: pop
+			IL_02c5: volatile.
+			IL_02c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_02cc: brfalse IL_02e1
 
-			IL_02a9: ldloc.1
-			IL_02aa: ldstr "next"
-			IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b4: br IL_02ce
+			IL_02d1: ldloc.1
+			IL_02d2: ldstr "next"
+			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02dc: br IL_02f6
 
-			IL_02b9: ldloc.1
-			IL_02ba: ldstr "next"
-			IL_02bf: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:35"
-			IL_02c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02e1: ldloc.1
+			IL_02e2: ldstr "next"
+			IL_02e7: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:35"
+			IL_02ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02ce: stloc.s 10
-			IL_02d0: ldloc.s 10
-			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02d7: stloc.s 10
-			IL_02d9: ldloc.s 10
-			IL_02db: ldstr "call"
-			IL_02e0: ldloc.2
-			IL_02e1: ldc.r8 10
-			IL_02ea: box [System.Runtime]System.Double
-			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_02f4: stloc.s 10
-			IL_02f6: ldloc.0
-			IL_02f7: ldc.i4.2
-			IL_02f8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02fd: ldloc.0
-			IL_02fe: ldloc.s 10
-			IL_0300: ldarg.0
-			IL_0301: ldc.i4.2
-			IL_0302: ldloc.0
-			IL_0303: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0308: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_030d: ldloc.0
-			IL_030e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0313: dup
-			IL_0314: ldc.i4.0
-			IL_0315: ldloc.1
-			IL_0316: stelem.ref
-			IL_0317: dup
-			IL_0318: ldc.i4.1
-			IL_0319: ldloc.2
-			IL_031a: stelem.ref
-			IL_031b: dup
-			IL_031c: ldc.i4.2
-			IL_031d: ldloc.3
-			IL_031e: stelem.ref
-			IL_031f: dup
-			IL_0320: ldc.i4.3
-			IL_0321: ldloc.s 4
-			IL_0323: stelem.ref
-			IL_0324: dup
-			IL_0325: ldc.i4.4
-			IL_0326: ldloc.s 5
-			IL_0328: stelem.ref
-			IL_0329: dup
-			IL_032a: ldc.i4.5
-			IL_032b: ldloc.s 6
-			IL_032d: stelem.ref
-			IL_032e: dup
-			IL_032f: ldc.i4.6
-			IL_0330: ldloc.s 7
-			IL_0332: stelem.ref
-			IL_0333: dup
-			IL_0334: ldc.i4.7
-			IL_0335: ldloc.s 8
-			IL_0337: stelem.ref
-			IL_0338: dup
-			IL_0339: ldc.i4.8
-			IL_033a: ldloc.s 9
-			IL_033c: stelem.ref
-			IL_033d: dup
-			IL_033e: ldc.i4.s 9
-			IL_0340: ldloc.s 10
+			IL_02f6: stloc.s 10
+			IL_02f8: ldloc.s 10
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ff: stloc.s 10
+			IL_0301: ldloc.s 10
+			IL_0303: ldstr "call"
+			IL_0308: ldloc.2
+			IL_0309: ldc.r8 10
+			IL_0312: box [System.Runtime]System.Double
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_031c: stloc.s 10
+			IL_031e: ldloc.0
+			IL_031f: ldc.i4.2
+			IL_0320: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0325: ldloc.0
+			IL_0326: ldloc.s 10
+			IL_0328: ldarg.0
+			IL_0329: ldc.i4.2
+			IL_032a: ldloc.0
+			IL_032b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0330: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0335: ldloc.0
+			IL_0336: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_033b: dup
+			IL_033c: ldc.i4.0
+			IL_033d: ldloc.1
+			IL_033e: stelem.ref
+			IL_033f: dup
+			IL_0340: ldc.i4.1
+			IL_0341: ldloc.2
 			IL_0342: stelem.ref
 			IL_0343: dup
-			IL_0344: ldc.i4.s 10
-			IL_0346: ldloc.s 11
-			IL_0348: stelem.ref
-			IL_0349: dup
-			IL_034a: ldc.i4.s 11
-			IL_034c: ldloc.s 12
-			IL_034e: stelem.ref
-			IL_034f: pop
-			IL_0350: ldloc.0
-			IL_0351: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0356: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_035b: ret
+			IL_0344: ldc.i4.2
+			IL_0345: ldloc.3
+			IL_0346: stelem.ref
+			IL_0347: dup
+			IL_0348: ldc.i4.3
+			IL_0349: ldloc.s 4
+			IL_034b: stelem.ref
+			IL_034c: dup
+			IL_034d: ldc.i4.4
+			IL_034e: ldloc.s 5
+			IL_0350: stelem.ref
+			IL_0351: dup
+			IL_0352: ldc.i4.5
+			IL_0353: ldloc.s 6
+			IL_0355: stelem.ref
+			IL_0356: dup
+			IL_0357: ldc.i4.6
+			IL_0358: ldloc.s 7
+			IL_035a: stelem.ref
+			IL_035b: dup
+			IL_035c: ldc.i4.7
+			IL_035d: ldloc.s 8
+			IL_035f: stelem.ref
+			IL_0360: dup
+			IL_0361: ldc.i4.8
+			IL_0362: ldloc.s 9
+			IL_0364: stelem.ref
+			IL_0365: dup
+			IL_0366: ldc.i4.s 9
+			IL_0368: ldloc.s 10
+			IL_036a: stelem.ref
+			IL_036b: dup
+			IL_036c: ldc.i4.s 10
+			IL_036e: ldloc.s 11
+			IL_0370: stelem.ref
+			IL_0371: dup
+			IL_0372: ldc.i4.s 11
+			IL_0374: ldloc.s 12
+			IL_0376: stelem.ref
+			IL_0377: pop
+			IL_0378: ldloc.0
+			IL_0379: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_037e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0383: ret
 
-			IL_035c: ldloc.0
-			IL_035d: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited2
-			IL_0362: stloc.s 4
-			IL_0364: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0369: stloc.s 11
-			IL_036b: volatile.
-			IL_036d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0372: brfalse IL_0388
+			IL_0384: ldloc.0
+			IL_0385: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited2
+			IL_038a: stloc.s 4
+			IL_038c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0391: stloc.s 11
+			IL_0393: volatile.
+			IL_0395: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_039a: brfalse IL_03b0
 
-			IL_0377: ldloc.s 4
-			IL_0379: ldstr "value"
-			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0383: br IL_039e
+			IL_039f: ldloc.s 4
+			IL_03a1: ldstr "value"
+			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ab: br IL_03c6
 
-			IL_0388: ldloc.s 4
-			IL_038a: ldstr "value"
-			IL_038f: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:46"
-			IL_0394: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03b0: ldloc.s 4
+			IL_03b2: ldstr "value"
+			IL_03b7: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:46"
+			IL_03bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_039e: stloc.s 10
-			IL_03a0: ldloc.s 10
-			IL_03a2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03a7: stloc.s 12
-			IL_03a9: ldstr "r2: "
-			IL_03ae: ldloc.s 12
-			IL_03b0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03b5: ldstr " done: "
-			IL_03ba: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03bf: volatile.
-			IL_03c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_03c6: brfalse IL_03dc
+			IL_03c6: stloc.s 10
+			IL_03c8: ldloc.s 10
+			IL_03ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03cf: stloc.s 12
+			IL_03d1: ldstr "r2: "
+			IL_03d6: ldloc.s 12
+			IL_03d8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03dd: ldstr " done: "
+			IL_03e2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03e7: volatile.
+			IL_03e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_03ee: brfalse IL_0404
 
-			IL_03cb: ldloc.s 4
-			IL_03cd: ldstr "done"
-			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d7: br IL_03f2
+			IL_03f3: ldloc.s 4
+			IL_03f5: ldstr "done"
+			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ff: br IL_041a
 
-			IL_03dc: ldloc.s 4
-			IL_03de: ldstr "done"
-			IL_03e3: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:52"
-			IL_03e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0404: ldloc.s 4
+			IL_0406: ldstr "done"
+			IL_040b: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:52"
+			IL_0410: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03f2: stloc.s 10
-			IL_03f4: ldloc.s 10
-			IL_03f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03fb: stloc.s 12
-			IL_03fd: ldloc.s 12
-			IL_03ff: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0404: stloc.s 12
-			IL_0406: ldloc.s 11
-			IL_0408: ldloc.s 12
-			IL_040a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_040f: pop
-			IL_0410: ldarg.0
-			IL_0411: ldc.i4.1
-			IL_0412: ldelem.ref
-			IL_0413: castclass Modules.AsyncGenerator_ExplicitReceiverAbi/Scope
-			IL_0418: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/Scope::g
-			IL_041d: ldc.i4.1
-			IL_041e: newarr [System.Runtime]System.Object
-			IL_0423: dup
-			IL_0424: ldc.i4.0
-			IL_0425: ldarg.0
-			IL_0426: ldc.i4.1
-			IL_0427: ldelem.ref
-			IL_0428: stelem.ref
-			IL_0429: stloc.s 9
-			IL_042b: ldloc.s 9
-			IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0432: stloc.s 5
-			IL_0434: volatile.
-			IL_0436: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_043b: brfalse IL_0450
+			IL_041a: stloc.s 10
+			IL_041c: ldloc.s 10
+			IL_041e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0423: stloc.s 12
+			IL_0425: ldloc.s 12
+			IL_0427: call string [System.Runtime]System.String::Concat(string, string)
+			IL_042c: stloc.s 12
+			IL_042e: ldloc.s 11
+			IL_0430: ldloc.s 12
+			IL_0432: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0437: pop
+			IL_0438: ldarg.0
+			IL_0439: ldc.i4.1
+			IL_043a: ldelem.ref
+			IL_043b: castclass Modules.AsyncGenerator_ExplicitReceiverAbi/Scope
+			IL_0440: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/Scope::g
+			IL_0445: ldc.i4.1
+			IL_0446: newarr [System.Runtime]System.Object
+			IL_044b: dup
+			IL_044c: ldc.i4.0
+			IL_044d: ldarg.0
+			IL_044e: ldc.i4.1
+			IL_044f: ldelem.ref
+			IL_0450: stelem.ref
+			IL_0451: stloc.s 9
+			IL_0453: ldloc.s 9
+			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_045a: stloc.s 5
+			IL_045c: volatile.
+			IL_045e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0463: brfalse IL_0478
 
-			IL_0440: ldloc.1
-			IL_0441: ldstr "next"
-			IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_044b: br IL_0465
+			IL_0468: ldloc.1
+			IL_0469: ldstr "next"
+			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0473: br IL_048d
 
-			IL_0450: ldloc.1
-			IL_0451: ldstr "next"
-			IL_0456: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:63"
-			IL_045b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0478: ldloc.1
+			IL_0479: ldstr "next"
+			IL_047e: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:63"
+			IL_0483: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0465: stloc.s 10
-			IL_0467: ldloc.s 10
-			IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_046e: stloc.s 10
-			IL_0470: ldloc.s 10
-			IL_0472: ldstr "call"
-			IL_0477: ldloc.s 5
-			IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_047e: stloc.s 10
-			IL_0480: ldloc.0
-			IL_0481: ldc.i4.3
-			IL_0482: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0487: ldloc.0
-			IL_0488: ldloc.s 10
-			IL_048a: ldarg.0
-			IL_048b: ldc.i4.3
-			IL_048c: ldloc.0
-			IL_048d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0492: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0497: ldloc.0
-			IL_0498: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_049d: dup
-			IL_049e: ldc.i4.0
-			IL_049f: ldloc.1
-			IL_04a0: stelem.ref
-			IL_04a1: dup
-			IL_04a2: ldc.i4.1
-			IL_04a3: ldloc.2
-			IL_04a4: stelem.ref
-			IL_04a5: dup
-			IL_04a6: ldc.i4.2
-			IL_04a7: ldloc.3
-			IL_04a8: stelem.ref
-			IL_04a9: dup
-			IL_04aa: ldc.i4.3
-			IL_04ab: ldloc.s 4
-			IL_04ad: stelem.ref
-			IL_04ae: dup
-			IL_04af: ldc.i4.4
-			IL_04b0: ldloc.s 5
-			IL_04b2: stelem.ref
-			IL_04b3: dup
-			IL_04b4: ldc.i4.5
-			IL_04b5: ldloc.s 6
-			IL_04b7: stelem.ref
-			IL_04b8: dup
-			IL_04b9: ldc.i4.6
-			IL_04ba: ldloc.s 7
-			IL_04bc: stelem.ref
-			IL_04bd: dup
-			IL_04be: ldc.i4.7
-			IL_04bf: ldloc.s 8
-			IL_04c1: stelem.ref
-			IL_04c2: dup
-			IL_04c3: ldc.i4.8
-			IL_04c4: ldloc.s 9
-			IL_04c6: stelem.ref
-			IL_04c7: dup
-			IL_04c8: ldc.i4.s 9
-			IL_04ca: ldloc.s 10
-			IL_04cc: stelem.ref
-			IL_04cd: dup
-			IL_04ce: ldc.i4.s 10
-			IL_04d0: ldloc.s 11
-			IL_04d2: stelem.ref
-			IL_04d3: dup
-			IL_04d4: ldc.i4.s 11
-			IL_04d6: ldloc.s 12
-			IL_04d8: stelem.ref
-			IL_04d9: pop
-			IL_04da: ldloc.0
-			IL_04db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04e0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04e5: ret
+			IL_048d: stloc.s 10
+			IL_048f: ldloc.s 10
+			IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0496: stloc.s 10
+			IL_0498: volatile.
+			IL_049a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_049f: brfalse IL_04b7
 
-			IL_04e6: ldloc.0
-			IL_04e7: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited3
-			IL_04ec: pop
-			IL_04ed: volatile.
-			IL_04ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_04f4: brfalse IL_0509
+			IL_04a4: ldloc.s 10
+			IL_04a6: ldstr "call"
+			IL_04ab: ldloc.s 5
+			IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04b2: br IL_04cf
 
-			IL_04f9: ldloc.1
-			IL_04fa: ldstr "throw"
-			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0504: br IL_051e
+			IL_04b7: ldloc.s 10
+			IL_04b9: ldstr "call"
+			IL_04be: ldloc.s 5
+			IL_04c0: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:65"
+			IL_04c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0509: ldloc.1
-			IL_050a: ldstr "throw"
-			IL_050f: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:69"
-			IL_0514: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04cf: stloc.s 10
+			IL_04d1: ldloc.0
+			IL_04d2: ldc.i4.3
+			IL_04d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04d8: ldloc.0
+			IL_04d9: ldloc.s 10
+			IL_04db: ldarg.0
+			IL_04dc: ldc.i4.3
+			IL_04dd: ldloc.0
+			IL_04de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_04e8: ldloc.0
+			IL_04e9: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04ee: dup
+			IL_04ef: ldc.i4.0
+			IL_04f0: ldloc.1
+			IL_04f1: stelem.ref
+			IL_04f2: dup
+			IL_04f3: ldc.i4.1
+			IL_04f4: ldloc.2
+			IL_04f5: stelem.ref
+			IL_04f6: dup
+			IL_04f7: ldc.i4.2
+			IL_04f8: ldloc.3
+			IL_04f9: stelem.ref
+			IL_04fa: dup
+			IL_04fb: ldc.i4.3
+			IL_04fc: ldloc.s 4
+			IL_04fe: stelem.ref
+			IL_04ff: dup
+			IL_0500: ldc.i4.4
+			IL_0501: ldloc.s 5
+			IL_0503: stelem.ref
+			IL_0504: dup
+			IL_0505: ldc.i4.5
+			IL_0506: ldloc.s 6
+			IL_0508: stelem.ref
+			IL_0509: dup
+			IL_050a: ldc.i4.6
+			IL_050b: ldloc.s 7
+			IL_050d: stelem.ref
+			IL_050e: dup
+			IL_050f: ldc.i4.7
+			IL_0510: ldloc.s 8
+			IL_0512: stelem.ref
+			IL_0513: dup
+			IL_0514: ldc.i4.8
+			IL_0515: ldloc.s 9
+			IL_0517: stelem.ref
+			IL_0518: dup
+			IL_0519: ldc.i4.s 9
+			IL_051b: ldloc.s 10
+			IL_051d: stelem.ref
+			IL_051e: dup
+			IL_051f: ldc.i4.s 10
+			IL_0521: ldloc.s 11
+			IL_0523: stelem.ref
+			IL_0524: dup
+			IL_0525: ldc.i4.s 11
+			IL_0527: ldloc.s 12
+			IL_0529: stelem.ref
+			IL_052a: pop
+			IL_052b: ldloc.0
+			IL_052c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0531: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0536: ret
 
-			IL_051e: stloc.s 10
-			IL_0520: ldloc.s 10
-			IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0527: stloc.s 10
-			IL_0529: ldloc.s 10
-			IL_052b: ldstr "call"
-			IL_0530: ldloc.s 5
-			IL_0532: ldstr "boom"
-			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_053c: stloc.s 10
-			IL_053e: ldloc.0
-			IL_053f: ldc.i4.4
-			IL_0540: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0545: ldloc.0
-			IL_0546: ldloc.s 10
-			IL_0548: ldarg.0
-			IL_0549: ldc.i4.4
-			IL_054a: ldloc.0
-			IL_054b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0550: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0555: ldloc.0
-			IL_0556: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_055b: dup
-			IL_055c: ldc.i4.0
-			IL_055d: ldloc.1
-			IL_055e: stelem.ref
-			IL_055f: dup
-			IL_0560: ldc.i4.1
-			IL_0561: ldloc.2
-			IL_0562: stelem.ref
-			IL_0563: dup
-			IL_0564: ldc.i4.2
-			IL_0565: ldloc.3
-			IL_0566: stelem.ref
-			IL_0567: dup
-			IL_0568: ldc.i4.3
-			IL_0569: ldloc.s 4
-			IL_056b: stelem.ref
-			IL_056c: dup
-			IL_056d: ldc.i4.4
-			IL_056e: ldloc.s 5
-			IL_0570: stelem.ref
-			IL_0571: dup
-			IL_0572: ldc.i4.5
-			IL_0573: ldloc.s 6
-			IL_0575: stelem.ref
-			IL_0576: dup
-			IL_0577: ldc.i4.6
-			IL_0578: ldloc.s 7
-			IL_057a: stelem.ref
-			IL_057b: dup
-			IL_057c: ldc.i4.7
-			IL_057d: ldloc.s 8
-			IL_057f: stelem.ref
-			IL_0580: dup
-			IL_0581: ldc.i4.8
-			IL_0582: ldloc.s 9
-			IL_0584: stelem.ref
-			IL_0585: dup
-			IL_0586: ldc.i4.s 9
-			IL_0588: ldloc.s 10
-			IL_058a: stelem.ref
-			IL_058b: dup
-			IL_058c: ldc.i4.s 10
-			IL_058e: ldloc.s 11
-			IL_0590: stelem.ref
-			IL_0591: dup
-			IL_0592: ldc.i4.s 11
-			IL_0594: ldloc.s 12
-			IL_0596: stelem.ref
-			IL_0597: pop
-			IL_0598: ldloc.0
-			IL_0599: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_059e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05a3: ret
+			IL_0537: ldloc.0
+			IL_0538: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited3
+			IL_053d: pop
+			IL_053e: volatile.
+			IL_0540: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0545: brfalse IL_055a
 
-			IL_05a4: ldloc.0
-			IL_05a5: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited4
-			IL_05aa: stloc.s 6
-			IL_05ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05b1: stloc.s 11
-			IL_05b3: volatile.
-			IL_05b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_05ba: brfalse IL_05d0
+			IL_054a: ldloc.1
+			IL_054b: ldstr "throw"
+			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0555: br IL_056f
 
-			IL_05bf: ldloc.s 6
-			IL_05c1: ldstr "value"
-			IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05cb: br IL_05e6
+			IL_055a: ldloc.1
+			IL_055b: ldstr "throw"
+			IL_0560: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:69"
+			IL_0565: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_05d0: ldloc.s 6
-			IL_05d2: ldstr "value"
-			IL_05d7: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:79"
-			IL_05dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_056f: stloc.s 10
+			IL_0571: ldloc.s 10
+			IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0578: stloc.s 10
+			IL_057a: ldloc.s 10
+			IL_057c: ldstr "call"
+			IL_0581: ldloc.s 5
+			IL_0583: ldstr "boom"
+			IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_058d: stloc.s 10
+			IL_058f: ldloc.0
+			IL_0590: ldc.i4.4
+			IL_0591: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0596: ldloc.0
+			IL_0597: ldloc.s 10
+			IL_0599: ldarg.0
+			IL_059a: ldc.i4.4
+			IL_059b: ldloc.0
+			IL_059c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_05a6: ldloc.0
+			IL_05a7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05ac: dup
+			IL_05ad: ldc.i4.0
+			IL_05ae: ldloc.1
+			IL_05af: stelem.ref
+			IL_05b0: dup
+			IL_05b1: ldc.i4.1
+			IL_05b2: ldloc.2
+			IL_05b3: stelem.ref
+			IL_05b4: dup
+			IL_05b5: ldc.i4.2
+			IL_05b6: ldloc.3
+			IL_05b7: stelem.ref
+			IL_05b8: dup
+			IL_05b9: ldc.i4.3
+			IL_05ba: ldloc.s 4
+			IL_05bc: stelem.ref
+			IL_05bd: dup
+			IL_05be: ldc.i4.4
+			IL_05bf: ldloc.s 5
+			IL_05c1: stelem.ref
+			IL_05c2: dup
+			IL_05c3: ldc.i4.5
+			IL_05c4: ldloc.s 6
+			IL_05c6: stelem.ref
+			IL_05c7: dup
+			IL_05c8: ldc.i4.6
+			IL_05c9: ldloc.s 7
+			IL_05cb: stelem.ref
+			IL_05cc: dup
+			IL_05cd: ldc.i4.7
+			IL_05ce: ldloc.s 8
+			IL_05d0: stelem.ref
+			IL_05d1: dup
+			IL_05d2: ldc.i4.8
+			IL_05d3: ldloc.s 9
+			IL_05d5: stelem.ref
+			IL_05d6: dup
+			IL_05d7: ldc.i4.s 9
+			IL_05d9: ldloc.s 10
+			IL_05db: stelem.ref
+			IL_05dc: dup
+			IL_05dd: ldc.i4.s 10
+			IL_05df: ldloc.s 11
+			IL_05e1: stelem.ref
+			IL_05e2: dup
+			IL_05e3: ldc.i4.s 11
+			IL_05e5: ldloc.s 12
+			IL_05e7: stelem.ref
+			IL_05e8: pop
+			IL_05e9: ldloc.0
+			IL_05ea: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05ef: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05f4: ret
 
-			IL_05e6: stloc.s 10
-			IL_05e8: ldloc.s 10
-			IL_05ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05ef: stloc.s 12
-			IL_05f1: ldstr "r3: "
-			IL_05f6: ldloc.s 12
-			IL_05f8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05fd: ldstr " done: "
-			IL_0602: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0607: volatile.
-			IL_0609: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_060e: brfalse IL_0624
+			IL_05f5: ldloc.0
+			IL_05f6: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited4
+			IL_05fb: stloc.s 6
+			IL_05fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0602: stloc.s 11
+			IL_0604: volatile.
+			IL_0606: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_060b: brfalse IL_0621
 
-			IL_0613: ldloc.s 6
-			IL_0615: ldstr "done"
-			IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_061f: br IL_063a
+			IL_0610: ldloc.s 6
+			IL_0612: ldstr "value"
+			IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_061c: br IL_0637
 
-			IL_0624: ldloc.s 6
-			IL_0626: ldstr "done"
-			IL_062b: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:85"
-			IL_0630: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0621: ldloc.s 6
+			IL_0623: ldstr "value"
+			IL_0628: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:79"
+			IL_062d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_063a: stloc.s 10
-			IL_063c: ldloc.s 10
-			IL_063e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0643: stloc.s 12
-			IL_0645: ldloc.s 12
-			IL_0647: call string [System.Runtime]System.String::Concat(string, string)
-			IL_064c: stloc.s 12
-			IL_064e: ldloc.s 11
-			IL_0650: ldloc.s 12
-			IL_0652: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0657: pop
-			IL_0658: ldarg.0
-			IL_0659: ldc.i4.1
-			IL_065a: ldelem.ref
-			IL_065b: castclass Modules.AsyncGenerator_ExplicitReceiverAbi/Scope
-			IL_0660: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/Scope::g
-			IL_0665: ldc.i4.1
-			IL_0666: newarr [System.Runtime]System.Object
-			IL_066b: dup
-			IL_066c: ldc.i4.0
-			IL_066d: ldarg.0
-			IL_066e: ldc.i4.1
-			IL_066f: ldelem.ref
-			IL_0670: stelem.ref
-			IL_0671: stloc.s 9
-			IL_0673: ldloc.s 9
-			IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_067a: stloc.s 7
-			IL_067c: volatile.
-			IL_067e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_0683: brfalse IL_0698
+			IL_0637: stloc.s 10
+			IL_0639: ldloc.s 10
+			IL_063b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0640: stloc.s 12
+			IL_0642: ldstr "r3: "
+			IL_0647: ldloc.s 12
+			IL_0649: call string [System.Runtime]System.String::Concat(string, string)
+			IL_064e: ldstr " done: "
+			IL_0653: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0658: volatile.
+			IL_065a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_065f: brfalse IL_0675
 
-			IL_0688: ldloc.1
-			IL_0689: ldstr "next"
-			IL_068e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0693: br IL_06ad
+			IL_0664: ldloc.s 6
+			IL_0666: ldstr "done"
+			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0670: br IL_068b
 
-			IL_0698: ldloc.1
-			IL_0699: ldstr "next"
-			IL_069e: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:96"
-			IL_06a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0675: ldloc.s 6
+			IL_0677: ldstr "done"
+			IL_067c: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:85"
+			IL_0681: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06ad: stloc.s 10
-			IL_06af: ldloc.s 10
-			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06b6: stloc.s 10
-			IL_06b8: ldloc.s 10
-			IL_06ba: ldstr "call"
-			IL_06bf: ldloc.s 7
-			IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06c6: stloc.s 10
-			IL_06c8: ldloc.0
-			IL_06c9: ldc.i4.5
-			IL_06ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06cf: ldloc.0
-			IL_06d0: ldloc.s 10
-			IL_06d2: ldarg.0
-			IL_06d3: ldc.i4.5
-			IL_06d4: ldloc.0
-			IL_06d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_06da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_06df: ldloc.0
-			IL_06e0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_06e5: dup
-			IL_06e6: ldc.i4.0
-			IL_06e7: ldloc.1
-			IL_06e8: stelem.ref
-			IL_06e9: dup
-			IL_06ea: ldc.i4.1
-			IL_06eb: ldloc.2
-			IL_06ec: stelem.ref
-			IL_06ed: dup
-			IL_06ee: ldc.i4.2
-			IL_06ef: ldloc.3
-			IL_06f0: stelem.ref
-			IL_06f1: dup
-			IL_06f2: ldc.i4.3
-			IL_06f3: ldloc.s 4
-			IL_06f5: stelem.ref
-			IL_06f6: dup
-			IL_06f7: ldc.i4.4
-			IL_06f8: ldloc.s 5
-			IL_06fa: stelem.ref
-			IL_06fb: dup
-			IL_06fc: ldc.i4.5
-			IL_06fd: ldloc.s 6
-			IL_06ff: stelem.ref
-			IL_0700: dup
-			IL_0701: ldc.i4.6
-			IL_0702: ldloc.s 7
-			IL_0704: stelem.ref
-			IL_0705: dup
-			IL_0706: ldc.i4.7
-			IL_0707: ldloc.s 8
-			IL_0709: stelem.ref
-			IL_070a: dup
-			IL_070b: ldc.i4.8
-			IL_070c: ldloc.s 9
-			IL_070e: stelem.ref
-			IL_070f: dup
-			IL_0710: ldc.i4.s 9
-			IL_0712: ldloc.s 10
-			IL_0714: stelem.ref
-			IL_0715: dup
-			IL_0716: ldc.i4.s 10
-			IL_0718: ldloc.s 11
-			IL_071a: stelem.ref
-			IL_071b: dup
-			IL_071c: ldc.i4.s 11
-			IL_071e: ldloc.s 12
-			IL_0720: stelem.ref
-			IL_0721: pop
-			IL_0722: ldloc.0
-			IL_0723: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0728: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_072d: ret
+			IL_068b: stloc.s 10
+			IL_068d: ldloc.s 10
+			IL_068f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0694: stloc.s 12
+			IL_0696: ldloc.s 12
+			IL_0698: call string [System.Runtime]System.String::Concat(string, string)
+			IL_069d: stloc.s 12
+			IL_069f: ldloc.s 11
+			IL_06a1: ldloc.s 12
+			IL_06a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06a8: pop
+			IL_06a9: ldarg.0
+			IL_06aa: ldc.i4.1
+			IL_06ab: ldelem.ref
+			IL_06ac: castclass Modules.AsyncGenerator_ExplicitReceiverAbi/Scope
+			IL_06b1: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/Scope::g
+			IL_06b6: ldc.i4.1
+			IL_06b7: newarr [System.Runtime]System.Object
+			IL_06bc: dup
+			IL_06bd: ldc.i4.0
+			IL_06be: ldarg.0
+			IL_06bf: ldc.i4.1
+			IL_06c0: ldelem.ref
+			IL_06c1: stelem.ref
+			IL_06c2: stloc.s 9
+			IL_06c4: ldloc.s 9
+			IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_06cb: stloc.s 7
+			IL_06cd: volatile.
+			IL_06cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_06d4: brfalse IL_06e9
 
-			IL_072e: ldloc.0
-			IL_072f: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited5
-			IL_0734: pop
-			IL_0735: volatile.
-			IL_0737: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_073c: brfalse IL_0751
+			IL_06d9: ldloc.1
+			IL_06da: ldstr "next"
+			IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06e4: br IL_06fe
 
-			IL_0741: ldloc.1
-			IL_0742: ldstr "return"
-			IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_074c: br IL_0766
+			IL_06e9: ldloc.1
+			IL_06ea: ldstr "next"
+			IL_06ef: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:96"
+			IL_06f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0751: ldloc.1
-			IL_0752: ldstr "return"
-			IL_0757: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:102"
-			IL_075c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06fe: stloc.s 10
+			IL_0700: ldloc.s 10
+			IL_0702: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0707: stloc.s 10
+			IL_0709: volatile.
+			IL_070b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0710: brfalse IL_0728
 
-			IL_0766: stloc.s 10
-			IL_0768: ldloc.s 10
-			IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_076f: stloc.s 10
-			IL_0771: ldloc.s 10
-			IL_0773: ldstr "call"
-			IL_0778: ldloc.s 7
-			IL_077a: ldc.r8 99
-			IL_0783: box [System.Runtime]System.Double
-			IL_0788: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_078d: stloc.s 10
-			IL_078f: ldloc.0
-			IL_0790: ldc.i4.6
-			IL_0791: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0796: ldloc.0
-			IL_0797: ldloc.s 10
-			IL_0799: ldarg.0
-			IL_079a: ldc.i4.6
-			IL_079b: ldloc.0
-			IL_079c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_07a6: ldloc.0
-			IL_07a7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_07ac: dup
-			IL_07ad: ldc.i4.0
-			IL_07ae: ldloc.1
-			IL_07af: stelem.ref
-			IL_07b0: dup
-			IL_07b1: ldc.i4.1
-			IL_07b2: ldloc.2
-			IL_07b3: stelem.ref
-			IL_07b4: dup
-			IL_07b5: ldc.i4.2
-			IL_07b6: ldloc.3
-			IL_07b7: stelem.ref
-			IL_07b8: dup
-			IL_07b9: ldc.i4.3
-			IL_07ba: ldloc.s 4
-			IL_07bc: stelem.ref
-			IL_07bd: dup
-			IL_07be: ldc.i4.4
-			IL_07bf: ldloc.s 5
-			IL_07c1: stelem.ref
-			IL_07c2: dup
-			IL_07c3: ldc.i4.5
-			IL_07c4: ldloc.s 6
-			IL_07c6: stelem.ref
-			IL_07c7: dup
-			IL_07c8: ldc.i4.6
-			IL_07c9: ldloc.s 7
-			IL_07cb: stelem.ref
-			IL_07cc: dup
-			IL_07cd: ldc.i4.7
-			IL_07ce: ldloc.s 8
-			IL_07d0: stelem.ref
-			IL_07d1: dup
-			IL_07d2: ldc.i4.8
-			IL_07d3: ldloc.s 9
-			IL_07d5: stelem.ref
-			IL_07d6: dup
-			IL_07d7: ldc.i4.s 9
-			IL_07d9: ldloc.s 10
-			IL_07db: stelem.ref
-			IL_07dc: dup
-			IL_07dd: ldc.i4.s 10
-			IL_07df: ldloc.s 11
-			IL_07e1: stelem.ref
-			IL_07e2: dup
-			IL_07e3: ldc.i4.s 11
-			IL_07e5: ldloc.s 12
-			IL_07e7: stelem.ref
-			IL_07e8: pop
-			IL_07e9: ldloc.0
-			IL_07ea: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07ef: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07f4: ret
+			IL_0715: ldloc.s 10
+			IL_0717: ldstr "call"
+			IL_071c: ldloc.s 7
+			IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0723: br IL_0740
 
-			IL_07f5: ldloc.0
-			IL_07f6: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited6
-			IL_07fb: stloc.s 8
-			IL_07fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0802: stloc.s 11
-			IL_0804: volatile.
-			IL_0806: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_080b: brfalse IL_0821
+			IL_0728: ldloc.s 10
+			IL_072a: ldstr "call"
+			IL_072f: ldloc.s 7
+			IL_0731: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:98"
+			IL_0736: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0810: ldloc.s 8
-			IL_0812: ldstr "value"
-			IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_081c: br IL_0837
+			IL_0740: stloc.s 10
+			IL_0742: ldloc.0
+			IL_0743: ldc.i4.5
+			IL_0744: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0749: ldloc.0
+			IL_074a: ldloc.s 10
+			IL_074c: ldarg.0
+			IL_074d: ldc.i4.5
+			IL_074e: ldloc.0
+			IL_074f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0754: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0759: ldloc.0
+			IL_075a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_075f: dup
+			IL_0760: ldc.i4.0
+			IL_0761: ldloc.1
+			IL_0762: stelem.ref
+			IL_0763: dup
+			IL_0764: ldc.i4.1
+			IL_0765: ldloc.2
+			IL_0766: stelem.ref
+			IL_0767: dup
+			IL_0768: ldc.i4.2
+			IL_0769: ldloc.3
+			IL_076a: stelem.ref
+			IL_076b: dup
+			IL_076c: ldc.i4.3
+			IL_076d: ldloc.s 4
+			IL_076f: stelem.ref
+			IL_0770: dup
+			IL_0771: ldc.i4.4
+			IL_0772: ldloc.s 5
+			IL_0774: stelem.ref
+			IL_0775: dup
+			IL_0776: ldc.i4.5
+			IL_0777: ldloc.s 6
+			IL_0779: stelem.ref
+			IL_077a: dup
+			IL_077b: ldc.i4.6
+			IL_077c: ldloc.s 7
+			IL_077e: stelem.ref
+			IL_077f: dup
+			IL_0780: ldc.i4.7
+			IL_0781: ldloc.s 8
+			IL_0783: stelem.ref
+			IL_0784: dup
+			IL_0785: ldc.i4.8
+			IL_0786: ldloc.s 9
+			IL_0788: stelem.ref
+			IL_0789: dup
+			IL_078a: ldc.i4.s 9
+			IL_078c: ldloc.s 10
+			IL_078e: stelem.ref
+			IL_078f: dup
+			IL_0790: ldc.i4.s 10
+			IL_0792: ldloc.s 11
+			IL_0794: stelem.ref
+			IL_0795: dup
+			IL_0796: ldc.i4.s 11
+			IL_0798: ldloc.s 12
+			IL_079a: stelem.ref
+			IL_079b: pop
+			IL_079c: ldloc.0
+			IL_079d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07a2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07a7: ret
 
-			IL_0821: ldloc.s 8
-			IL_0823: ldstr "value"
-			IL_0828: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:113"
-			IL_082d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07a8: ldloc.0
+			IL_07a9: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited5
+			IL_07ae: pop
+			IL_07af: volatile.
+			IL_07b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_07b6: brfalse IL_07cb
 
-			IL_0837: stloc.s 10
-			IL_0839: ldloc.s 10
-			IL_083b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0840: stloc.s 12
-			IL_0842: ldstr "r4: "
-			IL_0847: ldloc.s 12
-			IL_0849: call string [System.Runtime]System.String::Concat(string, string)
-			IL_084e: ldstr " done: "
-			IL_0853: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0858: volatile.
-			IL_085a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_085f: brfalse IL_0875
+			IL_07bb: ldloc.1
+			IL_07bc: ldstr "return"
+			IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07c6: br IL_07e0
 
-			IL_0864: ldloc.s 8
-			IL_0866: ldstr "done"
-			IL_086b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0870: br IL_088b
+			IL_07cb: ldloc.1
+			IL_07cc: ldstr "return"
+			IL_07d1: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:102"
+			IL_07d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_07db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0875: ldloc.s 8
-			IL_0877: ldstr "done"
-			IL_087c: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:119"
-			IL_0881: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0886: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07e0: stloc.s 10
+			IL_07e2: ldloc.s 10
+			IL_07e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07e9: stloc.s 10
+			IL_07eb: ldloc.s 10
+			IL_07ed: ldstr "call"
+			IL_07f2: ldloc.s 7
+			IL_07f4: ldc.r8 99
+			IL_07fd: box [System.Runtime]System.Double
+			IL_0802: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0807: stloc.s 10
+			IL_0809: ldloc.0
+			IL_080a: ldc.i4.6
+			IL_080b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0810: ldloc.0
+			IL_0811: ldloc.s 10
+			IL_0813: ldarg.0
+			IL_0814: ldc.i4.6
+			IL_0815: ldloc.0
+			IL_0816: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_081b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0820: ldloc.0
+			IL_0821: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0826: dup
+			IL_0827: ldc.i4.0
+			IL_0828: ldloc.1
+			IL_0829: stelem.ref
+			IL_082a: dup
+			IL_082b: ldc.i4.1
+			IL_082c: ldloc.2
+			IL_082d: stelem.ref
+			IL_082e: dup
+			IL_082f: ldc.i4.2
+			IL_0830: ldloc.3
+			IL_0831: stelem.ref
+			IL_0832: dup
+			IL_0833: ldc.i4.3
+			IL_0834: ldloc.s 4
+			IL_0836: stelem.ref
+			IL_0837: dup
+			IL_0838: ldc.i4.4
+			IL_0839: ldloc.s 5
+			IL_083b: stelem.ref
+			IL_083c: dup
+			IL_083d: ldc.i4.5
+			IL_083e: ldloc.s 6
+			IL_0840: stelem.ref
+			IL_0841: dup
+			IL_0842: ldc.i4.6
+			IL_0843: ldloc.s 7
+			IL_0845: stelem.ref
+			IL_0846: dup
+			IL_0847: ldc.i4.7
+			IL_0848: ldloc.s 8
+			IL_084a: stelem.ref
+			IL_084b: dup
+			IL_084c: ldc.i4.8
+			IL_084d: ldloc.s 9
+			IL_084f: stelem.ref
+			IL_0850: dup
+			IL_0851: ldc.i4.s 9
+			IL_0853: ldloc.s 10
+			IL_0855: stelem.ref
+			IL_0856: dup
+			IL_0857: ldc.i4.s 10
+			IL_0859: ldloc.s 11
+			IL_085b: stelem.ref
+			IL_085c: dup
+			IL_085d: ldc.i4.s 11
+			IL_085f: ldloc.s 12
+			IL_0861: stelem.ref
+			IL_0862: pop
+			IL_0863: ldloc.0
+			IL_0864: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0869: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_086e: ret
 
-			IL_088b: stloc.s 10
-			IL_088d: ldloc.s 10
-			IL_088f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0894: stloc.s 12
-			IL_0896: ldloc.s 12
-			IL_0898: call string [System.Runtime]System.String::Concat(string, string)
-			IL_089d: stloc.s 12
-			IL_089f: ldloc.s 11
-			IL_08a1: ldloc.s 12
-			IL_08a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08a8: pop
-			IL_08a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08ae: stloc.s 11
-			IL_08b0: volatile.
-			IL_08b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_08b7: brfalse IL_08cc
+			IL_086f: ldloc.0
+			IL_0870: ldfld object Modules.AsyncGenerator_ExplicitReceiverAbi/ArrowFunction_L13C2/Scope::_awaited6
+			IL_0875: stloc.s 8
+			IL_0877: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_087c: stloc.s 11
+			IL_087e: volatile.
+			IL_0880: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0885: brfalse IL_089b
 
-			IL_08bc: ldloc.1
-			IL_08bd: ldstr "next"
-			IL_08c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08c7: br IL_08e1
+			IL_088a: ldloc.s 8
+			IL_088c: ldstr "value"
+			IL_0891: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0896: br IL_08b1
 
-			IL_08cc: ldloc.1
-			IL_08cd: ldstr "next"
-			IL_08d2: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:126"
-			IL_08d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_08dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_089b: ldloc.s 8
+			IL_089d: ldstr "value"
+			IL_08a2: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:113"
+			IL_08a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_08ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08e1: stloc.s 10
-			IL_08e3: volatile.
-			IL_08e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-			IL_08ea: brfalse IL_0900
+			IL_08b1: stloc.s 10
+			IL_08b3: ldloc.s 10
+			IL_08b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08ba: stloc.s 12
+			IL_08bc: ldstr "r4: "
+			IL_08c1: ldloc.s 12
+			IL_08c3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08c8: ldstr " done: "
+			IL_08cd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08d2: volatile.
+			IL_08d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_08d9: brfalse IL_08ef
 
-			IL_08ef: ldloc.s 10
-			IL_08f1: ldstr "length"
-			IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08fb: br IL_0916
+			IL_08de: ldloc.s 8
+			IL_08e0: ldstr "done"
+			IL_08e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08ea: br IL_0905
 
-			IL_0900: ldloc.s 10
-			IL_0902: ldstr "length"
-			IL_0907: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:128"
-			IL_090c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-			IL_0911: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_08ef: ldloc.s 8
+			IL_08f1: ldstr "done"
+			IL_08f6: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:119"
+			IL_08fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0900: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0916: stloc.s 10
-			IL_0918: ldloc.s 11
-			IL_091a: ldloc.s 10
-			IL_091c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0921: pop
-			IL_0922: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0927: stloc.s 11
-			IL_0929: volatile.
-			IL_092b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_0930: brfalse IL_0945
+			IL_0905: stloc.s 10
+			IL_0907: ldloc.s 10
+			IL_0909: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_090e: stloc.s 12
+			IL_0910: ldloc.s 12
+			IL_0912: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0917: stloc.s 12
+			IL_0919: ldloc.s 11
+			IL_091b: ldloc.s 12
+			IL_091d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0922: pop
+			IL_0923: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0928: stloc.s 11
+			IL_092a: volatile.
+			IL_092c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0931: brfalse IL_0946
 
-			IL_0935: ldloc.1
-			IL_0936: ldstr "return"
-			IL_093b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0940: br IL_095a
+			IL_0936: ldloc.1
+			IL_0937: ldstr "next"
+			IL_093c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0941: br IL_095b
 
-			IL_0945: ldloc.1
-			IL_0946: ldstr "return"
-			IL_094b: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:133"
-			IL_0950: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_0955: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0946: ldloc.1
+			IL_0947: ldstr "next"
+			IL_094c: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:126"
+			IL_0951: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0956: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_095a: stloc.s 10
-			IL_095c: volatile.
-			IL_095e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_0963: brfalse IL_0979
+			IL_095b: stloc.s 10
+			IL_095d: volatile.
+			IL_095f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0964: brfalse IL_097a
 
-			IL_0968: ldloc.s 10
-			IL_096a: ldstr "length"
-			IL_096f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0974: br IL_098f
+			IL_0969: ldloc.s 10
+			IL_096b: ldstr "length"
+			IL_0970: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0975: br IL_0990
 
-			IL_0979: ldloc.s 10
-			IL_097b: ldstr "length"
-			IL_0980: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:135"
-			IL_0985: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_098a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_097a: ldloc.s 10
+			IL_097c: ldstr "length"
+			IL_0981: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:128"
+			IL_0986: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_098b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_098f: stloc.s 10
-			IL_0991: ldloc.s 11
-			IL_0993: ldloc.s 10
-			IL_0995: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_099a: pop
-			IL_099b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09a0: stloc.s 11
-			IL_09a2: volatile.
-			IL_09a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-			IL_09a9: brfalse IL_09be
+			IL_0990: stloc.s 10
+			IL_0992: ldloc.s 11
+			IL_0994: ldloc.s 10
+			IL_0996: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_099b: pop
+			IL_099c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09a1: stloc.s 11
+			IL_09a3: volatile.
+			IL_09a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_09aa: brfalse IL_09bf
 
-			IL_09ae: ldloc.1
-			IL_09af: ldstr "throw"
-			IL_09b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09b9: br IL_09d3
+			IL_09af: ldloc.1
+			IL_09b0: ldstr "return"
+			IL_09b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09ba: br IL_09d4
 
-			IL_09be: ldloc.1
-			IL_09bf: ldstr "throw"
-			IL_09c4: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:140"
-			IL_09c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-			IL_09ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_09bf: ldloc.1
+			IL_09c0: ldstr "return"
+			IL_09c5: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:133"
+			IL_09ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_09cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_09d3: stloc.s 10
-			IL_09d5: volatile.
-			IL_09d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-			IL_09dc: brfalse IL_09f2
+			IL_09d4: stloc.s 10
+			IL_09d6: volatile.
+			IL_09d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_09dd: brfalse IL_09f3
 
-			IL_09e1: ldloc.s 10
-			IL_09e3: ldstr "length"
-			IL_09e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09ed: br IL_0a08
+			IL_09e2: ldloc.s 10
+			IL_09e4: ldstr "length"
+			IL_09e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09ee: br IL_0a09
 
-			IL_09f2: ldloc.s 10
-			IL_09f4: ldstr "length"
-			IL_09f9: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:142"
-			IL_09fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_09f3: ldloc.s 10
+			IL_09f5: ldstr "length"
+			IL_09fa: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:135"
+			IL_09ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0a04: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0a08: stloc.s 10
-			IL_0a0a: ldloc.s 11
-			IL_0a0c: ldloc.s 10
-			IL_0a0e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a13: pop
-			IL_0a14: ldloc.0
-			IL_0a15: ldc.i4.m1
-			IL_0a16: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0a1b: ldloc.0
-			IL_0a1c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a21: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0a26: ldarg.0
-			IL_0a27: ldc.i4.1
-			IL_0a28: newarr [System.Runtime]System.Object
-			IL_0a2d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0a32: pop
-			IL_0a33: ldloc.0
-			IL_0a34: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a39: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a3e: ret
+			IL_0a09: stloc.s 10
+			IL_0a0b: ldloc.s 11
+			IL_0a0d: ldloc.s 10
+			IL_0a0f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a14: pop
+			IL_0a15: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a1a: stloc.s 11
+			IL_0a1c: volatile.
+			IL_0a1e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0a23: brfalse IL_0a38
+
+			IL_0a28: ldloc.1
+			IL_0a29: ldstr "throw"
+			IL_0a2e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a33: br IL_0a4d
+
+			IL_0a38: ldloc.1
+			IL_0a39: ldstr "throw"
+			IL_0a3e: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:140"
+			IL_0a43: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0a48: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0a4d: stloc.s 10
+			IL_0a4f: volatile.
+			IL_0a51: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0a56: brfalse IL_0a6c
+
+			IL_0a5b: ldloc.s 10
+			IL_0a5d: ldstr "length"
+			IL_0a62: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a67: br IL_0a82
+
+			IL_0a6c: ldloc.s 10
+			IL_0a6e: ldstr "length"
+			IL_0a73: ldstr "AsyncGenerator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:142"
+			IL_0a78: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0a7d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0a82: stloc.s 10
+			IL_0a84: ldloc.s 11
+			IL_0a86: ldloc.s 10
+			IL_0a88: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a8d: pop
+			IL_0a8e: ldloc.0
+			IL_0a8f: ldc.i4.m1
+			IL_0a90: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0a95: ldloc.0
+			IL_0a96: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a9b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0aa0: ldarg.0
+			IL_0aa1: ldc.i4.1
+			IL_0aa2: newarr [System.Runtime]System.Object
+			IL_0aa7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0aac: pop
+			IL_0aad: ldloc.0
+			IL_0aae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0ab3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0ab8: ret
 		} // end of method ArrowFunction_L13C2::__js_call__
 
 	} // end of class ArrowFunction_L13C2
@@ -2285,6 +2324,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_28
 	.field assembly static int32 __jroc_dynamicLookup_29
 	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_GeneratedFunctionObject_Semantics.verified.txt
@@ -2778,7 +2778,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 6910 (0x1afe)
+			// Code size: 7004 (0x1b5c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/Scope,
@@ -3020,7 +3020,7 @@
 
 			IL_018c: ldloc.0
 			IL_018d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0192: switch (IL_01bb, IL_07b1, IL_091b, IL_0a85, IL_0bef, IL_0dd8, IL_0fb2, IL_11bc, IL_1356)
+			IL_0192: switch (IL_01bb, IL_07b1, IL_091b, IL_0a85, IL_0bef, IL_0dd8, IL_0fb2, IL_11bc, IL_138b)
 
 			IL_01bb: ldc.i4.2
 			IL_01bc: newarr [System.Runtime]System.Object
@@ -4940,858 +4940,885 @@
 			IL_1201: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::AsyncGeneratorClass
 			IL_1206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_120b: stloc.s 24
-			IL_120d: ldloc.s 24
-			IL_120f: ldstr "twice"
-			IL_1214: ldc.r8 5
-			IL_121d: box [System.Runtime]System.Double
-			IL_1222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_1227: stloc.s 24
-			IL_1229: ldloc.s 24
-			IL_122b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1230: stloc.s 24
-			IL_1232: volatile.
-			IL_1234: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_1239: brfalse IL_124f
+			IL_120d: volatile.
+			IL_120f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_1214: brfalse IL_1238
 
-			IL_123e: ldloc.s 24
-			IL_1240: ldstr "next"
-			IL_1245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_124a: br IL_1265
+			IL_1219: ldloc.s 24
+			IL_121b: ldstr "twice"
+			IL_1220: ldc.r8 5
+			IL_1229: box [System.Runtime]System.Double
+			IL_122e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_1233: br IL_125c
 
-			IL_124f: ldloc.s 24
-			IL_1251: ldstr "next"
-			IL_1256: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:189"
-			IL_125b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_1260: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_1238: ldloc.s 24
+			IL_123a: ldstr "twice"
+			IL_123f: ldc.r8 5
+			IL_1248: box [System.Runtime]System.Double
+			IL_124d: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:187"
+			IL_1252: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_1257: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
+			IL_125c: stloc.s 24
+			IL_125e: ldloc.s 24
+			IL_1260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_1265: stloc.s 24
-			IL_1267: ldloc.0
-			IL_1268: ldc.i4.8
-			IL_1269: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_126e: ldloc.0
-			IL_126f: ldloc.s 24
-			IL_1271: ldarg.0
-			IL_1272: ldc.i4.8
-			IL_1273: ldloc.0
-			IL_1274: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_1279: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_127e: ldloc.0
-			IL_127f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_1284: dup
-			IL_1285: ldc.i4.0
-			IL_1286: ldloc.1
-			IL_1287: stelem.ref
-			IL_1288: dup
-			IL_1289: ldc.i4.1
-			IL_128a: ldloc.2
-			IL_128b: stelem.ref
-			IL_128c: dup
-			IL_128d: ldc.i4.2
-			IL_128e: ldloc.3
-			IL_128f: stelem.ref
-			IL_1290: dup
-			IL_1291: ldc.i4.3
-			IL_1292: ldloc.s 4
-			IL_1294: stelem.ref
-			IL_1295: dup
-			IL_1296: ldc.i4.4
-			IL_1297: ldloc.s 5
-			IL_1299: stelem.ref
-			IL_129a: dup
-			IL_129b: ldc.i4.5
-			IL_129c: ldloc.s 6
-			IL_129e: stelem.ref
-			IL_129f: dup
-			IL_12a0: ldc.i4.6
-			IL_12a1: ldloc.s 7
-			IL_12a3: stelem.ref
-			IL_12a4: dup
-			IL_12a5: ldc.i4.7
-			IL_12a6: ldloc.s 8
-			IL_12a8: stelem.ref
-			IL_12a9: dup
-			IL_12aa: ldc.i4.8
-			IL_12ab: ldloc.s 9
-			IL_12ad: stelem.ref
-			IL_12ae: dup
-			IL_12af: ldc.i4.s 9
-			IL_12b1: ldloc.s 10
-			IL_12b3: stelem.ref
-			IL_12b4: dup
-			IL_12b5: ldc.i4.s 10
-			IL_12b7: ldloc.s 11
-			IL_12b9: stelem.ref
-			IL_12ba: dup
-			IL_12bb: ldc.i4.s 11
-			IL_12bd: ldloc.s 12
-			IL_12bf: stelem.ref
-			IL_12c0: dup
-			IL_12c1: ldc.i4.s 12
-			IL_12c3: ldloc.s 13
-			IL_12c5: stelem.ref
-			IL_12c6: dup
-			IL_12c7: ldc.i4.s 13
-			IL_12c9: ldloc.s 14
-			IL_12cb: stelem.ref
-			IL_12cc: dup
-			IL_12cd: ldc.i4.s 14
-			IL_12cf: ldloc.s 15
-			IL_12d1: stelem.ref
-			IL_12d2: dup
-			IL_12d3: ldc.i4.s 15
-			IL_12d5: ldloc.s 16
-			IL_12d7: stelem.ref
-			IL_12d8: dup
-			IL_12d9: ldc.i4.s 16
-			IL_12db: ldloc.s 17
+			IL_1267: volatile.
+			IL_1269: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_126e: brfalse IL_1284
+
+			IL_1273: ldloc.s 24
+			IL_1275: ldstr "next"
+			IL_127a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_127f: br IL_129a
+
+			IL_1284: ldloc.s 24
+			IL_1286: ldstr "next"
+			IL_128b: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:189"
+			IL_1290: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_1295: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+			IL_129a: stloc.s 24
+			IL_129c: ldloc.0
+			IL_129d: ldc.i4.8
+			IL_129e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_12a3: ldloc.0
+			IL_12a4: ldloc.s 24
+			IL_12a6: ldarg.0
+			IL_12a7: ldc.i4.8
+			IL_12a8: ldloc.0
+			IL_12a9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_12ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_12b3: ldloc.0
+			IL_12b4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_12b9: dup
+			IL_12ba: ldc.i4.0
+			IL_12bb: ldloc.1
+			IL_12bc: stelem.ref
+			IL_12bd: dup
+			IL_12be: ldc.i4.1
+			IL_12bf: ldloc.2
+			IL_12c0: stelem.ref
+			IL_12c1: dup
+			IL_12c2: ldc.i4.2
+			IL_12c3: ldloc.3
+			IL_12c4: stelem.ref
+			IL_12c5: dup
+			IL_12c6: ldc.i4.3
+			IL_12c7: ldloc.s 4
+			IL_12c9: stelem.ref
+			IL_12ca: dup
+			IL_12cb: ldc.i4.4
+			IL_12cc: ldloc.s 5
+			IL_12ce: stelem.ref
+			IL_12cf: dup
+			IL_12d0: ldc.i4.5
+			IL_12d1: ldloc.s 6
+			IL_12d3: stelem.ref
+			IL_12d4: dup
+			IL_12d5: ldc.i4.6
+			IL_12d6: ldloc.s 7
+			IL_12d8: stelem.ref
+			IL_12d9: dup
+			IL_12da: ldc.i4.7
+			IL_12db: ldloc.s 8
 			IL_12dd: stelem.ref
 			IL_12de: dup
-			IL_12df: ldc.i4.s 17
-			IL_12e1: ldloc.s 18
-			IL_12e3: stelem.ref
-			IL_12e4: dup
-			IL_12e5: ldc.i4.s 18
-			IL_12e7: ldloc.s 19
-			IL_12e9: stelem.ref
-			IL_12ea: dup
-			IL_12eb: ldc.i4.s 19
-			IL_12ed: ldloc.s 20
-			IL_12ef: stelem.ref
-			IL_12f0: dup
-			IL_12f1: ldc.i4.s 20
-			IL_12f3: ldloc.s 21
-			IL_12f5: stelem.ref
-			IL_12f6: dup
-			IL_12f7: ldc.i4.s 21
-			IL_12f9: ldloc.s 22
-			IL_12fb: stelem.ref
-			IL_12fc: dup
-			IL_12fd: ldc.i4.s 22
-			IL_12ff: ldloc.s 23
-			IL_1301: stelem.ref
-			IL_1302: dup
-			IL_1303: ldc.i4.s 23
-			IL_1305: ldloc.s 24
-			IL_1307: stelem.ref
-			IL_1308: dup
-			IL_1309: ldc.i4.s 24
-			IL_130b: ldloc.s 25
-			IL_130d: stelem.ref
-			IL_130e: dup
-			IL_130f: ldc.i4.s 25
-			IL_1311: ldloc.s 26
-			IL_1313: box [System.Runtime]System.Boolean
+			IL_12df: ldc.i4.8
+			IL_12e0: ldloc.s 9
+			IL_12e2: stelem.ref
+			IL_12e3: dup
+			IL_12e4: ldc.i4.s 9
+			IL_12e6: ldloc.s 10
+			IL_12e8: stelem.ref
+			IL_12e9: dup
+			IL_12ea: ldc.i4.s 10
+			IL_12ec: ldloc.s 11
+			IL_12ee: stelem.ref
+			IL_12ef: dup
+			IL_12f0: ldc.i4.s 11
+			IL_12f2: ldloc.s 12
+			IL_12f4: stelem.ref
+			IL_12f5: dup
+			IL_12f6: ldc.i4.s 12
+			IL_12f8: ldloc.s 13
+			IL_12fa: stelem.ref
+			IL_12fb: dup
+			IL_12fc: ldc.i4.s 13
+			IL_12fe: ldloc.s 14
+			IL_1300: stelem.ref
+			IL_1301: dup
+			IL_1302: ldc.i4.s 14
+			IL_1304: ldloc.s 15
+			IL_1306: stelem.ref
+			IL_1307: dup
+			IL_1308: ldc.i4.s 15
+			IL_130a: ldloc.s 16
+			IL_130c: stelem.ref
+			IL_130d: dup
+			IL_130e: ldc.i4.s 16
+			IL_1310: ldloc.s 17
+			IL_1312: stelem.ref
+			IL_1313: dup
+			IL_1314: ldc.i4.s 17
+			IL_1316: ldloc.s 18
 			IL_1318: stelem.ref
 			IL_1319: dup
-			IL_131a: ldc.i4.s 26
-			IL_131c: ldloc.s 27
+			IL_131a: ldc.i4.s 18
+			IL_131c: ldloc.s 19
 			IL_131e: stelem.ref
 			IL_131f: dup
-			IL_1320: ldc.i4.s 27
-			IL_1322: ldloc.s 28
+			IL_1320: ldc.i4.s 19
+			IL_1322: ldloc.s 20
 			IL_1324: stelem.ref
 			IL_1325: dup
-			IL_1326: ldc.i4.s 28
-			IL_1328: ldloc.s 29
+			IL_1326: ldc.i4.s 20
+			IL_1328: ldloc.s 21
 			IL_132a: stelem.ref
 			IL_132b: dup
-			IL_132c: ldc.i4.s 29
-			IL_132e: ldloc.s 30
+			IL_132c: ldc.i4.s 21
+			IL_132e: ldloc.s 22
 			IL_1330: stelem.ref
 			IL_1331: dup
-			IL_1332: ldc.i4.s 30
-			IL_1334: ldloc.s 31
+			IL_1332: ldc.i4.s 22
+			IL_1334: ldloc.s 23
 			IL_1336: stelem.ref
 			IL_1337: dup
-			IL_1338: ldc.i4.s 31
-			IL_133a: ldloc.s 32
+			IL_1338: ldc.i4.s 23
+			IL_133a: ldloc.s 24
 			IL_133c: stelem.ref
 			IL_133d: dup
-			IL_133e: ldc.i4.s 32
-			IL_1340: ldloc.s 33
+			IL_133e: ldc.i4.s 24
+			IL_1340: ldloc.s 25
 			IL_1342: stelem.ref
 			IL_1343: dup
-			IL_1344: ldc.i4.s 33
-			IL_1346: ldloc.s 34
-			IL_1348: stelem.ref
-			IL_1349: pop
-			IL_134a: ldloc.0
-			IL_134b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_1350: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_1355: ret
+			IL_1344: ldc.i4.s 25
+			IL_1346: ldloc.s 26
+			IL_1348: box [System.Runtime]System.Boolean
+			IL_134d: stelem.ref
+			IL_134e: dup
+			IL_134f: ldc.i4.s 26
+			IL_1351: ldloc.s 27
+			IL_1353: stelem.ref
+			IL_1354: dup
+			IL_1355: ldc.i4.s 27
+			IL_1357: ldloc.s 28
+			IL_1359: stelem.ref
+			IL_135a: dup
+			IL_135b: ldc.i4.s 28
+			IL_135d: ldloc.s 29
+			IL_135f: stelem.ref
+			IL_1360: dup
+			IL_1361: ldc.i4.s 29
+			IL_1363: ldloc.s 30
+			IL_1365: stelem.ref
+			IL_1366: dup
+			IL_1367: ldc.i4.s 30
+			IL_1369: ldloc.s 31
+			IL_136b: stelem.ref
+			IL_136c: dup
+			IL_136d: ldc.i4.s 31
+			IL_136f: ldloc.s 32
+			IL_1371: stelem.ref
+			IL_1372: dup
+			IL_1373: ldc.i4.s 32
+			IL_1375: ldloc.s 33
+			IL_1377: stelem.ref
+			IL_1378: dup
+			IL_1379: ldc.i4.s 33
+			IL_137b: ldloc.s 34
+			IL_137d: stelem.ref
+			IL_137e: pop
+			IL_137f: ldloc.0
+			IL_1380: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_1385: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_138a: ret
 
-			IL_1356: ldloc.0
-			IL_1357: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/Scope::_awaited8
-			IL_135c: stloc.s 24
-			IL_135e: volatile.
-			IL_1360: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_1365: brfalse IL_137b
-
-			IL_136a: ldloc.s 24
-			IL_136c: ldstr "value"
-			IL_1371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1376: br IL_1391
-
-			IL_137b: ldloc.s 24
-			IL_137d: ldstr "value"
-			IL_1382: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:192"
-			IL_1387: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_138c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
+			IL_138b: ldloc.0
+			IL_138c: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/Scope::_awaited8
 			IL_1391: stloc.s 24
-			IL_1393: ldarg.0
-			IL_1394: ldc.i4.1
-			IL_1395: ldelem.ref
-			IL_1396: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_139b: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::'object'
-			IL_13a0: volatile.
-			IL_13a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_13a7: brfalse IL_13bb
+			IL_1393: volatile.
+			IL_1395: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_139a: brfalse IL_13b0
 
-			IL_13ac: ldstr "run"
-			IL_13b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_13b6: br IL_13cf
+			IL_139f: ldloc.s 24
+			IL_13a1: ldstr "value"
+			IL_13a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_13ab: br IL_13c6
 
-			IL_13bb: ldstr "run"
-			IL_13c0: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:195"
-			IL_13c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_13ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_13b0: ldloc.s 24
+			IL_13b2: ldstr "value"
+			IL_13b7: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:192"
+			IL_13bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_13c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_13cf: stloc.s 25
-			IL_13d1: ldloc.s 25
-			IL_13d3: ldstr "prototype"
-			IL_13d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-			IL_13dd: stloc.s 26
-			IL_13df: ldloc.s 26
-			IL_13e1: box [System.Runtime]System.Boolean
-			IL_13e6: stloc.s 30
-			IL_13e8: ldarg.0
-			IL_13e9: ldc.i4.1
-			IL_13ea: ldelem.ref
-			IL_13eb: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_13f0: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::AsyncGeneratorClass
-			IL_13f5: volatile.
-			IL_13f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_13fc: brfalse IL_1410
+			IL_13c6: stloc.s 24
+			IL_13c8: ldarg.0
+			IL_13c9: ldc.i4.1
+			IL_13ca: ldelem.ref
+			IL_13cb: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_13d0: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::'object'
+			IL_13d5: volatile.
+			IL_13d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_13dc: brfalse IL_13f0
 
-			IL_1401: ldstr "prototype"
-			IL_1406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_140b: br IL_1424
+			IL_13e1: ldstr "run"
+			IL_13e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_13eb: br IL_1404
 
-			IL_1410: ldstr "prototype"
-			IL_1415: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:201"
-			IL_141a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_141f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_13f0: ldstr "run"
+			IL_13f5: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:195"
+			IL_13fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_13ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1424: stloc.s 25
-			IL_1426: volatile.
-			IL_1428: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_142d: brfalse IL_1443
+			IL_1404: stloc.s 25
+			IL_1406: ldloc.s 25
+			IL_1408: ldstr "prototype"
+			IL_140d: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+			IL_1412: stloc.s 26
+			IL_1414: ldloc.s 26
+			IL_1416: box [System.Runtime]System.Boolean
+			IL_141b: stloc.s 30
+			IL_141d: ldarg.0
+			IL_141e: ldc.i4.1
+			IL_141f: ldelem.ref
+			IL_1420: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_1425: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::AsyncGeneratorClass
+			IL_142a: volatile.
+			IL_142c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_1431: brfalse IL_1445
 
-			IL_1432: ldloc.s 25
-			IL_1434: ldstr "run"
-			IL_1439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_143e: br IL_1459
+			IL_1436: ldstr "prototype"
+			IL_143b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1440: br IL_1459
 
-			IL_1443: ldloc.s 25
-			IL_1445: ldstr "run"
-			IL_144a: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:203"
+			IL_1445: ldstr "prototype"
+			IL_144a: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:201"
 			IL_144f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_1454: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1459: stloc.s 25
-			IL_145b: ldloc.s 25
-			IL_145d: ldstr "prototype"
-			IL_1462: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-			IL_1467: stloc.s 26
-			IL_1469: ldloc.s 26
-			IL_146b: box [System.Runtime]System.Boolean
-			IL_1470: stloc.s 28
-			IL_1472: ldarg.0
-			IL_1473: ldc.i4.1
-			IL_1474: ldelem.ref
-			IL_1475: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_147a: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::AsyncGeneratorClass
-			IL_147f: volatile.
-			IL_1481: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_1486: brfalse IL_149a
+			IL_145b: volatile.
+			IL_145d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_1462: brfalse IL_1478
 
-			IL_148b: ldstr "twice"
-			IL_1490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1495: br IL_14ae
+			IL_1467: ldloc.s 25
+			IL_1469: ldstr "run"
+			IL_146e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1473: br IL_148e
 
-			IL_149a: ldstr "twice"
-			IL_149f: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:209"
-			IL_14a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_14a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1478: ldloc.s 25
+			IL_147a: ldstr "run"
+			IL_147f: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:203"
+			IL_1484: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_1489: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_14ae: stloc.s 25
-			IL_14b0: ldloc.s 25
-			IL_14b2: ldstr "prototype"
-			IL_14b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-			IL_14bc: stloc.s 26
-			IL_14be: ldloc.s 26
-			IL_14c0: box [System.Runtime]System.Boolean
-			IL_14c5: stloc.s 27
-			IL_14c7: ldloc.s 21
-			IL_14c9: ldc.i4.7
-			IL_14ca: newarr [System.Runtime]System.Object
-			IL_14cf: dup
-			IL_14d0: ldc.i4.0
-			IL_14d1: ldstr "methods"
-			IL_14d6: stelem.ref
-			IL_14d7: dup
-			IL_14d8: ldc.i4.1
-			IL_14d9: ldloc.s 20
-			IL_14db: stelem.ref
-			IL_14dc: dup
-			IL_14dd: ldc.i4.2
-			IL_14de: ldloc.s 23
-			IL_14e0: stelem.ref
-			IL_14e1: dup
-			IL_14e2: ldc.i4.3
-			IL_14e3: ldloc.s 24
-			IL_14e5: stelem.ref
-			IL_14e6: dup
-			IL_14e7: ldc.i4.4
-			IL_14e8: ldloc.s 30
-			IL_14ea: stelem.ref
-			IL_14eb: dup
-			IL_14ec: ldc.i4.5
-			IL_14ed: ldloc.s 28
-			IL_14ef: stelem.ref
-			IL_14f0: dup
-			IL_14f1: ldc.i4.6
-			IL_14f2: ldloc.s 27
-			IL_14f4: stelem.ref
-			IL_14f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_14fa: pop
-			IL_14fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1500: stloc.s 21
-			IL_1502: ldarg.0
-			IL_1503: ldc.i4.1
-			IL_1504: ldelem.ref
-			IL_1505: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_150a: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::declared
-			IL_150f: volatile.
-			IL_1511: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_1516: brfalse IL_152a
+			IL_148e: stloc.s 25
+			IL_1490: ldloc.s 25
+			IL_1492: ldstr "prototype"
+			IL_1497: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+			IL_149c: stloc.s 26
+			IL_149e: ldloc.s 26
+			IL_14a0: box [System.Runtime]System.Boolean
+			IL_14a5: stloc.s 28
+			IL_14a7: ldarg.0
+			IL_14a8: ldc.i4.1
+			IL_14a9: ldelem.ref
+			IL_14aa: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_14af: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::AsyncGeneratorClass
+			IL_14b4: volatile.
+			IL_14b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_14bb: brfalse IL_14cf
 
-			IL_151b: ldstr "prototype"
-			IL_1520: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1525: br IL_153e
+			IL_14c0: ldstr "twice"
+			IL_14c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_14ca: br IL_14e3
 
-			IL_152a: ldstr "prototype"
-			IL_152f: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:219"
-			IL_1534: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_1539: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_14cf: ldstr "twice"
+			IL_14d4: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:209"
+			IL_14d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_14de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_153e: stloc.s 24
-			IL_1540: volatile.
-			IL_1542: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_1547: brfalse IL_155d
+			IL_14e3: stloc.s 25
+			IL_14e5: ldloc.s 25
+			IL_14e7: ldstr "prototype"
+			IL_14ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+			IL_14f1: stloc.s 26
+			IL_14f3: ldloc.s 26
+			IL_14f5: box [System.Runtime]System.Boolean
+			IL_14fa: stloc.s 27
+			IL_14fc: ldloc.s 21
+			IL_14fe: ldc.i4.7
+			IL_14ff: newarr [System.Runtime]System.Object
+			IL_1504: dup
+			IL_1505: ldc.i4.0
+			IL_1506: ldstr "methods"
+			IL_150b: stelem.ref
+			IL_150c: dup
+			IL_150d: ldc.i4.1
+			IL_150e: ldloc.s 20
+			IL_1510: stelem.ref
+			IL_1511: dup
+			IL_1512: ldc.i4.2
+			IL_1513: ldloc.s 23
+			IL_1515: stelem.ref
+			IL_1516: dup
+			IL_1517: ldc.i4.3
+			IL_1518: ldloc.s 24
+			IL_151a: stelem.ref
+			IL_151b: dup
+			IL_151c: ldc.i4.4
+			IL_151d: ldloc.s 30
+			IL_151f: stelem.ref
+			IL_1520: dup
+			IL_1521: ldc.i4.5
+			IL_1522: ldloc.s 28
+			IL_1524: stelem.ref
+			IL_1525: dup
+			IL_1526: ldc.i4.6
+			IL_1527: ldloc.s 27
+			IL_1529: stelem.ref
+			IL_152a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_152f: pop
+			IL_1530: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1535: stloc.s 21
+			IL_1537: ldarg.0
+			IL_1538: ldc.i4.1
+			IL_1539: ldelem.ref
+			IL_153a: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_153f: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::declared
+			IL_1544: volatile.
+			IL_1546: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_154b: brfalse IL_155f
 
-			IL_154c: ldloc.s 24
-			IL_154e: ldstr "next"
-			IL_1553: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1558: br IL_1573
+			IL_1550: ldstr "prototype"
+			IL_1555: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_155a: br IL_1573
 
-			IL_155d: ldloc.s 24
-			IL_155f: ldstr "next"
-			IL_1564: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:221"
+			IL_155f: ldstr "prototype"
+			IL_1564: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:219"
 			IL_1569: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_156e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1573: stloc.s 24
-			IL_1575: ldloc.s 24
-			IL_1577: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_157c: stloc.s 22
-			IL_157e: ldarg.0
-			IL_157f: ldc.i4.1
-			IL_1580: ldelem.ref
-			IL_1581: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_1586: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::declared
-			IL_158b: volatile.
-			IL_158d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_1592: brfalse IL_15a6
+			IL_1575: volatile.
+			IL_1577: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_157c: brfalse IL_1592
 
-			IL_1597: ldstr "prototype"
-			IL_159c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_15a1: br IL_15ba
+			IL_1581: ldloc.s 24
+			IL_1583: ldstr "next"
+			IL_1588: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_158d: br IL_15a8
 
-			IL_15a6: ldstr "prototype"
-			IL_15ab: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:225"
-			IL_15b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_15b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1592: ldloc.s 24
+			IL_1594: ldstr "next"
+			IL_1599: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:221"
+			IL_159e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_15a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_15ba: stloc.s 24
-			IL_15bc: volatile.
-			IL_15be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_15c3: brfalse IL_15d9
+			IL_15a8: stloc.s 24
+			IL_15aa: ldloc.s 24
+			IL_15ac: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_15b1: stloc.s 22
+			IL_15b3: ldarg.0
+			IL_15b4: ldc.i4.1
+			IL_15b5: ldelem.ref
+			IL_15b6: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_15bb: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::declared
+			IL_15c0: volatile.
+			IL_15c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_15c7: brfalse IL_15db
 
-			IL_15c8: ldloc.s 24
-			IL_15ca: ldstr "return"
-			IL_15cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_15d4: br IL_15ef
+			IL_15cc: ldstr "prototype"
+			IL_15d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_15d6: br IL_15ef
 
-			IL_15d9: ldloc.s 24
-			IL_15db: ldstr "return"
-			IL_15e0: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:227"
+			IL_15db: ldstr "prototype"
+			IL_15e0: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:225"
 			IL_15e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_15ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_15ef: stloc.s 24
-			IL_15f1: ldloc.s 24
-			IL_15f3: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_15f8: stloc.s 33
-			IL_15fa: ldarg.0
-			IL_15fb: ldc.i4.1
-			IL_15fc: ldelem.ref
-			IL_15fd: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_1602: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::declared
-			IL_1607: volatile.
-			IL_1609: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_160e: brfalse IL_1622
+			IL_15f1: volatile.
+			IL_15f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_15f8: brfalse IL_160e
 
-			IL_1613: ldstr "prototype"
-			IL_1618: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_161d: br IL_1636
+			IL_15fd: ldloc.s 24
+			IL_15ff: ldstr "return"
+			IL_1604: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1609: br IL_1624
 
-			IL_1622: ldstr "prototype"
-			IL_1627: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:231"
-			IL_162c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_1631: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_160e: ldloc.s 24
+			IL_1610: ldstr "return"
+			IL_1615: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:227"
+			IL_161a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_161f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1636: stloc.s 24
-			IL_1638: volatile.
-			IL_163a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_163f: brfalse IL_1655
+			IL_1624: stloc.s 24
+			IL_1626: ldloc.s 24
+			IL_1628: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_162d: stloc.s 33
+			IL_162f: ldarg.0
+			IL_1630: ldc.i4.1
+			IL_1631: ldelem.ref
+			IL_1632: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_1637: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::declared
+			IL_163c: volatile.
+			IL_163e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_1643: brfalse IL_1657
 
-			IL_1644: ldloc.s 24
-			IL_1646: ldstr "throw"
-			IL_164b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1650: br IL_166b
+			IL_1648: ldstr "prototype"
+			IL_164d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1652: br IL_166b
 
-			IL_1655: ldloc.s 24
-			IL_1657: ldstr "throw"
-			IL_165c: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:233"
+			IL_1657: ldstr "prototype"
+			IL_165c: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:231"
 			IL_1661: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_1666: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_166b: stloc.s 24
-			IL_166d: ldloc.s 24
-			IL_166f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_1674: stloc.s 34
-			IL_1676: ldstr "Object"
-			IL_167b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1680: stloc.s 24
-			IL_1682: volatile.
-			IL_1684: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_1689: brfalse IL_169f
+			IL_166d: volatile.
+			IL_166f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_1674: brfalse IL_168a
 
-			IL_168e: ldloc.s 24
-			IL_1690: ldstr "prototype"
-			IL_1695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_169a: br IL_16b5
+			IL_1679: ldloc.s 24
+			IL_167b: ldstr "throw"
+			IL_1680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1685: br IL_16a0
 
-			IL_169f: ldloc.s 24
-			IL_16a1: ldstr "prototype"
-			IL_16a6: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:238"
-			IL_16ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_16b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_168a: ldloc.s 24
+			IL_168c: ldstr "throw"
+			IL_1691: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:233"
+			IL_1696: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_169b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
+			IL_16a0: stloc.s 24
+			IL_16a2: ldloc.s 24
+			IL_16a4: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_16a9: stloc.s 34
+			IL_16ab: ldstr "Object"
+			IL_16b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_16b5: stloc.s 24
 			IL_16b7: volatile.
 			IL_16b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_16be: brfalse IL_16d4
 
 			IL_16c3: ldloc.s 24
-			IL_16c5: ldstr "toString"
+			IL_16c5: ldstr "prototype"
 			IL_16ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_16cf: br IL_16ea
 
 			IL_16d4: ldloc.s 24
-			IL_16d6: ldstr "toString"
-			IL_16db: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:240"
+			IL_16d6: ldstr "prototype"
+			IL_16db: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:238"
 			IL_16e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_16e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_16ea: stloc.s 24
-			IL_16ec: ldloc.s 24
-			IL_16ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_16f3: stloc.s 24
-			IL_16f5: ldarg.0
-			IL_16f6: ldc.i4.1
-			IL_16f7: ldelem.ref
-			IL_16f8: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_16fd: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::declared
-			IL_1702: ldc.i4.1
-			IL_1703: newarr [System.Runtime]System.Object
-			IL_1708: dup
-			IL_1709: ldc.i4.0
-			IL_170a: ldarg.0
-			IL_170b: ldc.i4.1
-			IL_170c: ldelem.ref
-			IL_170d: stelem.ref
-			IL_170e: stloc.s 19
-			IL_1710: ldloc.s 19
-			IL_1712: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_1717: stloc.s 23
-			IL_1719: ldloc.s 24
-			IL_171b: ldstr "call"
-			IL_1720: ldloc.s 23
-			IL_1722: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_1727: stloc.s 23
-			IL_1729: ldloc.s 21
-			IL_172b: ldc.i4.5
-			IL_172c: newarr [System.Runtime]System.Object
-			IL_1731: dup
-			IL_1732: ldc.i4.0
-			IL_1733: ldstr "asyncPrototype"
-			IL_1738: stelem.ref
-			IL_1739: dup
-			IL_173a: ldc.i4.1
-			IL_173b: ldloc.s 22
-			IL_173d: stelem.ref
-			IL_173e: dup
-			IL_173f: ldc.i4.2
-			IL_1740: ldloc.s 33
+			IL_16ec: volatile.
+			IL_16ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_16f3: brfalse IL_1709
+
+			IL_16f8: ldloc.s 24
+			IL_16fa: ldstr "toString"
+			IL_16ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1704: br IL_171f
+
+			IL_1709: ldloc.s 24
+			IL_170b: ldstr "toString"
+			IL_1710: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:240"
+			IL_1715: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_171a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_171f: stloc.s 24
+			IL_1721: ldloc.s 24
+			IL_1723: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1728: stloc.s 24
+			IL_172a: ldarg.0
+			IL_172b: ldc.i4.1
+			IL_172c: ldelem.ref
+			IL_172d: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_1732: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::declared
+			IL_1737: ldc.i4.1
+			IL_1738: newarr [System.Runtime]System.Object
+			IL_173d: dup
+			IL_173e: ldc.i4.0
+			IL_173f: ldarg.0
+			IL_1740: ldc.i4.1
+			IL_1741: ldelem.ref
 			IL_1742: stelem.ref
-			IL_1743: dup
-			IL_1744: ldc.i4.3
-			IL_1745: ldloc.s 34
-			IL_1747: stelem.ref
-			IL_1748: dup
-			IL_1749: ldc.i4.4
-			IL_174a: ldloc.s 23
-			IL_174c: stelem.ref
-			IL_174d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-			IL_1752: pop
-			IL_1753: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_1758: stloc.s 10
-			IL_175a: ldarg.0
-			IL_175b: ldc.i4.1
-			IL_175c: ldelem.ref
-			IL_175d: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_1762: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::AsyncGeneratorClass
-			IL_1767: volatile.
-			IL_1769: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_176e: brfalse IL_1782
+			IL_1743: stloc.s 19
+			IL_1745: ldloc.s 19
+			IL_1747: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_174c: stloc.s 23
+			IL_174e: volatile.
+			IL_1750: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_1755: brfalse IL_176d
 
-			IL_1773: ldstr "prototype"
-			IL_1778: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_177d: br IL_1796
+			IL_175a: ldloc.s 24
+			IL_175c: ldstr "call"
+			IL_1761: ldloc.s 23
+			IL_1763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_1768: br IL_1785
 
-			IL_1782: ldstr "prototype"
-			IL_1787: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:253"
-			IL_178c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_1791: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_176d: ldloc.s 24
+			IL_176f: ldstr "call"
+			IL_1774: ldloc.s 23
+			IL_1776: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:245"
+			IL_177b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_1780: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_1796: stloc.s 23
-			IL_1798: volatile.
-			IL_179a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_179f: brfalse IL_17b5
+			IL_1785: stloc.s 23
+			IL_1787: ldloc.s 21
+			IL_1789: ldc.i4.5
+			IL_178a: newarr [System.Runtime]System.Object
+			IL_178f: dup
+			IL_1790: ldc.i4.0
+			IL_1791: ldstr "asyncPrototype"
+			IL_1796: stelem.ref
+			IL_1797: dup
+			IL_1798: ldc.i4.1
+			IL_1799: ldloc.s 22
+			IL_179b: stelem.ref
+			IL_179c: dup
+			IL_179d: ldc.i4.2
+			IL_179e: ldloc.s 33
+			IL_17a0: stelem.ref
+			IL_17a1: dup
+			IL_17a2: ldc.i4.3
+			IL_17a3: ldloc.s 34
+			IL_17a5: stelem.ref
+			IL_17a6: dup
+			IL_17a7: ldc.i4.4
+			IL_17a8: ldloc.s 23
+			IL_17aa: stelem.ref
+			IL_17ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+			IL_17b0: pop
+			IL_17b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_17b6: stloc.s 10
+			IL_17b8: ldarg.0
+			IL_17b9: ldc.i4.1
+			IL_17ba: ldelem.ref
+			IL_17bb: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_17c0: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::AsyncGeneratorClass
+			IL_17c5: volatile.
+			IL_17c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_17cc: brfalse IL_17e0
 
-			IL_17a4: ldloc.s 23
-			IL_17a6: ldstr "run"
-			IL_17ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_17b0: br IL_17cb
+			IL_17d1: ldstr "prototype"
+			IL_17d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_17db: br IL_17f4
 
-			IL_17b5: ldloc.s 23
-			IL_17b7: ldstr "run"
-			IL_17bc: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:255"
-			IL_17c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_17c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_17e0: ldstr "prototype"
+			IL_17e5: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:253"
+			IL_17ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_17ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_17cb: stloc.s 23
-			IL_17cd: ldloc.s 23
-			IL_17cf: ldstr "prototype"
-			IL_17d4: ldloc.s 10
-			IL_17d6: ldc.i4.0
-			IL_17d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_17dc: pop
-			IL_17dd: ldc.i4.1
-			IL_17de: newarr [System.Runtime]System.Object
-			IL_17e3: dup
-			IL_17e4: ldc.i4.0
-			IL_17e5: ldc.r8 50
-			IL_17ee: box [System.Runtime]System.Double
-			IL_17f3: stelem.ref
-			IL_17f4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_17f9: ldc.r8 50
-			IL_1802: box [System.Runtime]System.Double
-			IL_1807: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::.ctor(object)
-			IL_180c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_1811: stloc.s 11
-			IL_1813: ldloc.s 11
-			IL_1815: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
-			IL_181a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-			IL_181f: ldstr "prototype"
-			IL_1824: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_1829: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_182e: ldarg.0
-			IL_182f: ldc.i4.1
-			IL_1830: ldelem.ref
-			IL_1831: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_1836: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::DerivedAsyncGeneratorClass
-			IL_183b: stloc.s 23
-			IL_183d: ldc.i4.1
-			IL_183e: newarr [System.Runtime]System.Object
-			IL_1843: dup
-			IL_1844: ldc.i4.0
-			IL_1845: ldarg.0
-			IL_1846: ldc.i4.1
-			IL_1847: ldelem.ref
-			IL_1848: stelem.ref
-			IL_1849: stloc.s 19
-			IL_184b: ldloc.s 19
-			IL_184d: ldc.i4.1
-			IL_184e: newarr [System.Runtime]System.Object
-			IL_1853: dup
-			IL_1854: ldc.i4.0
-			IL_1855: ldc.r8 60
-			IL_185e: box [System.Runtime]System.Double
-			IL_1863: stelem.ref
-			IL_1864: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-			IL_1869: ldloc.s 23
-			IL_186b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-			IL_1870: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-			IL_1875: ldc.r8 60
-			IL_187e: box [System.Runtime]System.Double
-			IL_1883: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass::.ctor(object[], object)
-			IL_1888: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-			IL_188d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-			IL_1892: dup
-			IL_1893: ldloc.s 23
-			IL_1895: ldstr "prototype"
-			IL_189a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-			IL_189f: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-			IL_18a4: stloc.s 12
-			IL_18a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_18ab: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_18b0: stloc.s 12
-			IL_18b2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-			IL_18b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_18bc: stloc.s 21
-			IL_18be: ldloc.s 11
-			IL_18c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass>(!!0)
-			IL_18c5: stloc.s 32
-			IL_18c7: ldloc.s 32
-			IL_18c9: ldc.r8 6
-			IL_18d2: box [System.Runtime]System.Double
-			IL_18d7: callvirt instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::callRun(object)
-			IL_18dc: stloc.s 23
-			IL_18de: ldloc.s 23
-			IL_18e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-			IL_18e5: stloc.s 23
-			IL_18e7: ldloc.s 23
-			IL_18e9: ldloc.s 10
-			IL_18eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_18f0: stloc.s 26
-			IL_18f2: ldloc.s 26
-			IL_18f4: box [System.Runtime]System.Boolean
-			IL_18f9: stloc.s 27
-			IL_18fb: ldloc.s 12
-			IL_18fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1902: stloc.s 23
-			IL_1904: ldloc.s 23
-			IL_1906: isinst Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
-			IL_190b: dup
-			IL_190c: brfalse IL_192b
+			IL_17f4: stloc.s 23
+			IL_17f6: volatile.
+			IL_17f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_17fd: brfalse IL_1813
 
-			IL_1911: ldc.r8 7
-			IL_191a: box [System.Runtime]System.Double
-			IL_191f: callvirt instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass::callSuper(object)
-			IL_1924: stloc.s 23
-			IL_1926: br IL_1948
+			IL_1802: ldloc.s 23
+			IL_1804: ldstr "run"
+			IL_1809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_180e: br IL_1829
 
-			IL_192b: pop
-			IL_192c: ldloc.s 23
-			IL_192e: ldstr "callSuper"
-			IL_1933: ldc.r8 7
-			IL_193c: box [System.Runtime]System.Double
-			IL_1941: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_1946: stloc.s 23
+			IL_1813: ldloc.s 23
+			IL_1815: ldstr "run"
+			IL_181a: ldstr "AsyncGenerator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:255"
+			IL_181f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_1824: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1948: ldloc.s 23
-			IL_194a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-			IL_194f: stloc.s 23
-			IL_1951: ldloc.s 23
-			IL_1953: ldloc.s 10
-			IL_1955: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_195a: stloc.s 26
-			IL_195c: ldloc.s 26
-			IL_195e: box [System.Runtime]System.Boolean
-			IL_1963: stloc.s 28
-			IL_1965: ldloc.s 21
-			IL_1967: ldstr "internalMethods"
-			IL_196c: ldloc.s 27
-			IL_196e: ldloc.s 28
-			IL_1970: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-			IL_1975: pop
-			IL_1976: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_197b: stloc.s 13
-			IL_197d: ldarg.0
-			IL_197e: ldc.i4.1
-			IL_197f: ldelem.ref
-			IL_1980: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
-			IL_1985: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::expression
-			IL_198a: ldstr "Cannot access 'expression' before initialization"
-			IL_198f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_1994: stloc.s 23
-			IL_1996: ldloc.s 23
-			IL_1998: ldstr "prototype"
-			IL_199d: ldloc.s 13
-			IL_199f: ldc.i4.0
-			IL_19a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_19a5: pop
-			IL_19a6: nop
-			IL_19a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_19ac: stloc.s 21
-			IL_19ae: ldc.i4.2
-			IL_19af: newarr [System.Runtime]System.Object
-			IL_19b4: dup
-			IL_19b5: ldc.i4.0
-			IL_19b6: ldarg.0
-			IL_19b7: ldc.i4.1
-			IL_19b8: ldelem.ref
-			IL_19b9: stelem.ref
-			IL_19ba: dup
-			IL_19bb: ldc.i4.1
-			IL_19bc: ldloc.0
-			IL_19bd: stelem.ref
-			IL_19be: stloc.s 19
-			IL_19c0: ldloc.s 19
-			IL_19c2: ldnull
-			IL_19c3: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator::__js_call__(object[], object)
-			IL_19c8: stloc.s 23
-			IL_19ca: ldloc.s 23
-			IL_19cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-			IL_19d1: stloc.s 23
-			IL_19d3: ldloc.s 23
-			IL_19d5: ldloc.s 13
-			IL_19d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_19dc: stloc.s 26
-			IL_19de: ldloc.s 26
-			IL_19e0: box [System.Runtime]System.Boolean
-			IL_19e5: stloc.s 28
-			IL_19e7: ldloc.s 21
-			IL_19e9: ldstr "tail"
-			IL_19ee: ldloc.s 28
-			IL_19f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_19f5: pop
-			IL_19f6: nop
-			IL_19f7: ldc.i4.0
-			IL_19f8: box [System.Runtime]System.Boolean
-			IL_19fd: stloc.s 14
+			IL_1829: stloc.s 23
+			IL_182b: ldloc.s 23
+			IL_182d: ldstr "prototype"
+			IL_1832: ldloc.s 10
+			IL_1834: ldc.i4.0
+			IL_1835: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_183a: pop
+			IL_183b: ldc.i4.1
+			IL_183c: newarr [System.Runtime]System.Object
+			IL_1841: dup
+			IL_1842: ldc.i4.0
+			IL_1843: ldc.r8 50
+			IL_184c: box [System.Runtime]System.Double
+			IL_1851: stelem.ref
+			IL_1852: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_1857: ldc.r8 50
+			IL_1860: box [System.Runtime]System.Double
+			IL_1865: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::.ctor(object)
+			IL_186a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_186f: stloc.s 11
+			IL_1871: ldloc.s 11
+			IL_1873: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
+			IL_1878: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_187d: ldstr "prototype"
+			IL_1882: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_1887: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_188c: ldarg.0
+			IL_188d: ldc.i4.1
+			IL_188e: ldelem.ref
+			IL_188f: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_1894: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::DerivedAsyncGeneratorClass
+			IL_1899: stloc.s 23
+			IL_189b: ldc.i4.1
+			IL_189c: newarr [System.Runtime]System.Object
+			IL_18a1: dup
+			IL_18a2: ldc.i4.0
+			IL_18a3: ldarg.0
+			IL_18a4: ldc.i4.1
+			IL_18a5: ldelem.ref
+			IL_18a6: stelem.ref
+			IL_18a7: stloc.s 19
+			IL_18a9: ldloc.s 19
+			IL_18ab: ldc.i4.1
+			IL_18ac: newarr [System.Runtime]System.Object
+			IL_18b1: dup
+			IL_18b2: ldc.i4.0
+			IL_18b3: ldc.r8 60
+			IL_18bc: box [System.Runtime]System.Double
+			IL_18c1: stelem.ref
+			IL_18c2: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+			IL_18c7: ldloc.s 23
+			IL_18c9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+			IL_18ce: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+			IL_18d3: ldc.r8 60
+			IL_18dc: box [System.Runtime]System.Double
+			IL_18e1: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass::.ctor(object[], object)
+			IL_18e6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+			IL_18eb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+			IL_18f0: dup
+			IL_18f1: ldloc.s 23
+			IL_18f3: ldstr "prototype"
+			IL_18f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+			IL_18fd: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+			IL_1902: stloc.s 12
+			IL_1904: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_1909: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_190e: stloc.s 12
+			IL_1910: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+			IL_1915: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_191a: stloc.s 21
+			IL_191c: ldloc.s 11
+			IL_191e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass>(!!0)
+			IL_1923: stloc.s 32
+			IL_1925: ldloc.s 32
+			IL_1927: ldc.r8 6
+			IL_1930: box [System.Runtime]System.Double
+			IL_1935: callvirt instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::callRun(object)
+			IL_193a: stloc.s 23
+			IL_193c: ldloc.s 23
+			IL_193e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+			IL_1943: stloc.s 23
+			IL_1945: ldloc.s 23
+			IL_1947: ldloc.s 10
+			IL_1949: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_194e: stloc.s 26
+			IL_1950: ldloc.s 26
+			IL_1952: box [System.Runtime]System.Boolean
+			IL_1957: stloc.s 27
+			IL_1959: ldloc.s 12
+			IL_195b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1960: stloc.s 23
+			IL_1962: ldloc.s 23
+			IL_1964: isinst Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
+			IL_1969: dup
+			IL_196a: brfalse IL_1989
+
+			IL_196f: ldc.r8 7
+			IL_1978: box [System.Runtime]System.Double
+			IL_197d: callvirt instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass::callSuper(object)
+			IL_1982: stloc.s 23
+			IL_1984: br IL_19a6
+
+			IL_1989: pop
+			IL_198a: ldloc.s 23
+			IL_198c: ldstr "callSuper"
+			IL_1991: ldc.r8 7
+			IL_199a: box [System.Runtime]System.Double
+			IL_199f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_19a4: stloc.s 23
+
+			IL_19a6: ldloc.s 23
+			IL_19a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+			IL_19ad: stloc.s 23
+			IL_19af: ldloc.s 23
+			IL_19b1: ldloc.s 10
+			IL_19b3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_19b8: stloc.s 26
+			IL_19ba: ldloc.s 26
+			IL_19bc: box [System.Runtime]System.Boolean
+			IL_19c1: stloc.s 28
+			IL_19c3: ldloc.s 21
+			IL_19c5: ldstr "internalMethods"
+			IL_19ca: ldloc.s 27
+			IL_19cc: ldloc.s 28
+			IL_19ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+			IL_19d3: pop
+			IL_19d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_19d9: stloc.s 13
+			IL_19db: ldarg.0
+			IL_19dc: ldc.i4.1
+			IL_19dd: ldelem.ref
+			IL_19de: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
+			IL_19e3: ldfld object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope::expression
+			IL_19e8: ldstr "Cannot access 'expression' before initialization"
+			IL_19ed: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_19f2: stloc.s 23
+			IL_19f4: ldloc.s 23
+			IL_19f6: ldstr "prototype"
+			IL_19fb: ldloc.s 13
+			IL_19fd: ldc.i4.0
+			IL_19fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_1a03: pop
+			IL_1a04: nop
+			IL_1a05: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1a0a: stloc.s 21
+			IL_1a0c: ldc.i4.2
+			IL_1a0d: newarr [System.Runtime]System.Object
+			IL_1a12: dup
+			IL_1a13: ldc.i4.0
+			IL_1a14: ldarg.0
+			IL_1a15: ldc.i4.1
+			IL_1a16: ldelem.ref
+			IL_1a17: stelem.ref
+			IL_1a18: dup
+			IL_1a19: ldc.i4.1
+			IL_1a1a: ldloc.0
+			IL_1a1b: stelem.ref
+			IL_1a1c: stloc.s 19
+			IL_1a1e: ldloc.s 19
+			IL_1a20: ldnull
+			IL_1a21: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator::__js_call__(object[], object)
+			IL_1a26: stloc.s 23
+			IL_1a28: ldloc.s 23
+			IL_1a2a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+			IL_1a2f: stloc.s 23
+			IL_1a31: ldloc.s 23
+			IL_1a33: ldloc.s 13
+			IL_1a35: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_1a3a: stloc.s 26
+			IL_1a3c: ldloc.s 26
+			IL_1a3e: box [System.Runtime]System.Boolean
+			IL_1a43: stloc.s 28
+			IL_1a45: ldloc.s 21
+			IL_1a47: ldstr "tail"
+			IL_1a4c: ldloc.s 28
+			IL_1a4e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_1a53: pop
+			IL_1a54: nop
+			IL_1a55: ldc.i4.0
+			IL_1a56: box [System.Runtime]System.Boolean
+			IL_1a5b: stloc.s 14
 			.try
 			{
-				IL_19ff: nop
-				IL_1a00: ldc.i4.1
-				IL_1a01: newarr [System.Runtime]System.Object
-				IL_1a06: dup
-				IL_1a07: ldc.i4.0
-				IL_1a08: ldarg.0
-				IL_1a09: ldc.i4.1
-				IL_1a0a: ldelem.ref
-				IL_1a0b: stelem.ref
-				IL_1a0c: stloc.s 19
-				IL_1a0e: ldloc.2
-				IL_1a0f: ldloc.s 19
-				IL_1a11: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_1a16: pop
-				IL_1a17: leave IL_1a7b
+				IL_1a5d: nop
+				IL_1a5e: ldc.i4.1
+				IL_1a5f: newarr [System.Runtime]System.Object
+				IL_1a64: dup
+				IL_1a65: ldc.i4.0
+				IL_1a66: ldarg.0
+				IL_1a67: ldc.i4.1
+				IL_1a68: ldelem.ref
+				IL_1a69: stelem.ref
+				IL_1a6a: stloc.s 19
+				IL_1a6c: ldloc.2
+				IL_1a6d: ldloc.s 19
+				IL_1a6f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_1a74: pop
+				IL_1a75: leave IL_1ad9
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_1a1c: stloc.s 15
-				IL_1a1e: ldloc.s 15
-				IL_1a20: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_1a25: dup
-				IL_1a26: brtrue IL_1a3c
+				IL_1a7a: stloc.s 15
+				IL_1a7c: ldloc.s 15
+				IL_1a7e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_1a83: dup
+				IL_1a84: brtrue IL_1a9a
 
-				IL_1a2b: pop
-				IL_1a2c: ldloc.s 15
-				IL_1a2e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_1a33: dup
-				IL_1a34: brtrue IL_1a48
+				IL_1a89: pop
+				IL_1a8a: ldloc.s 15
+				IL_1a8c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_1a91: dup
+				IL_1a92: brtrue IL_1aa6
 
-				IL_1a39: pop
-				IL_1a3a: rethrow
+				IL_1a97: pop
+				IL_1a98: rethrow
 
-				IL_1a3c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_1a41: stloc.s 16
-				IL_1a43: br IL_1a4a
+				IL_1a9a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_1a9f: stloc.s 16
+				IL_1aa1: br IL_1aa8
 
-				IL_1a48: stloc.s 16
+				IL_1aa6: stloc.s 16
 
-				IL_1a4a: ldloc.s 16
-				IL_1a4c: stloc.s 17
-				IL_1a4e: ldloc.s 17
-				IL_1a50: stloc.s 23
-				IL_1a52: ldstr "ReferenceError"
-				IL_1a57: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_1a5c: stloc.s 24
-				IL_1a5e: ldloc.s 23
-				IL_1a60: ldloc.s 24
-				IL_1a62: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-				IL_1a67: stloc.s 26
-				IL_1a69: ldloc.s 26
-				IL_1a6b: box [System.Runtime]System.Boolean
-				IL_1a70: stloc.s 28
-				IL_1a72: ldloc.s 28
-				IL_1a74: stloc.s 14
-				IL_1a76: leave IL_1a7b
+				IL_1aa8: ldloc.s 16
+				IL_1aaa: stloc.s 17
+				IL_1aac: ldloc.s 17
+				IL_1aae: stloc.s 23
+				IL_1ab0: ldstr "ReferenceError"
+				IL_1ab5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_1aba: stloc.s 24
+				IL_1abc: ldloc.s 23
+				IL_1abe: ldloc.s 24
+				IL_1ac0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+				IL_1ac5: stloc.s 26
+				IL_1ac7: ldloc.s 26
+				IL_1ac9: box [System.Runtime]System.Boolean
+				IL_1ace: stloc.s 28
+				IL_1ad0: ldloc.s 28
+				IL_1ad2: stloc.s 14
+				IL_1ad4: leave IL_1ad9
 			} // end handler
 
-			IL_1a7b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1a80: stloc.s 21
-			IL_1a82: ldloc.s 21
-			IL_1a84: ldstr "parameterSetup"
-			IL_1a89: ldloc.s 14
-			IL_1a8b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_1a90: pop
-			IL_1a91: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1a96: stloc.s 21
-			IL_1a98: ldnull
-			IL_1a99: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
-			IL_1a9e: stloc.s 24
-			IL_1aa0: ldnull
-			IL_1aa1: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
-			IL_1aa6: stloc.s 23
-			IL_1aa8: ldloc.s 24
-			IL_1aaa: ldloc.s 23
-			IL_1aac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_1ab1: stloc.s 26
-			IL_1ab3: ldloc.s 26
-			IL_1ab5: box [System.Runtime]System.Boolean
-			IL_1aba: stloc.s 28
-			IL_1abc: ldloc.s 21
-			IL_1abe: ldstr "identity"
-			IL_1ac3: ldloc.s 28
-			IL_1ac5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_1aca: pop
-			IL_1acb: ldnull
-			IL_1acc: stloc.s 18
-			IL_1ace: ldloc.0
-			IL_1acf: ldc.i4.m1
-			IL_1ad0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_1ad5: ldloc.0
-			IL_1ad6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_1adb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_1ae0: ldarg.0
-			IL_1ae1: ldc.i4.1
-			IL_1ae2: newarr [System.Runtime]System.Object
-			IL_1ae7: dup
-			IL_1ae8: ldc.i4.0
-			IL_1ae9: ldloc.s 18
-			IL_1aeb: stelem.ref
-			IL_1aec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_1af1: pop
-			IL_1af2: ldloc.0
-			IL_1af3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_1af8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_1afd: ret
+			IL_1ad9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1ade: stloc.s 21
+			IL_1ae0: ldloc.s 21
+			IL_1ae2: ldstr "parameterSetup"
+			IL_1ae7: ldloc.s 14
+			IL_1ae9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_1aee: pop
+			IL_1aef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1af4: stloc.s 21
+			IL_1af6: ldnull
+			IL_1af7: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
+			IL_1afc: stloc.s 24
+			IL_1afe: ldnull
+			IL_1aff: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
+			IL_1b04: stloc.s 23
+			IL_1b06: ldloc.s 24
+			IL_1b08: ldloc.s 23
+			IL_1b0a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_1b0f: stloc.s 26
+			IL_1b11: ldloc.s 26
+			IL_1b13: box [System.Runtime]System.Boolean
+			IL_1b18: stloc.s 28
+			IL_1b1a: ldloc.s 21
+			IL_1b1c: ldstr "identity"
+			IL_1b21: ldloc.s 28
+			IL_1b23: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_1b28: pop
+			IL_1b29: ldnull
+			IL_1b2a: stloc.s 18
+			IL_1b2c: ldloc.0
+			IL_1b2d: ldc.i4.m1
+			IL_1b2e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_1b33: ldloc.0
+			IL_1b34: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_1b39: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_1b3e: ldarg.0
+			IL_1b3f: ldc.i4.1
+			IL_1b40: newarr [System.Runtime]System.Object
+			IL_1b45: dup
+			IL_1b46: ldc.i4.0
+			IL_1b47: ldloc.s 18
+			IL_1b49: stelem.ref
+			IL_1b4a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_1b4f: pop
+			IL_1b50: ldloc.0
+			IL_1b51: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_1b56: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_1b5b: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -7439,6 +7466,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_79
 	.field assembly static int32 __jroc_dynamicLookup_80
 	.field assembly static int32 __jroc_dynamicLookup_81
+	.field assembly static int32 __jroc_dynamicLookup_82
+	.field assembly static int32 __jroc_dynamicLookup_83
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
@@ -779,7 +779,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 1188 (0x4a4)
+			// Code size: 1241 (0x4d9)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope,
@@ -877,7 +877,7 @@
 
 			IL_00aa: ldloc.0
 			IL_00ab: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00b0: switch (IL_00c5, IL_0174, IL_0292, IL_03c9)
+			IL_00b0: switch (IL_00c5, IL_0174, IL_02c7, IL_03fe)
 
 			IL_00c5: ldarg.0
 			IL_00c6: ldc.i4.1
@@ -1023,256 +1023,270 @@
 			IL_021f: ldloc.1
 			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0225: stloc.s 6
-			IL_0227: ldloc.s 6
-			IL_0229: ldstr "return"
-			IL_022e: ldc.r8 99
-			IL_0237: box [System.Runtime]System.Double
-			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0241: stloc.s 6
-			IL_0243: ldloc.0
-			IL_0244: ldc.i4.2
-			IL_0245: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_024a: ldloc.0
-			IL_024b: ldloc.s 6
-			IL_024d: ldarg.0
-			IL_024e: ldc.i4.2
-			IL_024f: ldloc.0
-			IL_0250: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0255: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_025a: ldloc.0
-			IL_025b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0260: dup
-			IL_0261: ldc.i4.0
-			IL_0262: ldloc.1
-			IL_0263: stelem.ref
-			IL_0264: dup
-			IL_0265: ldc.i4.1
-			IL_0266: ldloc.2
-			IL_0267: stelem.ref
-			IL_0268: dup
-			IL_0269: ldc.i4.2
-			IL_026a: ldloc.3
-			IL_026b: stelem.ref
-			IL_026c: dup
-			IL_026d: ldc.i4.3
-			IL_026e: ldloc.s 4
-			IL_0270: stelem.ref
-			IL_0271: dup
-			IL_0272: ldc.i4.4
-			IL_0273: ldloc.s 5
-			IL_0275: stelem.ref
-			IL_0276: dup
-			IL_0277: ldc.i4.5
-			IL_0278: ldloc.s 6
-			IL_027a: stelem.ref
-			IL_027b: dup
-			IL_027c: ldc.i4.6
-			IL_027d: ldloc.s 7
-			IL_027f: stelem.ref
-			IL_0280: dup
-			IL_0281: ldc.i4.7
-			IL_0282: ldloc.s 8
-			IL_0284: stelem.ref
-			IL_0285: pop
-			IL_0286: ldloc.0
-			IL_0287: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_028c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0291: ret
+			IL_0227: volatile.
+			IL_0229: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_022e: brfalse IL_0252
 
-			IL_0292: ldloc.0
-			IL_0293: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited2
-			IL_0298: stloc.3
-			IL_0299: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_029e: stloc.s 7
-			IL_02a0: volatile.
-			IL_02a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_02a7: brfalse IL_02bc
+			IL_0233: ldloc.s 6
+			IL_0235: ldstr "return"
+			IL_023a: ldc.r8 99
+			IL_0243: box [System.Runtime]System.Double
+			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_024d: br IL_0276
 
-			IL_02ac: ldloc.3
-			IL_02ad: ldstr "value"
-			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b7: br IL_02d1
+			IL_0252: ldloc.s 6
+			IL_0254: ldstr "return"
+			IL_0259: ldc.r8 99
+			IL_0262: box [System.Runtime]System.Double
+			IL_0267: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:29"
+			IL_026c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_02bc: ldloc.3
-			IL_02bd: ldstr "value"
-			IL_02c2: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:36"
-			IL_02c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0276: stloc.s 6
+			IL_0278: ldloc.0
+			IL_0279: ldc.i4.2
+			IL_027a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_027f: ldloc.0
+			IL_0280: ldloc.s 6
+			IL_0282: ldarg.0
+			IL_0283: ldc.i4.2
+			IL_0284: ldloc.0
+			IL_0285: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_028a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_028f: ldloc.0
+			IL_0290: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0295: dup
+			IL_0296: ldc.i4.0
+			IL_0297: ldloc.1
+			IL_0298: stelem.ref
+			IL_0299: dup
+			IL_029a: ldc.i4.1
+			IL_029b: ldloc.2
+			IL_029c: stelem.ref
+			IL_029d: dup
+			IL_029e: ldc.i4.2
+			IL_029f: ldloc.3
+			IL_02a0: stelem.ref
+			IL_02a1: dup
+			IL_02a2: ldc.i4.3
+			IL_02a3: ldloc.s 4
+			IL_02a5: stelem.ref
+			IL_02a6: dup
+			IL_02a7: ldc.i4.4
+			IL_02a8: ldloc.s 5
+			IL_02aa: stelem.ref
+			IL_02ab: dup
+			IL_02ac: ldc.i4.5
+			IL_02ad: ldloc.s 6
+			IL_02af: stelem.ref
+			IL_02b0: dup
+			IL_02b1: ldc.i4.6
+			IL_02b2: ldloc.s 7
+			IL_02b4: stelem.ref
+			IL_02b5: dup
+			IL_02b6: ldc.i4.7
+			IL_02b7: ldloc.s 8
+			IL_02b9: stelem.ref
+			IL_02ba: pop
+			IL_02bb: ldloc.0
+			IL_02bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02c1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02c6: ret
 
-			IL_02d1: stloc.s 6
-			IL_02d3: ldstr "r2.value="
-			IL_02d8: ldloc.s 6
-			IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02df: stloc.s 8
-			IL_02e1: ldloc.s 7
-			IL_02e3: ldloc.s 8
-			IL_02e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02ea: pop
-			IL_02eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02f0: stloc.s 7
-			IL_02f2: volatile.
-			IL_02f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_02f9: brfalse IL_030e
+			IL_02c7: ldloc.0
+			IL_02c8: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited2
+			IL_02cd: stloc.3
+			IL_02ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02d3: stloc.s 7
+			IL_02d5: volatile.
+			IL_02d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_02dc: brfalse IL_02f1
 
-			IL_02fe: ldloc.3
-			IL_02ff: ldstr "done"
-			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0309: br IL_0323
+			IL_02e1: ldloc.3
+			IL_02e2: ldstr "value"
+			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ec: br IL_0306
 
-			IL_030e: ldloc.3
-			IL_030f: ldstr "done"
-			IL_0314: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:43"
-			IL_0319: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02f1: ldloc.3
+			IL_02f2: ldstr "value"
+			IL_02f7: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:36"
+			IL_02fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0323: stloc.s 6
-			IL_0325: ldstr "r2.done="
-			IL_032a: ldloc.s 6
-			IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0331: stloc.s 8
-			IL_0333: ldloc.s 7
-			IL_0335: ldloc.s 8
-			IL_0337: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_033c: pop
-			IL_033d: ldloc.1
-			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0343: stloc.s 6
-			IL_0345: volatile.
-			IL_0347: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_034c: brfalse IL_0362
+			IL_0306: stloc.s 6
+			IL_0308: ldstr "r2.value="
+			IL_030d: ldloc.s 6
+			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0314: stloc.s 8
+			IL_0316: ldloc.s 7
+			IL_0318: ldloc.s 8
+			IL_031a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_031f: pop
+			IL_0320: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0325: stloc.s 7
+			IL_0327: volatile.
+			IL_0329: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_032e: brfalse IL_0343
 
-			IL_0351: ldloc.s 6
-			IL_0353: ldstr "next"
-			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_035d: br IL_0378
+			IL_0333: ldloc.3
+			IL_0334: ldstr "done"
+			IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033e: br IL_0358
 
-			IL_0362: ldloc.s 6
-			IL_0364: ldstr "next"
-			IL_0369: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:48"
-			IL_036e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0343: ldloc.3
+			IL_0344: ldstr "done"
+			IL_0349: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:43"
+			IL_034e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
+			IL_0358: stloc.s 6
+			IL_035a: ldstr "r2.done="
+			IL_035f: ldloc.s 6
+			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0366: stloc.s 8
+			IL_0368: ldloc.s 7
+			IL_036a: ldloc.s 8
+			IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0371: pop
+			IL_0372: ldloc.1
+			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0378: stloc.s 6
-			IL_037a: ldloc.0
-			IL_037b: ldc.i4.3
-			IL_037c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0381: ldloc.0
-			IL_0382: ldloc.s 6
-			IL_0384: ldarg.0
-			IL_0385: ldc.i4.3
-			IL_0386: ldloc.0
-			IL_0387: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_038c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0391: ldloc.0
-			IL_0392: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0397: dup
-			IL_0398: ldc.i4.0
-			IL_0399: ldloc.1
-			IL_039a: stelem.ref
-			IL_039b: dup
-			IL_039c: ldc.i4.1
-			IL_039d: ldloc.2
-			IL_039e: stelem.ref
-			IL_039f: dup
-			IL_03a0: ldc.i4.2
-			IL_03a1: ldloc.3
-			IL_03a2: stelem.ref
-			IL_03a3: dup
-			IL_03a4: ldc.i4.3
-			IL_03a5: ldloc.s 4
-			IL_03a7: stelem.ref
-			IL_03a8: dup
-			IL_03a9: ldc.i4.4
-			IL_03aa: ldloc.s 5
-			IL_03ac: stelem.ref
-			IL_03ad: dup
-			IL_03ae: ldc.i4.5
-			IL_03af: ldloc.s 6
-			IL_03b1: stelem.ref
-			IL_03b2: dup
-			IL_03b3: ldc.i4.6
-			IL_03b4: ldloc.s 7
-			IL_03b6: stelem.ref
-			IL_03b7: dup
-			IL_03b8: ldc.i4.7
-			IL_03b9: ldloc.s 8
-			IL_03bb: stelem.ref
-			IL_03bc: pop
-			IL_03bd: ldloc.0
-			IL_03be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03c3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03c8: ret
+			IL_037a: volatile.
+			IL_037c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0381: brfalse IL_0397
 
-			IL_03c9: ldloc.0
-			IL_03ca: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited3
-			IL_03cf: stloc.s 4
-			IL_03d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03d6: stloc.s 7
-			IL_03d8: volatile.
-			IL_03da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_03df: brfalse IL_03f5
+			IL_0386: ldloc.s 6
+			IL_0388: ldstr "next"
+			IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0392: br IL_03ad
 
-			IL_03e4: ldloc.s 4
-			IL_03e6: ldstr "value"
-			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03f0: br IL_040b
+			IL_0397: ldloc.s 6
+			IL_0399: ldstr "next"
+			IL_039e: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:48"
+			IL_03a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_03f5: ldloc.s 4
-			IL_03f7: ldstr "value"
-			IL_03fc: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:55"
-			IL_0401: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03ad: stloc.s 6
+			IL_03af: ldloc.0
+			IL_03b0: ldc.i4.3
+			IL_03b1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03b6: ldloc.0
+			IL_03b7: ldloc.s 6
+			IL_03b9: ldarg.0
+			IL_03ba: ldc.i4.3
+			IL_03bb: ldloc.0
+			IL_03bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_03c6: ldloc.0
+			IL_03c7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03cc: dup
+			IL_03cd: ldc.i4.0
+			IL_03ce: ldloc.1
+			IL_03cf: stelem.ref
+			IL_03d0: dup
+			IL_03d1: ldc.i4.1
+			IL_03d2: ldloc.2
+			IL_03d3: stelem.ref
+			IL_03d4: dup
+			IL_03d5: ldc.i4.2
+			IL_03d6: ldloc.3
+			IL_03d7: stelem.ref
+			IL_03d8: dup
+			IL_03d9: ldc.i4.3
+			IL_03da: ldloc.s 4
+			IL_03dc: stelem.ref
+			IL_03dd: dup
+			IL_03de: ldc.i4.4
+			IL_03df: ldloc.s 5
+			IL_03e1: stelem.ref
+			IL_03e2: dup
+			IL_03e3: ldc.i4.5
+			IL_03e4: ldloc.s 6
+			IL_03e6: stelem.ref
+			IL_03e7: dup
+			IL_03e8: ldc.i4.6
+			IL_03e9: ldloc.s 7
+			IL_03eb: stelem.ref
+			IL_03ec: dup
+			IL_03ed: ldc.i4.7
+			IL_03ee: ldloc.s 8
+			IL_03f0: stelem.ref
+			IL_03f1: pop
+			IL_03f2: ldloc.0
+			IL_03f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03f8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03fd: ret
 
-			IL_040b: stloc.s 6
-			IL_040d: ldstr "r3.value="
-			IL_0412: ldloc.s 6
-			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0419: stloc.s 8
-			IL_041b: ldloc.s 7
-			IL_041d: ldloc.s 8
-			IL_041f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0424: pop
-			IL_0425: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_042a: stloc.s 7
-			IL_042c: volatile.
-			IL_042e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0433: brfalse IL_0449
+			IL_03fe: ldloc.0
+			IL_03ff: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited3
+			IL_0404: stloc.s 4
+			IL_0406: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_040b: stloc.s 7
+			IL_040d: volatile.
+			IL_040f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0414: brfalse IL_042a
 
-			IL_0438: ldloc.s 4
-			IL_043a: ldstr "done"
-			IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0444: br IL_045f
+			IL_0419: ldloc.s 4
+			IL_041b: ldstr "value"
+			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0425: br IL_0440
 
-			IL_0449: ldloc.s 4
-			IL_044b: ldstr "done"
-			IL_0450: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:62"
-			IL_0455: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_042a: ldloc.s 4
+			IL_042c: ldstr "value"
+			IL_0431: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:55"
+			IL_0436: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_045f: stloc.s 6
-			IL_0461: ldstr "r3.done="
-			IL_0466: ldloc.s 6
-			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_046d: stloc.s 8
-			IL_046f: ldloc.s 7
-			IL_0471: ldloc.s 8
-			IL_0473: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0478: pop
-			IL_0479: ldloc.0
-			IL_047a: ldc.i4.m1
-			IL_047b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0480: ldloc.0
-			IL_0481: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0486: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_048b: ldarg.0
-			IL_048c: ldc.i4.1
-			IL_048d: newarr [System.Runtime]System.Object
-			IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0497: pop
-			IL_0498: ldloc.0
-			IL_0499: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_049e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04a3: ret
+			IL_0440: stloc.s 6
+			IL_0442: ldstr "r3.value="
+			IL_0447: ldloc.s 6
+			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_044e: stloc.s 8
+			IL_0450: ldloc.s 7
+			IL_0452: ldloc.s 8
+			IL_0454: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0459: pop
+			IL_045a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_045f: stloc.s 7
+			IL_0461: volatile.
+			IL_0463: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0468: brfalse IL_047e
+
+			IL_046d: ldloc.s 4
+			IL_046f: ldstr "done"
+			IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0479: br IL_0494
+
+			IL_047e: ldloc.s 4
+			IL_0480: ldstr "done"
+			IL_0485: ldstr "AsyncGenerator_Return:<TwoPhaseDummy_M5>:__js_call__:62"
+			IL_048a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0494: stloc.s 6
+			IL_0496: ldstr "r3.done="
+			IL_049b: ldloc.s 6
+			IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04a2: stloc.s 8
+			IL_04a4: ldloc.s 7
+			IL_04a6: ldloc.s 8
+			IL_04a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04ad: pop
+			IL_04ae: ldloc.0
+			IL_04af: ldc.i4.m1
+			IL_04b0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04b5: ldloc.0
+			IL_04b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04c0: ldarg.0
+			IL_04c1: ldc.i4.1
+			IL_04c2: newarr [System.Runtime]System.Object
+			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04cc: pop
+			IL_04cd: ldloc.0
+			IL_04ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04d8: ret
 		} // end of method ArrowFunction_L14C2::__js_call__
 
 	} // end of class ArrowFunction_L14C2
@@ -1411,6 +1425,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
@@ -842,7 +842,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 1179 (0x49b)
+			// Code size: 1223 (0x4c7)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope,
@@ -940,7 +940,7 @@
 
 			IL_00aa: ldloc.0
 			IL_00ab: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00b0: switch (IL_00c5, IL_0174, IL_0289, IL_03c0)
+			IL_00b0: switch (IL_00c5, IL_0174, IL_02b5, IL_03ec)
 
 			IL_00c5: ldarg.0
 			IL_00c6: ldc.i4.1
@@ -1086,255 +1086,268 @@
 			IL_021f: ldloc.1
 			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0225: stloc.s 6
-			IL_0227: ldloc.s 6
-			IL_0229: ldstr "throw"
-			IL_022e: ldstr "boom"
-			IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0238: stloc.s 6
-			IL_023a: ldloc.0
-			IL_023b: ldc.i4.2
-			IL_023c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0241: ldloc.0
-			IL_0242: ldloc.s 6
-			IL_0244: ldarg.0
-			IL_0245: ldc.i4.2
-			IL_0246: ldloc.0
-			IL_0247: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_024c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0251: ldloc.0
-			IL_0252: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0257: dup
-			IL_0258: ldc.i4.0
-			IL_0259: ldloc.1
-			IL_025a: stelem.ref
-			IL_025b: dup
-			IL_025c: ldc.i4.1
-			IL_025d: ldloc.2
-			IL_025e: stelem.ref
-			IL_025f: dup
-			IL_0260: ldc.i4.2
-			IL_0261: ldloc.3
-			IL_0262: stelem.ref
-			IL_0263: dup
-			IL_0264: ldc.i4.3
-			IL_0265: ldloc.s 4
-			IL_0267: stelem.ref
-			IL_0268: dup
-			IL_0269: ldc.i4.4
-			IL_026a: ldloc.s 5
-			IL_026c: stelem.ref
-			IL_026d: dup
-			IL_026e: ldc.i4.5
-			IL_026f: ldloc.s 6
-			IL_0271: stelem.ref
-			IL_0272: dup
-			IL_0273: ldc.i4.6
-			IL_0274: ldloc.s 7
-			IL_0276: stelem.ref
-			IL_0277: dup
-			IL_0278: ldc.i4.7
-			IL_0279: ldloc.s 8
-			IL_027b: stelem.ref
-			IL_027c: pop
+			IL_0227: volatile.
+			IL_0229: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_022e: brfalse IL_0249
+
+			IL_0233: ldloc.s 6
+			IL_0235: ldstr "throw"
+			IL_023a: ldstr "boom"
+			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0244: br IL_0264
+
+			IL_0249: ldloc.s 6
+			IL_024b: ldstr "throw"
+			IL_0250: ldstr "boom"
+			IL_0255: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:28"
+			IL_025a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0264: stloc.s 6
+			IL_0266: ldloc.0
+			IL_0267: ldc.i4.2
+			IL_0268: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_026d: ldloc.0
+			IL_026e: ldloc.s 6
+			IL_0270: ldarg.0
+			IL_0271: ldc.i4.2
+			IL_0272: ldloc.0
+			IL_0273: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0278: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
 			IL_027d: ldloc.0
-			IL_027e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0283: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0288: ret
+			IL_027e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0283: dup
+			IL_0284: ldc.i4.0
+			IL_0285: ldloc.1
+			IL_0286: stelem.ref
+			IL_0287: dup
+			IL_0288: ldc.i4.1
+			IL_0289: ldloc.2
+			IL_028a: stelem.ref
+			IL_028b: dup
+			IL_028c: ldc.i4.2
+			IL_028d: ldloc.3
+			IL_028e: stelem.ref
+			IL_028f: dup
+			IL_0290: ldc.i4.3
+			IL_0291: ldloc.s 4
+			IL_0293: stelem.ref
+			IL_0294: dup
+			IL_0295: ldc.i4.4
+			IL_0296: ldloc.s 5
+			IL_0298: stelem.ref
+			IL_0299: dup
+			IL_029a: ldc.i4.5
+			IL_029b: ldloc.s 6
+			IL_029d: stelem.ref
+			IL_029e: dup
+			IL_029f: ldc.i4.6
+			IL_02a0: ldloc.s 7
+			IL_02a2: stelem.ref
+			IL_02a3: dup
+			IL_02a4: ldc.i4.7
+			IL_02a5: ldloc.s 8
+			IL_02a7: stelem.ref
+			IL_02a8: pop
+			IL_02a9: ldloc.0
+			IL_02aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02af: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02b4: ret
 
-			IL_0289: ldloc.0
-			IL_028a: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited2
-			IL_028f: stloc.3
-			IL_0290: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0295: stloc.s 7
-			IL_0297: volatile.
-			IL_0299: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_029e: brfalse IL_02b3
+			IL_02b5: ldloc.0
+			IL_02b6: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited2
+			IL_02bb: stloc.3
+			IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02c1: stloc.s 7
+			IL_02c3: volatile.
+			IL_02c5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_02ca: brfalse IL_02df
 
-			IL_02a3: ldloc.3
-			IL_02a4: ldstr "value"
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ae: br IL_02c8
+			IL_02cf: ldloc.3
+			IL_02d0: ldstr "value"
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02da: br IL_02f4
 
-			IL_02b3: ldloc.3
-			IL_02b4: ldstr "value"
-			IL_02b9: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:35"
-			IL_02be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02df: ldloc.3
+			IL_02e0: ldstr "value"
+			IL_02e5: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:35"
+			IL_02ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02c8: stloc.s 6
-			IL_02ca: ldstr "r2.value="
-			IL_02cf: ldloc.s 6
-			IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02d6: stloc.s 8
-			IL_02d8: ldloc.s 7
-			IL_02da: ldloc.s 8
-			IL_02dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02e1: pop
-			IL_02e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02e7: stloc.s 7
-			IL_02e9: volatile.
-			IL_02eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_02f0: brfalse IL_0305
+			IL_02f4: stloc.s 6
+			IL_02f6: ldstr "r2.value="
+			IL_02fb: ldloc.s 6
+			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0302: stloc.s 8
+			IL_0304: ldloc.s 7
+			IL_0306: ldloc.s 8
+			IL_0308: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_030d: pop
+			IL_030e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0313: stloc.s 7
+			IL_0315: volatile.
+			IL_0317: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_031c: brfalse IL_0331
 
-			IL_02f5: ldloc.3
-			IL_02f6: ldstr "done"
-			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0300: br IL_031a
+			IL_0321: ldloc.3
+			IL_0322: ldstr "done"
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_032c: br IL_0346
 
-			IL_0305: ldloc.3
-			IL_0306: ldstr "done"
-			IL_030b: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:42"
-			IL_0310: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0331: ldloc.3
+			IL_0332: ldstr "done"
+			IL_0337: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:42"
+			IL_033c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_031a: stloc.s 6
-			IL_031c: ldstr "r2.done="
-			IL_0321: ldloc.s 6
-			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0328: stloc.s 8
-			IL_032a: ldloc.s 7
-			IL_032c: ldloc.s 8
-			IL_032e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0333: pop
-			IL_0334: ldloc.1
-			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_033a: stloc.s 6
-			IL_033c: volatile.
-			IL_033e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_0343: brfalse IL_0359
+			IL_0346: stloc.s 6
+			IL_0348: ldstr "r2.done="
+			IL_034d: ldloc.s 6
+			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0354: stloc.s 8
+			IL_0356: ldloc.s 7
+			IL_0358: ldloc.s 8
+			IL_035a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_035f: pop
+			IL_0360: ldloc.1
+			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0366: stloc.s 6
+			IL_0368: volatile.
+			IL_036a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_036f: brfalse IL_0385
 
-			IL_0348: ldloc.s 6
-			IL_034a: ldstr "next"
-			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0354: br IL_036f
+			IL_0374: ldloc.s 6
+			IL_0376: ldstr "next"
+			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0380: br IL_039b
 
-			IL_0359: ldloc.s 6
-			IL_035b: ldstr "next"
-			IL_0360: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:47"
-			IL_0365: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0385: ldloc.s 6
+			IL_0387: ldstr "next"
+			IL_038c: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:47"
+			IL_0391: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_036f: stloc.s 6
-			IL_0371: ldloc.0
-			IL_0372: ldc.i4.3
-			IL_0373: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0378: ldloc.0
-			IL_0379: ldloc.s 6
-			IL_037b: ldarg.0
-			IL_037c: ldc.i4.3
-			IL_037d: ldloc.0
-			IL_037e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0383: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0388: ldloc.0
-			IL_0389: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_038e: dup
-			IL_038f: ldc.i4.0
-			IL_0390: ldloc.1
-			IL_0391: stelem.ref
-			IL_0392: dup
-			IL_0393: ldc.i4.1
-			IL_0394: ldloc.2
-			IL_0395: stelem.ref
-			IL_0396: dup
-			IL_0397: ldc.i4.2
-			IL_0398: ldloc.3
-			IL_0399: stelem.ref
-			IL_039a: dup
-			IL_039b: ldc.i4.3
-			IL_039c: ldloc.s 4
-			IL_039e: stelem.ref
-			IL_039f: dup
-			IL_03a0: ldc.i4.4
-			IL_03a1: ldloc.s 5
-			IL_03a3: stelem.ref
-			IL_03a4: dup
-			IL_03a5: ldc.i4.5
-			IL_03a6: ldloc.s 6
-			IL_03a8: stelem.ref
-			IL_03a9: dup
-			IL_03aa: ldc.i4.6
-			IL_03ab: ldloc.s 7
-			IL_03ad: stelem.ref
-			IL_03ae: dup
-			IL_03af: ldc.i4.7
-			IL_03b0: ldloc.s 8
-			IL_03b2: stelem.ref
-			IL_03b3: pop
+			IL_039b: stloc.s 6
+			IL_039d: ldloc.0
+			IL_039e: ldc.i4.3
+			IL_039f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03a4: ldloc.0
+			IL_03a5: ldloc.s 6
+			IL_03a7: ldarg.0
+			IL_03a8: ldc.i4.3
+			IL_03a9: ldloc.0
+			IL_03aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
 			IL_03b4: ldloc.0
-			IL_03b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ba: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03bf: ret
+			IL_03b5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03ba: dup
+			IL_03bb: ldc.i4.0
+			IL_03bc: ldloc.1
+			IL_03bd: stelem.ref
+			IL_03be: dup
+			IL_03bf: ldc.i4.1
+			IL_03c0: ldloc.2
+			IL_03c1: stelem.ref
+			IL_03c2: dup
+			IL_03c3: ldc.i4.2
+			IL_03c4: ldloc.3
+			IL_03c5: stelem.ref
+			IL_03c6: dup
+			IL_03c7: ldc.i4.3
+			IL_03c8: ldloc.s 4
+			IL_03ca: stelem.ref
+			IL_03cb: dup
+			IL_03cc: ldc.i4.4
+			IL_03cd: ldloc.s 5
+			IL_03cf: stelem.ref
+			IL_03d0: dup
+			IL_03d1: ldc.i4.5
+			IL_03d2: ldloc.s 6
+			IL_03d4: stelem.ref
+			IL_03d5: dup
+			IL_03d6: ldc.i4.6
+			IL_03d7: ldloc.s 7
+			IL_03d9: stelem.ref
+			IL_03da: dup
+			IL_03db: ldc.i4.7
+			IL_03dc: ldloc.s 8
+			IL_03de: stelem.ref
+			IL_03df: pop
+			IL_03e0: ldloc.0
+			IL_03e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03eb: ret
 
-			IL_03c0: ldloc.0
-			IL_03c1: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited3
-			IL_03c6: stloc.s 4
-			IL_03c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03cd: stloc.s 7
-			IL_03cf: volatile.
-			IL_03d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_03d6: brfalse IL_03ec
+			IL_03ec: ldloc.0
+			IL_03ed: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited3
+			IL_03f2: stloc.s 4
+			IL_03f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03f9: stloc.s 7
+			IL_03fb: volatile.
+			IL_03fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0402: brfalse IL_0418
 
-			IL_03db: ldloc.s 4
-			IL_03dd: ldstr "value"
-			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e7: br IL_0402
+			IL_0407: ldloc.s 4
+			IL_0409: ldstr "value"
+			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0413: br IL_042e
 
-			IL_03ec: ldloc.s 4
-			IL_03ee: ldstr "value"
-			IL_03f3: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:54"
-			IL_03f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0418: ldloc.s 4
+			IL_041a: ldstr "value"
+			IL_041f: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:54"
+			IL_0424: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0402: stloc.s 6
-			IL_0404: ldstr "r3.value="
-			IL_0409: ldloc.s 6
-			IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0410: stloc.s 8
-			IL_0412: ldloc.s 7
-			IL_0414: ldloc.s 8
-			IL_0416: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_041b: pop
-			IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0421: stloc.s 7
-			IL_0423: volatile.
-			IL_0425: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_042a: brfalse IL_0440
+			IL_042e: stloc.s 6
+			IL_0430: ldstr "r3.value="
+			IL_0435: ldloc.s 6
+			IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_043c: stloc.s 8
+			IL_043e: ldloc.s 7
+			IL_0440: ldloc.s 8
+			IL_0442: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0447: pop
+			IL_0448: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_044d: stloc.s 7
+			IL_044f: volatile.
+			IL_0451: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0456: brfalse IL_046c
 
-			IL_042f: ldloc.s 4
-			IL_0431: ldstr "done"
-			IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_043b: br IL_0456
+			IL_045b: ldloc.s 4
+			IL_045d: ldstr "done"
+			IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0467: br IL_0482
 
-			IL_0440: ldloc.s 4
-			IL_0442: ldstr "done"
-			IL_0447: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:61"
-			IL_044c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_046c: ldloc.s 4
+			IL_046e: ldstr "done"
+			IL_0473: ldstr "AsyncGenerator_Throw:<TwoPhaseDummy_M5>:__js_call__:61"
+			IL_0478: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0456: stloc.s 6
-			IL_0458: ldstr "r3.done="
-			IL_045d: ldloc.s 6
-			IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0464: stloc.s 8
-			IL_0466: ldloc.s 7
-			IL_0468: ldloc.s 8
-			IL_046a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_046f: pop
-			IL_0470: ldloc.0
-			IL_0471: ldc.i4.m1
-			IL_0472: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0477: ldloc.0
-			IL_0478: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_047d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0482: ldarg.0
-			IL_0483: ldc.i4.1
-			IL_0484: newarr [System.Runtime]System.Object
-			IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_048e: pop
-			IL_048f: ldloc.0
-			IL_0490: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0495: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_049a: ret
+			IL_0482: stloc.s 6
+			IL_0484: ldstr "r3.done="
+			IL_0489: ldloc.s 6
+			IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0490: stloc.s 8
+			IL_0492: ldloc.s 7
+			IL_0494: ldloc.s 8
+			IL_0496: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_049b: pop
+			IL_049c: ldloc.0
+			IL_049d: ldc.i4.m1
+			IL_049e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04a3: ldloc.0
+			IL_04a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04ae: ldarg.0
+			IL_04af: ldc.i4.1
+			IL_04b0: newarr [System.Runtime]System.Object
+			IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04ba: pop
+			IL_04bb: ldloc.0
+			IL_04bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04c1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04c6: ret
 		} // end of method ArrowFunction_L15C2::__js_call__
 
 	} // end of class ArrowFunction_L15C2
@@ -1473,6 +1486,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/AsyncIterator/Snapshots/GeneratorTests.AsyncIterator_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/AsyncIterator/Snapshots/GeneratorTests.AsyncIterator_ExplicitReceiverAbi.verified.txt
@@ -637,7 +637,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 2349 (0x92d)
+			// Code size: 2471 (0x9a7)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncIterator_ExplicitReceiverAbi/ArrowFunction_L9C2/Scope,
@@ -784,7 +784,7 @@
 
 			IL_00f4: ldloc.0
 			IL_00f5: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00fa: switch (IL_010f, IL_0249, IL_03e1, IL_050d)
+			IL_00fa: switch (IL_010f, IL_0271, IL_0409, IL_0535)
 
 			IL_010f: ldarg.0
 			IL_0110: ldc.i4.1
@@ -841,761 +841,800 @@
 			IL_01a8: ldloc.s 11
 			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_01af: stloc.s 11
-			IL_01b1: ldloc.s 11
-			IL_01b3: ldstr "call"
-			IL_01b8: ldloc.1
-			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01be: stloc.s 11
-			IL_01c0: ldloc.0
-			IL_01c1: ldc.i4.1
-			IL_01c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01c7: ldloc.0
-			IL_01c8: ldloc.s 11
-			IL_01ca: ldarg.0
-			IL_01cb: ldc.i4.1
-			IL_01cc: ldloc.0
-			IL_01cd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_01d7: ldloc.0
-			IL_01d8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01dd: dup
-			IL_01de: ldc.i4.0
-			IL_01df: ldloc.1
-			IL_01e0: stelem.ref
-			IL_01e1: dup
-			IL_01e2: ldc.i4.1
-			IL_01e3: ldloc.2
-			IL_01e4: stelem.ref
-			IL_01e5: dup
-			IL_01e6: ldc.i4.2
-			IL_01e7: ldloc.3
-			IL_01e8: stelem.ref
-			IL_01e9: dup
-			IL_01ea: ldc.i4.3
-			IL_01eb: ldloc.s 4
-			IL_01ed: stelem.ref
-			IL_01ee: dup
-			IL_01ef: ldc.i4.4
-			IL_01f0: ldloc.s 5
-			IL_01f2: stelem.ref
-			IL_01f3: dup
-			IL_01f4: ldc.i4.5
-			IL_01f5: ldloc.s 6
-			IL_01f7: stelem.ref
-			IL_01f8: dup
-			IL_01f9: ldc.i4.6
-			IL_01fa: ldloc.s 7
-			IL_01fc: stelem.ref
-			IL_01fd: dup
-			IL_01fe: ldc.i4.7
-			IL_01ff: ldloc.s 8
-			IL_0201: stelem.ref
-			IL_0202: dup
-			IL_0203: ldc.i4.8
-			IL_0204: ldloc.s 9
-			IL_0206: stelem.ref
-			IL_0207: dup
-			IL_0208: ldc.i4.s 9
-			IL_020a: ldloc.s 10
+			IL_01b1: volatile.
+			IL_01b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_01b8: brfalse IL_01cf
+
+			IL_01bd: ldloc.s 11
+			IL_01bf: ldstr "call"
+			IL_01c4: ldloc.1
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ca: br IL_01e6
+
+			IL_01cf: ldloc.s 11
+			IL_01d1: ldstr "call"
+			IL_01d6: ldloc.1
+			IL_01d7: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:14"
+			IL_01dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_01e6: stloc.s 11
+			IL_01e8: ldloc.0
+			IL_01e9: ldc.i4.1
+			IL_01ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01ef: ldloc.0
+			IL_01f0: ldloc.s 11
+			IL_01f2: ldarg.0
+			IL_01f3: ldc.i4.1
+			IL_01f4: ldloc.0
+			IL_01f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_01ff: ldloc.0
+			IL_0200: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0205: dup
+			IL_0206: ldc.i4.0
+			IL_0207: ldloc.1
+			IL_0208: stelem.ref
+			IL_0209: dup
+			IL_020a: ldc.i4.1
+			IL_020b: ldloc.2
 			IL_020c: stelem.ref
 			IL_020d: dup
-			IL_020e: ldc.i4.s 10
-			IL_0210: ldloc.s 11
-			IL_0212: stelem.ref
-			IL_0213: dup
-			IL_0214: ldc.i4.s 11
-			IL_0216: ldloc.s 12
-			IL_0218: stelem.ref
-			IL_0219: dup
-			IL_021a: ldc.i4.s 12
-			IL_021c: ldloc.s 13
-			IL_021e: stelem.ref
-			IL_021f: dup
-			IL_0220: ldc.i4.s 13
-			IL_0222: ldloc.s 14
+			IL_020e: ldc.i4.2
+			IL_020f: ldloc.3
+			IL_0210: stelem.ref
+			IL_0211: dup
+			IL_0212: ldc.i4.3
+			IL_0213: ldloc.s 4
+			IL_0215: stelem.ref
+			IL_0216: dup
+			IL_0217: ldc.i4.4
+			IL_0218: ldloc.s 5
+			IL_021a: stelem.ref
+			IL_021b: dup
+			IL_021c: ldc.i4.5
+			IL_021d: ldloc.s 6
+			IL_021f: stelem.ref
+			IL_0220: dup
+			IL_0221: ldc.i4.6
+			IL_0222: ldloc.s 7
 			IL_0224: stelem.ref
 			IL_0225: dup
-			IL_0226: ldc.i4.s 14
-			IL_0228: ldloc.s 15
-			IL_022a: box [System.Runtime]System.Boolean
-			IL_022f: stelem.ref
-			IL_0230: dup
-			IL_0231: ldc.i4.s 15
-			IL_0233: ldloc.s 16
-			IL_0235: stelem.ref
-			IL_0236: dup
-			IL_0237: ldc.i4.s 16
-			IL_0239: ldloc.s 17
-			IL_023b: stelem.ref
-			IL_023c: pop
-			IL_023d: ldloc.0
-			IL_023e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0243: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0248: ret
+			IL_0226: ldc.i4.7
+			IL_0227: ldloc.s 8
+			IL_0229: stelem.ref
+			IL_022a: dup
+			IL_022b: ldc.i4.8
+			IL_022c: ldloc.s 9
+			IL_022e: stelem.ref
+			IL_022f: dup
+			IL_0230: ldc.i4.s 9
+			IL_0232: ldloc.s 10
+			IL_0234: stelem.ref
+			IL_0235: dup
+			IL_0236: ldc.i4.s 10
+			IL_0238: ldloc.s 11
+			IL_023a: stelem.ref
+			IL_023b: dup
+			IL_023c: ldc.i4.s 11
+			IL_023e: ldloc.s 12
+			IL_0240: stelem.ref
+			IL_0241: dup
+			IL_0242: ldc.i4.s 12
+			IL_0244: ldloc.s 13
+			IL_0246: stelem.ref
+			IL_0247: dup
+			IL_0248: ldc.i4.s 13
+			IL_024a: ldloc.s 14
+			IL_024c: stelem.ref
+			IL_024d: dup
+			IL_024e: ldc.i4.s 14
+			IL_0250: ldloc.s 15
+			IL_0252: box [System.Runtime]System.Boolean
+			IL_0257: stelem.ref
+			IL_0258: dup
+			IL_0259: ldc.i4.s 15
+			IL_025b: ldloc.s 16
+			IL_025d: stelem.ref
+			IL_025e: dup
+			IL_025f: ldc.i4.s 16
+			IL_0261: ldloc.s 17
+			IL_0263: stelem.ref
+			IL_0264: pop
+			IL_0265: ldloc.0
+			IL_0266: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_026b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0270: ret
 
-			IL_0249: ldloc.0
-			IL_024a: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/ArrowFunction_L9C2/Scope::_awaited1
-			IL_024f: stloc.2
-			IL_0250: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0255: stloc.s 12
-			IL_0257: volatile.
-			IL_0259: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_025e: brfalse IL_0273
+			IL_0271: ldloc.0
+			IL_0272: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/ArrowFunction_L9C2/Scope::_awaited1
+			IL_0277: stloc.2
+			IL_0278: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_027d: stloc.s 12
+			IL_027f: volatile.
+			IL_0281: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0286: brfalse IL_029b
 
-			IL_0263: ldloc.2
-			IL_0264: ldstr "value"
-			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_026e: br IL_0288
+			IL_028b: ldloc.2
+			IL_028c: ldstr "value"
+			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0296: br IL_02b0
 
-			IL_0273: ldloc.2
-			IL_0274: ldstr "value"
-			IL_0279: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:21"
-			IL_027e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_029b: ldloc.2
+			IL_029c: ldstr "value"
+			IL_02a1: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:21"
+			IL_02a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0288: stloc.s 11
-			IL_028a: ldloc.s 11
-			IL_028c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0291: stloc.s 13
-			IL_0293: ldstr "v1: "
-			IL_0298: ldloc.s 13
-			IL_029a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_029f: ldstr " done: "
-			IL_02a4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02a9: volatile.
-			IL_02ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_02b0: brfalse IL_02c5
+			IL_02b0: stloc.s 11
+			IL_02b2: ldloc.s 11
+			IL_02b4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02b9: stloc.s 13
+			IL_02bb: ldstr "v1: "
+			IL_02c0: ldloc.s 13
+			IL_02c2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02c7: ldstr " done: "
+			IL_02cc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02d1: volatile.
+			IL_02d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_02d8: brfalse IL_02ed
 
-			IL_02b5: ldloc.2
-			IL_02b6: ldstr "done"
-			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c0: br IL_02da
+			IL_02dd: ldloc.2
+			IL_02de: ldstr "done"
+			IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e8: br IL_0302
 
-			IL_02c5: ldloc.2
-			IL_02c6: ldstr "done"
-			IL_02cb: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:27"
-			IL_02d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02ed: ldloc.2
+			IL_02ee: ldstr "done"
+			IL_02f3: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:27"
+			IL_02f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02da: stloc.s 11
-			IL_02dc: ldloc.s 11
-			IL_02de: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02e3: stloc.s 13
-			IL_02e5: ldloc.s 13
-			IL_02e7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02ec: stloc.s 13
-			IL_02ee: ldloc.s 12
-			IL_02f0: ldloc.s 13
-			IL_02f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02f7: pop
-			IL_02f8: ldarg.0
-			IL_02f9: ldc.i4.1
-			IL_02fa: ldelem.ref
-			IL_02fb: castclass Modules.AsyncIterator_ExplicitReceiverAbi/Scope
-			IL_0300: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/Scope::g
-			IL_0305: ldc.i4.1
-			IL_0306: newarr [System.Runtime]System.Object
-			IL_030b: dup
-			IL_030c: ldc.i4.0
-			IL_030d: ldarg.0
-			IL_030e: ldc.i4.1
-			IL_030f: ldelem.ref
-			IL_0310: stelem.ref
-			IL_0311: stloc.s 10
-			IL_0313: ldloc.s 10
-			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_031a: stloc.3
-			IL_031b: ldloc.3
-			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0321: stloc.s 11
-			IL_0323: volatile.
-			IL_0325: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_032a: brfalse IL_0340
+			IL_0302: stloc.s 11
+			IL_0304: ldloc.s 11
+			IL_0306: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_030b: stloc.s 13
+			IL_030d: ldloc.s 13
+			IL_030f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0314: stloc.s 13
+			IL_0316: ldloc.s 12
+			IL_0318: ldloc.s 13
+			IL_031a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_031f: pop
+			IL_0320: ldarg.0
+			IL_0321: ldc.i4.1
+			IL_0322: ldelem.ref
+			IL_0323: castclass Modules.AsyncIterator_ExplicitReceiverAbi/Scope
+			IL_0328: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/Scope::g
+			IL_032d: ldc.i4.1
+			IL_032e: newarr [System.Runtime]System.Object
+			IL_0333: dup
+			IL_0334: ldc.i4.0
+			IL_0335: ldarg.0
+			IL_0336: ldc.i4.1
+			IL_0337: ldelem.ref
+			IL_0338: stelem.ref
+			IL_0339: stloc.s 10
+			IL_033b: ldloc.s 10
+			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0342: stloc.3
+			IL_0343: ldloc.3
+			IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0349: stloc.s 11
+			IL_034b: volatile.
+			IL_034d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0352: brfalse IL_0368
 
-			IL_032f: ldloc.s 11
-			IL_0331: ldstr "next"
-			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_033b: br IL_0356
+			IL_0357: ldloc.s 11
+			IL_0359: ldstr "next"
+			IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0363: br IL_037e
 
-			IL_0340: ldloc.s 11
-			IL_0342: ldstr "next"
-			IL_0347: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:38"
-			IL_034c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0368: ldloc.s 11
+			IL_036a: ldstr "next"
+			IL_036f: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:38"
+			IL_0374: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0356: stloc.s 11
-			IL_0358: ldloc.0
-			IL_0359: ldc.i4.2
-			IL_035a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_035f: ldloc.0
-			IL_0360: ldloc.s 11
-			IL_0362: ldarg.0
-			IL_0363: ldc.i4.2
-			IL_0364: ldloc.0
-			IL_0365: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_036a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_036f: ldloc.0
-			IL_0370: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0375: dup
-			IL_0376: ldc.i4.0
-			IL_0377: ldloc.1
-			IL_0378: stelem.ref
-			IL_0379: dup
-			IL_037a: ldc.i4.1
-			IL_037b: ldloc.2
-			IL_037c: stelem.ref
-			IL_037d: dup
-			IL_037e: ldc.i4.2
-			IL_037f: ldloc.3
-			IL_0380: stelem.ref
-			IL_0381: dup
-			IL_0382: ldc.i4.3
-			IL_0383: ldloc.s 4
-			IL_0385: stelem.ref
-			IL_0386: dup
-			IL_0387: ldc.i4.4
-			IL_0388: ldloc.s 5
-			IL_038a: stelem.ref
-			IL_038b: dup
-			IL_038c: ldc.i4.5
-			IL_038d: ldloc.s 6
-			IL_038f: stelem.ref
-			IL_0390: dup
-			IL_0391: ldc.i4.6
-			IL_0392: ldloc.s 7
-			IL_0394: stelem.ref
-			IL_0395: dup
-			IL_0396: ldc.i4.7
-			IL_0397: ldloc.s 8
-			IL_0399: stelem.ref
-			IL_039a: dup
-			IL_039b: ldc.i4.8
-			IL_039c: ldloc.s 9
-			IL_039e: stelem.ref
-			IL_039f: dup
-			IL_03a0: ldc.i4.s 9
-			IL_03a2: ldloc.s 10
+			IL_037e: stloc.s 11
+			IL_0380: ldloc.0
+			IL_0381: ldc.i4.2
+			IL_0382: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0387: ldloc.0
+			IL_0388: ldloc.s 11
+			IL_038a: ldarg.0
+			IL_038b: ldc.i4.2
+			IL_038c: ldloc.0
+			IL_038d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0392: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0397: ldloc.0
+			IL_0398: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_039d: dup
+			IL_039e: ldc.i4.0
+			IL_039f: ldloc.1
+			IL_03a0: stelem.ref
+			IL_03a1: dup
+			IL_03a2: ldc.i4.1
+			IL_03a3: ldloc.2
 			IL_03a4: stelem.ref
 			IL_03a5: dup
-			IL_03a6: ldc.i4.s 10
-			IL_03a8: ldloc.s 11
-			IL_03aa: stelem.ref
-			IL_03ab: dup
-			IL_03ac: ldc.i4.s 11
-			IL_03ae: ldloc.s 12
-			IL_03b0: stelem.ref
-			IL_03b1: dup
-			IL_03b2: ldc.i4.s 12
-			IL_03b4: ldloc.s 13
-			IL_03b6: stelem.ref
-			IL_03b7: dup
-			IL_03b8: ldc.i4.s 13
-			IL_03ba: ldloc.s 14
+			IL_03a6: ldc.i4.2
+			IL_03a7: ldloc.3
+			IL_03a8: stelem.ref
+			IL_03a9: dup
+			IL_03aa: ldc.i4.3
+			IL_03ab: ldloc.s 4
+			IL_03ad: stelem.ref
+			IL_03ae: dup
+			IL_03af: ldc.i4.4
+			IL_03b0: ldloc.s 5
+			IL_03b2: stelem.ref
+			IL_03b3: dup
+			IL_03b4: ldc.i4.5
+			IL_03b5: ldloc.s 6
+			IL_03b7: stelem.ref
+			IL_03b8: dup
+			IL_03b9: ldc.i4.6
+			IL_03ba: ldloc.s 7
 			IL_03bc: stelem.ref
 			IL_03bd: dup
-			IL_03be: ldc.i4.s 14
-			IL_03c0: ldloc.s 15
-			IL_03c2: box [System.Runtime]System.Boolean
-			IL_03c7: stelem.ref
-			IL_03c8: dup
-			IL_03c9: ldc.i4.s 15
-			IL_03cb: ldloc.s 16
-			IL_03cd: stelem.ref
-			IL_03ce: dup
-			IL_03cf: ldc.i4.s 16
-			IL_03d1: ldloc.s 17
-			IL_03d3: stelem.ref
-			IL_03d4: pop
-			IL_03d5: ldloc.0
-			IL_03d6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03db: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03e0: ret
+			IL_03be: ldc.i4.7
+			IL_03bf: ldloc.s 8
+			IL_03c1: stelem.ref
+			IL_03c2: dup
+			IL_03c3: ldc.i4.8
+			IL_03c4: ldloc.s 9
+			IL_03c6: stelem.ref
+			IL_03c7: dup
+			IL_03c8: ldc.i4.s 9
+			IL_03ca: ldloc.s 10
+			IL_03cc: stelem.ref
+			IL_03cd: dup
+			IL_03ce: ldc.i4.s 10
+			IL_03d0: ldloc.s 11
+			IL_03d2: stelem.ref
+			IL_03d3: dup
+			IL_03d4: ldc.i4.s 11
+			IL_03d6: ldloc.s 12
+			IL_03d8: stelem.ref
+			IL_03d9: dup
+			IL_03da: ldc.i4.s 12
+			IL_03dc: ldloc.s 13
+			IL_03de: stelem.ref
+			IL_03df: dup
+			IL_03e0: ldc.i4.s 13
+			IL_03e2: ldloc.s 14
+			IL_03e4: stelem.ref
+			IL_03e5: dup
+			IL_03e6: ldc.i4.s 14
+			IL_03e8: ldloc.s 15
+			IL_03ea: box [System.Runtime]System.Boolean
+			IL_03ef: stelem.ref
+			IL_03f0: dup
+			IL_03f1: ldc.i4.s 15
+			IL_03f3: ldloc.s 16
+			IL_03f5: stelem.ref
+			IL_03f6: dup
+			IL_03f7: ldc.i4.s 16
+			IL_03f9: ldloc.s 17
+			IL_03fb: stelem.ref
+			IL_03fc: pop
+			IL_03fd: ldloc.0
+			IL_03fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0403: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0408: ret
 
-			IL_03e1: ldloc.0
-			IL_03e2: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/ArrowFunction_L9C2/Scope::_awaited2
-			IL_03e7: pop
-			IL_03e8: ldstr "AsyncIterator"
-			IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03f2: stloc.s 11
-			IL_03f4: volatile.
-			IL_03f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_03fb: brfalse IL_0411
+			IL_0409: ldloc.0
+			IL_040a: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/ArrowFunction_L9C2/Scope::_awaited2
+			IL_040f: pop
+			IL_0410: ldstr "AsyncIterator"
+			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_041a: stloc.s 11
+			IL_041c: volatile.
+			IL_041e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0423: brfalse IL_0439
 
-			IL_0400: ldloc.s 11
-			IL_0402: ldstr "prototype"
-			IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_040c: br IL_0427
+			IL_0428: ldloc.s 11
+			IL_042a: ldstr "prototype"
+			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0434: br IL_044f
 
-			IL_0411: ldloc.s 11
-			IL_0413: ldstr "prototype"
-			IL_0418: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:44"
-			IL_041d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0439: ldloc.s 11
+			IL_043b: ldstr "prototype"
+			IL_0440: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:44"
+			IL_0445: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0427: stloc.s 11
-			IL_0429: volatile.
-			IL_042b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0430: brfalse IL_0446
+			IL_044f: stloc.s 11
+			IL_0451: volatile.
+			IL_0453: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0458: brfalse IL_046e
 
-			IL_0435: ldloc.s 11
-			IL_0437: ldstr "return"
-			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0441: br IL_045c
+			IL_045d: ldloc.s 11
+			IL_045f: ldstr "return"
+			IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0469: br IL_0484
 
-			IL_0446: ldloc.s 11
-			IL_0448: ldstr "return"
-			IL_044d: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:46"
-			IL_0452: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_046e: ldloc.s 11
+			IL_0470: ldstr "return"
+			IL_0475: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:46"
+			IL_047a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_045c: stloc.s 11
-			IL_045e: ldloc.s 11
-			IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0465: stloc.s 11
-			IL_0467: ldloc.s 11
-			IL_0469: ldstr "call"
-			IL_046e: ldloc.3
-			IL_046f: ldc.r8 42
-			IL_0478: box [System.Runtime]System.Double
-			IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0482: stloc.s 11
-			IL_0484: ldloc.0
-			IL_0485: ldc.i4.3
-			IL_0486: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_048b: ldloc.0
-			IL_048c: ldloc.s 11
-			IL_048e: ldarg.0
-			IL_048f: ldc.i4.3
-			IL_0490: ldloc.0
-			IL_0491: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0496: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_049b: ldloc.0
-			IL_049c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04a1: dup
-			IL_04a2: ldc.i4.0
-			IL_04a3: ldloc.1
-			IL_04a4: stelem.ref
-			IL_04a5: dup
-			IL_04a6: ldc.i4.1
-			IL_04a7: ldloc.2
-			IL_04a8: stelem.ref
-			IL_04a9: dup
-			IL_04aa: ldc.i4.2
-			IL_04ab: ldloc.3
-			IL_04ac: stelem.ref
-			IL_04ad: dup
-			IL_04ae: ldc.i4.3
-			IL_04af: ldloc.s 4
-			IL_04b1: stelem.ref
-			IL_04b2: dup
-			IL_04b3: ldc.i4.4
-			IL_04b4: ldloc.s 5
-			IL_04b6: stelem.ref
-			IL_04b7: dup
-			IL_04b8: ldc.i4.5
-			IL_04b9: ldloc.s 6
-			IL_04bb: stelem.ref
-			IL_04bc: dup
-			IL_04bd: ldc.i4.6
-			IL_04be: ldloc.s 7
-			IL_04c0: stelem.ref
-			IL_04c1: dup
-			IL_04c2: ldc.i4.7
-			IL_04c3: ldloc.s 8
-			IL_04c5: stelem.ref
-			IL_04c6: dup
-			IL_04c7: ldc.i4.8
-			IL_04c8: ldloc.s 9
-			IL_04ca: stelem.ref
-			IL_04cb: dup
-			IL_04cc: ldc.i4.s 9
-			IL_04ce: ldloc.s 10
+			IL_0484: stloc.s 11
+			IL_0486: ldloc.s 11
+			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_048d: stloc.s 11
+			IL_048f: ldloc.s 11
+			IL_0491: ldstr "call"
+			IL_0496: ldloc.3
+			IL_0497: ldc.r8 42
+			IL_04a0: box [System.Runtime]System.Double
+			IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_04aa: stloc.s 11
+			IL_04ac: ldloc.0
+			IL_04ad: ldc.i4.3
+			IL_04ae: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04b3: ldloc.0
+			IL_04b4: ldloc.s 11
+			IL_04b6: ldarg.0
+			IL_04b7: ldc.i4.3
+			IL_04b8: ldloc.0
+			IL_04b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_04c3: ldloc.0
+			IL_04c4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_04c9: dup
+			IL_04ca: ldc.i4.0
+			IL_04cb: ldloc.1
+			IL_04cc: stelem.ref
+			IL_04cd: dup
+			IL_04ce: ldc.i4.1
+			IL_04cf: ldloc.2
 			IL_04d0: stelem.ref
 			IL_04d1: dup
-			IL_04d2: ldc.i4.s 10
-			IL_04d4: ldloc.s 11
-			IL_04d6: stelem.ref
-			IL_04d7: dup
-			IL_04d8: ldc.i4.s 11
-			IL_04da: ldloc.s 12
-			IL_04dc: stelem.ref
-			IL_04dd: dup
-			IL_04de: ldc.i4.s 12
-			IL_04e0: ldloc.s 13
-			IL_04e2: stelem.ref
-			IL_04e3: dup
-			IL_04e4: ldc.i4.s 13
-			IL_04e6: ldloc.s 14
+			IL_04d2: ldc.i4.2
+			IL_04d3: ldloc.3
+			IL_04d4: stelem.ref
+			IL_04d5: dup
+			IL_04d6: ldc.i4.3
+			IL_04d7: ldloc.s 4
+			IL_04d9: stelem.ref
+			IL_04da: dup
+			IL_04db: ldc.i4.4
+			IL_04dc: ldloc.s 5
+			IL_04de: stelem.ref
+			IL_04df: dup
+			IL_04e0: ldc.i4.5
+			IL_04e1: ldloc.s 6
+			IL_04e3: stelem.ref
+			IL_04e4: dup
+			IL_04e5: ldc.i4.6
+			IL_04e6: ldloc.s 7
 			IL_04e8: stelem.ref
 			IL_04e9: dup
-			IL_04ea: ldc.i4.s 14
-			IL_04ec: ldloc.s 15
-			IL_04ee: box [System.Runtime]System.Boolean
-			IL_04f3: stelem.ref
-			IL_04f4: dup
-			IL_04f5: ldc.i4.s 15
-			IL_04f7: ldloc.s 16
-			IL_04f9: stelem.ref
-			IL_04fa: dup
-			IL_04fb: ldc.i4.s 16
-			IL_04fd: ldloc.s 17
-			IL_04ff: stelem.ref
-			IL_0500: pop
-			IL_0501: ldloc.0
-			IL_0502: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0507: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_050c: ret
+			IL_04ea: ldc.i4.7
+			IL_04eb: ldloc.s 8
+			IL_04ed: stelem.ref
+			IL_04ee: dup
+			IL_04ef: ldc.i4.8
+			IL_04f0: ldloc.s 9
+			IL_04f2: stelem.ref
+			IL_04f3: dup
+			IL_04f4: ldc.i4.s 9
+			IL_04f6: ldloc.s 10
+			IL_04f8: stelem.ref
+			IL_04f9: dup
+			IL_04fa: ldc.i4.s 10
+			IL_04fc: ldloc.s 11
+			IL_04fe: stelem.ref
+			IL_04ff: dup
+			IL_0500: ldc.i4.s 11
+			IL_0502: ldloc.s 12
+			IL_0504: stelem.ref
+			IL_0505: dup
+			IL_0506: ldc.i4.s 12
+			IL_0508: ldloc.s 13
+			IL_050a: stelem.ref
+			IL_050b: dup
+			IL_050c: ldc.i4.s 13
+			IL_050e: ldloc.s 14
+			IL_0510: stelem.ref
+			IL_0511: dup
+			IL_0512: ldc.i4.s 14
+			IL_0514: ldloc.s 15
+			IL_0516: box [System.Runtime]System.Boolean
+			IL_051b: stelem.ref
+			IL_051c: dup
+			IL_051d: ldc.i4.s 15
+			IL_051f: ldloc.s 16
+			IL_0521: stelem.ref
+			IL_0522: dup
+			IL_0523: ldc.i4.s 16
+			IL_0525: ldloc.s 17
+			IL_0527: stelem.ref
+			IL_0528: pop
+			IL_0529: ldloc.0
+			IL_052a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_052f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0534: ret
 
-			IL_050d: ldloc.0
-			IL_050e: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/ArrowFunction_L9C2/Scope::_awaited3
-			IL_0513: stloc.s 4
-			IL_0515: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_051a: stloc.s 12
-			IL_051c: volatile.
-			IL_051e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0523: brfalse IL_0539
+			IL_0535: ldloc.0
+			IL_0536: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/ArrowFunction_L9C2/Scope::_awaited3
+			IL_053b: stloc.s 4
+			IL_053d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0542: stloc.s 12
+			IL_0544: volatile.
+			IL_0546: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_054b: brfalse IL_0561
 
-			IL_0528: ldloc.s 4
-			IL_052a: ldstr "value"
-			IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0534: br IL_054f
+			IL_0550: ldloc.s 4
+			IL_0552: ldstr "value"
+			IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_055c: br IL_0577
 
-			IL_0539: ldloc.s 4
-			IL_053b: ldstr "value"
-			IL_0540: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:57"
-			IL_0545: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0561: ldloc.s 4
+			IL_0563: ldstr "value"
+			IL_0568: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:57"
+			IL_056d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_054f: stloc.s 11
-			IL_0551: ldloc.s 11
-			IL_0553: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0558: stloc.s 13
-			IL_055a: ldstr "v2: "
-			IL_055f: ldloc.s 13
-			IL_0561: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0566: ldstr " done: "
-			IL_056b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0570: volatile.
-			IL_0572: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0577: brfalse IL_058d
+			IL_0577: stloc.s 11
+			IL_0579: ldloc.s 11
+			IL_057b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0580: stloc.s 13
+			IL_0582: ldstr "v2: "
+			IL_0587: ldloc.s 13
+			IL_0589: call string [System.Runtime]System.String::Concat(string, string)
+			IL_058e: ldstr " done: "
+			IL_0593: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0598: volatile.
+			IL_059a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_059f: brfalse IL_05b5
 
-			IL_057c: ldloc.s 4
-			IL_057e: ldstr "done"
-			IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0588: br IL_05a3
+			IL_05a4: ldloc.s 4
+			IL_05a6: ldstr "done"
+			IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b0: br IL_05cb
 
-			IL_058d: ldloc.s 4
-			IL_058f: ldstr "done"
-			IL_0594: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:63"
-			IL_0599: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_05b5: ldloc.s 4
+			IL_05b7: ldstr "done"
+			IL_05bc: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:63"
+			IL_05c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_05a3: stloc.s 11
-			IL_05a5: ldloc.s 11
-			IL_05a7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05ac: stloc.s 13
-			IL_05ae: ldloc.s 13
-			IL_05b0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05b5: stloc.s 13
-			IL_05b7: ldloc.s 12
-			IL_05b9: ldloc.s 13
-			IL_05bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05c0: pop
-			IL_05c1: ldarg.0
-			IL_05c2: ldc.i4.1
-			IL_05c3: ldelem.ref
-			IL_05c4: castclass Modules.AsyncIterator_ExplicitReceiverAbi/Scope
-			IL_05c9: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/Scope::g
-			IL_05ce: ldc.i4.1
-			IL_05cf: newarr [System.Runtime]System.Object
-			IL_05d4: dup
-			IL_05d5: ldc.i4.0
-			IL_05d6: ldarg.0
-			IL_05d7: ldc.i4.1
-			IL_05d8: ldelem.ref
-			IL_05d9: stelem.ref
-			IL_05da: stloc.s 10
-			IL_05dc: ldloc.s 10
-			IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_05e3: stloc.s 5
-			IL_05e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05ea: stloc.s 12
-			IL_05ec: ldstr "AsyncIterator"
-			IL_05f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05f6: stloc.s 11
-			IL_05f8: volatile.
-			IL_05fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_05ff: brfalse IL_0615
+			IL_05cb: stloc.s 11
+			IL_05cd: ldloc.s 11
+			IL_05cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05d4: stloc.s 13
+			IL_05d6: ldloc.s 13
+			IL_05d8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05dd: stloc.s 13
+			IL_05df: ldloc.s 12
+			IL_05e1: ldloc.s 13
+			IL_05e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05e8: pop
+			IL_05e9: ldarg.0
+			IL_05ea: ldc.i4.1
+			IL_05eb: ldelem.ref
+			IL_05ec: castclass Modules.AsyncIterator_ExplicitReceiverAbi/Scope
+			IL_05f1: ldfld object Modules.AsyncIterator_ExplicitReceiverAbi/Scope::g
+			IL_05f6: ldc.i4.1
+			IL_05f7: newarr [System.Runtime]System.Object
+			IL_05fc: dup
+			IL_05fd: ldc.i4.0
+			IL_05fe: ldarg.0
+			IL_05ff: ldc.i4.1
+			IL_0600: ldelem.ref
+			IL_0601: stelem.ref
+			IL_0602: stloc.s 10
+			IL_0604: ldloc.s 10
+			IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_060b: stloc.s 5
+			IL_060d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0612: stloc.s 12
+			IL_0614: ldstr "AsyncIterator"
+			IL_0619: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_061e: stloc.s 11
+			IL_0620: volatile.
+			IL_0622: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0627: brfalse IL_063d
 
-			IL_0604: ldloc.s 11
-			IL_0606: ldstr "prototype"
-			IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0610: br IL_062b
+			IL_062c: ldloc.s 11
+			IL_062e: ldstr "prototype"
+			IL_0633: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0638: br IL_0653
 
-			IL_0615: ldloc.s 11
-			IL_0617: ldstr "prototype"
-			IL_061c: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:77"
-			IL_0621: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_063d: ldloc.s 11
+			IL_063f: ldstr "prototype"
+			IL_0644: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:77"
+			IL_0649: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_062b: stloc.s 11
-			IL_062d: ldstr "asyncIterator"
-			IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-			IL_0637: stloc.s 14
-			IL_0639: ldloc.s 11
-			IL_063b: ldloc.s 14
-			IL_063d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0642: stloc.s 14
-			IL_0644: ldloc.s 14
-			IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_064b: stloc.s 14
-			IL_064d: ldloc.s 14
-			IL_064f: ldstr "call"
-			IL_0654: ldloc.s 5
-			IL_0656: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_065b: stloc.s 14
-			IL_065d: ldloc.s 14
-			IL_065f: ldloc.s 5
-			IL_0661: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0666: stloc.s 15
-			IL_0668: ldloc.s 15
-			IL_066a: box [System.Runtime]System.Boolean
-			IL_066f: stloc.s 16
-			IL_0671: ldloc.s 12
-			IL_0673: ldloc.s 16
-			IL_0675: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_067a: pop
+			IL_0653: stloc.s 11
+			IL_0655: ldstr "asyncIterator"
+			IL_065a: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+			IL_065f: stloc.s 14
+			IL_0661: ldloc.s 11
+			IL_0663: ldloc.s 14
+			IL_0665: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_066a: stloc.s 14
+			IL_066c: ldloc.s 14
+			IL_066e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0673: stloc.s 14
+			IL_0675: volatile.
+			IL_0677: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_067c: brfalse IL_0694
+
+			IL_0681: ldloc.s 14
+			IL_0683: ldstr "call"
+			IL_0688: ldloc.s 5
+			IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_068f: br IL_06ac
+
+			IL_0694: ldloc.s 14
+			IL_0696: ldstr "call"
+			IL_069b: ldloc.s 5
+			IL_069d: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:82"
+			IL_06a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_06a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_06ac: stloc.s 14
+			IL_06ae: ldloc.s 14
+			IL_06b0: ldloc.s 5
+			IL_06b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_06b7: stloc.s 15
+			IL_06b9: ldloc.s 15
+			IL_06bb: box [System.Runtime]System.Boolean
+			IL_06c0: stloc.s 16
+			IL_06c2: ldloc.s 12
+			IL_06c4: ldloc.s 16
+			IL_06c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06cb: pop
 			.try
 			{
-				IL_067b: nop
-				IL_067c: ldstr "AsyncIterator"
-				IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0686: stloc.s 14
-				IL_0688: volatile.
-				IL_068a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_068f: brfalse IL_06a5
+				IL_06cc: nop
+				IL_06cd: ldstr "AsyncIterator"
+				IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_06d7: stloc.s 14
+				IL_06d9: volatile.
+				IL_06db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_06e0: brfalse IL_06f6
 
-				IL_0694: ldloc.s 14
-				IL_0696: ldstr "prototype"
-				IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_06a0: br IL_06bb
+				IL_06e5: ldloc.s 14
+				IL_06e7: ldstr "prototype"
+				IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_06f1: br IL_070c
 
-				IL_06a5: ldloc.s 14
-				IL_06a7: ldstr "prototype"
-				IL_06ac: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:93"
-				IL_06b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_06f6: ldloc.s 14
+				IL_06f8: ldstr "prototype"
+				IL_06fd: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:93"
+				IL_0702: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_06bb: stloc.s 14
-				IL_06bd: volatile.
-				IL_06bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-				IL_06c4: brfalse IL_06da
+				IL_070c: stloc.s 14
+				IL_070e: volatile.
+				IL_0710: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_0715: brfalse IL_072b
 
-				IL_06c9: ldloc.s 14
-				IL_06cb: ldstr "next"
-				IL_06d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_06d5: br IL_06f0
+				IL_071a: ldloc.s 14
+				IL_071c: ldstr "next"
+				IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0726: br IL_0741
 
-				IL_06da: ldloc.s 14
-				IL_06dc: ldstr "next"
-				IL_06e1: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:95"
-				IL_06e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-				IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_072b: ldloc.s 14
+				IL_072d: ldstr "next"
+				IL_0732: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:95"
+				IL_0737: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_06f0: stloc.s 14
-				IL_06f2: ldloc.s 14
-				IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_06f9: stloc.s 14
-				IL_06fb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0700: stloc.s 17
-				IL_0702: ldloc.s 14
-				IL_0704: ldstr "call"
-				IL_0709: ldloc.s 17
-				IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0710: pop
-				IL_0711: leave IL_0782
+				IL_0741: stloc.s 14
+				IL_0743: ldloc.s 14
+				IL_0745: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_074a: stloc.s 14
+				IL_074c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0751: stloc.s 17
+				IL_0753: volatile.
+				IL_0755: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_075a: brfalse IL_0772
+
+				IL_075f: ldloc.s 14
+				IL_0761: ldstr "call"
+				IL_0766: ldloc.s 17
+				IL_0768: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_076d: br IL_078a
+
+				IL_0772: ldloc.s 14
+				IL_0774: ldstr "call"
+				IL_0779: ldloc.s 17
+				IL_077b: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:98"
+				IL_0780: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_0785: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_078a: pop
+				IL_078b: leave IL_07fc
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0716: stloc.s 6
-				IL_0718: ldloc.s 6
-				IL_071a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_071f: dup
-				IL_0720: brtrue IL_0736
+				IL_0790: stloc.s 6
+				IL_0792: ldloc.s 6
+				IL_0794: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0799: dup
+				IL_079a: brtrue IL_07b0
 
-				IL_0725: pop
-				IL_0726: ldloc.s 6
-				IL_0728: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_072d: dup
-				IL_072e: brtrue IL_0742
+				IL_079f: pop
+				IL_07a0: ldloc.s 6
+				IL_07a2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_07a7: dup
+				IL_07a8: brtrue IL_07bc
 
-				IL_0733: pop
-				IL_0734: rethrow
+				IL_07ad: pop
+				IL_07ae: rethrow
 
-				IL_0736: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_073b: stloc.s 7
-				IL_073d: br IL_0744
+				IL_07b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_07b5: stloc.s 7
+				IL_07b7: br IL_07be
 
-				IL_0742: stloc.s 7
+				IL_07bc: stloc.s 7
 
-				IL_0744: ldloc.s 7
-				IL_0746: stloc.s 8
-				IL_0748: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_074d: stloc.s 12
-				IL_074f: ldloc.s 8
-				IL_0751: stloc.s 14
-				IL_0753: ldstr "TypeError"
-				IL_0758: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_075d: stloc.s 11
-				IL_075f: ldloc.s 14
-				IL_0761: ldloc.s 11
-				IL_0763: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-				IL_0768: stloc.s 15
-				IL_076a: ldloc.s 15
-				IL_076c: box [System.Runtime]System.Boolean
-				IL_0771: stloc.s 16
-				IL_0773: ldloc.s 12
-				IL_0775: ldloc.s 16
-				IL_0777: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_077c: pop
-				IL_077d: leave IL_0782
+				IL_07be: ldloc.s 7
+				IL_07c0: stloc.s 8
+				IL_07c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_07c7: stloc.s 12
+				IL_07c9: ldloc.s 8
+				IL_07cb: stloc.s 14
+				IL_07cd: ldstr "TypeError"
+				IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_07d7: stloc.s 11
+				IL_07d9: ldloc.s 14
+				IL_07db: ldloc.s 11
+				IL_07dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+				IL_07e2: stloc.s 15
+				IL_07e4: ldloc.s 15
+				IL_07e6: box [System.Runtime]System.Boolean
+				IL_07eb: stloc.s 16
+				IL_07ed: ldloc.s 12
+				IL_07ef: ldloc.s 16
+				IL_07f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_07f6: pop
+				IL_07f7: leave IL_07fc
 			} // end handler
 
-			IL_0782: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0787: stloc.s 12
-			IL_0789: ldstr "AsyncIterator"
-			IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0793: stloc.s 11
-			IL_0795: volatile.
-			IL_0797: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_079c: brfalse IL_07b2
+			IL_07fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0801: stloc.s 12
+			IL_0803: ldstr "AsyncIterator"
+			IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_080d: stloc.s 11
+			IL_080f: volatile.
+			IL_0811: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0816: brfalse IL_082c
 
-			IL_07a1: ldloc.s 11
-			IL_07a3: ldstr "prototype"
-			IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07ad: br IL_07c8
+			IL_081b: ldloc.s 11
+			IL_081d: ldstr "prototype"
+			IL_0822: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0827: br IL_0842
 
-			IL_07b2: ldloc.s 11
-			IL_07b4: ldstr "prototype"
-			IL_07b9: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:123"
-			IL_07be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_082c: ldloc.s 11
+			IL_082e: ldstr "prototype"
+			IL_0833: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:123"
+			IL_0838: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_083d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07c8: stloc.s 11
-			IL_07ca: volatile.
-			IL_07cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_07d1: brfalse IL_07e7
+			IL_0842: stloc.s 11
+			IL_0844: volatile.
+			IL_0846: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_084b: brfalse IL_0861
 
-			IL_07d6: ldloc.s 11
-			IL_07d8: ldstr "next"
-			IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07e2: br IL_07fd
+			IL_0850: ldloc.s 11
+			IL_0852: ldstr "next"
+			IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_085c: br IL_0877
 
-			IL_07e7: ldloc.s 11
-			IL_07e9: ldstr "next"
-			IL_07ee: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:125"
-			IL_07f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0861: ldloc.s 11
+			IL_0863: ldstr "next"
+			IL_0868: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:125"
+			IL_086d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0872: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07fd: stloc.s 11
-			IL_07ff: volatile.
-			IL_0801: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_0806: brfalse IL_081c
+			IL_0877: stloc.s 11
+			IL_0879: volatile.
+			IL_087b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0880: brfalse IL_0896
 
-			IL_080b: ldloc.s 11
-			IL_080d: ldstr "length"
-			IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0817: br IL_0832
+			IL_0885: ldloc.s 11
+			IL_0887: ldstr "length"
+			IL_088c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0891: br IL_08ac
 
-			IL_081c: ldloc.s 11
-			IL_081e: ldstr "length"
-			IL_0823: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:127"
-			IL_0828: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0896: ldloc.s 11
+			IL_0898: ldstr "length"
+			IL_089d: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:127"
+			IL_08a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_08a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0832: stloc.s 11
-			IL_0834: ldloc.s 12
-			IL_0836: ldloc.s 11
-			IL_0838: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_083d: pop
-			IL_083e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0843: stloc.s 12
-			IL_0845: ldstr "AsyncIterator"
-			IL_084a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_084f: stloc.s 11
-			IL_0851: volatile.
-			IL_0853: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_0858: brfalse IL_086e
+			IL_08ac: stloc.s 11
+			IL_08ae: ldloc.s 12
+			IL_08b0: ldloc.s 11
+			IL_08b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_08b7: pop
+			IL_08b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08bd: stloc.s 12
+			IL_08bf: ldstr "AsyncIterator"
+			IL_08c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08c9: stloc.s 11
+			IL_08cb: volatile.
+			IL_08cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_08d2: brfalse IL_08e8
 
-			IL_085d: ldloc.s 11
-			IL_085f: ldstr "prototype"
-			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0869: br IL_0884
+			IL_08d7: ldloc.s 11
+			IL_08d9: ldstr "prototype"
+			IL_08de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08e3: br IL_08fe
 
-			IL_086e: ldloc.s 11
-			IL_0870: ldstr "prototype"
-			IL_0875: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:134"
-			IL_087a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_087f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_08e8: ldloc.s 11
+			IL_08ea: ldstr "prototype"
+			IL_08ef: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:134"
+			IL_08f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_08f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0884: stloc.s 11
-			IL_0886: volatile.
-			IL_0888: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_088d: brfalse IL_08a3
+			IL_08fe: stloc.s 11
+			IL_0900: volatile.
+			IL_0902: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0907: brfalse IL_091d
 
-			IL_0892: ldloc.s 11
-			IL_0894: ldstr "return"
-			IL_0899: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_089e: br IL_08b9
+			IL_090c: ldloc.s 11
+			IL_090e: ldstr "return"
+			IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0918: br IL_0933
 
-			IL_08a3: ldloc.s 11
-			IL_08a5: ldstr "return"
-			IL_08aa: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:136"
-			IL_08af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_08b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_091d: ldloc.s 11
+			IL_091f: ldstr "return"
+			IL_0924: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:136"
+			IL_0929: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_092e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08b9: stloc.s 11
-			IL_08bb: volatile.
-			IL_08bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_08c2: brfalse IL_08d8
+			IL_0933: stloc.s 11
+			IL_0935: volatile.
+			IL_0937: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_093c: brfalse IL_0952
 
-			IL_08c7: ldloc.s 11
-			IL_08c9: ldstr "length"
-			IL_08ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08d3: br IL_08ee
+			IL_0941: ldloc.s 11
+			IL_0943: ldstr "length"
+			IL_0948: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_094d: br IL_0968
 
-			IL_08d8: ldloc.s 11
-			IL_08da: ldstr "length"
-			IL_08df: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:138"
-			IL_08e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_08e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0952: ldloc.s 11
+			IL_0954: ldstr "length"
+			IL_0959: ldstr "AsyncIterator_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:138"
+			IL_095e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08ee: stloc.s 11
-			IL_08f0: ldloc.s 12
-			IL_08f2: ldloc.s 11
-			IL_08f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08f9: pop
-			IL_08fa: ldnull
-			IL_08fb: stloc.s 9
-			IL_08fd: ldloc.0
-			IL_08fe: ldc.i4.m1
-			IL_08ff: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0904: ldloc.0
-			IL_0905: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_090a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_090f: ldarg.0
-			IL_0910: ldc.i4.1
-			IL_0911: newarr [System.Runtime]System.Object
-			IL_0916: dup
-			IL_0917: ldc.i4.0
-			IL_0918: ldloc.s 9
-			IL_091a: stelem.ref
-			IL_091b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0920: pop
-			IL_0921: ldloc.0
-			IL_0922: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0927: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_092c: ret
+			IL_0968: stloc.s 11
+			IL_096a: ldloc.s 12
+			IL_096c: ldloc.s 11
+			IL_096e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0973: pop
+			IL_0974: ldnull
+			IL_0975: stloc.s 9
+			IL_0977: ldloc.0
+			IL_0978: ldc.i4.m1
+			IL_0979: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_097e: ldloc.0
+			IL_097f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0984: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0989: ldarg.0
+			IL_098a: ldc.i4.1
+			IL_098b: newarr [System.Runtime]System.Object
+			IL_0990: dup
+			IL_0991: ldc.i4.0
+			IL_0992: ldloc.s 9
+			IL_0994: stelem.ref
+			IL_0995: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_099a: pop
+			IL_099b: ldloc.0
+			IL_099c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09a1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09a6: ret
 		} // end of method ArrowFunction_L9C2::__js_call__
 
 	} // end of class ArrowFunction_L9C2
@@ -1744,6 +1783,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
 	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_BigInt_Operators.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_BigInt_Operators.verified.txt
@@ -257,7 +257,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1577 (0x629)
+		// Code size: 1628 (0x65c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_BigInt_Operators/Scope,
@@ -345,508 +345,521 @@
 		IL_00b9: stloc.s 16
 		IL_00bb: ldloc.1
 		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c1: ldstr "toString"
-		IL_00c6: ldc.r8 16
-		IL_00cf: box [System.Runtime]System.Double
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d9: stloc.s 19
-		IL_00db: ldloc.s 16
-		IL_00dd: ldloc.s 19
-		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e4: pop
-		IL_00e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ea: stloc.s 16
-		IL_00ec: ldloc.1
-		IL_00ed: ldloc.2
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Subtract(object, object)
-		IL_00f3: stloc.s 17
-		IL_00f5: ldloc.s 16
-		IL_00f7: ldloc.s 17
-		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fe: pop
-		IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0104: stloc.s 16
-		IL_0106: ldloc.1
-		IL_0107: ldloc.2
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Multiply(object, object)
-		IL_010d: stloc.s 17
-		IL_010f: ldloc.s 16
-		IL_0111: ldloc.s 17
-		IL_0113: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0118: pop
-		IL_0119: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011e: stloc.s 16
-		IL_0120: ldloc.1
-		IL_0121: ldloc.2
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Divide(object, object)
-		IL_0127: stloc.s 17
-		IL_0129: ldloc.s 16
-		IL_012b: ldloc.s 17
-		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0132: pop
-		IL_0133: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0138: stloc.s 16
-		IL_013a: ldloc.1
-		IL_013b: ldloc.2
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Remainder(object, object)
-		IL_0141: stloc.s 17
-		IL_0143: ldloc.s 16
-		IL_0145: ldloc.s 17
-		IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_014c: pop
-		IL_014d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0152: stloc.s 16
-		IL_0154: ldc.r8 3
-		IL_015d: box [System.Runtime]System.Double
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_0167: stloc.s 20
-		IL_0169: ldloc.1
-		IL_016a: ldloc.s 20
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Exponentiate(object, object)
-		IL_0171: stloc.s 17
-		IL_0173: ldloc.s 16
-		IL_0175: ldloc.s 17
-		IL_0177: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017c: pop
-		IL_017d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0182: stloc.s 16
-		IL_0184: ldloc.1
-		IL_0185: ldloc.2
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseAnd(object, object)
-		IL_018b: stloc.s 17
-		IL_018d: ldloc.s 16
-		IL_018f: ldloc.s 17
-		IL_0191: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0196: pop
-		IL_0197: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_019c: stloc.s 16
-		IL_019e: ldloc.1
-		IL_019f: ldloc.2
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseOr(object, object)
-		IL_01a5: stloc.s 17
-		IL_01a7: ldloc.s 16
-		IL_01a9: ldloc.s 17
-		IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b0: pop
-		IL_01b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b6: stloc.s 16
-		IL_01b8: ldloc.1
-		IL_01b9: ldloc.2
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseXor(object, object)
-		IL_01bf: stloc.s 17
-		IL_01c1: ldloc.s 16
-		IL_01c3: ldloc.s 17
-		IL_01c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ca: pop
-		IL_01cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d0: stloc.s 16
-		IL_01d2: ldc.r8 2
-		IL_01db: box [System.Runtime]System.Double
-		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_01e5: stloc.s 20
-		IL_01e7: ldloc.1
-		IL_01e8: ldloc.s 20
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::LeftShift(object, object)
-		IL_01ef: stloc.s 17
-		IL_01f1: ldloc.s 16
-		IL_01f3: ldloc.s 17
-		IL_01f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01fa: pop
-		IL_01fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0200: stloc.s 16
-		IL_0202: ldc.r8 1
-		IL_020b: box [System.Runtime]System.Double
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_0215: stloc.s 20
-		IL_0217: ldloc.1
-		IL_0218: ldloc.s 20
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::SignedRightShift(object, object)
-		IL_021f: stloc.s 17
-		IL_0221: ldloc.s 16
-		IL_0223: ldloc.s 17
-		IL_0225: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_022a: pop
-		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0230: stloc.s 16
-		IL_0232: ldloc.1
-		IL_0233: ldloc.2
-		IL_0234: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-		IL_0239: stloc.s 21
-		IL_023b: ldloc.s 21
-		IL_023d: box [System.Runtime]System.Boolean
-		IL_0242: stloc.s 22
-		IL_0244: ldloc.s 16
-		IL_0246: ldloc.s 22
-		IL_0248: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024d: pop
-		IL_024e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0253: stloc.s 16
-		IL_0255: ldloc.1
-		IL_0256: ldloc.2
-		IL_0257: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThan(object, object)
-		IL_025c: stloc.s 21
-		IL_025e: ldloc.s 21
-		IL_0260: box [System.Runtime]System.Boolean
-		IL_0265: stloc.s 22
-		IL_0267: ldloc.s 16
-		IL_0269: ldloc.s 22
-		IL_026b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0270: pop
-		IL_0271: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0276: stloc.s 16
-		IL_0278: ldloc.1
-		IL_0279: ldloc.2
-		IL_027a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThanOrEqual(object, object)
-		IL_027f: stloc.s 21
-		IL_0281: ldloc.s 21
-		IL_0283: box [System.Runtime]System.Boolean
-		IL_0288: stloc.s 22
-		IL_028a: ldloc.s 16
-		IL_028c: ldloc.s 22
-		IL_028e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0293: pop
-		IL_0294: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0299: stloc.s 16
-		IL_029b: ldloc.1
-		IL_029c: ldloc.2
-		IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
-		IL_02a2: stloc.s 21
-		IL_02a4: ldloc.s 21
-		IL_02a6: box [System.Runtime]System.Boolean
-		IL_02ab: stloc.s 22
-		IL_02ad: ldloc.s 16
-		IL_02af: ldloc.s 22
-		IL_02b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b6: pop
-		IL_02b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02bc: stloc.s 16
-		IL_02be: ldc.r8 10
-		IL_02c7: box [System.Runtime]System.Double
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_02d1: stloc.s 20
-		IL_02d3: ldloc.1
-		IL_02d4: ldloc.s 20
-		IL_02d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-		IL_02db: stloc.s 21
-		IL_02dd: ldloc.s 21
-		IL_02df: box [System.Runtime]System.Boolean
-		IL_02e4: stloc.s 22
-		IL_02e6: ldloc.s 16
-		IL_02e8: ldloc.s 22
-		IL_02ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ef: pop
-		IL_02f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f5: stloc.s 16
-		IL_02f7: ldc.r8 10
-		IL_0300: box [System.Runtime]System.Double
-		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-		IL_030a: stloc.s 20
-		IL_030c: ldloc.1
-		IL_030d: ldloc.s 20
-		IL_030f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0314: stloc.s 21
-		IL_0316: ldloc.s 21
-		IL_0318: box [System.Runtime]System.Boolean
-		IL_031d: stloc.s 22
-		IL_031f: ldloc.s 16
-		IL_0321: ldloc.s 22
-		IL_0323: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0328: pop
-		IL_0329: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_032e: stloc.s 16
-		IL_0330: ldloc.1
-		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-		IL_0336: stloc.s 20
-		IL_0338: ldloc.s 16
-		IL_033a: ldloc.s 20
-		IL_033c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0341: pop
-		IL_0342: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0347: stloc.s 16
-		IL_0349: ldloc.1
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseNot(object)
-		IL_034f: stloc.s 17
-		IL_0351: ldloc.s 16
-		IL_0353: ldloc.s 17
-		IL_0355: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_035a: pop
+		IL_00c1: volatile.
+		IL_00c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c8: brfalse IL_00ea
+
+		IL_00cd: ldstr "toString"
+		IL_00d2: ldc.r8 16
+		IL_00db: box [System.Runtime]System.Double
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e5: br IL_010c
+
+		IL_00ea: ldstr "toString"
+		IL_00ef: ldc.r8 16
+		IL_00f8: box [System.Runtime]System.Double
+		IL_00fd: ldstr "BinaryOperator_BigInt_Operators:Modules.BinaryOperator_BigInt_Operators:__js_module_init__:32"
+		IL_0102: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_010c: stloc.s 19
+		IL_010e: ldloc.s 16
+		IL_0110: ldloc.s 19
+		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0117: pop
+		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011d: stloc.s 16
+		IL_011f: ldloc.1
+		IL_0120: ldloc.2
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Subtract(object, object)
+		IL_0126: stloc.s 17
+		IL_0128: ldloc.s 16
+		IL_012a: ldloc.s 17
+		IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0131: pop
+		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0137: stloc.s 16
+		IL_0139: ldloc.1
+		IL_013a: ldloc.2
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Multiply(object, object)
+		IL_0140: stloc.s 17
+		IL_0142: ldloc.s 16
+		IL_0144: ldloc.s 17
+		IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014b: pop
+		IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0151: stloc.s 16
+		IL_0153: ldloc.1
+		IL_0154: ldloc.2
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Divide(object, object)
+		IL_015a: stloc.s 17
+		IL_015c: ldloc.s 16
+		IL_015e: ldloc.s 17
+		IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0165: pop
+		IL_0166: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016b: stloc.s 16
+		IL_016d: ldloc.1
+		IL_016e: ldloc.2
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Remainder(object, object)
+		IL_0174: stloc.s 17
+		IL_0176: ldloc.s 16
+		IL_0178: ldloc.s 17
+		IL_017a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_017f: pop
+		IL_0180: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0185: stloc.s 16
+		IL_0187: ldc.r8 3
+		IL_0190: box [System.Runtime]System.Double
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+		IL_019a: stloc.s 20
+		IL_019c: ldloc.1
+		IL_019d: ldloc.s 20
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Exponentiate(object, object)
+		IL_01a4: stloc.s 17
+		IL_01a6: ldloc.s 16
+		IL_01a8: ldloc.s 17
+		IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01af: pop
+		IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b5: stloc.s 16
+		IL_01b7: ldloc.1
+		IL_01b8: ldloc.2
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseAnd(object, object)
+		IL_01be: stloc.s 17
+		IL_01c0: ldloc.s 16
+		IL_01c2: ldloc.s 17
+		IL_01c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c9: pop
+		IL_01ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cf: stloc.s 16
+		IL_01d1: ldloc.1
+		IL_01d2: ldloc.2
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseOr(object, object)
+		IL_01d8: stloc.s 17
+		IL_01da: ldloc.s 16
+		IL_01dc: ldloc.s 17
+		IL_01de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01e3: pop
+		IL_01e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e9: stloc.s 16
+		IL_01eb: ldloc.1
+		IL_01ec: ldloc.2
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseXor(object, object)
+		IL_01f2: stloc.s 17
+		IL_01f4: ldloc.s 16
+		IL_01f6: ldloc.s 17
+		IL_01f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01fd: pop
+		IL_01fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0203: stloc.s 16
+		IL_0205: ldc.r8 2
+		IL_020e: box [System.Runtime]System.Double
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+		IL_0218: stloc.s 20
+		IL_021a: ldloc.1
+		IL_021b: ldloc.s 20
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::LeftShift(object, object)
+		IL_0222: stloc.s 17
+		IL_0224: ldloc.s 16
+		IL_0226: ldloc.s 17
+		IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_022d: pop
+		IL_022e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0233: stloc.s 16
+		IL_0235: ldc.r8 1
+		IL_023e: box [System.Runtime]System.Double
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+		IL_0248: stloc.s 20
+		IL_024a: ldloc.1
+		IL_024b: ldloc.s 20
+		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::SignedRightShift(object, object)
+		IL_0252: stloc.s 17
+		IL_0254: ldloc.s 16
+		IL_0256: ldloc.s 17
+		IL_0258: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_025d: pop
+		IL_025e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0263: stloc.s 16
+		IL_0265: ldloc.1
+		IL_0266: ldloc.2
+		IL_0267: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+		IL_026c: stloc.s 21
+		IL_026e: ldloc.s 21
+		IL_0270: box [System.Runtime]System.Boolean
+		IL_0275: stloc.s 22
+		IL_0277: ldloc.s 16
+		IL_0279: ldloc.s 22
+		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0280: pop
+		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0286: stloc.s 16
+		IL_0288: ldloc.1
+		IL_0289: ldloc.2
+		IL_028a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThan(object, object)
+		IL_028f: stloc.s 21
+		IL_0291: ldloc.s 21
+		IL_0293: box [System.Runtime]System.Boolean
+		IL_0298: stloc.s 22
+		IL_029a: ldloc.s 16
+		IL_029c: ldloc.s 22
+		IL_029e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a3: pop
+		IL_02a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a9: stloc.s 16
+		IL_02ab: ldloc.1
+		IL_02ac: ldloc.2
+		IL_02ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThanOrEqual(object, object)
+		IL_02b2: stloc.s 21
+		IL_02b4: ldloc.s 21
+		IL_02b6: box [System.Runtime]System.Boolean
+		IL_02bb: stloc.s 22
+		IL_02bd: ldloc.s 16
+		IL_02bf: ldloc.s 22
+		IL_02c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c6: pop
+		IL_02c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02cc: stloc.s 16
+		IL_02ce: ldloc.1
+		IL_02cf: ldloc.2
+		IL_02d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
+		IL_02d5: stloc.s 21
+		IL_02d7: ldloc.s 21
+		IL_02d9: box [System.Runtime]System.Boolean
+		IL_02de: stloc.s 22
+		IL_02e0: ldloc.s 16
+		IL_02e2: ldloc.s 22
+		IL_02e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e9: pop
+		IL_02ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ef: stloc.s 16
+		IL_02f1: ldc.r8 10
+		IL_02fa: box [System.Runtime]System.Double
+		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+		IL_0304: stloc.s 20
+		IL_0306: ldloc.1
+		IL_0307: ldloc.s 20
+		IL_0309: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+		IL_030e: stloc.s 21
+		IL_0310: ldloc.s 21
+		IL_0312: box [System.Runtime]System.Boolean
+		IL_0317: stloc.s 22
+		IL_0319: ldloc.s 16
+		IL_031b: ldloc.s 22
+		IL_031d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0322: pop
+		IL_0323: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0328: stloc.s 16
+		IL_032a: ldc.r8 10
+		IL_0333: box [System.Runtime]System.Double
+		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+		IL_033d: stloc.s 20
+		IL_033f: ldloc.1
+		IL_0340: ldloc.s 20
+		IL_0342: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0347: stloc.s 21
+		IL_0349: ldloc.s 21
+		IL_034b: box [System.Runtime]System.Boolean
+		IL_0350: stloc.s 22
+		IL_0352: ldloc.s 16
+		IL_0354: ldloc.s 22
+		IL_0356: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_035b: pop
+		IL_035c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0361: stloc.s 16
+		IL_0363: ldloc.1
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+		IL_0369: stloc.s 20
+		IL_036b: ldloc.s 16
+		IL_036d: ldloc.s 20
+		IL_036f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0374: pop
+		IL_0375: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_037a: stloc.s 16
+		IL_037c: ldloc.1
+		IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::BitwiseNot(object)
+		IL_0382: stloc.s 17
+		IL_0384: ldloc.s 16
+		IL_0386: ldloc.s 17
+		IL_0388: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_038d: pop
 		.try
 		{
-			IL_035b: nop
-			IL_035c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0361: stloc.s 16
-			IL_0363: ldc.r8 0.0
-			IL_036c: box [System.Runtime]System.Double
-			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_0376: stloc.s 20
-			IL_0378: ldloc.1
-			IL_0379: ldloc.s 20
-			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Divide(object, object)
-			IL_0380: stloc.s 17
-			IL_0382: ldloc.s 16
-			IL_0384: ldloc.s 17
-			IL_0386: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_038b: pop
-			IL_038c: leave IL_040b
+			IL_038e: nop
+			IL_038f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0394: stloc.s 16
+			IL_0396: ldc.r8 0.0
+			IL_039f: box [System.Runtime]System.Double
+			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_03a9: stloc.s 20
+			IL_03ab: ldloc.1
+			IL_03ac: ldloc.s 20
+			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Divide(object, object)
+			IL_03b3: stloc.s 17
+			IL_03b5: ldloc.s 16
+			IL_03b7: ldloc.s 17
+			IL_03b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03be: pop
+			IL_03bf: leave IL_043e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0391: stloc.3
-			IL_0392: ldloc.3
-			IL_0393: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0398: dup
-			IL_0399: brtrue IL_03ae
+			IL_03c4: stloc.3
+			IL_03c5: ldloc.3
+			IL_03c6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03cb: dup
+			IL_03cc: brtrue IL_03e1
 
-			IL_039e: pop
-			IL_039f: ldloc.3
-			IL_03a0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03a5: dup
-			IL_03a6: brtrue IL_03ba
+			IL_03d1: pop
+			IL_03d2: ldloc.3
+			IL_03d3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03d8: dup
+			IL_03d9: brtrue IL_03ed
 
-			IL_03ab: pop
-			IL_03ac: rethrow
+			IL_03de: pop
+			IL_03df: rethrow
 
-			IL_03ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03b3: stloc.s 4
-			IL_03b5: br IL_03bc
+			IL_03e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03e6: stloc.s 4
+			IL_03e8: br IL_03ef
 
-			IL_03ba: stloc.s 4
+			IL_03ed: stloc.s 4
 
-			IL_03bc: ldloc.s 4
-			IL_03be: stloc.s 5
-			IL_03c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03c5: stloc.s 16
-			IL_03c7: volatile.
-			IL_03c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-			IL_03ce: brfalse IL_03e4
+			IL_03ef: ldloc.s 4
+			IL_03f1: stloc.s 5
+			IL_03f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03f8: stloc.s 16
+			IL_03fa: volatile.
+			IL_03fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0401: brfalse IL_0417
 
-			IL_03d3: ldloc.s 5
-			IL_03d5: ldstr "name"
-			IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03df: br IL_03fa
+			IL_0406: ldloc.s 5
+			IL_0408: ldstr "name"
+			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0412: br IL_042d
 
-			IL_03e4: ldloc.s 5
-			IL_03e6: ldstr "name"
-			IL_03eb: ldstr "BinaryOperator_BigInt_Operators:Modules.BinaryOperator_BigInt_Operators:__js_module_init__:147"
-			IL_03f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-			IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0417: ldloc.s 5
+			IL_0419: ldstr "name"
+			IL_041e: ldstr "BinaryOperator_BigInt_Operators:Modules.BinaryOperator_BigInt_Operators:__js_module_init__:147"
+			IL_0423: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03fa: stloc.s 19
-			IL_03fc: ldloc.s 16
-			IL_03fe: ldloc.s 19
-			IL_0400: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0405: pop
-			IL_0406: leave IL_040b
+			IL_042d: stloc.s 19
+			IL_042f: ldloc.s 16
+			IL_0431: ldloc.s 19
+			IL_0433: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0438: pop
+			IL_0439: leave IL_043e
 		} // end handler
 		.try
 		{
-			IL_040b: nop
-			IL_040c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0411: stloc.s 16
-			IL_0413: ldc.r8 0.0
-			IL_041c: box [System.Runtime]System.Double
-			IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_0426: stloc.s 20
-			IL_0428: ldloc.1
-			IL_0429: ldloc.s 20
-			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Remainder(object, object)
-			IL_0430: stloc.s 17
-			IL_0432: ldloc.s 16
-			IL_0434: ldloc.s 17
-			IL_0436: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_043b: pop
-			IL_043c: leave IL_04be
+			IL_043e: nop
+			IL_043f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0444: stloc.s 16
+			IL_0446: ldc.r8 0.0
+			IL_044f: box [System.Runtime]System.Double
+			IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_0459: stloc.s 20
+			IL_045b: ldloc.1
+			IL_045c: ldloc.s 20
+			IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Remainder(object, object)
+			IL_0463: stloc.s 17
+			IL_0465: ldloc.s 16
+			IL_0467: ldloc.s 17
+			IL_0469: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_046e: pop
+			IL_046f: leave IL_04f1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0441: stloc.s 6
-			IL_0443: ldloc.s 6
-			IL_0445: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_044a: dup
-			IL_044b: brtrue IL_0461
+			IL_0474: stloc.s 6
+			IL_0476: ldloc.s 6
+			IL_0478: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_047d: dup
+			IL_047e: brtrue IL_0494
 
-			IL_0450: pop
-			IL_0451: ldloc.s 6
-			IL_0453: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0458: dup
-			IL_0459: brtrue IL_046d
+			IL_0483: pop
+			IL_0484: ldloc.s 6
+			IL_0486: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_048b: dup
+			IL_048c: brtrue IL_04a0
 
-			IL_045e: pop
-			IL_045f: rethrow
+			IL_0491: pop
+			IL_0492: rethrow
 
-			IL_0461: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0466: stloc.s 7
-			IL_0468: br IL_046f
+			IL_0494: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0499: stloc.s 7
+			IL_049b: br IL_04a2
 
-			IL_046d: stloc.s 7
+			IL_04a0: stloc.s 7
 
-			IL_046f: ldloc.s 7
-			IL_0471: stloc.s 8
-			IL_0473: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0478: stloc.s 16
-			IL_047a: volatile.
-			IL_047c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-			IL_0481: brfalse IL_0497
+			IL_04a2: ldloc.s 7
+			IL_04a4: stloc.s 8
+			IL_04a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04ab: stloc.s 16
+			IL_04ad: volatile.
+			IL_04af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_04b4: brfalse IL_04ca
 
-			IL_0486: ldloc.s 8
-			IL_0488: ldstr "name"
-			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0492: br IL_04ad
+			IL_04b9: ldloc.s 8
+			IL_04bb: ldstr "name"
+			IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04c5: br IL_04e0
 
-			IL_0497: ldloc.s 8
-			IL_0499: ldstr "name"
-			IL_049e: ldstr "BinaryOperator_BigInt_Operators:Modules.BinaryOperator_BigInt_Operators:__js_module_init__:173"
-			IL_04a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-			IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04ca: ldloc.s 8
+			IL_04cc: ldstr "name"
+			IL_04d1: ldstr "BinaryOperator_BigInt_Operators:Modules.BinaryOperator_BigInt_Operators:__js_module_init__:173"
+			IL_04d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04ad: stloc.s 19
-			IL_04af: ldloc.s 16
-			IL_04b1: ldloc.s 19
-			IL_04b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04b8: pop
-			IL_04b9: leave IL_04be
+			IL_04e0: stloc.s 19
+			IL_04e2: ldloc.s 16
+			IL_04e4: ldloc.s 19
+			IL_04e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04eb: pop
+			IL_04ec: leave IL_04f1
 		} // end handler
 		.try
 		{
-			IL_04be: nop
-			IL_04bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04c4: stloc.s 16
-			IL_04c6: ldc.r8 1
-			IL_04cf: neg
-			IL_04d0: box [System.Runtime]System.Double
-			IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_04da: stloc.s 20
-			IL_04dc: ldloc.1
-			IL_04dd: ldloc.s 20
-			IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Exponentiate(object, object)
-			IL_04e4: stloc.s 17
-			IL_04e6: ldloc.s 16
-			IL_04e8: ldloc.s 17
-			IL_04ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04ef: pop
-			IL_04f0: leave IL_0572
+			IL_04f1: nop
+			IL_04f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04f7: stloc.s 16
+			IL_04f9: ldc.r8 1
+			IL_0502: neg
+			IL_0503: box [System.Runtime]System.Double
+			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_050d: stloc.s 20
+			IL_050f: ldloc.1
+			IL_0510: ldloc.s 20
+			IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Exponentiate(object, object)
+			IL_0517: stloc.s 17
+			IL_0519: ldloc.s 16
+			IL_051b: ldloc.s 17
+			IL_051d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0522: pop
+			IL_0523: leave IL_05a5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_04f5: stloc.s 9
-			IL_04f7: ldloc.s 9
-			IL_04f9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_04fe: dup
-			IL_04ff: brtrue IL_0515
+			IL_0528: stloc.s 9
+			IL_052a: ldloc.s 9
+			IL_052c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0531: dup
+			IL_0532: brtrue IL_0548
 
-			IL_0504: pop
-			IL_0505: ldloc.s 9
-			IL_0507: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_050c: dup
-			IL_050d: brtrue IL_0521
+			IL_0537: pop
+			IL_0538: ldloc.s 9
+			IL_053a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_053f: dup
+			IL_0540: brtrue IL_0554
 
-			IL_0512: pop
-			IL_0513: rethrow
+			IL_0545: pop
+			IL_0546: rethrow
 
-			IL_0515: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_051a: stloc.s 10
-			IL_051c: br IL_0523
+			IL_0548: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_054d: stloc.s 10
+			IL_054f: br IL_0556
 
-			IL_0521: stloc.s 10
+			IL_0554: stloc.s 10
 
-			IL_0523: ldloc.s 10
-			IL_0525: stloc.s 11
-			IL_0527: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_052c: stloc.s 16
-			IL_052e: volatile.
-			IL_0530: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-			IL_0535: brfalse IL_054b
+			IL_0556: ldloc.s 10
+			IL_0558: stloc.s 11
+			IL_055a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_055f: stloc.s 16
+			IL_0561: volatile.
+			IL_0563: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0568: brfalse IL_057e
 
-			IL_053a: ldloc.s 11
-			IL_053c: ldstr "name"
-			IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0546: br IL_0561
+			IL_056d: ldloc.s 11
+			IL_056f: ldstr "name"
+			IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0579: br IL_0594
 
-			IL_054b: ldloc.s 11
-			IL_054d: ldstr "name"
-			IL_0552: ldstr "BinaryOperator_BigInt_Operators:Modules.BinaryOperator_BigInt_Operators:__js_module_init__:200"
-			IL_0557: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-			IL_055c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_057e: ldloc.s 11
+			IL_0580: ldstr "name"
+			IL_0585: ldstr "BinaryOperator_BigInt_Operators:Modules.BinaryOperator_BigInt_Operators:__js_module_init__:200"
+			IL_058a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0561: stloc.s 19
-			IL_0563: ldloc.s 16
-			IL_0565: ldloc.s 19
-			IL_0567: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_056c: pop
-			IL_056d: leave IL_0572
+			IL_0594: stloc.s 19
+			IL_0596: ldloc.s 16
+			IL_0598: ldloc.s 19
+			IL_059a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_059f: pop
+			IL_05a0: leave IL_05a5
 		} // end handler
 		.try
 		{
-			IL_0572: nop
-			IL_0573: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0578: stloc.s 16
-			IL_057a: ldc.r8 1
-			IL_0583: box [System.Runtime]System.Double
-			IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_058d: stloc.s 20
-			IL_058f: ldloc.1
-			IL_0590: ldloc.s 20
-			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnsignedRightShift(object, object)
-			IL_0597: stloc.s 17
-			IL_0599: ldloc.s 16
-			IL_059b: ldloc.s 17
-			IL_059d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05a2: pop
-			IL_05a3: leave IL_0625
+			IL_05a5: nop
+			IL_05a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05ab: stloc.s 16
+			IL_05ad: ldc.r8 1
+			IL_05b6: box [System.Runtime]System.Double
+			IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_05c0: stloc.s 20
+			IL_05c2: ldloc.1
+			IL_05c3: ldloc.s 20
+			IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnsignedRightShift(object, object)
+			IL_05ca: stloc.s 17
+			IL_05cc: ldloc.s 16
+			IL_05ce: ldloc.s 17
+			IL_05d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05d5: pop
+			IL_05d6: leave IL_0658
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_05a8: stloc.s 12
-			IL_05aa: ldloc.s 12
-			IL_05ac: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_05b1: dup
-			IL_05b2: brtrue IL_05c8
+			IL_05db: stloc.s 12
+			IL_05dd: ldloc.s 12
+			IL_05df: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05e4: dup
+			IL_05e5: brtrue IL_05fb
 
-			IL_05b7: pop
-			IL_05b8: ldloc.s 12
-			IL_05ba: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_05bf: dup
-			IL_05c0: brtrue IL_05d4
+			IL_05ea: pop
+			IL_05eb: ldloc.s 12
+			IL_05ed: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_05f2: dup
+			IL_05f3: brtrue IL_0607
 
-			IL_05c5: pop
-			IL_05c6: rethrow
+			IL_05f8: pop
+			IL_05f9: rethrow
 
-			IL_05c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_05cd: stloc.s 13
-			IL_05cf: br IL_05d6
+			IL_05fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0600: stloc.s 13
+			IL_0602: br IL_0609
 
-			IL_05d4: stloc.s 13
+			IL_0607: stloc.s 13
 
-			IL_05d6: ldloc.s 13
-			IL_05d8: stloc.s 14
-			IL_05da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05df: stloc.s 16
-			IL_05e1: volatile.
-			IL_05e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-			IL_05e8: brfalse IL_05fe
+			IL_0609: ldloc.s 13
+			IL_060b: stloc.s 14
+			IL_060d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0612: stloc.s 16
+			IL_0614: volatile.
+			IL_0616: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_061b: brfalse IL_0631
 
-			IL_05ed: ldloc.s 14
-			IL_05ef: ldstr "name"
-			IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05f9: br IL_0614
+			IL_0620: ldloc.s 14
+			IL_0622: ldstr "name"
+			IL_0627: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_062c: br IL_0647
 
-			IL_05fe: ldloc.s 14
-			IL_0600: ldstr "name"
-			IL_0605: ldstr "BinaryOperator_BigInt_Operators:Modules.BinaryOperator_BigInt_Operators:__js_module_init__:226"
-			IL_060a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-			IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0631: ldloc.s 14
+			IL_0633: ldstr "name"
+			IL_0638: ldstr "BinaryOperator_BigInt_Operators:Modules.BinaryOperator_BigInt_Operators:__js_module_init__:226"
+			IL_063d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0614: stloc.s 19
-			IL_0616: ldloc.s 16
-			IL_0618: ldloc.s 19
-			IL_061a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_061f: pop
-			IL_0620: leave IL_0625
+			IL_0647: stloc.s 19
+			IL_0649: ldloc.s 16
+			IL_064b: ldloc.s 19
+			IL_064d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0652: pop
+			IL_0653: leave IL_0658
 		} // end handler
 
-		IL_0625: ldnull
-		IL_0626: stloc.s 15
-		IL_0628: ret
+		IL_0658: ldnull
+		IL_0659: stloc.s 15
+		IL_065b: ret
 	} // end of method BinaryOperator_BigInt_Operators::__js_module_init__
 
 } // end of class Modules.BinaryOperator_BigInt_Operators
@@ -881,6 +894,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
@@ -1779,7 +1779,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1157 (0x485)
+		// Code size: 1199 (0x4af)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypedNumericScheduler/Scope,
@@ -2172,15 +2172,27 @@
 		IL_0460: stloc.s 17
 		IL_0462: ldloc.s 17
 		IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0469: ldstr "join"
-		IL_046e: ldstr ","
-		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0478: stloc.s 17
-		IL_047a: ldloc.s 12
-		IL_047c: ldloc.s 17
-		IL_047e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0483: pop
-		IL_0484: ret
+		IL_0469: volatile.
+		IL_046b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0470: brfalse IL_0489
+
+		IL_0475: ldstr "join"
+		IL_047a: ldstr ","
+		IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0484: br IL_04a2
+
+		IL_0489: ldstr "join"
+		IL_048e: ldstr ","
+		IL_0493: ldstr "BinaryOperator_TypedNumericScheduler:Modules.BinaryOperator_TypedNumericScheduler:__js_module_init__:152"
+		IL_0498: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_04a2: stloc.s 17
+		IL_04a4: ldloc.s 12
+		IL_04a6: ldloc.s 17
+		IL_04a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04ad: pop
+		IL_04ae: ret
 	} // end of method BinaryOperator_TypedNumericScheduler::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypedNumericScheduler
@@ -2205,4 +2217,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_15
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
@@ -402,7 +402,7 @@
 			IL_0015: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_001a: stloc.1
 			IL_001b: volatile.
-			IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_0022: brfalse IL_0037
 
 			IL_0027: ldloc.1
@@ -413,7 +413,7 @@
 			IL_0037: ldloc.1
 			IL_0038: ldstr "prototype"
 			IL_003d: ldstr "Classes_GeneratedMethodFunctionObjects:<TwoPhaseDummy_M4>:__js_call__:4"
-			IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004c: stloc.2
@@ -1060,7 +1060,7 @@
 			IL_0015: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_001a: stloc.1
 			IL_001b: volatile.
-			IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_0022: brfalse IL_0037
 
 			IL_0027: ldloc.1
@@ -1071,7 +1071,7 @@
 			IL_0037: ldloc.1
 			IL_0038: ldstr "prototype"
 			IL_003d: ldstr "Classes_GeneratedMethodFunctionObjects:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004c: stloc.2
@@ -1983,7 +1983,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_0007: brfalse IL_0025
 
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
@@ -1996,7 +1996,7 @@
 			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_002f: ldstr "prefix"
 			IL_0034: ldstr "Classes_GeneratedMethodFunctionObjects:<TwoPhaseDummy_M12>:identify:3"
-			IL_0039: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0039: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0043: stloc.0
@@ -2460,7 +2460,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 5018 (0x139a)
+		// Code size: 5294 (0x14ae)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_GeneratedMethodFunctionObjects/Scope,
@@ -2943,1243 +2943,1327 @@
 		IL_0528: stloc.s 36
 		IL_052a: ldloc.s 36
 		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0531: ldstr "call"
-		IL_0536: ldloc.s 4
-		IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_053d: stloc.s 36
-		IL_053f: ldloc.s 39
-		IL_0541: ldstr "accessors"
-		IL_0546: ldloc.s 40
-		IL_0548: ldloc.s 36
-		IL_054a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_054f: pop
-		IL_0550: volatile.
-		IL_0552: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0557: brfalse IL_056d
+		IL_0531: volatile.
+		IL_0533: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0538: brfalse IL_054e
 
-		IL_055c: ldloc.s 6
-		IL_055e: ldstr "set"
-		IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0568: br IL_0583
+		IL_053d: ldstr "call"
+		IL_0542: ldloc.s 4
+		IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0549: br IL_0564
 
-		IL_056d: ldloc.s 6
-		IL_056f: ldstr "set"
-		IL_0574: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:109"
-		IL_0579: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_057e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_054e: ldstr "call"
+		IL_0553: ldloc.s 4
+		IL_0555: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:105"
+		IL_055a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0583: stloc.s 36
-		IL_0585: ldloc.s 36
-		IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_058c: ldstr "call"
-		IL_0591: ldloc.s 4
-		IL_0593: ldc.r8 11
-		IL_059c: box [System.Runtime]System.Double
-		IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_05a6: pop
-		IL_05a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05ac: stloc.s 39
-		IL_05ae: volatile.
-		IL_05b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_05b5: brfalse IL_05cb
+		IL_0564: stloc.s 36
+		IL_0566: ldloc.s 39
+		IL_0568: ldstr "accessors"
+		IL_056d: ldloc.s 40
+		IL_056f: ldloc.s 36
+		IL_0571: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0576: pop
+		IL_0577: volatile.
+		IL_0579: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_057e: brfalse IL_0594
 
-		IL_05ba: ldloc.s 4
-		IL_05bc: ldstr "current"
-		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05c6: br IL_05e1
+		IL_0583: ldloc.s 6
+		IL_0585: ldstr "set"
+		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_058f: br IL_05aa
 
-		IL_05cb: ldloc.s 4
-		IL_05cd: ldstr "current"
-		IL_05d2: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:118"
-		IL_05d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0594: ldloc.s 6
+		IL_0596: ldstr "set"
+		IL_059b: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:109"
+		IL_05a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_05a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05e1: stloc.s 36
-		IL_05e3: ldloc.s 39
-		IL_05e5: ldstr "setter"
-		IL_05ea: ldloc.s 36
-		IL_05ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_05f1: pop
-		IL_05f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05f7: stloc.s 39
-		IL_05f9: ldloc.3
-		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05ff: ldstr "identify"
-		IL_0604: ldstr "ok"
-		IL_0609: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_060e: stloc.s 36
-		IL_0610: volatile.
-		IL_0612: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_0617: brfalse IL_062d
+		IL_05aa: stloc.s 36
+		IL_05ac: ldloc.s 36
+		IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05b3: ldstr "call"
+		IL_05b8: ldloc.s 4
+		IL_05ba: ldc.r8 11
+		IL_05c3: box [System.Runtime]System.Double
+		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05cd: pop
+		IL_05ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05d3: stloc.s 39
+		IL_05d5: volatile.
+		IL_05d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_05dc: brfalse IL_05f2
 
-		IL_061c: ldloc.s 7
-		IL_061e: ldstr "value"
-		IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0628: br IL_0643
+		IL_05e1: ldloc.s 4
+		IL_05e3: ldstr "current"
+		IL_05e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ed: br IL_0608
 
-		IL_062d: ldloc.s 7
-		IL_062f: ldstr "value"
-		IL_0634: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:127"
-		IL_0639: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_063e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05f2: ldloc.s 4
+		IL_05f4: ldstr "current"
+		IL_05f9: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:118"
+		IL_05fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0603: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0643: stloc.s 40
-		IL_0645: ldloc.s 40
-		IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_064c: ldstr "call"
-		IL_0651: ldloc.3
-		IL_0652: ldstr "call"
-		IL_0657: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_065c: stloc.s 40
-		IL_065e: ldloc.s 39
-		IL_0660: ldstr "static"
-		IL_0665: ldloc.s 36
-		IL_0667: ldloc.s 40
-		IL_0669: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_066e: pop
-		IL_066f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0674: stloc.s 39
-		IL_0676: volatile.
-		IL_0678: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_067d: brfalse IL_0693
+		IL_0608: stloc.s 36
+		IL_060a: ldloc.s 39
+		IL_060c: ldstr "setter"
+		IL_0611: ldloc.s 36
+		IL_0613: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0618: pop
+		IL_0619: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_061e: stloc.s 39
+		IL_0620: ldloc.3
+		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0626: volatile.
+		IL_0628: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_062d: brfalse IL_0646
 
-		IL_0682: ldloc.s 5
-		IL_0684: ldstr "value"
-		IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_068e: br IL_06a9
+		IL_0632: ldstr "identify"
+		IL_0637: ldstr "ok"
+		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0641: br IL_065f
 
-		IL_0693: ldloc.s 5
-		IL_0695: ldstr "value"
-		IL_069a: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:136"
-		IL_069f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0646: ldstr "identify"
+		IL_064b: ldstr "ok"
+		IL_0650: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:125"
+		IL_0655: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_065a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_06a9: stloc.s 40
-		IL_06ab: volatile.
-		IL_06ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_06b2: brfalse IL_06c8
+		IL_065f: stloc.s 36
+		IL_0661: volatile.
+		IL_0663: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_0668: brfalse IL_067e
 
-		IL_06b7: ldloc.s 40
-		IL_06b9: ldstr "name"
-		IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06c3: br IL_06de
+		IL_066d: ldloc.s 7
+		IL_066f: ldstr "value"
+		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0679: br IL_0694
 
-		IL_06c8: ldloc.s 40
-		IL_06ca: ldstr "name"
-		IL_06cf: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:138"
-		IL_06d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_067e: ldloc.s 7
+		IL_0680: ldstr "value"
+		IL_0685: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:127"
+		IL_068a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06de: stloc.s 40
-		IL_06e0: volatile.
-		IL_06e2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_06e7: brfalse IL_06fd
+		IL_0694: stloc.s 40
+		IL_0696: ldloc.s 40
+		IL_0698: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_069d: ldstr "call"
+		IL_06a2: ldloc.3
+		IL_06a3: ldstr "call"
+		IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_06ad: stloc.s 40
+		IL_06af: ldloc.s 39
+		IL_06b1: ldstr "static"
+		IL_06b6: ldloc.s 36
+		IL_06b8: ldloc.s 40
+		IL_06ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_06bf: pop
+		IL_06c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06c5: stloc.s 39
+		IL_06c7: volatile.
+		IL_06c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_06ce: brfalse IL_06e4
 
-		IL_06ec: ldloc.s 5
-		IL_06ee: ldstr "value"
-		IL_06f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06f8: br IL_0713
+		IL_06d3: ldloc.s 5
+		IL_06d5: ldstr "value"
+		IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06df: br IL_06fa
 
-		IL_06fd: ldloc.s 5
-		IL_06ff: ldstr "value"
-		IL_0704: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:140"
-		IL_0709: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06e4: ldloc.s 5
+		IL_06e6: ldstr "value"
+		IL_06eb: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:136"
+		IL_06f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_06f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0713: stloc.s 36
-		IL_0715: volatile.
-		IL_0717: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_071c: brfalse IL_0732
+		IL_06fa: stloc.s 40
+		IL_06fc: volatile.
+		IL_06fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0703: brfalse IL_0719
 
-		IL_0721: ldloc.s 36
-		IL_0723: ldstr "length"
-		IL_0728: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_072d: br IL_0748
+		IL_0708: ldloc.s 40
+		IL_070a: ldstr "name"
+		IL_070f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0714: br IL_072f
 
-		IL_0732: ldloc.s 36
-		IL_0734: ldstr "length"
-		IL_0739: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:142"
-		IL_073e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0719: ldloc.s 40
+		IL_071b: ldstr "name"
+		IL_0720: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:138"
+		IL_0725: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_072a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0748: stloc.s 36
-		IL_074a: volatile.
-		IL_074c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-		IL_0751: brfalse IL_0767
+		IL_072f: stloc.s 40
+		IL_0731: volatile.
+		IL_0733: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_0738: brfalse IL_074e
 
-		IL_0756: ldloc.s 6
-		IL_0758: ldstr "get"
-		IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0762: br IL_077d
+		IL_073d: ldloc.s 5
+		IL_073f: ldstr "value"
+		IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0749: br IL_0764
 
-		IL_0767: ldloc.s 6
-		IL_0769: ldstr "get"
-		IL_076e: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:144"
-		IL_0773: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-		IL_0778: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_074e: ldloc.s 5
+		IL_0750: ldstr "value"
+		IL_0755: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:140"
+		IL_075a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_075f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_077d: stloc.s 41
-		IL_077f: volatile.
-		IL_0781: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-		IL_0786: brfalse IL_079c
+		IL_0764: stloc.s 36
+		IL_0766: volatile.
+		IL_0768: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_076d: brfalse IL_0783
 
-		IL_078b: ldloc.s 41
-		IL_078d: ldstr "name"
-		IL_0792: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0797: br IL_07b2
+		IL_0772: ldloc.s 36
+		IL_0774: ldstr "length"
+		IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_077e: br IL_0799
 
-		IL_079c: ldloc.s 41
-		IL_079e: ldstr "name"
-		IL_07a3: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:146"
-		IL_07a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-		IL_07ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0783: ldloc.s 36
+		IL_0785: ldstr "length"
+		IL_078a: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:142"
+		IL_078f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_0794: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07b2: stloc.s 41
-		IL_07b4: volatile.
-		IL_07b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-		IL_07bb: brfalse IL_07d1
+		IL_0799: stloc.s 36
+		IL_079b: volatile.
+		IL_079d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_07a2: brfalse IL_07b8
 
-		IL_07c0: ldloc.s 6
-		IL_07c2: ldstr "set"
-		IL_07c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07cc: br IL_07e7
+		IL_07a7: ldloc.s 6
+		IL_07a9: ldstr "get"
+		IL_07ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07b3: br IL_07ce
 
-		IL_07d1: ldloc.s 6
-		IL_07d3: ldstr "set"
-		IL_07d8: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:148"
-		IL_07dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-		IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07b8: ldloc.s 6
+		IL_07ba: ldstr "get"
+		IL_07bf: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:144"
+		IL_07c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07e7: stloc.s 42
-		IL_07e9: volatile.
-		IL_07eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-		IL_07f0: brfalse IL_0806
+		IL_07ce: stloc.s 41
+		IL_07d0: volatile.
+		IL_07d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_07d7: brfalse IL_07ed
 
-		IL_07f5: ldloc.s 42
-		IL_07f7: ldstr "name"
-		IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0801: br IL_081c
+		IL_07dc: ldloc.s 41
+		IL_07de: ldstr "name"
+		IL_07e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07e8: br IL_0803
 
-		IL_0806: ldloc.s 42
-		IL_0808: ldstr "name"
-		IL_080d: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:150"
-		IL_0812: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-		IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07ed: ldloc.s 41
+		IL_07ef: ldstr "name"
+		IL_07f4: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:146"
+		IL_07f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_07fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_081c: stloc.s 42
-		IL_081e: volatile.
-		IL_0820: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-		IL_0825: brfalse IL_083b
+		IL_0803: stloc.s 41
+		IL_0805: volatile.
+		IL_0807: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+		IL_080c: brfalse IL_0822
 
-		IL_082a: ldloc.s 7
-		IL_082c: ldstr "value"
-		IL_0831: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0836: br IL_0851
+		IL_0811: ldloc.s 6
+		IL_0813: ldstr "set"
+		IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_081d: br IL_0838
 
-		IL_083b: ldloc.s 7
-		IL_083d: ldstr "value"
-		IL_0842: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:152"
-		IL_0847: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-		IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0822: ldloc.s 6
+		IL_0824: ldstr "set"
+		IL_0829: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:148"
+		IL_082e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+		IL_0833: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0851: stloc.s 43
-		IL_0853: volatile.
-		IL_0855: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-		IL_085a: brfalse IL_0870
+		IL_0838: stloc.s 42
+		IL_083a: volatile.
+		IL_083c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+		IL_0841: brfalse IL_0857
 
-		IL_085f: ldloc.s 43
-		IL_0861: ldstr "name"
-		IL_0866: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_086b: br IL_0886
+		IL_0846: ldloc.s 42
+		IL_0848: ldstr "name"
+		IL_084d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0852: br IL_086d
 
-		IL_0870: ldloc.s 43
-		IL_0872: ldstr "name"
-		IL_0877: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:154"
-		IL_087c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-		IL_0881: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0857: ldloc.s 42
+		IL_0859: ldstr "name"
+		IL_085e: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:150"
+		IL_0863: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+		IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0886: stloc.s 43
-		IL_0888: ldloc.s 39
-		IL_088a: ldc.i4.6
-		IL_088b: newarr [System.Runtime]System.Object
-		IL_0890: dup
-		IL_0891: ldc.i4.0
-		IL_0892: ldstr "metadata"
-		IL_0897: stelem.ref
-		IL_0898: dup
-		IL_0899: ldc.i4.1
-		IL_089a: ldloc.s 40
-		IL_089c: stelem.ref
-		IL_089d: dup
-		IL_089e: ldc.i4.2
-		IL_089f: ldloc.s 36
-		IL_08a1: stelem.ref
-		IL_08a2: dup
-		IL_08a3: ldc.i4.3
-		IL_08a4: ldloc.s 41
-		IL_08a6: stelem.ref
-		IL_08a7: dup
-		IL_08a8: ldc.i4.4
-		IL_08a9: ldloc.s 42
-		IL_08ab: stelem.ref
-		IL_08ac: dup
-		IL_08ad: ldc.i4.5
-		IL_08ae: ldloc.s 43
-		IL_08b0: stelem.ref
-		IL_08b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_08b6: pop
-		IL_08b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08bc: stloc.s 39
-		IL_08be: volatile.
-		IL_08c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-		IL_08c5: brfalse IL_08db
+		IL_086d: stloc.s 42
+		IL_086f: volatile.
+		IL_0871: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+		IL_0876: brfalse IL_088c
 
-		IL_08ca: ldloc.s 5
-		IL_08cc: ldstr "value"
-		IL_08d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08d6: br IL_08f1
+		IL_087b: ldloc.s 7
+		IL_087d: ldstr "value"
+		IL_0882: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0887: br IL_08a2
 
-		IL_08db: ldloc.s 5
-		IL_08dd: ldstr "value"
-		IL_08e2: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:160"
-		IL_08e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-		IL_08ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_088c: ldloc.s 7
+		IL_088e: ldstr "value"
+		IL_0893: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:152"
+		IL_0898: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+		IL_089d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_08f1: stloc.s 43
-		IL_08f3: volatile.
-		IL_08f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-		IL_08fa: brfalse IL_090f
+		IL_08a2: stloc.s 43
+		IL_08a4: volatile.
+		IL_08a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+		IL_08ab: brfalse IL_08c1
 
-		IL_08ff: ldloc.3
-		IL_0900: ldstr "prototype"
-		IL_0905: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_090a: br IL_0924
+		IL_08b0: ldloc.s 43
+		IL_08b2: ldstr "name"
+		IL_08b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08bc: br IL_08d7
 
-		IL_090f: ldloc.3
-		IL_0910: ldstr "prototype"
-		IL_0915: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:162"
-		IL_091a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-		IL_091f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_08c1: ldloc.s 43
+		IL_08c3: ldstr "name"
+		IL_08c8: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:154"
+		IL_08cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+		IL_08d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0924: stloc.s 42
-		IL_0926: volatile.
-		IL_0928: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-		IL_092d: brfalse IL_0943
+		IL_08d7: stloc.s 43
+		IL_08d9: ldloc.s 39
+		IL_08db: ldc.i4.6
+		IL_08dc: newarr [System.Runtime]System.Object
+		IL_08e1: dup
+		IL_08e2: ldc.i4.0
+		IL_08e3: ldstr "metadata"
+		IL_08e8: stelem.ref
+		IL_08e9: dup
+		IL_08ea: ldc.i4.1
+		IL_08eb: ldloc.s 40
+		IL_08ed: stelem.ref
+		IL_08ee: dup
+		IL_08ef: ldc.i4.2
+		IL_08f0: ldloc.s 36
+		IL_08f2: stelem.ref
+		IL_08f3: dup
+		IL_08f4: ldc.i4.3
+		IL_08f5: ldloc.s 41
+		IL_08f7: stelem.ref
+		IL_08f8: dup
+		IL_08f9: ldc.i4.4
+		IL_08fa: ldloc.s 42
+		IL_08fc: stelem.ref
+		IL_08fd: dup
+		IL_08fe: ldc.i4.5
+		IL_08ff: ldloc.s 43
+		IL_0901: stelem.ref
+		IL_0902: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0907: pop
+		IL_0908: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_090d: stloc.s 39
+		IL_090f: volatile.
+		IL_0911: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+		IL_0916: brfalse IL_092c
 
-		IL_0932: ldloc.s 42
-		IL_0934: ldstr "add"
-		IL_0939: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_093e: br IL_0959
+		IL_091b: ldloc.s 5
+		IL_091d: ldstr "value"
+		IL_0922: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0927: br IL_0942
 
-		IL_0943: ldloc.s 42
-		IL_0945: ldstr "add"
-		IL_094a: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:164"
-		IL_094f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-		IL_0954: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_092c: ldloc.s 5
+		IL_092e: ldstr "value"
+		IL_0933: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:160"
+		IL_0938: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+		IL_093d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0959: stloc.s 42
-		IL_095b: ldloc.s 43
-		IL_095d: ldloc.s 42
-		IL_095f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0964: stloc.s 44
-		IL_0966: ldloc.s 44
-		IL_0968: box [System.Runtime]System.Boolean
-		IL_096d: stloc.s 45
-		IL_096f: volatile.
-		IL_0971: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-		IL_0976: brfalse IL_098c
+		IL_0942: stloc.s 43
+		IL_0944: volatile.
+		IL_0946: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+		IL_094b: brfalse IL_0960
 
-		IL_097b: ldloc.s 6
-		IL_097d: ldstr "get"
-		IL_0982: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0987: br IL_09a2
+		IL_0950: ldloc.3
+		IL_0951: ldstr "prototype"
+		IL_0956: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_095b: br IL_0975
 
-		IL_098c: ldloc.s 6
-		IL_098e: ldstr "get"
-		IL_0993: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:168"
-		IL_0998: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-		IL_099d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0960: ldloc.3
+		IL_0961: ldstr "prototype"
+		IL_0966: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:162"
+		IL_096b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+		IL_0970: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_09a2: stloc.s 42
-		IL_09a4: volatile.
-		IL_09a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-		IL_09ab: brfalse IL_09c0
+		IL_0975: stloc.s 42
+		IL_0977: volatile.
+		IL_0979: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+		IL_097e: brfalse IL_0994
 
-		IL_09b0: ldloc.3
-		IL_09b1: ldstr "prototype"
-		IL_09b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09bb: br IL_09d5
+		IL_0983: ldloc.s 42
+		IL_0985: ldstr "add"
+		IL_098a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_098f: br IL_09aa
 
-		IL_09c0: ldloc.3
-		IL_09c1: ldstr "prototype"
-		IL_09c6: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:170"
-		IL_09cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-		IL_09d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0994: ldloc.s 42
+		IL_0996: ldstr "add"
+		IL_099b: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:164"
+		IL_09a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+		IL_09a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_09d5: stloc.s 43
-		IL_09d7: ldloc.s 43
-		IL_09d9: ldstr "current"
-		IL_09de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_09e3: volatile.
-		IL_09e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-		IL_09ea: brfalse IL_09fe
+		IL_09aa: stloc.s 42
+		IL_09ac: ldloc.s 43
+		IL_09ae: ldloc.s 42
+		IL_09b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_09b5: stloc.s 44
+		IL_09b7: ldloc.s 44
+		IL_09b9: box [System.Runtime]System.Boolean
+		IL_09be: stloc.s 45
+		IL_09c0: volatile.
+		IL_09c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+		IL_09c7: brfalse IL_09dd
 
-		IL_09ef: ldstr "get"
-		IL_09f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09f9: br IL_0a12
+		IL_09cc: ldloc.s 6
+		IL_09ce: ldstr "get"
+		IL_09d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09d8: br IL_09f3
 
-		IL_09fe: ldstr "get"
-		IL_0a03: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:174"
-		IL_0a08: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-		IL_0a0d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09dd: ldloc.s 6
+		IL_09df: ldstr "get"
+		IL_09e4: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:168"
+		IL_09e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+		IL_09ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a12: stloc.s 43
-		IL_0a14: ldloc.s 42
-		IL_0a16: ldloc.s 43
-		IL_0a18: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0a1d: stloc.s 44
-		IL_0a1f: ldloc.s 44
-		IL_0a21: box [System.Runtime]System.Boolean
-		IL_0a26: stloc.s 46
-		IL_0a28: volatile.
-		IL_0a2a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-		IL_0a2f: brfalse IL_0a45
+		IL_09f3: stloc.s 42
+		IL_09f5: volatile.
+		IL_09f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+		IL_09fc: brfalse IL_0a11
 
-		IL_0a34: ldloc.s 5
-		IL_0a36: ldstr "value"
-		IL_0a3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a40: br IL_0a5b
+		IL_0a01: ldloc.3
+		IL_0a02: ldstr "prototype"
+		IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a0c: br IL_0a26
 
-		IL_0a45: ldloc.s 5
-		IL_0a47: ldstr "value"
-		IL_0a4c: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:178"
-		IL_0a51: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-		IL_0a56: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0a11: ldloc.3
+		IL_0a12: ldstr "prototype"
+		IL_0a17: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:170"
+		IL_0a1c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+		IL_0a21: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a5b: stloc.s 43
-		IL_0a5d: ldloc.s 43
-		IL_0a5f: ldstr "prototype"
-		IL_0a64: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0a69: box [System.Runtime]System.Boolean
-		IL_0a6e: stloc.s 47
-		IL_0a70: ldloc.s 39
-		IL_0a72: ldc.i4.4
-		IL_0a73: newarr [System.Runtime]System.Object
-		IL_0a78: dup
-		IL_0a79: ldc.i4.0
-		IL_0a7a: ldstr "descriptors"
-		IL_0a7f: stelem.ref
-		IL_0a80: dup
-		IL_0a81: ldc.i4.1
-		IL_0a82: ldloc.s 45
-		IL_0a84: stelem.ref
-		IL_0a85: dup
-		IL_0a86: ldc.i4.2
-		IL_0a87: ldloc.s 46
-		IL_0a89: stelem.ref
-		IL_0a8a: dup
-		IL_0a8b: ldc.i4.3
-		IL_0a8c: ldloc.s 47
-		IL_0a8e: stelem.ref
-		IL_0a8f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0a94: pop
-		IL_0a95: ldc.i4.0
-		IL_0a96: box [System.Runtime]System.Boolean
-		IL_0a9b: stloc.s 8
+		IL_0a26: stloc.s 43
+		IL_0a28: ldloc.s 43
+		IL_0a2a: ldstr "current"
+		IL_0a2f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0a34: volatile.
+		IL_0a36: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+		IL_0a3b: brfalse IL_0a4f
+
+		IL_0a40: ldstr "get"
+		IL_0a45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a4a: br IL_0a63
+
+		IL_0a4f: ldstr "get"
+		IL_0a54: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:174"
+		IL_0a59: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+		IL_0a5e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0a63: stloc.s 43
+		IL_0a65: ldloc.s 42
+		IL_0a67: ldloc.s 43
+		IL_0a69: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0a6e: stloc.s 44
+		IL_0a70: ldloc.s 44
+		IL_0a72: box [System.Runtime]System.Boolean
+		IL_0a77: stloc.s 46
+		IL_0a79: volatile.
+		IL_0a7b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+		IL_0a80: brfalse IL_0a96
+
+		IL_0a85: ldloc.s 5
+		IL_0a87: ldstr "value"
+		IL_0a8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a91: br IL_0aac
+
+		IL_0a96: ldloc.s 5
+		IL_0a98: ldstr "value"
+		IL_0a9d: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:178"
+		IL_0aa2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+		IL_0aa7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0aac: stloc.s 43
+		IL_0aae: ldloc.s 43
+		IL_0ab0: ldstr "prototype"
+		IL_0ab5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0aba: box [System.Runtime]System.Boolean
+		IL_0abf: stloc.s 47
+		IL_0ac1: ldloc.s 39
+		IL_0ac3: ldc.i4.4
+		IL_0ac4: newarr [System.Runtime]System.Object
+		IL_0ac9: dup
+		IL_0aca: ldc.i4.0
+		IL_0acb: ldstr "descriptors"
+		IL_0ad0: stelem.ref
+		IL_0ad1: dup
+		IL_0ad2: ldc.i4.1
+		IL_0ad3: ldloc.s 45
+		IL_0ad5: stelem.ref
+		IL_0ad6: dup
+		IL_0ad7: ldc.i4.2
+		IL_0ad8: ldloc.s 46
+		IL_0ada: stelem.ref
+		IL_0adb: dup
+		IL_0adc: ldc.i4.3
+		IL_0add: ldloc.s 47
+		IL_0adf: stelem.ref
+		IL_0ae0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0ae5: pop
+		IL_0ae6: ldc.i4.0
+		IL_0ae7: box [System.Runtime]System.Boolean
+		IL_0aec: stloc.s 8
 		.try
 		{
-			IL_0a9d: nop
-			IL_0a9e: ldstr "Reflect"
-			IL_0aa3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0aa8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0aad: stloc.s 43
-			IL_0aaf: volatile.
-			IL_0ab1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-			IL_0ab6: brfalse IL_0acc
+			IL_0aee: nop
+			IL_0aef: ldstr "Reflect"
+			IL_0af4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0af9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0afe: stloc.s 43
+			IL_0b00: volatile.
+			IL_0b02: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_0b07: brfalse IL_0b1d
 
-			IL_0abb: ldloc.s 5
-			IL_0abd: ldstr "value"
-			IL_0ac2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ac7: br IL_0ae2
+			IL_0b0c: ldloc.s 5
+			IL_0b0e: ldstr "value"
+			IL_0b13: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b18: br IL_0b33
 
-			IL_0acc: ldloc.s 5
-			IL_0ace: ldstr "value"
-			IL_0ad3: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:195"
-			IL_0ad8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0b1d: ldloc.s 5
+			IL_0b1f: ldstr "value"
+			IL_0b24: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:195"
+			IL_0b29: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_0b2e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0ae2: stloc.s 42
-			IL_0ae4: ldc.i4.0
-			IL_0ae5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0aea: stloc.s 48
-			IL_0aec: ldloc.s 43
-			IL_0aee: ldstr "construct"
-			IL_0af3: ldloc.s 42
-			IL_0af5: ldloc.s 48
-			IL_0af7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0afc: pop
-			IL_0afd: leave IL_0b61
-		} // end .try
-		catch [System.Runtime]System.Exception
-		{
-			IL_0b02: stloc.s 9
-			IL_0b04: ldloc.s 9
-			IL_0b06: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0b0b: dup
-			IL_0b0c: brtrue IL_0b22
-
-			IL_0b11: pop
-			IL_0b12: ldloc.s 9
-			IL_0b14: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0b19: dup
-			IL_0b1a: brtrue IL_0b2e
-
-			IL_0b1f: pop
-			IL_0b20: rethrow
-
-			IL_0b22: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0b27: stloc.s 10
-			IL_0b29: br IL_0b30
-
-			IL_0b2e: stloc.s 10
-
-			IL_0b30: ldloc.s 10
-			IL_0b32: stloc.s 11
-			IL_0b34: ldloc.s 11
-			IL_0b36: stloc.s 42
-			IL_0b38: ldstr "TypeError"
-			IL_0b3d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b42: stloc.s 43
+			IL_0b33: stloc.s 42
+			IL_0b35: ldc.i4.0
+			IL_0b36: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0b3b: stloc.s 48
+			IL_0b3d: ldloc.s 43
+			IL_0b3f: ldstr "construct"
 			IL_0b44: ldloc.s 42
-			IL_0b46: ldloc.s 43
-			IL_0b48: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0b4d: stloc.s 44
-			IL_0b4f: ldloc.s 44
-			IL_0b51: box [System.Runtime]System.Boolean
-			IL_0b56: stloc.s 47
-			IL_0b58: ldloc.s 47
-			IL_0b5a: stloc.s 8
-			IL_0b5c: leave IL_0b61
-		} // end handler
-
-		IL_0b61: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b66: stloc.s 39
-		IL_0b68: ldloc.s 39
-		IL_0b6a: ldstr "nonconstructor"
-		IL_0b6f: ldloc.s 8
-		IL_0b71: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0b76: pop
-		IL_0b77: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_0b7c: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0b81: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_0b86: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0b8b: stloc.s 35
-		IL_0b8d: volatile.
-		IL_0b8f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-		IL_0b94: brfalse IL_0baa
-
-		IL_0b99: ldloc.s 35
-		IL_0b9b: ldstr "prototype"
-		IL_0ba0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ba5: br IL_0bc0
-
-		IL_0baa: ldloc.s 35
-		IL_0bac: ldstr "prototype"
-		IL_0bb1: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:224"
-		IL_0bb6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-		IL_0bbb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0bc0: stloc.s 43
-		IL_0bc2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0bc7: stloc.s 34
-		IL_0bc9: ldloc.s 43
-		IL_0bcb: ldstr "read"
-		IL_0bd0: ldloc.s 35
-		IL_0bd2: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject::.ctor(class [System.Runtime]System.Object)
-		IL_0bd7: ldc.i4.0
-		IL_0bd8: conv.r8
-		IL_0bd9: ldstr "read"
-		IL_0bde: ldc.i4.1
-		IL_0bdf: ldc.i4.1
-		IL_0be0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0be5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject>(!!0)
-		IL_0bea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0bef: pop
-		IL_0bf0: ldc.i4.1
-		IL_0bf1: newarr [System.Runtime]System.Object
-		IL_0bf6: dup
-		IL_0bf7: ldc.i4.0
-		IL_0bf8: ldloc.0
-		IL_0bf9: stelem.ref
-		IL_0bfa: stloc.s 34
-		IL_0bfc: ldloc.s 34
-		IL_0bfe: ldnull
-		IL_0bff: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object)
-		IL_0c04: ldloc.s 35
-		IL_0c06: ldloc.s 34
-		IL_0c08: ldc.i4.1
-		IL_0c09: conv.r8
-		IL_0c0a: ldc.i4.0
-		IL_0c0b: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0c10: castclass Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_ctor/FunctionObject
-		IL_0c15: stloc.s 49
-		IL_0c17: ldloc.s 49
-		IL_0c19: stloc.s 12
-		IL_0c1b: ldc.i4.1
-		IL_0c1c: newarr [System.Runtime]System.Object
-		IL_0c21: dup
-		IL_0c22: ldc.i4.0
-		IL_0c23: ldloc.0
-		IL_0c24: stelem.ref
-		IL_0c25: stloc.s 34
-		IL_0c27: ldloc.s 34
-		IL_0c29: ldc.i4.1
-		IL_0c2a: newarr [System.Runtime]System.Object
-		IL_0c2f: dup
-		IL_0c30: ldc.i4.0
-		IL_0c31: ldc.r8 17
-		IL_0c3a: box [System.Runtime]System.Double
-		IL_0c3f: stelem.ref
-		IL_0c40: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0c45: ldc.r8 17
-		IL_0c4e: box [System.Runtime]System.Double
-		IL_0c53: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret::.ctor(object[], object)
-		IL_0c58: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0c5d: stloc.s 13
-		IL_0c5f: ldloc.s 13
-		IL_0c61: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-		IL_0c66: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0c6b: ldstr "prototype"
-		IL_0c70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0c75: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0c7a: volatile.
-		IL_0c7c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-		IL_0c81: brfalse IL_0c97
-
-		IL_0c86: ldloc.s 12
-		IL_0c88: ldstr "prototype"
-		IL_0c8d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c92: br IL_0cad
-
-		IL_0c97: ldloc.s 12
-		IL_0c99: ldstr "prototype"
-		IL_0c9e: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:241"
-		IL_0ca3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-		IL_0ca8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0cad: stloc.s 43
-		IL_0caf: volatile.
-		IL_0cb1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-		IL_0cb6: brfalse IL_0ccc
-
-		IL_0cbb: ldloc.s 43
-		IL_0cbd: ldstr "read"
-		IL_0cc2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0cc7: br IL_0ce2
-
-		IL_0ccc: ldloc.s 43
-		IL_0cce: ldstr "read"
-		IL_0cd3: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:243"
-		IL_0cd8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-		IL_0cdd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0ce2: stloc.s 14
-		IL_0ce4: ldc.i4.0
-		IL_0ce5: box [System.Runtime]System.Boolean
-		IL_0cea: stloc.s 15
-		.try
-		{
-			IL_0cec: nop
-			IL_0ced: ldloc.s 14
-			IL_0cef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0cf4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0cf9: stloc.s 50
-			IL_0cfb: ldstr "call"
-			IL_0d00: ldloc.s 50
-			IL_0d02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0d07: pop
-			IL_0d08: leave IL_0d6c
+			IL_0b46: ldloc.s 48
+			IL_0b48: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0b4d: pop
+			IL_0b4e: leave IL_0bb2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0d0d: stloc.s 16
-			IL_0d0f: ldloc.s 16
-			IL_0d11: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0d16: dup
-			IL_0d17: brtrue IL_0d2d
+			IL_0b53: stloc.s 9
+			IL_0b55: ldloc.s 9
+			IL_0b57: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0b5c: dup
+			IL_0b5d: brtrue IL_0b73
 
-			IL_0d1c: pop
-			IL_0d1d: ldloc.s 16
-			IL_0d1f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0d24: dup
-			IL_0d25: brtrue IL_0d39
+			IL_0b62: pop
+			IL_0b63: ldloc.s 9
+			IL_0b65: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0b6a: dup
+			IL_0b6b: brtrue IL_0b7f
 
-			IL_0d2a: pop
-			IL_0d2b: rethrow
+			IL_0b70: pop
+			IL_0b71: rethrow
 
-			IL_0d2d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0d32: stloc.s 17
-			IL_0d34: br IL_0d3b
+			IL_0b73: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b78: stloc.s 10
+			IL_0b7a: br IL_0b81
 
-			IL_0d39: stloc.s 17
+			IL_0b7f: stloc.s 10
 
-			IL_0d3b: ldloc.s 17
-			IL_0d3d: stloc.s 18
-			IL_0d3f: ldloc.s 18
-			IL_0d41: stloc.s 43
-			IL_0d43: ldstr "TypeError"
-			IL_0d48: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0d4d: stloc.s 42
-			IL_0d4f: ldloc.s 43
-			IL_0d51: ldloc.s 42
-			IL_0d53: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0d58: stloc.s 44
-			IL_0d5a: ldloc.s 44
-			IL_0d5c: box [System.Runtime]System.Boolean
-			IL_0d61: stloc.s 47
-			IL_0d63: ldloc.s 47
-			IL_0d65: stloc.s 15
-			IL_0d67: leave IL_0d6c
+			IL_0b81: ldloc.s 10
+			IL_0b83: stloc.s 11
+			IL_0b85: ldloc.s 11
+			IL_0b87: stloc.s 42
+			IL_0b89: ldstr "TypeError"
+			IL_0b8e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b93: stloc.s 43
+			IL_0b95: ldloc.s 42
+			IL_0b97: ldloc.s 43
+			IL_0b99: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0b9e: stloc.s 44
+			IL_0ba0: ldloc.s 44
+			IL_0ba2: box [System.Runtime]System.Boolean
+			IL_0ba7: stloc.s 47
+			IL_0ba9: ldloc.s 47
+			IL_0bab: stloc.s 8
+			IL_0bad: leave IL_0bb2
 		} // end handler
 
-		IL_0d6c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0d71: stloc.s 39
-		IL_0d73: ldloc.s 14
-		IL_0d75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0d7a: ldstr "call"
-		IL_0d7f: ldloc.s 13
-		IL_0d81: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0d86: stloc.s 42
-		IL_0d88: ldloc.s 39
-		IL_0d8a: ldstr "private"
-		IL_0d8f: ldloc.s 42
-		IL_0d91: ldloc.s 15
-		IL_0d93: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0d98: pop
-		IL_0d99: nop
-		IL_0d9a: ldloc.1
-		IL_0d9b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0da0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0da5: stloc.s 19
-		IL_0da7: ldloc.1
-		IL_0da8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0dad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0db2: stloc.s 20
-		IL_0db4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0db9: stloc.s 39
-		IL_0dbb: volatile.
-		IL_0dbd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-		IL_0dc2: brfalse IL_0dd8
+		IL_0bb2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0bb7: stloc.s 39
+		IL_0bb9: ldloc.s 39
+		IL_0bbb: ldstr "nonconstructor"
+		IL_0bc0: ldloc.s 8
+		IL_0bc2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0bc7: pop
+		IL_0bc8: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_0bcd: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0bd2: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_0bd7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0bdc: stloc.s 35
+		IL_0bde: volatile.
+		IL_0be0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+		IL_0be5: brfalse IL_0bfb
 
-		IL_0dc7: ldloc.s 19
-		IL_0dc9: ldstr "prototype"
-		IL_0dce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0dd3: br IL_0dee
+		IL_0bea: ldloc.s 35
+		IL_0bec: ldstr "prototype"
+		IL_0bf1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0bf6: br IL_0c11
 
-		IL_0dd8: ldloc.s 19
-		IL_0dda: ldstr "prototype"
-		IL_0ddf: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:294"
-		IL_0de4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-		IL_0de9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0bfb: ldloc.s 35
+		IL_0bfd: ldstr "prototype"
+		IL_0c02: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:224"
+		IL_0c07: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+		IL_0c0c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0dee: stloc.s 42
-		IL_0df0: volatile.
-		IL_0df2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-		IL_0df7: brfalse IL_0e0d
+		IL_0c11: stloc.s 43
+		IL_0c13: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0c18: stloc.s 34
+		IL_0c1a: ldloc.s 43
+		IL_0c1c: ldstr "read"
+		IL_0c21: ldloc.s 35
+		IL_0c23: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject::.ctor(class [System.Runtime]System.Object)
+		IL_0c28: ldc.i4.0
+		IL_0c29: conv.r8
+		IL_0c2a: ldstr "read"
+		IL_0c2f: ldc.i4.1
+		IL_0c30: ldc.i4.1
+		IL_0c31: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c36: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject>(!!0)
+		IL_0c3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0c40: pop
+		IL_0c41: ldc.i4.1
+		IL_0c42: newarr [System.Runtime]System.Object
+		IL_0c47: dup
+		IL_0c48: ldc.i4.0
+		IL_0c49: ldloc.0
+		IL_0c4a: stelem.ref
+		IL_0c4b: stloc.s 34
+		IL_0c4d: ldloc.s 34
+		IL_0c4f: ldnull
+		IL_0c50: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object)
+		IL_0c55: ldloc.s 35
+		IL_0c57: ldloc.s 34
+		IL_0c59: ldc.i4.1
+		IL_0c5a: conv.r8
+		IL_0c5b: ldc.i4.0
+		IL_0c5c: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0c61: castclass Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_ctor/FunctionObject
+		IL_0c66: stloc.s 49
+		IL_0c68: ldloc.s 49
+		IL_0c6a: stloc.s 12
+		IL_0c6c: ldc.i4.1
+		IL_0c6d: newarr [System.Runtime]System.Object
+		IL_0c72: dup
+		IL_0c73: ldc.i4.0
+		IL_0c74: ldloc.0
+		IL_0c75: stelem.ref
+		IL_0c76: stloc.s 34
+		IL_0c78: ldloc.s 34
+		IL_0c7a: ldc.i4.1
+		IL_0c7b: newarr [System.Runtime]System.Object
+		IL_0c80: dup
+		IL_0c81: ldc.i4.0
+		IL_0c82: ldc.r8 17
+		IL_0c8b: box [System.Runtime]System.Double
+		IL_0c90: stelem.ref
+		IL_0c91: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0c96: ldc.r8 17
+		IL_0c9f: box [System.Runtime]System.Double
+		IL_0ca4: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret::.ctor(object[], object)
+		IL_0ca9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0cae: stloc.s 13
+		IL_0cb0: ldloc.s 13
+		IL_0cb2: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+		IL_0cb7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0cbc: ldstr "prototype"
+		IL_0cc1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0cc6: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0ccb: volatile.
+		IL_0ccd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+		IL_0cd2: brfalse IL_0ce8
 
-		IL_0dfc: ldloc.s 42
-		IL_0dfe: ldstr "method"
-		IL_0e03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0e08: br IL_0e23
+		IL_0cd7: ldloc.s 12
+		IL_0cd9: ldstr "prototype"
+		IL_0cde: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ce3: br IL_0cfe
 
-		IL_0e0d: ldloc.s 42
-		IL_0e0f: ldstr "method"
-		IL_0e14: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:296"
-		IL_0e19: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-		IL_0e1e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ce8: ldloc.s 12
+		IL_0cea: ldstr "prototype"
+		IL_0cef: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:241"
+		IL_0cf4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+		IL_0cf9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0e23: stloc.s 42
-		IL_0e25: volatile.
-		IL_0e27: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-		IL_0e2c: brfalse IL_0e42
+		IL_0cfe: stloc.s 43
+		IL_0d00: volatile.
+		IL_0d02: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+		IL_0d07: brfalse IL_0d1d
 
-		IL_0e31: ldloc.s 20
-		IL_0e33: ldstr "prototype"
-		IL_0e38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0e3d: br IL_0e58
+		IL_0d0c: ldloc.s 43
+		IL_0d0e: ldstr "read"
+		IL_0d13: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d18: br IL_0d33
 
-		IL_0e42: ldloc.s 20
-		IL_0e44: ldstr "prototype"
-		IL_0e49: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:298"
-		IL_0e4e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-		IL_0e53: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0d1d: ldloc.s 43
+		IL_0d1f: ldstr "read"
+		IL_0d24: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:243"
+		IL_0d29: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+		IL_0d2e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0e58: stloc.s 43
+		IL_0d33: stloc.s 14
+		IL_0d35: ldc.i4.0
+		IL_0d36: box [System.Runtime]System.Boolean
+		IL_0d3b: stloc.s 15
+		.try
+		{
+			IL_0d3d: nop
+			IL_0d3e: ldloc.s 14
+			IL_0d40: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0d45: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0d4a: stloc.s 50
+			IL_0d4c: volatile.
+			IL_0d4e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0d53: brfalse IL_0d69
+
+			IL_0d58: ldstr "call"
+			IL_0d5d: ldloc.s 50
+			IL_0d5f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0d64: br IL_0d7f
+
+			IL_0d69: ldstr "call"
+			IL_0d6e: ldloc.s 50
+			IL_0d70: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:255"
+			IL_0d75: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0d7a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0d7f: pop
+			IL_0d80: leave IL_0de4
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_0d85: stloc.s 16
+			IL_0d87: ldloc.s 16
+			IL_0d89: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0d8e: dup
+			IL_0d8f: brtrue IL_0da5
+
+			IL_0d94: pop
+			IL_0d95: ldloc.s 16
+			IL_0d97: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0d9c: dup
+			IL_0d9d: brtrue IL_0db1
+
+			IL_0da2: pop
+			IL_0da3: rethrow
+
+			IL_0da5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0daa: stloc.s 17
+			IL_0dac: br IL_0db3
+
+			IL_0db1: stloc.s 17
+
+			IL_0db3: ldloc.s 17
+			IL_0db5: stloc.s 18
+			IL_0db7: ldloc.s 18
+			IL_0db9: stloc.s 43
+			IL_0dbb: ldstr "TypeError"
+			IL_0dc0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0dc5: stloc.s 42
+			IL_0dc7: ldloc.s 43
+			IL_0dc9: ldloc.s 42
+			IL_0dcb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0dd0: stloc.s 44
+			IL_0dd2: ldloc.s 44
+			IL_0dd4: box [System.Runtime]System.Boolean
+			IL_0dd9: stloc.s 47
+			IL_0ddb: ldloc.s 47
+			IL_0ddd: stloc.s 15
+			IL_0ddf: leave IL_0de4
+		} // end handler
+
+		IL_0de4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0de9: stloc.s 39
+		IL_0deb: ldloc.s 14
+		IL_0ded: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0df2: volatile.
+		IL_0df4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+		IL_0df9: brfalse IL_0e0f
+
+		IL_0dfe: ldstr "call"
+		IL_0e03: ldloc.s 13
+		IL_0e05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0e0a: br IL_0e25
+
+		IL_0e0f: ldstr "call"
+		IL_0e14: ldloc.s 13
+		IL_0e16: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:279"
+		IL_0e1b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+		IL_0e20: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0e25: stloc.s 42
+		IL_0e27: ldloc.s 39
+		IL_0e29: ldstr "private"
+		IL_0e2e: ldloc.s 42
+		IL_0e30: ldloc.s 15
+		IL_0e32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0e37: pop
+		IL_0e38: nop
+		IL_0e39: ldloc.1
+		IL_0e3a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0e3f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0e44: stloc.s 19
+		IL_0e46: ldloc.1
+		IL_0e47: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0e4c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0e51: stloc.s 20
+		IL_0e53: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0e58: stloc.s 39
 		IL_0e5a: volatile.
-		IL_0e5c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+		IL_0e5c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 		IL_0e61: brfalse IL_0e77
 
-		IL_0e66: ldloc.s 43
-		IL_0e68: ldstr "method"
+		IL_0e66: ldloc.s 19
+		IL_0e68: ldstr "prototype"
 		IL_0e6d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0e72: br IL_0e8d
 
-		IL_0e77: ldloc.s 43
-		IL_0e79: ldstr "method"
-		IL_0e7e: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:300"
-		IL_0e83: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+		IL_0e77: ldloc.s 19
+		IL_0e79: ldstr "prototype"
+		IL_0e7e: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:294"
+		IL_0e83: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 		IL_0e88: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0e8d: stloc.s 43
-		IL_0e8f: ldloc.s 42
-		IL_0e91: ldloc.s 43
-		IL_0e93: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0e98: stloc.s 44
-		IL_0e9a: ldloc.s 44
-		IL_0e9c: box [System.Runtime]System.Boolean
-		IL_0ea1: stloc.s 47
-		IL_0ea3: ldloc.s 39
-		IL_0ea5: ldstr "identity"
-		IL_0eaa: ldloc.s 47
-		IL_0eac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0eb1: pop
-		IL_0eb2: nop
-		IL_0eb3: ldloc.2
-		IL_0eb4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0eb9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0ebe: stloc.s 21
-		IL_0ec0: ldloc.2
-		IL_0ec1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0ec6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0ecb: stloc.s 22
-		IL_0ecd: ldloc.s 21
-		IL_0ecf: dup
-		IL_0ed0: ldc.r8 1
-		IL_0ed9: box [System.Runtime]System.Double
-		IL_0ede: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0ee3: stloc.s 23
-		IL_0ee5: ldloc.s 22
-		IL_0ee7: dup
-		IL_0ee8: ldc.r8 2
-		IL_0ef1: box [System.Runtime]System.Double
-		IL_0ef6: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0efb: stloc.s 24
-		IL_0efd: ldc.i4.0
-		IL_0efe: box [System.Runtime]System.Boolean
-		IL_0f03: stloc.s 25
+		IL_0e8d: stloc.s 42
+		IL_0e8f: volatile.
+		IL_0e91: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_0e96: brfalse IL_0eac
+
+		IL_0e9b: ldloc.s 42
+		IL_0e9d: ldstr "method"
+		IL_0ea2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ea7: br IL_0ec2
+
+		IL_0eac: ldloc.s 42
+		IL_0eae: ldstr "method"
+		IL_0eb3: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:296"
+		IL_0eb8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_0ebd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0ec2: stloc.s 42
+		IL_0ec4: volatile.
+		IL_0ec6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_0ecb: brfalse IL_0ee1
+
+		IL_0ed0: ldloc.s 20
+		IL_0ed2: ldstr "prototype"
+		IL_0ed7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0edc: br IL_0ef7
+
+		IL_0ee1: ldloc.s 20
+		IL_0ee3: ldstr "prototype"
+		IL_0ee8: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:298"
+		IL_0eed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_0ef2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0ef7: stloc.s 43
+		IL_0ef9: volatile.
+		IL_0efb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_0f00: brfalse IL_0f16
+
+		IL_0f05: ldloc.s 43
+		IL_0f07: ldstr "method"
+		IL_0f0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0f11: br IL_0f2c
+
+		IL_0f16: ldloc.s 43
+		IL_0f18: ldstr "method"
+		IL_0f1d: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:300"
+		IL_0f22: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_0f27: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0f2c: stloc.s 43
+		IL_0f2e: ldloc.s 42
+		IL_0f30: ldloc.s 43
+		IL_0f32: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0f37: stloc.s 44
+		IL_0f39: ldloc.s 44
+		IL_0f3b: box [System.Runtime]System.Boolean
+		IL_0f40: stloc.s 47
+		IL_0f42: ldloc.s 39
+		IL_0f44: ldstr "identity"
+		IL_0f49: ldloc.s 47
+		IL_0f4b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0f50: pop
+		IL_0f51: nop
+		IL_0f52: ldloc.2
+		IL_0f53: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0f58: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0f5d: stloc.s 21
+		IL_0f5f: ldloc.2
+		IL_0f60: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0f65: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0f6a: stloc.s 22
+		IL_0f6c: ldloc.s 21
+		IL_0f6e: dup
+		IL_0f6f: ldc.r8 1
+		IL_0f78: box [System.Runtime]System.Double
+		IL_0f7d: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0f82: stloc.s 23
+		IL_0f84: ldloc.s 22
+		IL_0f86: dup
+		IL_0f87: ldc.r8 2
+		IL_0f90: box [System.Runtime]System.Double
+		IL_0f95: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0f9a: stloc.s 24
+		IL_0f9c: ldc.i4.0
+		IL_0f9d: box [System.Runtime]System.Boolean
+		IL_0fa2: stloc.s 25
 		.try
 		{
-			IL_0f05: nop
-			IL_0f06: volatile.
-			IL_0f08: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_0f0d: brfalse IL_0f23
+			IL_0fa4: nop
+			IL_0fa5: volatile.
+			IL_0fa7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0fac: brfalse IL_0fc2
 
-			IL_0f12: ldloc.s 21
-			IL_0f14: ldstr "prototype"
-			IL_0f19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f1e: br IL_0f39
+			IL_0fb1: ldloc.s 21
+			IL_0fb3: ldstr "prototype"
+			IL_0fb8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fbd: br IL_0fd8
 
-			IL_0f23: ldloc.s 21
-			IL_0f25: ldstr "prototype"
-			IL_0f2a: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:332"
-			IL_0f2f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_0f34: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0fc2: ldloc.s 21
+			IL_0fc4: ldstr "prototype"
+			IL_0fc9: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:332"
+			IL_0fce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0fd3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f39: stloc.s 43
-			IL_0f3b: volatile.
-			IL_0f3d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_0f42: brfalse IL_0f58
+			IL_0fd8: stloc.s 43
+			IL_0fda: volatile.
+			IL_0fdc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0fe1: brfalse IL_0ff7
 
-			IL_0f47: ldloc.s 43
-			IL_0f49: ldstr "read"
-			IL_0f4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f53: br IL_0f6e
+			IL_0fe6: ldloc.s 43
+			IL_0fe8: ldstr "read"
+			IL_0fed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ff2: br IL_100d
 
-			IL_0f58: ldloc.s 43
-			IL_0f5a: ldstr "read"
-			IL_0f5f: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:334"
-			IL_0f64: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_0f69: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0ff7: ldloc.s 43
+			IL_0ff9: ldstr "read"
+			IL_0ffe: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:334"
+			IL_1003: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_1008: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f6e: stloc.s 43
-			IL_0f70: ldloc.s 43
-			IL_0f72: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0f77: ldstr "call"
-			IL_0f7c: ldloc.s 24
-			IL_0f7e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0f83: pop
-			IL_0f84: leave IL_0fe8
+			IL_100d: stloc.s 43
+			IL_100f: ldloc.s 43
+			IL_1011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1016: volatile.
+			IL_1018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_101d: brfalse IL_1033
+
+			IL_1022: ldstr "call"
+			IL_1027: ldloc.s 24
+			IL_1029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_102e: br IL_1049
+
+			IL_1033: ldstr "call"
+			IL_1038: ldloc.s 24
+			IL_103a: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:336"
+			IL_103f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_1044: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_1049: pop
+			IL_104a: leave IL_10ae
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0f89: stloc.s 26
-			IL_0f8b: ldloc.s 26
-			IL_0f8d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0f92: dup
-			IL_0f93: brtrue IL_0fa9
+			IL_104f: stloc.s 26
+			IL_1051: ldloc.s 26
+			IL_1053: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_1058: dup
+			IL_1059: brtrue IL_106f
 
-			IL_0f98: pop
-			IL_0f99: ldloc.s 26
-			IL_0f9b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0fa0: dup
-			IL_0fa1: brtrue IL_0fb5
+			IL_105e: pop
+			IL_105f: ldloc.s 26
+			IL_1061: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_1066: dup
+			IL_1067: brtrue IL_107b
 
-			IL_0fa6: pop
-			IL_0fa7: rethrow
+			IL_106c: pop
+			IL_106d: rethrow
 
-			IL_0fa9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0fae: stloc.s 27
-			IL_0fb0: br IL_0fb7
+			IL_106f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_1074: stloc.s 27
+			IL_1076: br IL_107d
 
-			IL_0fb5: stloc.s 27
+			IL_107b: stloc.s 27
 
-			IL_0fb7: ldloc.s 27
-			IL_0fb9: stloc.s 28
-			IL_0fbb: ldloc.s 28
-			IL_0fbd: stloc.s 43
-			IL_0fbf: ldstr "TypeError"
-			IL_0fc4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0fc9: stloc.s 42
-			IL_0fcb: ldloc.s 43
-			IL_0fcd: ldloc.s 42
-			IL_0fcf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0fd4: stloc.s 44
-			IL_0fd6: ldloc.s 44
-			IL_0fd8: box [System.Runtime]System.Boolean
-			IL_0fdd: stloc.s 47
-			IL_0fdf: ldloc.s 47
-			IL_0fe1: stloc.s 25
-			IL_0fe3: leave IL_0fe8
+			IL_107d: ldloc.s 27
+			IL_107f: stloc.s 28
+			IL_1081: ldloc.s 28
+			IL_1083: stloc.s 43
+			IL_1085: ldstr "TypeError"
+			IL_108a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_108f: stloc.s 42
+			IL_1091: ldloc.s 43
+			IL_1093: ldloc.s 42
+			IL_1095: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_109a: stloc.s 44
+			IL_109c: ldloc.s 44
+			IL_109e: box [System.Runtime]System.Boolean
+			IL_10a3: stloc.s 47
+			IL_10a5: ldloc.s 47
+			IL_10a7: stloc.s 25
+			IL_10a9: leave IL_10ae
 		} // end handler
 
-		IL_0fe8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0fed: stloc.s 39
-		IL_0fef: volatile.
-		IL_0ff1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_0ff6: brfalse IL_100c
+		IL_10ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_10b3: stloc.s 39
+		IL_10b5: volatile.
+		IL_10b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_10bc: brfalse IL_10d2
 
-		IL_0ffb: ldloc.s 21
-		IL_0ffd: ldstr "prototype"
-		IL_1002: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1007: br IL_1022
+		IL_10c1: ldloc.s 21
+		IL_10c3: ldstr "prototype"
+		IL_10c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_10cd: br IL_10e8
 
-		IL_100c: ldloc.s 21
-		IL_100e: ldstr "prototype"
-		IL_1013: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:360"
-		IL_1018: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_101d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_10d2: ldloc.s 21
+		IL_10d4: ldstr "prototype"
+		IL_10d9: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:360"
+		IL_10de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_10e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1022: stloc.s 42
-		IL_1024: volatile.
-		IL_1026: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-		IL_102b: brfalse IL_1041
+		IL_10e8: stloc.s 42
+		IL_10ea: volatile.
+		IL_10ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_10f1: brfalse IL_1107
 
-		IL_1030: ldloc.s 22
-		IL_1032: ldstr "prototype"
-		IL_1037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_103c: br IL_1057
+		IL_10f6: ldloc.s 22
+		IL_10f8: ldstr "prototype"
+		IL_10fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1102: br IL_111d
 
-		IL_1041: ldloc.s 22
-		IL_1043: ldstr "prototype"
-		IL_1048: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:362"
-		IL_104d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-		IL_1052: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1107: ldloc.s 22
+		IL_1109: ldstr "prototype"
+		IL_110e: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:362"
+		IL_1113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_1118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1057: stloc.s 43
-		IL_1059: ldloc.s 42
-		IL_105b: ldloc.s 43
-		IL_105d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_1062: stloc.s 44
-		IL_1064: ldloc.s 44
-		IL_1066: box [System.Runtime]System.Boolean
-		IL_106b: stloc.s 47
-		IL_106d: volatile.
-		IL_106f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-		IL_1074: brfalse IL_108a
+		IL_111d: stloc.s 43
+		IL_111f: ldloc.s 42
+		IL_1121: ldloc.s 43
+		IL_1123: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_1128: stloc.s 44
+		IL_112a: ldloc.s 44
+		IL_112c: box [System.Runtime]System.Boolean
+		IL_1131: stloc.s 47
+		IL_1133: volatile.
+		IL_1135: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+		IL_113a: brfalse IL_1150
 
-		IL_1079: ldloc.s 21
-		IL_107b: ldstr "prototype"
-		IL_1080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1085: br IL_10a0
+		IL_113f: ldloc.s 21
+		IL_1141: ldstr "prototype"
+		IL_1146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_114b: br IL_1166
 
-		IL_108a: ldloc.s 21
-		IL_108c: ldstr "prototype"
-		IL_1091: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:366"
-		IL_1096: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-		IL_109b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1150: ldloc.s 21
+		IL_1152: ldstr "prototype"
+		IL_1157: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:366"
+		IL_115c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+		IL_1161: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_10a0: stloc.s 43
-		IL_10a2: volatile.
-		IL_10a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-		IL_10a9: brfalse IL_10bf
+		IL_1166: stloc.s 43
+		IL_1168: volatile.
+		IL_116a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+		IL_116f: brfalse IL_1185
 
-		IL_10ae: ldloc.s 43
-		IL_10b0: ldstr "read"
-		IL_10b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_10ba: br IL_10d5
+		IL_1174: ldloc.s 43
+		IL_1176: ldstr "read"
+		IL_117b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1180: br IL_119b
 
-		IL_10bf: ldloc.s 43
-		IL_10c1: ldstr "read"
-		IL_10c6: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:368"
-		IL_10cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-		IL_10d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1185: ldloc.s 43
+		IL_1187: ldstr "read"
+		IL_118c: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:368"
+		IL_1191: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+		IL_1196: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_10d5: stloc.s 43
-		IL_10d7: volatile.
-		IL_10d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-		IL_10de: brfalse IL_10f4
+		IL_119b: stloc.s 43
+		IL_119d: volatile.
+		IL_119f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_11a4: brfalse IL_11ba
 
-		IL_10e3: ldloc.s 22
-		IL_10e5: ldstr "prototype"
-		IL_10ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_10ef: br IL_110a
+		IL_11a9: ldloc.s 22
+		IL_11ab: ldstr "prototype"
+		IL_11b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_11b5: br IL_11d0
 
-		IL_10f4: ldloc.s 22
-		IL_10f6: ldstr "prototype"
-		IL_10fb: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:370"
-		IL_1100: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-		IL_1105: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_11ba: ldloc.s 22
+		IL_11bc: ldstr "prototype"
+		IL_11c1: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:370"
+		IL_11c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_11cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_110a: stloc.s 42
-		IL_110c: volatile.
-		IL_110e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_1113: brfalse IL_1129
+		IL_11d0: stloc.s 42
+		IL_11d2: volatile.
+		IL_11d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_11d9: brfalse IL_11ef
 
-		IL_1118: ldloc.s 42
-		IL_111a: ldstr "read"
-		IL_111f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1124: br IL_113f
+		IL_11de: ldloc.s 42
+		IL_11e0: ldstr "read"
+		IL_11e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_11ea: br IL_1205
 
-		IL_1129: ldloc.s 42
-		IL_112b: ldstr "read"
-		IL_1130: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:372"
-		IL_1135: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_113a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_11ef: ldloc.s 42
+		IL_11f1: ldstr "read"
+		IL_11f6: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:372"
+		IL_11fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_1200: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_113f: stloc.s 42
-		IL_1141: ldloc.s 43
-		IL_1143: ldloc.s 42
-		IL_1145: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_114a: stloc.s 44
-		IL_114c: ldloc.s 44
-		IL_114e: box [System.Runtime]System.Boolean
-		IL_1153: stloc.s 46
-		IL_1155: volatile.
-		IL_1157: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-		IL_115c: brfalse IL_1172
+		IL_1205: stloc.s 42
+		IL_1207: ldloc.s 43
+		IL_1209: ldloc.s 42
+		IL_120b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_1210: stloc.s 44
+		IL_1212: ldloc.s 44
+		IL_1214: box [System.Runtime]System.Boolean
+		IL_1219: stloc.s 46
+		IL_121b: volatile.
+		IL_121d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_1222: brfalse IL_1238
 
-		IL_1161: ldloc.s 21
-		IL_1163: ldstr "prototype"
-		IL_1168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_116d: br IL_1188
+		IL_1227: ldloc.s 21
+		IL_1229: ldstr "prototype"
+		IL_122e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1233: br IL_124e
 
-		IL_1172: ldloc.s 21
-		IL_1174: ldstr "prototype"
-		IL_1179: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:376"
-		IL_117e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-		IL_1183: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1238: ldloc.s 21
+		IL_123a: ldstr "prototype"
+		IL_123f: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:376"
+		IL_1244: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_1249: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1188: stloc.s 42
-		IL_118a: volatile.
-		IL_118c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-		IL_1191: brfalse IL_11a7
+		IL_124e: stloc.s 42
+		IL_1250: volatile.
+		IL_1252: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+		IL_1257: brfalse IL_126d
 
-		IL_1196: ldloc.s 42
-		IL_1198: ldstr "read"
-		IL_119d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_11a2: br IL_11bd
+		IL_125c: ldloc.s 42
+		IL_125e: ldstr "read"
+		IL_1263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1268: br IL_1283
 
-		IL_11a7: ldloc.s 42
-		IL_11a9: ldstr "read"
-		IL_11ae: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:378"
-		IL_11b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-		IL_11b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_126d: ldloc.s 42
+		IL_126f: ldstr "read"
+		IL_1274: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:378"
+		IL_1279: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+		IL_127e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_11bd: stloc.s 42
-		IL_11bf: ldloc.s 42
-		IL_11c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_11c6: ldstr "call"
-		IL_11cb: ldloc.s 23
-		IL_11cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_11d2: stloc.s 42
-		IL_11d4: ldloc.s 39
-		IL_11d6: ldc.i4.5
-		IL_11d7: newarr [System.Runtime]System.Object
-		IL_11dc: dup
-		IL_11dd: ldc.i4.0
-		IL_11de: ldstr "privateIdentity"
-		IL_11e3: stelem.ref
-		IL_11e4: dup
-		IL_11e5: ldc.i4.1
-		IL_11e6: ldloc.s 47
-		IL_11e8: stelem.ref
-		IL_11e9: dup
-		IL_11ea: ldc.i4.2
-		IL_11eb: ldloc.s 46
-		IL_11ed: stelem.ref
-		IL_11ee: dup
-		IL_11ef: ldc.i4.3
-		IL_11f0: ldloc.s 42
-		IL_11f2: stelem.ref
-		IL_11f3: dup
-		IL_11f4: ldc.i4.4
-		IL_11f5: ldloc.s 25
-		IL_11f7: stelem.ref
-		IL_11f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_11fd: pop
-		IL_11fe: ldc.i4.0
-		IL_11ff: box [System.Runtime]System.Boolean
-		IL_1204: stloc.s 29
+		IL_1283: stloc.s 42
+		IL_1285: ldloc.s 42
+		IL_1287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_128c: volatile.
+		IL_128e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+		IL_1293: brfalse IL_12a9
+
+		IL_1298: ldstr "call"
+		IL_129d: ldloc.s 23
+		IL_129f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_12a4: br IL_12bf
+
+		IL_12a9: ldstr "call"
+		IL_12ae: ldloc.s 23
+		IL_12b0: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:380"
+		IL_12b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+		IL_12ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_12bf: stloc.s 42
+		IL_12c1: ldloc.s 39
+		IL_12c3: ldc.i4.5
+		IL_12c4: newarr [System.Runtime]System.Object
+		IL_12c9: dup
+		IL_12ca: ldc.i4.0
+		IL_12cb: ldstr "privateIdentity"
+		IL_12d0: stelem.ref
+		IL_12d1: dup
+		IL_12d2: ldc.i4.1
+		IL_12d3: ldloc.s 47
+		IL_12d5: stelem.ref
+		IL_12d6: dup
+		IL_12d7: ldc.i4.2
+		IL_12d8: ldloc.s 46
+		IL_12da: stelem.ref
+		IL_12db: dup
+		IL_12dc: ldc.i4.3
+		IL_12dd: ldloc.s 42
+		IL_12df: stelem.ref
+		IL_12e0: dup
+		IL_12e1: ldc.i4.4
+		IL_12e2: ldloc.s 25
+		IL_12e4: stelem.ref
+		IL_12e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_12ea: pop
+		IL_12eb: ldc.i4.0
+		IL_12ec: box [System.Runtime]System.Boolean
+		IL_12f1: stloc.s 29
 		.try
 		{
-			IL_1206: nop
-			IL_1207: volatile.
-			IL_1209: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_120e: brfalse IL_1224
+			IL_12f3: nop
+			IL_12f4: volatile.
+			IL_12f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_12fb: brfalse IL_1311
 
-			IL_1213: ldloc.s 21
-			IL_1215: ldstr "readStatic"
-			IL_121a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_121f: br IL_123a
+			IL_1300: ldloc.s 21
+			IL_1302: ldstr "readStatic"
+			IL_1307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_130c: br IL_1327
 
-			IL_1224: ldloc.s 21
-			IL_1226: ldstr "readStatic"
-			IL_122b: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:391"
-			IL_1230: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_1235: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1311: ldloc.s 21
+			IL_1313: ldstr "readStatic"
+			IL_1318: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:391"
+			IL_131d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_1322: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_123a: stloc.s 42
-			IL_123c: ldloc.s 42
-			IL_123e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1243: ldstr "call"
-			IL_1248: ldloc.s 22
-			IL_124a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_124f: pop
-			IL_1250: leave IL_12b4
+			IL_1327: stloc.s 42
+			IL_1329: ldloc.s 42
+			IL_132b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1330: volatile.
+			IL_1332: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_1337: brfalse IL_134d
+
+			IL_133c: ldstr "call"
+			IL_1341: ldloc.s 22
+			IL_1343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_1348: br IL_1363
+
+			IL_134d: ldstr "call"
+			IL_1352: ldloc.s 22
+			IL_1354: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:393"
+			IL_1359: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_135e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_1363: pop
+			IL_1364: leave IL_13c8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_1255: stloc.s 30
-			IL_1257: ldloc.s 30
-			IL_1259: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_125e: dup
-			IL_125f: brtrue IL_1275
+			IL_1369: stloc.s 30
+			IL_136b: ldloc.s 30
+			IL_136d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_1372: dup
+			IL_1373: brtrue IL_1389
 
-			IL_1264: pop
-			IL_1265: ldloc.s 30
-			IL_1267: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_126c: dup
-			IL_126d: brtrue IL_1281
+			IL_1378: pop
+			IL_1379: ldloc.s 30
+			IL_137b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_1380: dup
+			IL_1381: brtrue IL_1395
 
-			IL_1272: pop
-			IL_1273: rethrow
+			IL_1386: pop
+			IL_1387: rethrow
 
-			IL_1275: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_127a: stloc.s 31
-			IL_127c: br IL_1283
+			IL_1389: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_138e: stloc.s 31
+			IL_1390: br IL_1397
 
-			IL_1281: stloc.s 31
+			IL_1395: stloc.s 31
 
-			IL_1283: ldloc.s 31
-			IL_1285: stloc.s 32
-			IL_1287: ldloc.s 32
-			IL_1289: stloc.s 42
-			IL_128b: ldstr "TypeError"
-			IL_1290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1295: stloc.s 43
-			IL_1297: ldloc.s 42
-			IL_1299: ldloc.s 43
-			IL_129b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_12a0: stloc.s 44
-			IL_12a2: ldloc.s 44
-			IL_12a4: box [System.Runtime]System.Boolean
-			IL_12a9: stloc.s 46
-			IL_12ab: ldloc.s 46
-			IL_12ad: stloc.s 29
-			IL_12af: leave IL_12b4
+			IL_1397: ldloc.s 31
+			IL_1399: stloc.s 32
+			IL_139b: ldloc.s 32
+			IL_139d: stloc.s 42
+			IL_139f: ldstr "TypeError"
+			IL_13a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_13a9: stloc.s 43
+			IL_13ab: ldloc.s 42
+			IL_13ad: ldloc.s 43
+			IL_13af: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_13b4: stloc.s 44
+			IL_13b6: ldloc.s 44
+			IL_13b8: box [System.Runtime]System.Boolean
+			IL_13bd: stloc.s 46
+			IL_13bf: ldloc.s 46
+			IL_13c1: stloc.s 29
+			IL_13c3: leave IL_13c8
 		} // end handler
 
-		IL_12b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_12b9: stloc.s 39
-		IL_12bb: volatile.
-		IL_12bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_12c2: brfalse IL_12d8
+		IL_13c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_13cd: stloc.s 39
+		IL_13cf: volatile.
+		IL_13d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+		IL_13d6: brfalse IL_13ec
 
-		IL_12c7: ldloc.s 21
-		IL_12c9: ldstr "readStatic"
-		IL_12ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_12d3: br IL_12ee
+		IL_13db: ldloc.s 21
+		IL_13dd: ldstr "readStatic"
+		IL_13e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_13e7: br IL_1402
 
-		IL_12d8: ldloc.s 21
-		IL_12da: ldstr "readStatic"
-		IL_12df: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:417"
-		IL_12e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_12e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_13ec: ldloc.s 21
+		IL_13ee: ldstr "readStatic"
+		IL_13f3: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:417"
+		IL_13f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+		IL_13fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_12ee: stloc.s 43
-		IL_12f0: volatile.
-		IL_12f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_12f7: brfalse IL_130d
+		IL_1402: stloc.s 43
+		IL_1404: volatile.
+		IL_1406: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_140b: brfalse IL_1421
 
-		IL_12fc: ldloc.s 22
-		IL_12fe: ldstr "readStatic"
-		IL_1303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1308: br IL_1323
+		IL_1410: ldloc.s 22
+		IL_1412: ldstr "readStatic"
+		IL_1417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_141c: br IL_1437
 
-		IL_130d: ldloc.s 22
-		IL_130f: ldstr "readStatic"
-		IL_1314: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:419"
-		IL_1319: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_131e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1421: ldloc.s 22
+		IL_1423: ldstr "readStatic"
+		IL_1428: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:419"
+		IL_142d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_1432: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1323: stloc.s 42
-		IL_1325: ldloc.s 43
-		IL_1327: ldloc.s 42
-		IL_1329: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_132e: stloc.s 44
-		IL_1330: ldloc.s 44
-		IL_1332: box [System.Runtime]System.Boolean
-		IL_1337: stloc.s 46
-		IL_1339: ldloc.s 21
-		IL_133b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_1340: volatile.
-		IL_1342: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-		IL_1347: brfalse IL_135b
+		IL_1437: stloc.s 42
+		IL_1439: ldloc.s 43
+		IL_143b: ldloc.s 42
+		IL_143d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_1442: stloc.s 44
+		IL_1444: ldloc.s 44
+		IL_1446: box [System.Runtime]System.Boolean
+		IL_144b: stloc.s 46
+		IL_144d: ldloc.s 21
+		IL_144f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_1454: volatile.
+		IL_1456: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+		IL_145b: brfalse IL_146f
 
-		IL_134c: ldstr "readStatic"
-		IL_1351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_1356: br IL_136f
+		IL_1460: ldstr "readStatic"
+		IL_1465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_146a: br IL_1483
 
-		IL_135b: ldstr "readStatic"
-		IL_1360: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:423"
-		IL_1365: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-		IL_136a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_146f: ldstr "readStatic"
+		IL_1474: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:423"
+		IL_1479: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+		IL_147e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_136f: stloc.s 42
-		IL_1371: ldloc.s 39
-		IL_1373: ldc.i4.4
-		IL_1374: newarr [System.Runtime]System.Object
-		IL_1379: dup
-		IL_137a: ldc.i4.0
-		IL_137b: ldstr "staticPrivateIdentity"
-		IL_1380: stelem.ref
-		IL_1381: dup
-		IL_1382: ldc.i4.1
-		IL_1383: ldloc.s 46
-		IL_1385: stelem.ref
-		IL_1386: dup
-		IL_1387: ldc.i4.2
-		IL_1388: ldloc.s 42
-		IL_138a: stelem.ref
-		IL_138b: dup
-		IL_138c: ldc.i4.3
-		IL_138d: ldloc.s 29
-		IL_138f: stelem.ref
-		IL_1390: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_1395: pop
-		IL_1396: ldnull
-		IL_1397: stloc.s 33
-		IL_1399: ret
+		IL_1483: stloc.s 42
+		IL_1485: ldloc.s 39
+		IL_1487: ldc.i4.4
+		IL_1488: newarr [System.Runtime]System.Object
+		IL_148d: dup
+		IL_148e: ldc.i4.0
+		IL_148f: ldstr "staticPrivateIdentity"
+		IL_1494: stelem.ref
+		IL_1495: dup
+		IL_1496: ldc.i4.1
+		IL_1497: ldloc.s 46
+		IL_1499: stelem.ref
+		IL_149a: dup
+		IL_149b: ldc.i4.2
+		IL_149c: ldloc.s 42
+		IL_149e: stelem.ref
+		IL_149f: dup
+		IL_14a0: ldc.i4.3
+		IL_14a1: ldloc.s 29
+		IL_14a3: stelem.ref
+		IL_14a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_14a9: pop
+		IL_14aa: ldnull
+		IL_14ab: stloc.s 33
+		IL_14ad: ret
 	} // end of method Classes_GeneratedMethodFunctionObjects::__js_module_init__
 
 } // end of class Modules.Classes_GeneratedMethodFunctionObjects
@@ -4264,6 +4348,13 @@
 	.field assembly static int32 __jroc_dynamicLookup_76
 	.field assembly static int32 __jroc_dynamicLookup_77
 	.field assembly static int32 __jroc_dynamicLookup_78
+	.field assembly static int32 __jroc_dynamicLookup_79
+	.field assembly static int32 __jroc_dynamicLookup_80
+	.field assembly static int32 __jroc_dynamicLookup_81
+	.field assembly static int32 __jroc_dynamicLookup_82
+	.field assembly static int32 __jroc_dynamicLookup_83
+	.field assembly static int32 __jroc_dynamicLookup_84
+	.field assembly static int32 __jroc_dynamicLookup_85
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrivateBrandCheck.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrivateBrandCheck.verified.txt
@@ -856,7 +856,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1212 (0x4bc)
+		// Code size: 1509 (0x5e5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_PrivateBrandCheck/Scope,
@@ -1026,299 +1026,391 @@
 		IL_018d: ldstr "prototype"
 		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
 		IL_0197: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_019c: ldloc.s 15
-		IL_019e: ldstr "hasBrand"
-		IL_01a3: ldloc.s 19
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01aa: stloc.s 17
-		IL_01ac: ldloc.s 18
-		IL_01ae: ldloc.s 17
-		IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b5: pop
-		IL_01b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01bb: stloc.s 18
-		IL_01bd: ldc.i4.1
-		IL_01be: newarr [System.Runtime]System.Object
-		IL_01c3: dup
-		IL_01c4: ldc.i4.0
-		IL_01c5: ldloc.0
-		IL_01c6: stelem.ref
-		IL_01c7: stloc.s 14
-		IL_01c9: ldloc.s 14
-		IL_01cb: ldc.i4.0
-		IL_01cc: newarr [System.Runtime]System.Object
-		IL_01d1: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_01d6: ldloc.1
-		IL_01d7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_01dc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_01e1: ldnull
-		IL_01e2: newobj instance void Modules.Classes_PrivateBrandCheck/Derived::.ctor(object[], object)
-		IL_01e7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_01ec: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_01f1: dup
-		IL_01f2: ldloc.1
-		IL_01f3: ldstr "prototype"
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01fd: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0202: stloc.s 17
-		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_020e: stloc.s 17
-		IL_0210: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_0215: ldloc.s 15
-		IL_0217: ldstr "hasBrand"
-		IL_021c: ldloc.s 17
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0223: stloc.s 17
-		IL_0225: ldloc.s 18
-		IL_0227: ldloc.s 17
-		IL_0229: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_022e: pop
-		IL_022f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0234: stloc.s 18
-		IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_023b: stloc.s 20
-		IL_023d: ldloc.s 15
-		IL_023f: ldstr "hasBrand"
-		IL_0244: ldloc.s 20
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024b: stloc.s 17
-		IL_024d: ldloc.s 18
-		IL_024f: ldloc.s 17
-		IL_0251: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0256: pop
-		IL_0257: ldc.i4.1
-		IL_0258: newarr [System.Runtime]System.Object
-		IL_025d: dup
-		IL_025e: ldc.i4.0
-		IL_025f: ldloc.0
-		IL_0260: stelem.ref
-		IL_0261: stloc.s 14
-		IL_0263: ldloc.s 14
-		IL_0265: ldc.i4.1
-		IL_0266: newarr [System.Runtime]System.Object
-		IL_026b: dup
-		IL_026c: ldc.i4.0
-		IL_026d: ldc.r8 1
-		IL_0276: box [System.Runtime]System.Double
-		IL_027b: stelem.ref
-		IL_027c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0281: ldc.r8 1
-		IL_028a: box [System.Runtime]System.Double
-		IL_028f: newobj instance void Modules.Classes_PrivateBrandCheck/Example::.ctor(object[], object)
-		IL_0294: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0299: stloc.2
-		IL_029a: ldloc.2
-		IL_029b: ldtoken Modules.Classes_PrivateBrandCheck/Example
-		IL_02a0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_02a5: ldstr "prototype"
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_02af: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b9: stloc.s 18
-		IL_02bb: ldloc.s 15
-		IL_02bd: ldstr "read"
-		IL_02c2: ldloc.2
-		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c8: stloc.s 17
-		IL_02ca: ldloc.s 18
-		IL_02cc: ldloc.s 17
-		IL_02ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d3: pop
-		IL_02d4: ldloc.s 15
-		IL_02d6: ldstr "write"
-		IL_02db: ldloc.2
-		IL_02dc: ldc.r8 2
-		IL_02e5: box [System.Runtime]System.Double
-		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02ef: pop
-		IL_02f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f5: stloc.s 18
-		IL_02f7: ldloc.s 15
-		IL_02f9: ldstr "read"
-		IL_02fe: ldloc.2
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0304: stloc.s 17
-		IL_0306: ldloc.s 18
-		IL_0308: ldloc.s 17
-		IL_030a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_030f: pop
+		IL_019c: volatile.
+		IL_019e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_01a3: brfalse IL_01bb
+
+		IL_01a8: ldloc.s 15
+		IL_01aa: ldstr "hasBrand"
+		IL_01af: ldloc.s 19
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b6: br IL_01d3
+
+		IL_01bb: ldloc.s 15
+		IL_01bd: ldstr "hasBrand"
+		IL_01c2: ldloc.s 19
+		IL_01c4: ldstr "Classes_PrivateBrandCheck:Modules.Classes_PrivateBrandCheck:__js_module_init__:33"
+		IL_01c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01d3: stloc.s 17
+		IL_01d5: ldloc.s 18
+		IL_01d7: ldloc.s 17
+		IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01de: pop
+		IL_01df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e4: stloc.s 18
+		IL_01e6: ldc.i4.1
+		IL_01e7: newarr [System.Runtime]System.Object
+		IL_01ec: dup
+		IL_01ed: ldc.i4.0
+		IL_01ee: ldloc.0
+		IL_01ef: stelem.ref
+		IL_01f0: stloc.s 14
+		IL_01f2: ldloc.s 14
+		IL_01f4: ldc.i4.0
+		IL_01f5: newarr [System.Runtime]System.Object
+		IL_01fa: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_01ff: ldloc.1
+		IL_0200: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0205: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_020a: ldnull
+		IL_020b: newobj instance void Modules.Classes_PrivateBrandCheck/Derived::.ctor(object[], object)
+		IL_0210: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0215: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_021a: dup
+		IL_021b: ldloc.1
+		IL_021c: ldstr "prototype"
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0226: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_022b: stloc.s 17
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0237: stloc.s 17
+		IL_0239: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_023e: volatile.
+		IL_0240: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0245: brfalse IL_025d
+
+		IL_024a: ldloc.s 15
+		IL_024c: ldstr "hasBrand"
+		IL_0251: ldloc.s 17
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0258: br IL_0275
+
+		IL_025d: ldloc.s 15
+		IL_025f: ldstr "hasBrand"
+		IL_0264: ldloc.s 17
+		IL_0266: ldstr "Classes_PrivateBrandCheck:Modules.Classes_PrivateBrandCheck:__js_module_init__:39"
+		IL_026b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0275: stloc.s 17
+		IL_0277: ldloc.s 18
+		IL_0279: ldloc.s 17
+		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0280: pop
+		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0286: stloc.s 18
+		IL_0288: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_028d: stloc.s 20
+		IL_028f: volatile.
+		IL_0291: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0296: brfalse IL_02ae
+
+		IL_029b: ldloc.s 15
+		IL_029d: ldstr "hasBrand"
+		IL_02a2: ldloc.s 20
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a9: br IL_02c6
+
+		IL_02ae: ldloc.s 15
+		IL_02b0: ldstr "hasBrand"
+		IL_02b5: ldloc.s 20
+		IL_02b7: ldstr "Classes_PrivateBrandCheck:Modules.Classes_PrivateBrandCheck:__js_module_init__:44"
+		IL_02bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02c6: stloc.s 17
+		IL_02c8: ldloc.s 18
+		IL_02ca: ldloc.s 17
+		IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d1: pop
+		IL_02d2: ldc.i4.1
+		IL_02d3: newarr [System.Runtime]System.Object
+		IL_02d8: dup
+		IL_02d9: ldc.i4.0
+		IL_02da: ldloc.0
+		IL_02db: stelem.ref
+		IL_02dc: stloc.s 14
+		IL_02de: ldloc.s 14
+		IL_02e0: ldc.i4.1
+		IL_02e1: newarr [System.Runtime]System.Object
+		IL_02e6: dup
+		IL_02e7: ldc.i4.0
+		IL_02e8: ldc.r8 1
+		IL_02f1: box [System.Runtime]System.Double
+		IL_02f6: stelem.ref
+		IL_02f7: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_02fc: ldc.r8 1
+		IL_0305: box [System.Runtime]System.Double
+		IL_030a: newobj instance void Modules.Classes_PrivateBrandCheck/Example::.ctor(object[], object)
+		IL_030f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0314: stloc.2
+		IL_0315: ldloc.2
+		IL_0316: ldtoken Modules.Classes_PrivateBrandCheck/Example
+		IL_031b: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0320: ldstr "prototype"
+		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_032a: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0334: stloc.s 18
+		IL_0336: volatile.
+		IL_0338: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_033d: brfalse IL_0354
+
+		IL_0342: ldloc.s 15
+		IL_0344: ldstr "read"
+		IL_0349: ldloc.2
+		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_034f: br IL_036b
+
+		IL_0354: ldloc.s 15
+		IL_0356: ldstr "read"
+		IL_035b: ldloc.2
+		IL_035c: ldstr "Classes_PrivateBrandCheck:Modules.Classes_PrivateBrandCheck:__js_module_init__:54"
+		IL_0361: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_036b: stloc.s 17
+		IL_036d: ldloc.s 18
+		IL_036f: ldloc.s 17
+		IL_0371: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0376: pop
+		IL_0377: ldloc.s 15
+		IL_0379: ldstr "write"
+		IL_037e: ldloc.2
+		IL_037f: ldc.r8 2
+		IL_0388: box [System.Runtime]System.Double
+		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0392: pop
+		IL_0393: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0398: stloc.s 18
+		IL_039a: volatile.
+		IL_039c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_03a1: brfalse IL_03b8
+
+		IL_03a6: ldloc.s 15
+		IL_03a8: ldstr "read"
+		IL_03ad: ldloc.2
+		IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03b3: br IL_03cf
+
+		IL_03b8: ldloc.s 15
+		IL_03ba: ldstr "read"
+		IL_03bf: ldloc.2
+		IL_03c0: ldstr "Classes_PrivateBrandCheck:Modules.Classes_PrivateBrandCheck:__js_module_init__:62"
+		IL_03c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03cf: stloc.s 17
+		IL_03d1: ldloc.s 18
+		IL_03d3: ldloc.s 17
+		IL_03d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03da: pop
 		.try
 		{
-			IL_0310: nop
-			IL_0311: ldloc.s 15
-			IL_0313: ldstr "hasBrand"
-			IL_0318: ldc.r8 1
-			IL_0321: box [System.Runtime]System.Double
-			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_032b: pop
-			IL_032c: leave IL_039a
+			IL_03db: nop
+			IL_03dc: volatile.
+			IL_03de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_03e3: brfalse IL_0407
+
+			IL_03e8: ldloc.s 15
+			IL_03ea: ldstr "hasBrand"
+			IL_03ef: ldc.r8 1
+			IL_03f8: box [System.Runtime]System.Double
+			IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0402: br IL_042b
+
+			IL_0407: ldloc.s 15
+			IL_0409: ldstr "hasBrand"
+			IL_040e: ldc.r8 1
+			IL_0417: box [System.Runtime]System.Double
+			IL_041c: ldstr "Classes_PrivateBrandCheck:Modules.Classes_PrivateBrandCheck:__js_module_init__:70"
+			IL_0421: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_042b: pop
+			IL_042c: leave IL_049a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0331: stloc.3
-			IL_0332: ldloc.3
-			IL_0333: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0338: dup
-			IL_0339: brtrue IL_034e
+			IL_0431: stloc.3
+			IL_0432: ldloc.3
+			IL_0433: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0438: dup
+			IL_0439: brtrue IL_044e
 
-			IL_033e: pop
-			IL_033f: ldloc.3
-			IL_0340: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0345: dup
-			IL_0346: brtrue IL_035a
+			IL_043e: pop
+			IL_043f: ldloc.3
+			IL_0440: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0445: dup
+			IL_0446: brtrue IL_045a
 
-			IL_034b: pop
-			IL_034c: rethrow
+			IL_044b: pop
+			IL_044c: rethrow
 
-			IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0353: stloc.s 4
-			IL_0355: br IL_035c
+			IL_044e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0453: stloc.s 4
+			IL_0455: br IL_045c
 
-			IL_035a: stloc.s 4
+			IL_045a: stloc.s 4
 
-			IL_035c: ldloc.s 4
-			IL_035e: stloc.s 5
-			IL_0360: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0365: stloc.s 18
-			IL_0367: ldloc.s 5
-			IL_0369: stloc.s 17
-			IL_036b: ldstr "TypeError"
-			IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0375: stloc.s 21
-			IL_0377: ldloc.s 17
-			IL_0379: ldloc.s 21
-			IL_037b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0380: stloc.s 22
-			IL_0382: ldloc.s 22
-			IL_0384: box [System.Runtime]System.Boolean
-			IL_0389: stloc.s 23
-			IL_038b: ldloc.s 18
-			IL_038d: ldloc.s 23
-			IL_038f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0394: pop
-			IL_0395: leave IL_039a
+			IL_045c: ldloc.s 4
+			IL_045e: stloc.s 5
+			IL_0460: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0465: stloc.s 18
+			IL_0467: ldloc.s 5
+			IL_0469: stloc.s 17
+			IL_046b: ldstr "TypeError"
+			IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0475: stloc.s 21
+			IL_0477: ldloc.s 17
+			IL_0479: ldloc.s 21
+			IL_047b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0480: stloc.s 22
+			IL_0482: ldloc.s 22
+			IL_0484: box [System.Runtime]System.Boolean
+			IL_0489: stloc.s 23
+			IL_048b: ldloc.s 18
+			IL_048d: ldloc.s 23
+			IL_048f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0494: pop
+			IL_0495: leave IL_049a
 		} // end handler
 		.try
 		{
-			IL_039a: nop
-			IL_039b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03a0: stloc.s 20
-			IL_03a2: ldloc.s 15
-			IL_03a4: ldstr "read"
-			IL_03a9: ldloc.s 20
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03b0: pop
-			IL_03b1: leave IL_0422
+			IL_049a: nop
+			IL_049b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04a0: stloc.s 20
+			IL_04a2: volatile.
+			IL_04a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_04a9: brfalse IL_04c1
+
+			IL_04ae: ldloc.s 15
+			IL_04b0: ldstr "read"
+			IL_04b5: ldloc.s 20
+			IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04bc: br IL_04d9
+
+			IL_04c1: ldloc.s 15
+			IL_04c3: ldstr "read"
+			IL_04c8: ldloc.s 20
+			IL_04ca: ldstr "Classes_PrivateBrandCheck:Modules.Classes_PrivateBrandCheck:__js_module_init__:95"
+			IL_04cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_04d9: pop
+			IL_04da: leave IL_054b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03b6: stloc.s 6
-			IL_03b8: ldloc.s 6
-			IL_03ba: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03bf: dup
-			IL_03c0: brtrue IL_03d6
+			IL_04df: stloc.s 6
+			IL_04e1: ldloc.s 6
+			IL_04e3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04e8: dup
+			IL_04e9: brtrue IL_04ff
 
-			IL_03c5: pop
-			IL_03c6: ldloc.s 6
-			IL_03c8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03cd: dup
-			IL_03ce: brtrue IL_03e2
+			IL_04ee: pop
+			IL_04ef: ldloc.s 6
+			IL_04f1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04f6: dup
+			IL_04f7: brtrue IL_050b
 
-			IL_03d3: pop
-			IL_03d4: rethrow
+			IL_04fc: pop
+			IL_04fd: rethrow
 
-			IL_03d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03db: stloc.s 7
-			IL_03dd: br IL_03e4
+			IL_04ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0504: stloc.s 7
+			IL_0506: br IL_050d
 
-			IL_03e2: stloc.s 7
+			IL_050b: stloc.s 7
 
-			IL_03e4: ldloc.s 7
-			IL_03e6: stloc.s 8
-			IL_03e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03ed: stloc.s 18
-			IL_03ef: ldloc.s 8
-			IL_03f1: stloc.s 21
-			IL_03f3: ldstr "TypeError"
-			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03fd: stloc.s 17
-			IL_03ff: ldloc.s 21
-			IL_0401: ldloc.s 17
-			IL_0403: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0408: stloc.s 22
-			IL_040a: ldloc.s 22
-			IL_040c: box [System.Runtime]System.Boolean
-			IL_0411: stloc.s 23
-			IL_0413: ldloc.s 18
-			IL_0415: ldloc.s 23
-			IL_0417: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_041c: pop
-			IL_041d: leave IL_0422
+			IL_050d: ldloc.s 7
+			IL_050f: stloc.s 8
+			IL_0511: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0516: stloc.s 18
+			IL_0518: ldloc.s 8
+			IL_051a: stloc.s 21
+			IL_051c: ldstr "TypeError"
+			IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0526: stloc.s 17
+			IL_0528: ldloc.s 21
+			IL_052a: ldloc.s 17
+			IL_052c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0531: stloc.s 22
+			IL_0533: ldloc.s 22
+			IL_0535: box [System.Runtime]System.Boolean
+			IL_053a: stloc.s 23
+			IL_053c: ldloc.s 18
+			IL_053e: ldloc.s 23
+			IL_0540: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0545: pop
+			IL_0546: leave IL_054b
 		} // end handler
 		.try
 		{
-			IL_0422: nop
-			IL_0423: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0428: stloc.s 20
-			IL_042a: ldloc.s 15
-			IL_042c: ldstr "write"
-			IL_0431: ldloc.s 20
-			IL_0433: ldc.r8 3
-			IL_043c: box [System.Runtime]System.Double
-			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0446: pop
-			IL_0447: leave IL_04b8
+			IL_054b: nop
+			IL_054c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0551: stloc.s 20
+			IL_0553: ldloc.s 15
+			IL_0555: ldstr "write"
+			IL_055a: ldloc.s 20
+			IL_055c: ldc.r8 3
+			IL_0565: box [System.Runtime]System.Double
+			IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_056f: pop
+			IL_0570: leave IL_05e1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_044c: stloc.s 9
-			IL_044e: ldloc.s 9
-			IL_0450: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0455: dup
-			IL_0456: brtrue IL_046c
+			IL_0575: stloc.s 9
+			IL_0577: ldloc.s 9
+			IL_0579: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_057e: dup
+			IL_057f: brtrue IL_0595
 
-			IL_045b: pop
-			IL_045c: ldloc.s 9
-			IL_045e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0463: dup
-			IL_0464: brtrue IL_0478
+			IL_0584: pop
+			IL_0585: ldloc.s 9
+			IL_0587: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_058c: dup
+			IL_058d: brtrue IL_05a1
 
-			IL_0469: pop
-			IL_046a: rethrow
+			IL_0592: pop
+			IL_0593: rethrow
 
-			IL_046c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0471: stloc.s 10
-			IL_0473: br IL_047a
+			IL_0595: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_059a: stloc.s 10
+			IL_059c: br IL_05a3
 
-			IL_0478: stloc.s 10
+			IL_05a1: stloc.s 10
 
-			IL_047a: ldloc.s 10
-			IL_047c: stloc.s 11
-			IL_047e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0483: stloc.s 18
-			IL_0485: ldloc.s 11
-			IL_0487: stloc.s 17
-			IL_0489: ldstr "TypeError"
-			IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0493: stloc.s 21
-			IL_0495: ldloc.s 17
-			IL_0497: ldloc.s 21
-			IL_0499: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_049e: stloc.s 22
-			IL_04a0: ldloc.s 22
-			IL_04a2: box [System.Runtime]System.Boolean
-			IL_04a7: stloc.s 23
-			IL_04a9: ldloc.s 18
-			IL_04ab: ldloc.s 23
-			IL_04ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04b2: pop
-			IL_04b3: leave IL_04b8
+			IL_05a3: ldloc.s 10
+			IL_05a5: stloc.s 11
+			IL_05a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05ac: stloc.s 18
+			IL_05ae: ldloc.s 11
+			IL_05b0: stloc.s 17
+			IL_05b2: ldstr "TypeError"
+			IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05bc: stloc.s 21
+			IL_05be: ldloc.s 17
+			IL_05c0: ldloc.s 21
+			IL_05c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_05c7: stloc.s 22
+			IL_05c9: ldloc.s 22
+			IL_05cb: box [System.Runtime]System.Boolean
+			IL_05d0: stloc.s 23
+			IL_05d2: ldloc.s 18
+			IL_05d4: ldloc.s 23
+			IL_05d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05db: pop
+			IL_05dc: leave IL_05e1
 		} // end handler
 
-		IL_04b8: ldnull
-		IL_04b9: stloc.s 12
-		IL_04bb: ret
+		IL_05e1: ldnull
+		IL_05e2: stloc.s 12
+		IL_05e4: ret
 	} // end of method Classes_PrivateBrandCheck::__js_module_init__
 
 } // end of class Modules.Classes_PrivateBrandCheck
@@ -1349,6 +1441,13 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
@@ -131,7 +131,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 605 (0x25d)
+		// Code size: 656 (0x290)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_NestedObjects/Scope,
@@ -316,17 +316,30 @@
 		IL_022f: stloc.3
 		IL_0230: ldloc.3
 		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0236: ldstr "formatNum"
-		IL_023b: ldc.r8 42
-		IL_0244: box [System.Runtime]System.Double
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024e: stloc.3
-		IL_024f: ldloc.2
-		IL_0250: ldstr "formatNum:"
-		IL_0255: ldloc.3
-		IL_0256: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_025b: pop
-		IL_025c: ret
+		IL_0236: volatile.
+		IL_0238: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_023d: brfalse IL_025f
+
+		IL_0242: ldstr "formatNum"
+		IL_0247: ldc.r8 42
+		IL_0250: box [System.Runtime]System.Double
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025a: br IL_0281
+
+		IL_025f: ldstr "formatNum"
+		IL_0264: ldc.r8 42
+		IL_026d: box [System.Runtime]System.Double
+		IL_0272: ldstr "CommonJS_Export_NestedObjects:Modules.CommonJS_Export_NestedObjects:__js_module_init__:60"
+		IL_0277: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0281: stloc.3
+		IL_0282: ldloc.2
+		IL_0283: ldstr "formatNum:"
+		IL_0288: ldloc.3
+		IL_0289: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_028e: pop
+		IL_028f: ret
 	} // end of method CommonJS_Export_NestedObjects::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_NestedObjects
@@ -957,6 +970,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -131,7 +131,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 226 (0xe2)
+		// Code size: 379 (0x17b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ObjectWithClosure/Scope,
@@ -152,61 +152,100 @@
 		IL_0018: stloc.3
 		IL_0019: ldloc.1
 		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001f: ldstr "multiplyModuleFactor"
-		IL_0024: ldc.r8 3
-		IL_002d: box [System.Runtime]System.Double
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0037: stloc.s 4
-		IL_0039: ldloc.3
-		IL_003a: ldstr "lib.multiplyModuleFactor(3):"
-		IL_003f: ldloc.s 4
-		IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0046: pop
-		IL_0047: ldloc.1
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004d: ldstr "createCalculator"
-		IL_0052: ldc.r8 10
-		IL_005b: box [System.Runtime]System.Double
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0065: stloc.2
-		IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006b: stloc.3
-		IL_006c: volatile.
-		IL_006e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0073: brfalse IL_0088
+		IL_001f: volatile.
+		IL_0021: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0026: brfalse IL_0048
 
-		IL_0078: ldloc.2
-		IL_0079: ldstr "factor"
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0083: br IL_009d
+		IL_002b: ldstr "multiplyModuleFactor"
+		IL_0030: ldc.r8 3
+		IL_0039: box [System.Runtime]System.Double
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0043: br IL_006a
 
-		IL_0088: ldloc.2
-		IL_0089: ldstr "factor"
-		IL_008e: ldstr "CommonJS_Export_ObjectWithClosure:Modules.CommonJS_Export_ObjectWithClosure:__js_module_init__:26"
-		IL_0093: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0048: ldstr "multiplyModuleFactor"
+		IL_004d: ldc.r8 3
+		IL_0056: box [System.Runtime]System.Double
+		IL_005b: ldstr "CommonJS_Export_ObjectWithClosure:Modules.CommonJS_Export_ObjectWithClosure:__js_module_init__:14"
+		IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_009d: stloc.s 4
-		IL_009f: ldloc.3
-		IL_00a0: ldstr "calc.factor:"
-		IL_00a5: ldloc.s 4
-		IL_00a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00ac: pop
-		IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b2: stloc.3
-		IL_00b3: ldloc.2
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b9: ldstr "multiply"
-		IL_00be: ldc.r8 5
-		IL_00c7: box [System.Runtime]System.Double
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d1: stloc.s 4
-		IL_00d3: ldloc.3
-		IL_00d4: ldstr "calc.multiply(5):"
-		IL_00d9: ldloc.s 4
-		IL_00db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00e0: pop
-		IL_00e1: ret
+		IL_006a: stloc.s 4
+		IL_006c: ldloc.3
+		IL_006d: ldstr "lib.multiplyModuleFactor(3):"
+		IL_0072: ldloc.s 4
+		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0079: pop
+		IL_007a: ldloc.1
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0080: volatile.
+		IL_0082: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0087: brfalse IL_00a9
+
+		IL_008c: ldstr "createCalculator"
+		IL_0091: ldc.r8 10
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a4: br IL_00cb
+
+		IL_00a9: ldstr "createCalculator"
+		IL_00ae: ldc.r8 10
+		IL_00b7: box [System.Runtime]System.Double
+		IL_00bc: ldstr "CommonJS_Export_ObjectWithClosure:Modules.CommonJS_Export_ObjectWithClosure:__js_module_init__:20"
+		IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00cb: stloc.2
+		IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d1: stloc.3
+		IL_00d2: volatile.
+		IL_00d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00d9: brfalse IL_00ee
+
+		IL_00de: ldloc.2
+		IL_00df: ldstr "factor"
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e9: br IL_0103
+
+		IL_00ee: ldloc.2
+		IL_00ef: ldstr "factor"
+		IL_00f4: ldstr "CommonJS_Export_ObjectWithClosure:Modules.CommonJS_Export_ObjectWithClosure:__js_module_init__:26"
+		IL_00f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0103: stloc.s 4
+		IL_0105: ldloc.3
+		IL_0106: ldstr "calc.factor:"
+		IL_010b: ldloc.s 4
+		IL_010d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0112: pop
+		IL_0113: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0118: stloc.3
+		IL_0119: ldloc.2
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011f: volatile.
+		IL_0121: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0126: brfalse IL_0148
+
+		IL_012b: ldstr "multiply"
+		IL_0130: ldc.r8 5
+		IL_0139: box [System.Runtime]System.Double
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0143: br IL_016a
+
+		IL_0148: ldstr "multiply"
+		IL_014d: ldc.r8 5
+		IL_0156: box [System.Runtime]System.Double
+		IL_015b: ldstr "CommonJS_Export_ObjectWithClosure:Modules.CommonJS_Export_ObjectWithClosure:__js_module_init__:34"
+		IL_0160: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_016a: stloc.s 4
+		IL_016c: ldloc.3
+		IL_016d: ldstr "calc.multiply(5):"
+		IL_0172: ldloc.s 4
+		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0179: pop
+		IL_017a: ret
 	} // end of method CommonJS_Export_ObjectWithClosure::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ObjectWithClosure
@@ -924,6 +963,9 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_ImportMeta_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_ImportMeta_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 687 (0x2af)
+		// Code size: 771 (0x303)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_ImportMeta_Basic/Scope,
@@ -312,54 +312,78 @@
 		IL_0222: stloc.3
 		IL_0223: ldloc.3
 		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0229: ldstr "split"
-		IL_022e: ldstr "\\"
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0238: stloc.3
-		IL_0239: ldloc.3
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023f: ldstr "join"
-		IL_0244: ldstr "/"
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024e: stloc.3
-		IL_024f: ldloc.3
-		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0255: stloc.3
-		IL_0256: ldc.i4.0
-		IL_0257: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_025c: brfalse IL_0295
+		IL_0229: volatile.
+		IL_022b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0230: brfalse IL_0249
 
-		IL_0261: ldloc.3
-		IL_0262: isinst [System.Runtime]System.String
-		IL_0267: dup
-		IL_0268: brtrue IL_027f
+		IL_0235: ldstr "split"
+		IL_023a: ldstr "\\"
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0244: br IL_0262
 
-		IL_026d: pop
-		IL_026e: ldloc.3
-		IL_026f: ldstr "endsWith"
-		IL_0274: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_0279: dup
-		IL_027a: brfalse IL_0294
+		IL_0249: ldstr "split"
+		IL_024e: ldstr "\\"
+		IL_0253: ldstr "CommonJS_ImportMeta_Basic:Modules.CommonJS_ImportMeta_Basic:__js_module_init__:64"
+		IL_0258: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_027f: ldstr "/fixtures/demo.txt"
-		IL_0284: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
-		IL_0289: box [System.Runtime]System.Boolean
-		IL_028e: stloc.3
-		IL_028f: br IL_02a6
+		IL_0262: stloc.3
+		IL_0263: ldloc.3
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0269: volatile.
+		IL_026b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0270: brfalse IL_0289
 
-		IL_0294: pop
+		IL_0275: ldstr "join"
+		IL_027a: ldstr "/"
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0284: br IL_02a2
 
-		IL_0295: ldloc.3
-		IL_0296: ldstr "endsWith"
-		IL_029b: ldstr "/fixtures/demo.txt"
-		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a5: stloc.3
+		IL_0289: ldstr "join"
+		IL_028e: ldstr "/"
+		IL_0293: ldstr "CommonJS_ImportMeta_Basic:Modules.CommonJS_ImportMeta_Basic:__js_module_init__:67"
+		IL_0298: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02a6: ldloc.2
-		IL_02a7: ldloc.3
-		IL_02a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ad: pop
-		IL_02ae: ret
+		IL_02a2: stloc.3
+		IL_02a3: ldloc.3
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a9: stloc.3
+		IL_02aa: ldc.i4.0
+		IL_02ab: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_02b0: brfalse IL_02e9
+
+		IL_02b5: ldloc.3
+		IL_02b6: isinst [System.Runtime]System.String
+		IL_02bb: dup
+		IL_02bc: brtrue IL_02d3
+
+		IL_02c1: pop
+		IL_02c2: ldloc.3
+		IL_02c3: ldstr "endsWith"
+		IL_02c8: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_02cd: dup
+		IL_02ce: brfalse IL_02e8
+
+		IL_02d3: ldstr "/fixtures/demo.txt"
+		IL_02d8: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_02dd: box [System.Runtime]System.Boolean
+		IL_02e2: stloc.3
+		IL_02e3: br IL_02fa
+
+		IL_02e8: pop
+
+		IL_02e9: ldloc.3
+		IL_02ea: ldstr "endsWith"
+		IL_02ef: ldstr "/fixtures/demo.txt"
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02f9: stloc.3
+
+		IL_02fa: ldloc.2
+		IL_02fb: ldloc.3
+		IL_02fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0301: pop
+		IL_0302: ret
 	} // end of method CommonJS_ImportMeta_Basic::__js_module_init__
 
 } // end of class Modules.CommonJS_ImportMeta_Basic
@@ -393,6 +417,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
@@ -131,7 +131,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 130 (0x82)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_Exports_ChainedAssignment/Scope,
@@ -174,16 +174,28 @@
 		IL_005d: stloc.2
 		IL_005e: ldloc.1
 		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0064: ldstr "greet"
-		IL_0069: ldstr "world"
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0073: stloc.3
-		IL_0074: ldloc.2
-		IL_0075: ldstr "greet:"
-		IL_007a: ldloc.3
-		IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0080: pop
-		IL_0081: ret
+		IL_0064: volatile.
+		IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_006b: brfalse IL_0084
+
+		IL_0070: ldstr "greet"
+		IL_0075: ldstr "world"
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007f: br IL_009d
+
+		IL_0084: ldstr "greet"
+		IL_0089: ldstr "world"
+		IL_008e: ldstr "CommonJS_Module_Exports_ChainedAssignment:Modules.CommonJS_Module_Exports_ChainedAssignment:__js_module_init__:19"
+		IL_0093: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009d: stloc.3
+		IL_009e: ldloc.2
+		IL_009f: ldstr "greet:"
+		IL_00a4: ldloc.3
+		IL_00a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method CommonJS_Module_Exports_ChainedAssignment::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Exports_ChainedAssignment
@@ -446,6 +458,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Require.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Require.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 381 (0x17d)
+		// Code size: 465 (0x1d1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_Require/Scope,
@@ -229,24 +229,48 @@
 
 		IL_0139: ldloc.2
 		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_013f: ldstr "split"
-		IL_0144: ldstr "\\"
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014e: stloc.s 5
-		IL_0150: ldloc.s 5
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0157: ldstr "join"
-		IL_015c: ldstr "/"
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0166: stloc.3
-		IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016c: stloc.s 4
-		IL_016e: ldloc.s 4
-		IL_0170: ldstr "path.join result:"
-		IL_0175: ldloc.3
-		IL_0176: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_017b: pop
-		IL_017c: ret
+		IL_013f: volatile.
+		IL_0141: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0146: brfalse IL_015f
+
+		IL_014b: ldstr "split"
+		IL_0150: ldstr "\\"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015a: br IL_0178
+
+		IL_015f: ldstr "split"
+		IL_0164: ldstr "\\"
+		IL_0169: ldstr "CommonJS_Module_Require:Modules.CommonJS_Module_Require:__js_module_init__:37"
+		IL_016e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0178: stloc.s 5
+		IL_017a: ldloc.s 5
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0181: volatile.
+		IL_0183: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0188: brfalse IL_01a1
+
+		IL_018d: ldstr "join"
+		IL_0192: ldstr "/"
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019c: br IL_01ba
+
+		IL_01a1: ldstr "join"
+		IL_01a6: ldstr "/"
+		IL_01ab: ldstr "CommonJS_Module_Require:Modules.CommonJS_Module_Require:__js_module_init__:40"
+		IL_01b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01ba: stloc.3
+		IL_01bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c0: stloc.s 4
+		IL_01c2: ldloc.s 4
+		IL_01c4: ldstr "path.join result:"
+		IL_01c9: ldloc.3
+		IL_01ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01cf: pop
+		IL_01d0: ret
 	} // end of method CommonJS_Module_Require::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Require
@@ -278,6 +302,8 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
@@ -245,7 +245,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 40 (0x28)
+			// Code size: 78 (0x4e)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -261,12 +261,24 @@
 			IL_0013: stloc.0
 			IL_0014: ldloc.0
 			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001a: ldstr "resolve"
-			IL_001f: ldarg.2
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0025: stloc.0
-			IL_0026: ldloc.0
-			IL_0027: ret
+			IL_001a: volatile.
+			IL_001c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0021: brfalse IL_0036
+
+			IL_0026: ldstr "resolve"
+			IL_002b: ldarg.2
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0031: br IL_004b
+
+			IL_0036: ldstr "resolve"
+			IL_003b: ldarg.2
+			IL_003c: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL:<TwoPhaseDummy_M6>:__js_call__:6"
+			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_004b: stloc.0
+			IL_004c: ldloc.0
+			IL_004d: ret
 		} // end of method FunctionExpression_descriptor::__js_call__
 
 	} // end of class FunctionExpression_descriptor
@@ -368,7 +380,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 114 (0x72)
+		// Code size: 157 (0x9d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope,
@@ -415,16 +427,29 @@
 		IL_004b: callvirt instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL/ObjectLiterals/L5C18_descriptor::set_value(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
 		IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0055: stloc.s 5
-		IL_0057: ldloc.1
-		IL_0058: ldstr "value"
-		IL_005d: ldstr "child"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0067: stloc.2
-		IL_0068: ldloc.s 5
-		IL_006a: ldloc.2
-		IL_006b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0070: pop
-		IL_0071: ret
+		IL_0057: volatile.
+		IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_005e: brfalse IL_0078
+
+		IL_0063: ldloc.1
+		IL_0064: ldstr "value"
+		IL_0069: ldstr "child"
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0073: br IL_0092
+
+		IL_0078: ldloc.1
+		IL_0079: ldstr "value"
+		IL_007e: ldstr "child"
+		IL_0083: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL:Modules.CommonJS_Require_Captures_Shadowed_Global_URL:__js_module_init__:16"
+		IL_0088: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0092: stloc.2
+		IL_0093: ldloc.s 5
+		IL_0095: ldloc.2
+		IL_0096: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009b: pop
+		IL_009c: ret
 	} // end of method CommonJS_Require_Captures_Shadowed_Global_URL::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Captures_Shadowed_Global_URL
@@ -756,7 +781,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -771,7 +796,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
 			IL_0036: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL_Lib:<TwoPhaseDummy_M8>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -857,7 +882,7 @@
 		IL_0025: nop
 		IL_0026: nop
 		IL_0027: volatile.
-		IL_0029: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0029: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 		IL_002e: brfalse IL_0043
 
 		IL_0033: ldloc.1
@@ -868,7 +893,7 @@
 		IL_0043: ldloc.1
 		IL_0044: ldstr "prototype"
 		IL_0049: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL_Lib:Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib:__js_module_init__:9"
-		IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0058: stloc.3
@@ -931,6 +956,8 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/DynamicLookupInlineCacheTests.cs
+++ b/tests/Jroc.Tests/DynamicLookupInlineCacheTests.cs
@@ -516,6 +516,293 @@ public sealed class DynamicLookupInlineCacheTests
     }
 
     [Fact]
+    public void CallMember1_SharesPrototypeEntryAcrossArraysAndPreservesThisAndArgument()
+    {
+        WithRealm(
+            () =>
+            {
+                const int count = 500;
+                var prototype = new JsObject();
+                var receivers = Enumerable
+                    .Range(0, count)
+                    .Select(
+                        _ =>
+                        {
+                            var receiver = new JavaScriptRuntime.Array();
+                            PrototypeChain.SetPrototype(receiver, prototype);
+                            return receiver;
+                        })
+                    .ToArray();
+                BuiltinFunction1 method = (thisArgument, argument0) =>
+                {
+                    var index = (int)(double)argument0!;
+                    return ReferenceEquals(
+                        thisArgument,
+                        receivers[index]);
+                };
+                prototype.SetValue(
+                    "method",
+                    BuiltinDelegateFunctionAdapter.FromDelegate(method));
+
+                for (var index = 0; index < count; index++)
+                {
+                    Assert.Equal(
+                        true,
+                        DynamicLookupInlineCache.CallMember1(
+                            receivers[index],
+                            "method",
+                            (double)index,
+                            "call1-prototype-same-shape"));
+                }
+
+                var site = Assert.IsType<
+                    DynamicLookupInlineCacheSite>(
+                    DynamicLookupInlineCache.GetSiteForTests(
+                        "call1-prototype-same-shape"));
+                Assert.Equal(
+                    DynamicLookupInlineCacheState.Monomorphic,
+                    site.State);
+                Assert.Equal(1, site.EntryCount);
+            });
+    }
+
+    [Fact]
+    public void CallMember1_CachesUserMethodOnSharedArrayPrototype()
+    {
+        WithRealm(
+            () =>
+            {
+                BuiltinFunction1 method =
+                    static (_, argument0) => argument0;
+                JavaScriptRuntime.Array.Prototype.SetValue(
+                    "phase4Method",
+                    BuiltinDelegateFunctionAdapter
+                        .FromDelegate(method));
+                var receiver =
+                    new JavaScriptRuntime.Array();
+
+                Assert.Equal(
+                    "argument",
+                    DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "phase4Method",
+                        "argument",
+                        "call1-shared-array-prototype"));
+                Assert.Equal(
+                    "updated",
+                    DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "phase4Method",
+                        "updated",
+                        "call1-shared-array-prototype"));
+
+                var site = Assert.IsType<
+                    DynamicLookupInlineCacheSite>(
+                    DynamicLookupInlineCache.GetSiteForTests(
+                        "call1-shared-array-prototype"));
+                Assert.Equal(
+                    DynamicLookupInlineCacheState.Monomorphic,
+                    site.State);
+                Assert.Equal(1, site.EntryCount);
+            });
+    }
+
+    [Fact]
+    public void CallMember1_InvalidatesForShadowingReassignmentDescriptorsAndPrototypeMutation()
+    {
+        WithRealm(
+            () =>
+            {
+                var prototype = new JsObject();
+                prototype.SetValue(
+                    "method",
+                    CreateFunction1("prototype:first"));
+                var receiver = new JavaScriptRuntime.Array();
+                PrototypeChain.SetPrototype(receiver, prototype);
+
+                Assert.Equal(
+                    "prototype:first:arg",
+                    DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "method",
+                        "arg",
+                        "call1-invalidation"));
+
+                prototype.SetValue(
+                    "method",
+                    CreateFunction1("prototype:updated"));
+                Assert.Equal(
+                    "prototype:updated:arg",
+                    DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "method",
+                        "arg",
+                        "call1-invalidation"));
+
+                receiver.SetValue(
+                    "method",
+                    CreateFunction1("own"));
+                Assert.Equal(
+                    "own:arg",
+                    DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "method",
+                        "arg",
+                        "call1-invalidation"));
+
+                Assert.True(receiver.Remove("method"));
+                Assert.Equal(
+                    "prototype:updated:arg",
+                    DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "method",
+                        "arg",
+                        "call1-invalidation"));
+
+                var getterCalls = 0;
+                BuiltinFunction0 getter = _ =>
+                {
+                    getterCalls++;
+                    return CreateFunction1("accessor");
+                };
+                PropertyDescriptorStore.DefineOrUpdate(
+                    prototype,
+                    "method",
+                    new JsPropertyDescriptor
+                    {
+                        Kind = JsPropertyDescriptorKind.Accessor,
+                        Get = BuiltinDelegateFunctionAdapter
+                            .FromDelegate(getter),
+                        Enumerable = true,
+                        Configurable = true
+                    });
+                Assert.Equal(
+                    "accessor:arg",
+                    DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "method",
+                        "arg",
+                        "call1-invalidation"));
+                Assert.Equal(1, getterCalls);
+
+                var replacementPrototype = new JsObject();
+                replacementPrototype.SetValue(
+                    "method",
+                    CreateFunction1("replacement"));
+                PrototypeChain.SetPrototype(
+                    receiver,
+                    replacementPrototype);
+                Assert.Equal(
+                    "replacement:arg",
+                    DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "method",
+                        "arg",
+                        "call1-invalidation"));
+            });
+    }
+
+    [Fact]
+    public void CallMember1_TransitionsToPolymorphicThenMegamorphic()
+    {
+        WithRealm(
+            () =>
+            {
+                var prototype = new JsObject();
+                prototype.SetValue(
+                    "method",
+                    CreateFunction1("prototype"));
+                var receivers = Enumerable
+                    .Range(
+                        0,
+                        DynamicLookupInlineCacheSite
+                            .MaxPolymorphicEntries + 1)
+                    .Select(
+                        index =>
+                        {
+                            var receiver = new JavaScriptRuntime.Array();
+                            receiver.SetValue($"shape{index}", true);
+                            PrototypeChain.SetPrototype(receiver, prototype);
+                            return receiver;
+                        })
+                    .ToArray();
+
+                foreach (var receiver in receivers)
+                {
+                    Assert.Equal(
+                        "prototype:arg",
+                        DynamicLookupInlineCache.CallMember1(
+                            receiver,
+                            "method",
+                            "arg",
+                            "call1-transition"));
+                }
+
+                var site = Assert.IsType<
+                    DynamicLookupInlineCacheSite>(
+                    DynamicLookupInlineCache.GetSiteForTests(
+                        "call1-transition"));
+                Assert.Equal(
+                    DynamicLookupInlineCacheState.Megamorphic,
+                    site.State);
+                Assert.Equal(0, site.EntryCount);
+            });
+    }
+
+    [Fact]
+    public void CallMember1_ProxyBypassesCache()
+    {
+        WithRealm(
+            () =>
+            {
+                var target = new JsObject();
+                target.SetValue(
+                    "method",
+                    CreateFunction1("target"));
+                var proxy = new JavaScriptRuntime.Proxy(
+                    target,
+                    new JsObject());
+
+                Assert.Equal(
+                    "target:arg",
+                    DynamicLookupInlineCache.CallMember1(
+                        proxy,
+                        "method",
+                        "arg",
+                        "call1-proxy"));
+                Assert.Null(
+                    DynamicLookupInlineCache.GetSiteForTests(
+                        "call1-proxy"));
+            });
+    }
+
+    [Fact]
+    public void CallMember1_SymbolKeyBypassesCache()
+    {
+        WithRealm(
+            () =>
+            {
+                var receiver = new JsObject();
+                var symbolKey = ObjectRuntime.ToPropertyKeyString(
+                    new Symbol("method"));
+                receiver.SetValue(
+                    symbolKey,
+                    CreateFunction1("symbol"));
+
+                Assert.Equal(
+                    "symbol:arg",
+                    DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        symbolKey,
+                        "arg",
+                        "call1-symbol"));
+                Assert.Null(
+                    DynamicLookupInlineCache.GetSiteForTests(
+                        "call1-symbol"));
+            });
+    }
+
+    [Fact]
     public void Site_TransitionsToPolymorphicThenMegamorphic()
     {
         WithRealm(
@@ -821,6 +1108,54 @@ public sealed class DynamicLookupInlineCacheTests
     }
 
     [Fact]
+    public void MonomorphicCallMember1PrototypeHit_AllocatesZeroBytes()
+    {
+        WithRealm(
+            () =>
+            {
+                var prototype = new JsObject();
+                BuiltinFunction1 method =
+                    static (_, _) => "cached";
+                prototype.SetValue(
+                    "method",
+                    BuiltinDelegateFunctionAdapter
+                        .FromDelegate(method));
+                var receiver = new JavaScriptRuntime.Array();
+                PrototypeChain.SetPrototype(receiver, prototype);
+                _ = DynamicLookupInlineCache.CallMember1(
+                    receiver,
+                    "method",
+                    "arg",
+                    "call1-allocation");
+
+                for (var index = 0; index < 100; index++)
+                {
+                    _ = DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "method",
+                        "arg",
+                        "call1-allocation");
+                }
+
+                var before =
+                    GC.GetAllocatedBytesForCurrentThread();
+                for (var index = 0; index < 1_000; index++)
+                {
+                    _ = DynamicLookupInlineCache.CallMember1(
+                        receiver,
+                        "method",
+                        "arg",
+                        "call1-allocation");
+                }
+                var allocated =
+                    GC.GetAllocatedBytesForCurrentThread()
+                    - before;
+
+                Assert.Equal(0, allocated);
+            });
+    }
+
+    [Fact]
     public void DisposedRealmCache_DoesNotRetainReceiver()
     {
         var receiverReference =
@@ -864,6 +1199,39 @@ public sealed class DynamicLookupInlineCacheTests
 
             Assert.False(references.Receiver.IsAlive);
             Assert.False(references.Value.IsAlive);
+        }
+        finally
+        {
+            services.OwningRealm!.Agent.Cluster.Dispose();
+        }
+    }
+
+    [Fact]
+    public void LiveRealmCallMember1Cache_DoesNotRetainPrototypeOrCallable()
+    {
+        var services =
+            RuntimeServices.BuildServiceProvider();
+        var context =
+            RuntimeExecutionContext.GetOrCreate(services);
+
+        try
+        {
+            var references =
+                PopulateCollectibleCallMember1Entry(context);
+
+            for (var attempt = 0;
+                 attempt < 10
+                    && (references.Prototype.IsAlive
+                        || references.Callable.IsAlive);
+                 attempt++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+
+            Assert.False(references.Prototype.IsAlive);
+            Assert.False(references.Callable.IsAlive);
         }
         finally
         {
@@ -943,6 +1311,14 @@ public sealed class DynamicLookupInlineCacheTests
     private static object CreateFunction(string result)
     {
         BuiltinFunction0 function = _ => result;
+        return BuiltinDelegateFunctionAdapter
+            .FromDelegate(function);
+    }
+
+    private static object CreateFunction1(string result)
+    {
+        BuiltinFunction1 function =
+            (_, argument0) => $"{result}:{argument0}";
         return BuiltinDelegateFunctionAdapter
             .FromDelegate(function);
     }
@@ -1043,6 +1419,39 @@ public sealed class DynamicLookupInlineCacheTests
                         return new WeakReference(receiver);
                     })
                 .ToArray();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Prototype, WeakReference Callable)
+        PopulateCollectibleCallMember1Entry(
+            RuntimeExecutionContext context)
+    {
+        using (context.EnterAsRoot())
+        {
+            var prototype = new JsObject();
+            BuiltinFunction1 first =
+                static (_, _) => null;
+            BuiltinFunction1 second =
+                static (_, argument0) => argument0;
+            var function = (BuiltinFunction1)Delegate.Combine(
+                first,
+                second);
+            var callable =
+                BuiltinDelegateFunctionAdapter
+                    .FromDelegate(function);
+            prototype.SetValue("method", callable);
+            var receiver =
+                new JavaScriptRuntime.Array();
+            PrototypeChain.SetPrototype(receiver, prototype);
+            _ = DynamicLookupInlineCache.CallMember1(
+                receiver,
+                "method",
+                "argument",
+                "call1-gc");
+            return (
+                new WeakReference(prototype),
+                new WeakReference(callable));
         }
     }
 

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
@@ -834,7 +834,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 755 (0x2f3)
+		// Code size: 796 (0x31c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FinalizationRegistry_Cleanup_Order/Scope,
@@ -932,216 +932,229 @@
 		IL_00d8: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
 		IL_00dd: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
 		IL_00e2: stloc.s 9
-		IL_00e4: ldloc.s 11
-		IL_00e6: ldstr "call"
-		IL_00eb: ldloc.s 9
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f2: stloc.s 11
-		IL_00f4: ldloc.s 10
-		IL_00f6: ldloc.s 11
-		IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fd: pop
+		IL_00e4: volatile.
+		IL_00e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_00eb: brfalse IL_0103
+
+		IL_00f0: ldloc.s 11
+		IL_00f2: ldstr "call"
+		IL_00f7: ldloc.s 9
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fe: br IL_011b
+
+		IL_0103: ldloc.s 11
+		IL_0105: ldstr "call"
+		IL_010a: ldloc.s 9
+		IL_010c: ldstr "FinalizationRegistry_Cleanup_Order:Modules.FinalizationRegistry_Cleanup_Order:__js_module_init__:21"
+		IL_0111: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_011b: stloc.s 11
+		IL_011d: ldloc.s 10
+		IL_011f: ldloc.s 11
+		IL_0121: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0126: pop
 		.try
 		{
-			IL_00fe: nop
-			IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0104: stloc.1
-			IL_0105: ldloc.0
-			IL_0106: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
-			IL_010b: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
-			IL_0110: stloc.s 9
-			IL_0112: ldloc.s 9
-			IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry>(!!0)
-			IL_0119: stloc.s 9
-			IL_011b: ldloc.s 9
-			IL_011d: ldstr "register"
-			IL_0122: ldloc.1
-			IL_0123: ldloc.1
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0129: pop
-			IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_012f: stloc.s 10
-			IL_0131: ldloc.s 10
-			IL_0133: ldstr "same target threw:"
-			IL_0138: ldc.i4.0
-			IL_0139: box [System.Runtime]System.Boolean
-			IL_013e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0143: pop
-			IL_0144: leave IL_01df
+			IL_0127: nop
+			IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_012d: stloc.1
+			IL_012e: ldloc.0
+			IL_012f: ldfld object Modules.FinalizationRegistry_Cleanup_Order/Scope::registry
+			IL_0134: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
+			IL_0139: stloc.s 9
+			IL_013b: ldloc.s 9
+			IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry>(!!0)
+			IL_0142: stloc.s 9
+			IL_0144: ldloc.s 9
+			IL_0146: ldstr "register"
+			IL_014b: ldloc.1
+			IL_014c: ldloc.1
+			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0152: pop
+			IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0158: stloc.s 10
+			IL_015a: ldloc.s 10
+			IL_015c: ldstr "same target threw:"
+			IL_0161: ldc.i4.0
+			IL_0162: box [System.Runtime]System.Boolean
+			IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_016c: pop
+			IL_016d: leave IL_0208
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0149: stloc.2
-			IL_014a: ldloc.2
-			IL_014b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0150: dup
-			IL_0151: brtrue IL_0166
+			IL_0172: stloc.2
+			IL_0173: ldloc.2
+			IL_0174: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0179: dup
+			IL_017a: brtrue IL_018f
 
-			IL_0156: pop
-			IL_0157: ldloc.2
-			IL_0158: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_015d: dup
-			IL_015e: brtrue IL_0171
+			IL_017f: pop
+			IL_0180: ldloc.2
+			IL_0181: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0186: dup
+			IL_0187: brtrue IL_019a
 
-			IL_0163: pop
-			IL_0164: rethrow
+			IL_018c: pop
+			IL_018d: rethrow
 
-			IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_016b: stloc.3
-			IL_016c: br IL_0172
+			IL_018f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0194: stloc.3
+			IL_0195: br IL_019b
 
-			IL_0171: stloc.3
+			IL_019a: stloc.3
 
-			IL_0172: ldloc.3
-			IL_0173: stloc.s 4
-			IL_0175: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_017a: stloc.s 10
-			IL_017c: ldloc.s 10
-			IL_017e: ldstr "same target threw:"
-			IL_0183: ldc.i4.1
-			IL_0184: box [System.Runtime]System.Boolean
-			IL_0189: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_018e: pop
-			IL_018f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0194: stloc.s 10
-			IL_0196: volatile.
-			IL_0198: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_019d: brfalse IL_01b3
+			IL_019b: ldloc.3
+			IL_019c: stloc.s 4
+			IL_019e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01a3: stloc.s 10
+			IL_01a5: ldloc.s 10
+			IL_01a7: ldstr "same target threw:"
+			IL_01ac: ldc.i4.1
+			IL_01ad: box [System.Runtime]System.Boolean
+			IL_01b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01b7: pop
+			IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01bd: stloc.s 10
+			IL_01bf: volatile.
+			IL_01c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_01c6: brfalse IL_01dc
 
-			IL_01a2: ldloc.s 4
-			IL_01a4: ldstr "name"
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ae: br IL_01c9
+			IL_01cb: ldloc.s 4
+			IL_01cd: ldstr "name"
+			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d7: br IL_01f2
 
-			IL_01b3: ldloc.s 4
-			IL_01b5: ldstr "name"
-			IL_01ba: ldstr "FinalizationRegistry_Cleanup_Order:Modules.FinalizationRegistry_Cleanup_Order:__js_module_init__:56"
-			IL_01bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01dc: ldloc.s 4
+			IL_01de: ldstr "name"
+			IL_01e3: ldstr "FinalizationRegistry_Cleanup_Order:Modules.FinalizationRegistry_Cleanup_Order:__js_module_init__:56"
+			IL_01e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01c9: stloc.s 11
-			IL_01cb: ldloc.s 10
-			IL_01cd: ldstr "same target name:"
-			IL_01d2: ldloc.s 11
-			IL_01d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01d9: pop
-			IL_01da: leave IL_01df
+			IL_01f2: stloc.s 11
+			IL_01f4: ldloc.s 10
+			IL_01f6: ldstr "same target name:"
+			IL_01fb: ldloc.s 11
+			IL_01fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0202: pop
+			IL_0203: leave IL_0208
 		} // end handler
 
-		IL_01df: ldc.i4.1
-		IL_01e0: newarr [System.Runtime]System.Object
-		IL_01e5: dup
-		IL_01e6: ldc.i4.0
-		IL_01e7: ldloc.0
-		IL_01e8: stelem.ref
-		IL_01e9: stloc.s 7
-		IL_01eb: ldloc.s 7
-		IL_01ed: ldc.i4.0
-		IL_01ee: ldelem.ref
-		IL_01ef: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_01f4: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
-		IL_01f9: ldc.i4.0
-		IL_01fa: conv.r8
-		IL_01fb: ldstr ""
-		IL_0200: ldc.i4.0
-		IL_0201: ldc.i4.1
-		IL_0202: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0207: stloc.s 12
-		IL_0209: ldloc.s 12
-		IL_020b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0215: pop
-		IL_0216: ldc.i4.1
-		IL_0217: newarr [System.Runtime]System.Object
-		IL_021c: dup
-		IL_021d: ldc.i4.0
-		IL_021e: ldloc.0
-		IL_021f: stelem.ref
-		IL_0220: stloc.s 7
-		IL_0222: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13/FunctionObject::.ctor()
-		IL_0227: ldc.i4.1
-		IL_0228: conv.r8
-		IL_0229: ldstr ""
-		IL_022e: ldc.i4.0
-		IL_022f: ldc.i4.0
-		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13/FunctionObject>(!!0)
-		IL_023a: stloc.s 13
-		IL_023c: ldloc.s 13
-		IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
-		IL_0243: stloc.s 14
-		IL_0245: ldc.i4.1
-		IL_0246: newarr [System.Runtime]System.Object
-		IL_024b: dup
-		IL_024c: ldc.i4.0
-		IL_024d: ldloc.0
-		IL_024e: stelem.ref
-		IL_024f: stloc.s 7
-		IL_0251: ldloc.s 7
-		IL_0253: ldc.i4.0
-		IL_0254: ldelem.ref
-		IL_0255: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_025a: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42/FunctionObject::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
-		IL_025f: ldc.i4.0
-		IL_0260: conv.r8
-		IL_0261: ldstr ""
-		IL_0266: ldc.i4.0
-		IL_0267: ldc.i4.0
-		IL_0268: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_026d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42/FunctionObject>(!!0)
-		IL_0272: stloc.s 15
-		IL_0274: ldloc.s 14
-		IL_0276: ldstr "then"
-		IL_027b: call bool [JavaScriptRuntime]JavaScriptRuntime.Promise::HasMemberOverride(object, string)
-		IL_0280: brtrue IL_0294
+		IL_0208: ldc.i4.1
+		IL_0209: newarr [System.Runtime]System.Object
+		IL_020e: dup
+		IL_020f: ldc.i4.0
+		IL_0210: ldloc.0
+		IL_0211: stelem.ref
+		IL_0212: stloc.s 7
+		IL_0214: ldloc.s 7
+		IL_0216: ldc.i4.0
+		IL_0217: ldelem.ref
+		IL_0218: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_021d: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
+		IL_0222: ldc.i4.0
+		IL_0223: conv.r8
+		IL_0224: ldstr ""
+		IL_0229: ldc.i4.0
+		IL_022a: ldc.i4.1
+		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0230: stloc.s 12
+		IL_0232: ldloc.s 12
+		IL_0234: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_023e: pop
+		IL_023f: ldc.i4.1
+		IL_0240: newarr [System.Runtime]System.Object
+		IL_0245: dup
+		IL_0246: ldc.i4.0
+		IL_0247: ldloc.0
+		IL_0248: stelem.ref
+		IL_0249: stloc.s 7
+		IL_024b: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13/FunctionObject::.ctor()
+		IL_0250: ldc.i4.1
+		IL_0251: conv.r8
+		IL_0252: ldstr ""
+		IL_0257: ldc.i4.0
+		IL_0258: ldc.i4.0
+		IL_0259: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_025e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13/FunctionObject>(!!0)
+		IL_0263: stloc.s 13
+		IL_0265: ldloc.s 13
+		IL_0267: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+		IL_026c: stloc.s 14
+		IL_026e: ldc.i4.1
+		IL_026f: newarr [System.Runtime]System.Object
+		IL_0274: dup
+		IL_0275: ldc.i4.0
+		IL_0276: ldloc.0
+		IL_0277: stelem.ref
+		IL_0278: stloc.s 7
+		IL_027a: ldloc.s 7
+		IL_027c: ldc.i4.0
+		IL_027d: ldelem.ref
+		IL_027e: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_0283: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42/FunctionObject::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
+		IL_0288: ldc.i4.0
+		IL_0289: conv.r8
+		IL_028a: ldstr ""
+		IL_028f: ldc.i4.0
+		IL_0290: ldc.i4.0
+		IL_0291: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0296: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42/FunctionObject>(!!0)
+		IL_029b: stloc.s 15
+		IL_029d: ldloc.s 14
+		IL_029f: ldstr "then"
+		IL_02a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Promise::HasMemberOverride(object, string)
+		IL_02a9: brtrue IL_02bd
 
-		IL_0285: ldloc.s 14
-		IL_0287: ldloc.s 15
-		IL_0289: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Promise::then(object)
-		IL_028e: pop
-		IL_028f: br IL_02ac
+		IL_02ae: ldloc.s 14
+		IL_02b0: ldloc.s 15
+		IL_02b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Promise::then(object)
+		IL_02b7: pop
+		IL_02b8: br IL_02d5
 
-		IL_0294: ldloc.s 14
-		IL_0296: ldstr "then"
-		IL_029b: ldc.i4.1
-		IL_029c: newarr [System.Runtime]System.Object
-		IL_02a1: dup
-		IL_02a2: ldc.i4.0
-		IL_02a3: ldloc.s 15
-		IL_02a5: stelem.ref
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-		IL_02ab: pop
+		IL_02bd: ldloc.s 14
+		IL_02bf: ldstr "then"
+		IL_02c4: ldc.i4.1
+		IL_02c5: newarr [System.Runtime]System.Object
+		IL_02ca: dup
+		IL_02cb: ldc.i4.0
+		IL_02cc: ldloc.s 15
+		IL_02ce: stelem.ref
+		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_02d4: pop
 
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-		IL_02b1: pop
-		IL_02b2: ldc.i4.1
-		IL_02b3: newarr [System.Runtime]System.Object
-		IL_02b8: dup
-		IL_02b9: ldc.i4.0
-		IL_02ba: ldloc.0
-		IL_02bb: stelem.ref
-		IL_02bc: stloc.s 7
-		IL_02be: ldloc.s 7
-		IL_02c0: ldc.i4.0
-		IL_02c1: ldelem.ref
-		IL_02c2: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_02c7: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14/FunctionObject::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
-		IL_02cc: ldc.i4.0
-		IL_02cd: conv.r8
-		IL_02ce: ldstr ""
-		IL_02d3: ldc.i4.0
-		IL_02d4: ldc.i4.0
-		IL_02d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14/FunctionObject>(!!0)
-		IL_02df: stloc.s 16
-		IL_02e1: ldloc.s 16
-		IL_02e3: ldc.i4.0
-		IL_02e4: newarr [System.Runtime]System.Object
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_02ee: pop
-		IL_02ef: ldnull
-		IL_02f0: stloc.s 5
-		IL_02f2: ret
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+		IL_02da: pop
+		IL_02db: ldc.i4.1
+		IL_02dc: newarr [System.Runtime]System.Object
+		IL_02e1: dup
+		IL_02e2: ldc.i4.0
+		IL_02e3: ldloc.0
+		IL_02e4: stelem.ref
+		IL_02e5: stloc.s 7
+		IL_02e7: ldloc.s 7
+		IL_02e9: ldc.i4.0
+		IL_02ea: ldelem.ref
+		IL_02eb: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
+		IL_02f0: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14/FunctionObject::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
+		IL_02f5: ldc.i4.0
+		IL_02f6: conv.r8
+		IL_02f7: ldstr ""
+		IL_02fc: ldc.i4.0
+		IL_02fd: ldc.i4.0
+		IL_02fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0303: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L27C14/FunctionObject>(!!0)
+		IL_0308: stloc.s 16
+		IL_030a: ldloc.s 16
+		IL_030c: ldc.i4.0
+		IL_030d: newarr [System.Runtime]System.Object
+		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0317: pop
+		IL_0318: ldnull
+		IL_0319: stloc.s 5
+		IL_031b: ret
 	} // end of method FinalizationRegistry_Cleanup_Order::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Cleanup_Order
@@ -1174,6 +1187,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
@@ -587,7 +587,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 519 (0x207)
+		// Code size: 613 (0x265)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FinalizationRegistry_Unregister_Basic/Scope,
@@ -681,130 +681,157 @@
 		IL_00ba: ldloc.0
 		IL_00bb: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::token
 		IL_00c0: stloc.s 12
-		IL_00c2: ldloc.s 8
-		IL_00c4: ldstr "unregister"
-		IL_00c9: ldloc.s 12
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d0: stloc.s 12
-		IL_00d2: ldloc.s 11
-		IL_00d4: ldloc.s 12
-		IL_00d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00db: pop
+		IL_00c2: volatile.
+		IL_00c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00c9: brfalse IL_00e1
+
+		IL_00ce: ldloc.s 8
+		IL_00d0: ldstr "unregister"
+		IL_00d5: ldloc.s 12
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00dc: br IL_00f9
+
+		IL_00e1: ldloc.s 8
+		IL_00e3: ldstr "unregister"
+		IL_00e8: ldloc.s 12
+		IL_00ea: ldstr "FinalizationRegistry_Unregister_Basic:Modules.FinalizationRegistry_Unregister_Basic:__js_module_init__:24"
+		IL_00ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f9: stloc.s 12
+		IL_00fb: ldloc.s 11
+		IL_00fd: ldloc.s 12
+		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0104: pop
 		.try
 		{
-			IL_00dc: nop
-			IL_00dd: ldloc.0
-			IL_00de: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
-			IL_00e3: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
-			IL_00e8: stloc.s 8
-			IL_00ea: ldloc.s 8
-			IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry>(!!0)
-			IL_00f1: stloc.s 8
-			IL_00f3: ldloc.s 8
-			IL_00f5: ldstr "unregister"
-			IL_00fa: ldc.r8 123
-			IL_0103: box [System.Runtime]System.Double
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_010d: pop
-			IL_010e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0113: stloc.s 11
-			IL_0115: ldloc.s 11
-			IL_0117: ldstr "bad token threw:"
-			IL_011c: ldc.i4.0
-			IL_011d: box [System.Runtime]System.Boolean
-			IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0127: pop
-			IL_0128: leave IL_01c0
+			IL_0105: nop
+			IL_0106: ldloc.0
+			IL_0107: ldfld object Modules.FinalizationRegistry_Unregister_Basic/Scope::registry
+			IL_010c: castclass [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry
+			IL_0111: stloc.s 8
+			IL_0113: ldloc.s 8
+			IL_0115: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry>(!!0)
+			IL_011a: stloc.s 8
+			IL_011c: volatile.
+			IL_011e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0123: brfalse IL_0147
+
+			IL_0128: ldloc.s 8
+			IL_012a: ldstr "unregister"
+			IL_012f: ldc.r8 123
+			IL_0138: box [System.Runtime]System.Double
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0142: br IL_016b
+
+			IL_0147: ldloc.s 8
+			IL_0149: ldstr "unregister"
+			IL_014e: ldc.r8 123
+			IL_0157: box [System.Runtime]System.Double
+			IL_015c: ldstr "FinalizationRegistry_Unregister_Basic:Modules.FinalizationRegistry_Unregister_Basic:__js_module_init__:34"
+			IL_0161: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_016b: pop
+			IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0171: stloc.s 11
+			IL_0173: ldloc.s 11
+			IL_0175: ldstr "bad token threw:"
+			IL_017a: ldc.i4.0
+			IL_017b: box [System.Runtime]System.Boolean
+			IL_0180: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0185: pop
+			IL_0186: leave IL_021e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_012d: stloc.1
-			IL_012e: ldloc.1
-			IL_012f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0134: dup
-			IL_0135: brtrue IL_014a
+			IL_018b: stloc.1
+			IL_018c: ldloc.1
+			IL_018d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0192: dup
+			IL_0193: brtrue IL_01a8
 
-			IL_013a: pop
-			IL_013b: ldloc.1
-			IL_013c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0141: dup
-			IL_0142: brtrue IL_0155
+			IL_0198: pop
+			IL_0199: ldloc.1
+			IL_019a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_019f: dup
+			IL_01a0: brtrue IL_01b3
 
-			IL_0147: pop
-			IL_0148: rethrow
+			IL_01a5: pop
+			IL_01a6: rethrow
 
-			IL_014a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_014f: stloc.2
-			IL_0150: br IL_0156
+			IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_01ad: stloc.2
+			IL_01ae: br IL_01b4
 
-			IL_0155: stloc.2
+			IL_01b3: stloc.2
 
-			IL_0156: ldloc.2
-			IL_0157: stloc.3
-			IL_0158: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_015d: stloc.s 11
-			IL_015f: ldloc.s 11
-			IL_0161: ldstr "bad token threw:"
-			IL_0166: ldc.i4.1
-			IL_0167: box [System.Runtime]System.Boolean
-			IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0171: pop
-			IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0177: stloc.s 11
-			IL_0179: volatile.
-			IL_017b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_0180: brfalse IL_0195
+			IL_01b4: ldloc.2
+			IL_01b5: stloc.3
+			IL_01b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01bb: stloc.s 11
+			IL_01bd: ldloc.s 11
+			IL_01bf: ldstr "bad token threw:"
+			IL_01c4: ldc.i4.1
+			IL_01c5: box [System.Runtime]System.Boolean
+			IL_01ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01cf: pop
+			IL_01d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01d5: stloc.s 11
+			IL_01d7: volatile.
+			IL_01d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_01de: brfalse IL_01f3
 
-			IL_0185: ldloc.3
-			IL_0186: ldstr "name"
-			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0190: br IL_01aa
+			IL_01e3: ldloc.3
+			IL_01e4: ldstr "name"
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ee: br IL_0208
 
-			IL_0195: ldloc.3
-			IL_0196: ldstr "name"
-			IL_019b: ldstr "FinalizationRegistry_Unregister_Basic:Modules.FinalizationRegistry_Unregister_Basic:__js_module_init__:58"
-			IL_01a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01f3: ldloc.3
+			IL_01f4: ldstr "name"
+			IL_01f9: ldstr "FinalizationRegistry_Unregister_Basic:Modules.FinalizationRegistry_Unregister_Basic:__js_module_init__:58"
+			IL_01fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01aa: stloc.s 12
-			IL_01ac: ldloc.s 11
-			IL_01ae: ldstr "bad token name:"
-			IL_01b3: ldloc.s 12
-			IL_01b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01ba: pop
-			IL_01bb: leave IL_01c0
+			IL_0208: stloc.s 12
+			IL_020a: ldloc.s 11
+			IL_020c: ldstr "bad token name:"
+			IL_0211: ldloc.s 12
+			IL_0213: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0218: pop
+			IL_0219: leave IL_021e
 		} // end handler
 
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
-		IL_01c5: pop
-		IL_01c6: ldc.i4.1
-		IL_01c7: newarr [System.Runtime]System.Object
-		IL_01cc: dup
-		IL_01cd: ldc.i4.0
-		IL_01ce: ldloc.0
-		IL_01cf: stelem.ref
-		IL_01d0: stloc.s 6
-		IL_01d2: ldloc.s 6
-		IL_01d4: ldc.i4.0
-		IL_01d5: ldelem.ref
-		IL_01d6: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
-		IL_01db: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14/FunctionObject::.ctor(class Modules.FinalizationRegistry_Unregister_Basic/Scope)
-		IL_01e0: ldc.i4.0
-		IL_01e1: conv.r8
-		IL_01e2: ldstr ""
-		IL_01e7: ldc.i4.0
-		IL_01e8: ldc.i4.0
-		IL_01e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14/FunctionObject>(!!0)
-		IL_01f3: stloc.s 13
-		IL_01f5: ldloc.s 13
-		IL_01f7: ldc.i4.0
-		IL_01f8: newarr [System.Runtime]System.Object
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0202: pop
-		IL_0203: ldnull
-		IL_0204: stloc.s 4
-		IL_0206: ret
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::gc()
+		IL_0223: pop
+		IL_0224: ldc.i4.1
+		IL_0225: newarr [System.Runtime]System.Object
+		IL_022a: dup
+		IL_022b: ldc.i4.0
+		IL_022c: ldloc.0
+		IL_022d: stelem.ref
+		IL_022e: stloc.s 6
+		IL_0230: ldloc.s 6
+		IL_0232: ldc.i4.0
+		IL_0233: ldelem.ref
+		IL_0234: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
+		IL_0239: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14/FunctionObject::.ctor(class Modules.FinalizationRegistry_Unregister_Basic/Scope)
+		IL_023e: ldc.i4.0
+		IL_023f: conv.r8
+		IL_0240: ldstr ""
+		IL_0245: ldc.i4.0
+		IL_0246: ldc.i4.0
+		IL_0247: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_024c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14/FunctionObject>(!!0)
+		IL_0251: stloc.s 13
+		IL_0253: ldloc.s 13
+		IL_0255: ldc.i4.0
+		IL_0256: newarr [System.Runtime]System.Object
+		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0260: pop
+		IL_0261: ldnull
+		IL_0262: stloc.s 4
+		IL_0264: ret
 	} // end of method FinalizationRegistry_Unregister_Basic::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Unregister_Basic
@@ -835,6 +862,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ApplyBind_DominoPushAll.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ApplyBind_DominoPushAll.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 570 (0x23a)
+		// Code size: 611 (0x263)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ApplyBind_DominoPushAll/Scope,
@@ -188,108 +188,121 @@
 		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_00ee: stloc.s 5
-		IL_00f0: ldloc.s 4
-		IL_00f2: ldstr "bind"
-		IL_00f7: ldloc.s 5
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fe: stloc.1
-		IL_00ff: ldc.i4.0
-		IL_0100: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0105: stloc.2
-		IL_0106: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_010b: stloc.s 6
-		IL_010d: ldc.i4.3
-		IL_010e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0113: dup
-		IL_0114: ldc.r8 1
-		IL_011d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0122: dup
-		IL_0123: ldc.r8 2
-		IL_012c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0131: dup
-		IL_0132: ldc.r8 3
-		IL_013b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0140: stloc.s 7
-		IL_0142: ldloc.1
-		IL_0143: ldloc.s 6
-		IL_0145: ldloc.2
-		IL_0146: ldloc.s 7
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_014d: pop
-		IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0153: stloc.s 8
-		IL_0155: ldloc.2
-		IL_0156: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_015b: box [System.Runtime]System.Double
-		IL_0160: stloc.s 9
-		IL_0162: ldloc.s 8
-		IL_0164: ldloc.s 9
-		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_016b: pop
-		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0171: stloc.s 8
-		IL_0173: ldloc.2
-		IL_0174: ldc.r8 0.0
-		IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0182: stloc.s 5
-		IL_0184: ldloc.s 8
-		IL_0186: ldloc.s 5
-		IL_0188: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018d: pop
-		IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0193: stloc.s 8
-		IL_0195: ldloc.2
-		IL_0196: ldc.r8 2
-		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01a4: stloc.s 5
-		IL_01a6: ldloc.s 8
-		IL_01a8: ldloc.s 5
-		IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01af: pop
-		IL_01b0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b5: stloc.s 6
-		IL_01b7: ldc.i4.2
-		IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01bd: dup
-		IL_01be: ldc.r8 4
-		IL_01c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01cc: dup
-		IL_01cd: ldc.r8 5
-		IL_01d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01db: stloc.s 7
-		IL_01dd: ldloc.1
-		IL_01de: ldloc.s 6
-		IL_01e0: ldloc.2
-		IL_01e1: ldloc.s 7
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01e8: stloc.3
-		IL_01e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ee: stloc.s 8
-		IL_01f0: ldloc.s 8
-		IL_01f2: ldloc.3
-		IL_01f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01f8: pop
-		IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fe: stloc.s 8
-		IL_0200: ldloc.2
-		IL_0201: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0206: box [System.Runtime]System.Double
-		IL_020b: stloc.s 9
-		IL_020d: ldloc.s 8
-		IL_020f: ldloc.s 9
-		IL_0211: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0216: pop
-		IL_0217: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021c: stloc.s 8
-		IL_021e: ldloc.2
-		IL_021f: ldc.r8 4
-		IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_022d: stloc.s 5
-		IL_022f: ldloc.s 8
-		IL_0231: ldloc.s 5
-		IL_0233: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0238: pop
-		IL_0239: ret
+		IL_00f0: volatile.
+		IL_00f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00f7: brfalse IL_010f
+
+		IL_00fc: ldloc.s 4
+		IL_00fe: ldstr "bind"
+		IL_0103: ldloc.s 5
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010a: br IL_0127
+
+		IL_010f: ldloc.s 4
+		IL_0111: ldstr "bind"
+		IL_0116: ldloc.s 5
+		IL_0118: ldstr "Function_ApplyBind_DominoPushAll:Modules.Function_ApplyBind_DominoPushAll:__js_module_init__:17"
+		IL_011d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0127: stloc.1
+		IL_0128: ldc.i4.0
+		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_012e: stloc.2
+		IL_012f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0134: stloc.s 6
+		IL_0136: ldc.i4.3
+		IL_0137: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_013c: dup
+		IL_013d: ldc.r8 1
+		IL_0146: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_014b: dup
+		IL_014c: ldc.r8 2
+		IL_0155: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_015a: dup
+		IL_015b: ldc.r8 3
+		IL_0164: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0169: stloc.s 7
+		IL_016b: ldloc.1
+		IL_016c: ldloc.s 6
+		IL_016e: ldloc.2
+		IL_016f: ldloc.s 7
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0176: pop
+		IL_0177: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017c: stloc.s 8
+		IL_017e: ldloc.2
+		IL_017f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0184: box [System.Runtime]System.Double
+		IL_0189: stloc.s 9
+		IL_018b: ldloc.s 8
+		IL_018d: ldloc.s 9
+		IL_018f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0194: pop
+		IL_0195: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019a: stloc.s 8
+		IL_019c: ldloc.2
+		IL_019d: ldc.r8 0.0
+		IL_01a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01ab: stloc.s 5
+		IL_01ad: ldloc.s 8
+		IL_01af: ldloc.s 5
+		IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b6: pop
+		IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01bc: stloc.s 8
+		IL_01be: ldloc.2
+		IL_01bf: ldc.r8 2
+		IL_01c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01cd: stloc.s 5
+		IL_01cf: ldloc.s 8
+		IL_01d1: ldloc.s 5
+		IL_01d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d8: pop
+		IL_01d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01de: stloc.s 6
+		IL_01e0: ldc.i4.2
+		IL_01e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01e6: dup
+		IL_01e7: ldc.r8 4
+		IL_01f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01f5: dup
+		IL_01f6: ldc.r8 5
+		IL_01ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0204: stloc.s 7
+		IL_0206: ldloc.1
+		IL_0207: ldloc.s 6
+		IL_0209: ldloc.2
+		IL_020a: ldloc.s 7
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0211: stloc.3
+		IL_0212: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0217: stloc.s 8
+		IL_0219: ldloc.s 8
+		IL_021b: ldloc.3
+		IL_021c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0221: pop
+		IL_0222: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0227: stloc.s 8
+		IL_0229: ldloc.2
+		IL_022a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_022f: box [System.Runtime]System.Double
+		IL_0234: stloc.s 9
+		IL_0236: ldloc.s 8
+		IL_0238: ldloc.s 9
+		IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_023f: pop
+		IL_0240: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0245: stloc.s 8
+		IL_0247: ldloc.2
+		IL_0248: ldc.r8 4
+		IL_0251: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0256: stloc.s 5
+		IL_0258: ldloc.s 8
+		IL_025a: ldloc.s 5
+		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0261: pop
+		IL_0262: ret
 	} // end of method Function_ApplyBind_DominoPushAll::__js_module_init__
 
 } // end of class Modules.Function_ApplyBind_DominoPushAll
@@ -323,6 +336,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_CalleeIdentity.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_CalleeIdentity.verified.txt
@@ -273,7 +273,7 @@
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
 			// Header size: 12
-			// Code size: 224 (0xe0)
+			// Code size: 304 (0x130)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Arguments_CalleeIdentity/inspect/Scope,
@@ -324,41 +324,67 @@
 			IL_006b: ldloc.s 4
 			IL_006d: box [System.Runtime]System.Boolean
 			IL_0072: stloc.s 5
-			IL_0074: ldloc.1
-			IL_0075: ldstr "log"
-			IL_007a: ldloc.s 5
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0081: pop
-			IL_0082: ldstr "console"
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0091: stloc.1
-			IL_0092: ldloc.0
-			IL_0093: ldfld object Modules.Function_Arguments_CalleeIdentity/inspect/Scope::arguments
-			IL_0098: volatile.
-			IL_009a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_009f: brfalse IL_00b3
+			IL_0074: volatile.
+			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_007b: brfalse IL_0092
 
-			IL_00a4: ldstr "callee"
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ae: br IL_00c7
+			IL_0080: ldloc.1
+			IL_0081: ldstr "log"
+			IL_0086: ldloc.s 5
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_008d: br IL_00a9
 
-			IL_00b3: ldstr "callee"
-			IL_00b8: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M4>:__js_call__:18"
-			IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0092: ldloc.1
+			IL_0093: ldstr "log"
+			IL_0098: ldloc.s 5
+			IL_009a: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M4>:__js_call__:11"
+			IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_00c7: stloc.3
-			IL_00c8: ldloc.3
-			IL_00c9: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_00ce: stloc.s 6
-			IL_00d0: ldloc.1
-			IL_00d1: ldstr "log"
-			IL_00d6: ldloc.s 6
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00dd: pop
-			IL_00de: ldnull
-			IL_00df: ret
+			IL_00a9: pop
+			IL_00aa: ldstr "console"
+			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b9: stloc.1
+			IL_00ba: ldloc.0
+			IL_00bb: ldfld object Modules.Function_Arguments_CalleeIdentity/inspect/Scope::arguments
+			IL_00c0: volatile.
+			IL_00c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_00c7: brfalse IL_00db
+
+			IL_00cc: ldstr "callee"
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d6: br IL_00ef
+
+			IL_00db: ldstr "callee"
+			IL_00e0: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M4>:__js_call__:18"
+			IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_00ef: stloc.3
+			IL_00f0: ldloc.3
+			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_00f6: stloc.s 6
+			IL_00f8: volatile.
+			IL_00fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_00ff: brfalse IL_0116
+
+			IL_0104: ldloc.1
+			IL_0105: ldstr "log"
+			IL_010a: ldloc.s 6
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0111: br IL_012d
+
+			IL_0116: ldloc.1
+			IL_0117: ldstr "log"
+			IL_011c: ldloc.s 6
+			IL_011e: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M4>:__js_call__:20"
+			IL_0123: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_012d: pop
+			IL_012e: ldnull
+			IL_012f: ret
 		} // end of method inspect::__js_call__
 
 	} // end of class inspect
@@ -563,7 +589,7 @@
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 106 (0x6a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -588,13 +614,26 @@
 			IL_002d: ldloc.2
 			IL_002e: box [System.Runtime]System.Boolean
 			IL_0033: stloc.3
-			IL_0034: ldloc.0
-			IL_0035: ldstr "log"
-			IL_003a: ldloc.3
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0040: pop
-			IL_0041: ldnull
-			IL_0042: ret
+			IL_0034: volatile.
+			IL_0036: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_003b: brfalse IL_0051
+
+			IL_0040: ldloc.0
+			IL_0041: ldstr "log"
+			IL_0046: ldloc.3
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_004c: br IL_0067
+
+			IL_0051: ldloc.0
+			IL_0052: ldstr "log"
+			IL_0057: ldloc.3
+			IL_0058: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M5>:__js_call__:9"
+			IL_005d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0067: pop
+			IL_0068: ldnull
+			IL_0069: ret
 		} // end of method spreadThis::__js_call__
 
 	} // end of class spreadThis
@@ -800,7 +839,7 @@
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
 			// Header size: 12
-			// Code size: 351 (0x15f)
+			// Code size: 431 (0x1af)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Arguments_CalleeIdentity/outer/Scope,
@@ -830,7 +869,7 @@
 			IL_0025: ldloc.0
 			IL_0026: ldfld object Modules.Function_Arguments_CalleeIdentity/outer/Scope::arguments
 			IL_002b: volatile.
-			IL_002d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_002d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_0032: brfalse IL_0046
 
 			IL_0037: ldstr "callee"
@@ -839,7 +878,7 @@
 
 			IL_0046: ldstr "callee"
 			IL_004b: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M6>:__js_call__:7"
-			IL_0050: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0050: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_005a: stloc.2
@@ -853,83 +892,109 @@
 			IL_006b: ldloc.s 4
 			IL_006d: box [System.Runtime]System.Boolean
 			IL_0072: stloc.s 5
-			IL_0074: ldloc.1
-			IL_0075: ldstr "log"
-			IL_007a: ldloc.s 5
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0081: pop
-			IL_0082: ldarg.0
-			IL_0083: ldfld object Modules.Function_Arguments_CalleeIdentity/Scope::inspect
-			IL_0088: stloc.1
-			IL_0089: ldc.i4.0
-			IL_008a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_008f: stloc.s 6
-			IL_0091: ldc.i4.3
-			IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0097: dup
-			IL_0098: ldc.r8 1
-			IL_00a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_00a6: dup
-			IL_00a7: ldc.r8 2
-			IL_00b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_00b5: dup
-			IL_00b6: ldc.r8 3
-			IL_00bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_00c4: stloc.s 7
-			IL_00c6: ldloc.s 6
-			IL_00c8: ldloc.s 7
-			IL_00ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-			IL_00cf: ldloc.s 6
-			IL_00d1: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-			IL_00d6: stloc.s 8
-			IL_00d8: ldloc.1
-			IL_00d9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			IL_00de: ldc.i4.1
-			IL_00df: newarr [System.Runtime]System.Object
-			IL_00e4: dup
-			IL_00e5: ldc.i4.0
-			IL_00e6: ldarg.0
-			IL_00e7: stelem.ref
-			IL_00e8: ldloc.s 8
-			IL_00ea: call object Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
-			IL_00ef: pop
-			IL_00f0: ldstr "console"
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ff: stloc.1
-			IL_0100: ldloc.0
-			IL_0101: ldfld object Modules.Function_Arguments_CalleeIdentity/outer/Scope::arguments
-			IL_0106: volatile.
-			IL_0108: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_010d: brfalse IL_0121
+			IL_0074: volatile.
+			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_007b: brfalse IL_0092
 
-			IL_0112: ldstr "callee"
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_011c: br IL_0135
+			IL_0080: ldloc.1
+			IL_0081: ldstr "log"
+			IL_0086: ldloc.s 5
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_008d: br IL_00a9
 
-			IL_0121: ldstr "callee"
-			IL_0126: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M6>:__js_call__:29"
-			IL_012b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0092: ldloc.1
+			IL_0093: ldstr "log"
+			IL_0098: ldloc.s 5
+			IL_009a: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M6>:__js_call__:11"
+			IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0135: stloc.3
-			IL_0136: ldarg.0
-			IL_0137: ldfld object Modules.Function_Arguments_CalleeIdentity/Scope::outer
-			IL_013c: stloc.2
-			IL_013d: ldloc.3
-			IL_013e: ldloc.2
-			IL_013f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0144: stloc.s 4
-			IL_0146: ldloc.s 4
-			IL_0148: box [System.Runtime]System.Boolean
-			IL_014d: stloc.s 5
-			IL_014f: ldloc.1
-			IL_0150: ldstr "log"
-			IL_0155: ldloc.s 5
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_015c: pop
-			IL_015d: ldnull
-			IL_015e: ret
+			IL_00a9: pop
+			IL_00aa: ldarg.0
+			IL_00ab: ldfld object Modules.Function_Arguments_CalleeIdentity/Scope::inspect
+			IL_00b0: stloc.1
+			IL_00b1: ldc.i4.0
+			IL_00b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00b7: stloc.s 6
+			IL_00b9: ldc.i4.3
+			IL_00ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00bf: dup
+			IL_00c0: ldc.r8 1
+			IL_00c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_00ce: dup
+			IL_00cf: ldc.r8 2
+			IL_00d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_00dd: dup
+			IL_00de: ldc.r8 3
+			IL_00e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_00ec: stloc.s 7
+			IL_00ee: ldloc.s 6
+			IL_00f0: ldloc.s 7
+			IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+			IL_00f7: ldloc.s 6
+			IL_00f9: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+			IL_00fe: stloc.s 8
+			IL_0100: ldloc.1
+			IL_0101: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			IL_0106: ldc.i4.1
+			IL_0107: newarr [System.Runtime]System.Object
+			IL_010c: dup
+			IL_010d: ldc.i4.0
+			IL_010e: ldarg.0
+			IL_010f: stelem.ref
+			IL_0110: ldloc.s 8
+			IL_0112: call object Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+			IL_0117: pop
+			IL_0118: ldstr "console"
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0127: stloc.1
+			IL_0128: ldloc.0
+			IL_0129: ldfld object Modules.Function_Arguments_CalleeIdentity/outer/Scope::arguments
+			IL_012e: volatile.
+			IL_0130: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0135: brfalse IL_0149
+
+			IL_013a: ldstr "callee"
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0144: br IL_015d
+
+			IL_0149: ldstr "callee"
+			IL_014e: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M6>:__js_call__:29"
+			IL_0153: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_015d: stloc.3
+			IL_015e: ldarg.0
+			IL_015f: ldfld object Modules.Function_Arguments_CalleeIdentity/Scope::outer
+			IL_0164: stloc.2
+			IL_0165: ldloc.3
+			IL_0166: ldloc.2
+			IL_0167: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_016c: stloc.s 4
+			IL_016e: ldloc.s 4
+			IL_0170: box [System.Runtime]System.Boolean
+			IL_0175: stloc.s 5
+			IL_0177: volatile.
+			IL_0179: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_017e: brfalse IL_0195
+
+			IL_0183: ldloc.1
+			IL_0184: ldstr "log"
+			IL_0189: ldloc.s 5
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0190: br IL_01ac
+
+			IL_0195: ldloc.1
+			IL_0196: ldstr "log"
+			IL_019b: ldloc.s 5
+			IL_019d: ldstr "Function_Arguments_CalleeIdentity:<TwoPhaseDummy_M6>:__js_call__:33"
+			IL_01a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_01ac: pop
+			IL_01ad: ldnull
+			IL_01ae: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -1159,6 +1224,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Length_Delete.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Length_Delete.verified.txt
@@ -277,7 +277,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 342 (0x156)
+			// Code size: 384 (0x180)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/Scope,
@@ -322,7 +322,7 @@
 			IL_004c: ldloc.0
 			IL_004d: ldfld object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/Scope::arguments
 			IL_0052: volatile.
-			IL_0054: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0054: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0059: brfalse IL_006d
 
 			IL_005e: ldstr "length"
@@ -331,7 +331,7 @@
 
 			IL_006d: ldstr "length"
 			IL_0072: ldstr "Function_Arguments_Length_Delete:<TwoPhaseDummy_M4>:__js_call__:9"
-			IL_0077: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0077: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0081: stloc.2
@@ -376,7 +376,7 @@
 			IL_00e4: ldloc.0
 			IL_00e5: ldfld object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/Scope::arguments
 			IL_00ea: volatile.
-			IL_00ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_00ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_00f1: brfalse IL_0105
 
 			IL_00f6: ldstr "length"
@@ -385,7 +385,7 @@
 
 			IL_0105: ldstr "length"
 			IL_010a: ldstr "Function_Arguments_Length_Delete:<TwoPhaseDummy_M4>:__js_call__:30"
-			IL_010f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_010f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0119: stloc.2
@@ -403,16 +403,28 @@
 			IL_0135: stloc.2
 			IL_0136: ldloc.2
 			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013c: ldstr "join"
-			IL_0141: ldstr ","
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_014b: stloc.2
-			IL_014c: ldloc.1
-			IL_014d: ldloc.2
-			IL_014e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0153: pop
-			IL_0154: ldnull
-			IL_0155: ret
+			IL_013c: volatile.
+			IL_013e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0143: brfalse IL_015c
+
+			IL_0148: ldstr "join"
+			IL_014d: ldstr ","
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0157: br IL_0175
+
+			IL_015c: ldstr "join"
+			IL_0161: ldstr ","
+			IL_0166: ldstr "Function_Arguments_Length_Delete:<TwoPhaseDummy_M4>:__js_call__:38"
+			IL_016b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0175: stloc.2
+			IL_0176: ldloc.1
+			IL_0177: ldloc.2
+			IL_0178: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_017d: pop
+			IL_017e: ldnull
+			IL_017f: ret
 		} // end of method '<>DynamicFunction_L3C16'::__js_call__
 
 	} // end of class <>DynamicFunction_L3C16
@@ -652,7 +664,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 429 (0x1ad)
+		// Code size: 471 (0x1d7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Length_Delete/Scope,
@@ -796,15 +808,27 @@
 		IL_0186: ldloc.3
 		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
 		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0191: ldstr "join"
-		IL_0196: ldstr ","
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a0: stloc.s 6
-		IL_01a2: ldloc.s 5
-		IL_01a4: ldloc.s 6
-		IL_01a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ab: pop
-		IL_01ac: ret
+		IL_0191: volatile.
+		IL_0193: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0198: brfalse IL_01b1
+
+		IL_019d: ldstr "join"
+		IL_01a2: ldstr ","
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ac: br IL_01ca
+
+		IL_01b1: ldstr "join"
+		IL_01b6: ldstr ","
+		IL_01bb: ldstr "Function_Arguments_Length_Delete:Modules.Function_Arguments_Length_Delete:__js_module_init__:54"
+		IL_01c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01ca: stloc.s 6
+		IL_01cc: ldloc.s 5
+		IL_01ce: ldloc.s 6
+		IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d5: pop
+		IL_01d6: ret
 	} // end of method Function_Arguments_Length_Delete::__js_module_init__
 
 } // end of class Modules.Function_Arguments_Length_Delete
@@ -838,6 +862,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_MappedParameterAliasing.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_MappedParameterAliasing.verified.txt
@@ -277,7 +277,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 484 (0x1e4)
+			// Code size: 526 (0x20e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/Scope,
@@ -445,16 +445,28 @@
 			IL_01c3: stloc.2
 			IL_01c4: ldloc.2
 			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ca: ldstr "join"
-			IL_01cf: ldstr ","
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01d9: stloc.2
-			IL_01da: ldloc.1
-			IL_01db: ldloc.2
-			IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01e1: pop
-			IL_01e2: ldnull
-			IL_01e3: ret
+			IL_01ca: volatile.
+			IL_01cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_01d1: brfalse IL_01ea
+
+			IL_01d6: ldstr "join"
+			IL_01db: ldstr ","
+			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01e5: br IL_0203
+
+			IL_01ea: ldstr "join"
+			IL_01ef: ldstr ","
+			IL_01f4: ldstr "Function_Arguments_MappedParameterAliasing:<TwoPhaseDummy_M4>:__js_call__:69"
+			IL_01f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0203: stloc.2
+			IL_0204: ldloc.1
+			IL_0205: ldloc.2
+			IL_0206: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_020b: pop
+			IL_020c: ldnull
+			IL_020d: ret
 		} // end of method '<>DynamicFunction_L3C16'::__js_call__
 
 	} // end of class <>DynamicFunction_L3C16
@@ -558,6 +570,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Unmapped_StrictAndComplex.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Unmapped_StrictAndComplex.verified.txt
@@ -536,7 +536,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 303 (0x12f)
+			// Code size: 345 (0x159)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/Scope,
@@ -633,16 +633,28 @@
 			IL_010e: stloc.2
 			IL_010f: ldloc.2
 			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0115: ldstr "join"
-			IL_011a: ldstr ","
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0124: stloc.2
-			IL_0125: ldloc.1
-			IL_0126: ldloc.2
-			IL_0127: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_012c: pop
-			IL_012d: ldnull
-			IL_012e: ret
+			IL_0115: volatile.
+			IL_0117: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_011c: brfalse IL_0135
+
+			IL_0121: ldstr "join"
+			IL_0126: ldstr ","
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0130: br IL_014e
+
+			IL_0135: ldstr "join"
+			IL_013a: ldstr ","
+			IL_013f: ldstr "Function_Arguments_Unmapped_StrictAndComplex:<TwoPhaseDummy_M5>:__js_call__:52"
+			IL_0144: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_014e: stloc.2
+			IL_014f: ldloc.1
+			IL_0150: ldloc.2
+			IL_0151: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0156: pop
+			IL_0157: ldnull
+			IL_0158: ret
 		} // end of method '<>DynamicFunction_L9C19'::__js_call__
 
 	} // end of class <>DynamicFunction_L9C19
@@ -762,4 +774,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
@@ -229,7 +229,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -244,7 +244,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
 			IL_0036: ldstr "Function_Bind_ThisBinding_IgnoresCallReceiver:<TwoPhaseDummy_M4>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -296,7 +296,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 164 (0xa4)
+		// Code size: 256 (0x100)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/Scope,
@@ -334,34 +334,61 @@
 		IL_0033: ldc.r8 7
 		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_0041: stloc.2
-		IL_0042: ldloc.1
-		IL_0043: ldstr "bind"
-		IL_0048: ldloc.2
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004e: stloc.3
-		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0054: dup
-		IL_0055: ldstr "base"
-		IL_005a: ldc.r8 100
-		IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0068: dup
-		IL_0069: ldstr "m"
-		IL_006e: ldloc.3
-		IL_006f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0074: stloc.s 4
-		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007b: stloc.s 6
-		IL_007d: ldloc.s 4
-		IL_007f: ldstr "m"
-		IL_0084: ldc.r8 5
-		IL_008d: box [System.Runtime]System.Double
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0097: stloc.s 7
-		IL_0099: ldloc.s 6
-		IL_009b: ldloc.s 7
-		IL_009d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a2: pop
-		IL_00a3: ret
+		IL_0042: volatile.
+		IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0049: brfalse IL_005f
+
+		IL_004e: ldloc.1
+		IL_004f: ldstr "bind"
+		IL_0054: ldloc.2
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005a: br IL_0075
+
+		IL_005f: ldloc.1
+		IL_0060: ldstr "bind"
+		IL_0065: ldloc.2
+		IL_0066: ldstr "Function_Bind_ThisBinding_IgnoresCallReceiver:Modules.Function_Bind_ThisBinding_IgnoresCallReceiver:__js_module_init__:12"
+		IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0075: stloc.3
+		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_007b: dup
+		IL_007c: ldstr "base"
+		IL_0081: ldc.r8 100
+		IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_008f: dup
+		IL_0090: ldstr "m"
+		IL_0095: ldloc.3
+		IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_009b: stloc.s 4
+		IL_009d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a2: stloc.s 6
+		IL_00a4: volatile.
+		IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ab: brfalse IL_00cf
+
+		IL_00b0: ldloc.s 4
+		IL_00b2: ldstr "m"
+		IL_00b7: ldc.r8 5
+		IL_00c0: box [System.Runtime]System.Double
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ca: br IL_00f3
+
+		IL_00cf: ldloc.s 4
+		IL_00d1: ldstr "m"
+		IL_00d6: ldc.r8 5
+		IL_00df: box [System.Runtime]System.Double
+		IL_00e4: ldstr "Function_Bind_ThisBinding_IgnoresCallReceiver:Modules.Function_Bind_ThisBinding_IgnoresCallReceiver:__js_module_init__:22"
+		IL_00e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f3: stloc.s 7
+		IL_00f5: ldloc.s 6
+		IL_00f7: ldloc.s 7
+		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fe: pop
+		IL_00ff: ret
 	} // end of method Function_Bind_ThisBinding_IgnoresCallReceiver::__js_module_init__
 
 } // end of class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver
@@ -392,6 +419,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
@@ -243,7 +243,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -258,7 +258,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
 			IL_0036: ldstr "Function_BoundFunctionObject_UnifiedTargets:<TwoPhaseDummy_M4>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -393,7 +393,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -408,7 +408,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "value"
 			IL_0036: ldstr "Function_BoundFunctionObject_UnifiedTargets:<TwoPhaseDummy_M5>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -887,7 +887,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2235 (0x8bb)
+		// Code size: 2274 (0x8e2)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_BoundFunctionObject_UnifiedTargets/Scope,
@@ -1338,337 +1338,349 @@
 		IL_050b: ldc.r8 100
 		IL_0514: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_0519: stloc.s 17
-		IL_051b: ldstr "call"
-		IL_0520: ldloc.s 17
-		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0527: stloc.s 22
-		IL_0529: ldloc.s 18
-		IL_052b: ldstr "method"
-		IL_0530: ldloc.s 23
-		IL_0532: ldloc.s 22
-		IL_0534: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0539: pop
-		IL_053a: ldc.i4.1
-		IL_053b: newarr [System.Runtime]System.Object
-		IL_0540: dup
-		IL_0541: ldc.i4.0
-		IL_0542: ldloc.0
-		IL_0543: stelem.ref
-		IL_0544: stloc.s 16
-		IL_0546: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject::.ctor()
-		IL_054b: ldc.i4.1
-		IL_054c: conv.r8
-		IL_054d: ldstr ""
-		IL_0552: ldc.i4.0
-		IL_0553: ldc.i4.0
-		IL_0554: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0559: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0)
-		IL_055e: stloc.s 31
-		IL_0560: ldloc.s 31
-		IL_0562: ldstr "arrow"
-		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_056c: stloc.s 6
-		IL_056e: ldloc.s 6
-		IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0575: ldstr "bind"
+		IL_051b: volatile.
+		IL_051d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0522: brfalse IL_0538
+
+		IL_0527: ldstr "call"
+		IL_052c: ldloc.s 17
+		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0533: br IL_054e
+
+		IL_0538: ldstr "call"
+		IL_053d: ldloc.s 17
+		IL_053f: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:123"
+		IL_0544: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_054e: stloc.s 22
+		IL_0550: ldloc.s 18
+		IL_0552: ldstr "method"
+		IL_0557: ldloc.s 23
+		IL_0559: ldloc.s 22
+		IL_055b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0560: pop
+		IL_0561: ldc.i4.1
+		IL_0562: newarr [System.Runtime]System.Object
+		IL_0567: dup
+		IL_0568: ldc.i4.0
+		IL_0569: ldloc.0
+		IL_056a: stelem.ref
+		IL_056b: stloc.s 16
+		IL_056d: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject::.ctor()
+		IL_0572: ldc.i4.1
+		IL_0573: conv.r8
+		IL_0574: ldstr ""
+		IL_0579: ldc.i4.0
 		IL_057a: ldc.i4.0
-		IL_057b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0580: ldc.r8 4
-		IL_0589: box [System.Runtime]System.Double
-		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0593: stloc.s 7
-		IL_0595: ldc.i4.0
-		IL_0596: box [System.Runtime]System.Boolean
-		IL_059b: stloc.s 8
+		IL_057b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0580: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0)
+		IL_0585: stloc.s 31
+		IL_0587: ldloc.s 31
+		IL_0589: ldstr "arrow"
+		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0593: stloc.s 6
+		IL_0595: ldloc.s 6
+		IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_059c: ldstr "bind"
+		IL_05a1: ldc.i4.0
+		IL_05a2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_05a7: ldc.r8 4
+		IL_05b0: box [System.Runtime]System.Double
+		IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05ba: stloc.s 7
+		IL_05bc: ldc.i4.0
+		IL_05bd: box [System.Runtime]System.Boolean
+		IL_05c2: stloc.s 8
 		.try
 		{
-			IL_059d: nop
-			IL_059e: ldstr "Reflect"
-			IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ad: ldc.i4.0
-			IL_05ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_05b3: stloc.s 21
-			IL_05b5: ldstr "construct"
-			IL_05ba: ldloc.s 7
-			IL_05bc: ldloc.s 21
-			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_05c3: pop
-			IL_05c4: leave IL_0628
+			IL_05c4: nop
+			IL_05c5: ldstr "Reflect"
+			IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05d4: ldc.i4.0
+			IL_05d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_05da: stloc.s 21
+			IL_05dc: ldstr "construct"
+			IL_05e1: ldloc.s 7
+			IL_05e3: ldloc.s 21
+			IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_05ea: pop
+			IL_05eb: leave IL_064f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_05c9: stloc.s 9
-			IL_05cb: ldloc.s 9
-			IL_05cd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_05d2: dup
-			IL_05d3: brtrue IL_05e9
+			IL_05f0: stloc.s 9
+			IL_05f2: ldloc.s 9
+			IL_05f4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05f9: dup
+			IL_05fa: brtrue IL_0610
 
-			IL_05d8: pop
-			IL_05d9: ldloc.s 9
-			IL_05db: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_05e0: dup
-			IL_05e1: brtrue IL_05f5
+			IL_05ff: pop
+			IL_0600: ldloc.s 9
+			IL_0602: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0607: dup
+			IL_0608: brtrue IL_061c
 
-			IL_05e6: pop
-			IL_05e7: rethrow
+			IL_060d: pop
+			IL_060e: rethrow
 
-			IL_05e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_05ee: stloc.s 10
-			IL_05f0: br IL_05f7
+			IL_0610: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0615: stloc.s 10
+			IL_0617: br IL_061e
 
-			IL_05f5: stloc.s 10
+			IL_061c: stloc.s 10
 
-			IL_05f7: ldloc.s 10
-			IL_05f9: stloc.s 11
-			IL_05fb: ldloc.s 11
-			IL_05fd: stloc.s 22
-			IL_05ff: ldstr "TypeError"
-			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0609: stloc.s 23
-			IL_060b: ldloc.s 22
-			IL_060d: ldloc.s 23
-			IL_060f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0614: stloc.s 28
-			IL_0616: ldloc.s 28
-			IL_0618: box [System.Runtime]System.Boolean
-			IL_061d: stloc.s 29
-			IL_061f: ldloc.s 29
-			IL_0621: stloc.s 8
-			IL_0623: leave IL_0628
+			IL_061e: ldloc.s 10
+			IL_0620: stloc.s 11
+			IL_0622: ldloc.s 11
+			IL_0624: stloc.s 22
+			IL_0626: ldstr "TypeError"
+			IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0630: stloc.s 23
+			IL_0632: ldloc.s 22
+			IL_0634: ldloc.s 23
+			IL_0636: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_063b: stloc.s 28
+			IL_063d: ldloc.s 28
+			IL_063f: box [System.Runtime]System.Boolean
+			IL_0644: stloc.s 29
+			IL_0646: ldloc.s 29
+			IL_0648: stloc.s 8
+			IL_064a: leave IL_064f
 		} // end handler
 
-		IL_0628: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_062d: stloc.s 18
-		IL_062f: ldloc.s 7
-		IL_0631: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_063b: stloc.s 23
-		IL_063d: ldloc.s 18
-		IL_063f: ldstr "arrow"
-		IL_0644: ldloc.s 23
-		IL_0646: ldloc.s 8
-		IL_0648: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_064d: pop
-		IL_064e: ldc.i4.1
-		IL_064f: newarr [System.Runtime]System.Object
-		IL_0654: dup
-		IL_0655: ldc.i4.0
-		IL_0656: ldloc.0
-		IL_0657: stelem.ref
-		IL_0658: stloc.s 16
-		IL_065a: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
-		IL_065f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0664: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
-		IL_0669: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_066e: stloc.s 32
-		IL_0670: ldloc.s 16
-		IL_0672: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject::.ctor(object[])
-		IL_0677: ldloc.s 32
-		IL_0679: ldloc.s 16
-		IL_067b: ldc.i4.2
-		IL_067c: conv.r8
-		IL_067d: ldc.i4.0
-		IL_067e: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0683: castclass Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject
-		IL_0688: stloc.s 33
-		IL_068a: ldloc.s 33
-		IL_068c: stloc.s 12
-		IL_068e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0693: dup
-		IL_0694: ldstr "ignored"
-		IL_0699: ldc.i4.1
-		IL_069a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_069f: stloc.s 17
-		IL_06a1: ldloc.s 12
-		IL_06a3: ldstr "bind"
-		IL_06a8: ldloc.s 17
-		IL_06aa: ldc.r8 7
-		IL_06b3: box [System.Runtime]System.Double
-		IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06bd: stloc.s 13
-		IL_06bf: ldloc.s 13
-		IL_06c1: dup
-		IL_06c2: ldc.r8 8
-		IL_06cb: box [System.Runtime]System.Double
-		IL_06d0: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_06d5: stloc.s 14
-		IL_06d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06dc: stloc.s 18
-		IL_06de: volatile.
-		IL_06e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_06e5: brfalse IL_06fb
+		IL_064f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0654: stloc.s 18
+		IL_0656: ldloc.s 7
+		IL_0658: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0662: stloc.s 23
+		IL_0664: ldloc.s 18
+		IL_0666: ldstr "arrow"
+		IL_066b: ldloc.s 23
+		IL_066d: ldloc.s 8
+		IL_066f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0674: pop
+		IL_0675: ldc.i4.1
+		IL_0676: newarr [System.Runtime]System.Object
+		IL_067b: dup
+		IL_067c: ldc.i4.0
+		IL_067d: ldloc.0
+		IL_067e: stelem.ref
+		IL_067f: stloc.s 16
+		IL_0681: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
+		IL_0686: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_068b: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
+		IL_0690: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0695: stloc.s 32
+		IL_0697: ldloc.s 16
+		IL_0699: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject::.ctor(object[])
+		IL_069e: ldloc.s 32
+		IL_06a0: ldloc.s 16
+		IL_06a2: ldc.i4.2
+		IL_06a3: conv.r8
+		IL_06a4: ldc.i4.0
+		IL_06a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_06aa: castclass Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject
+		IL_06af: stloc.s 33
+		IL_06b1: ldloc.s 33
+		IL_06b3: stloc.s 12
+		IL_06b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_06ba: dup
+		IL_06bb: ldstr "ignored"
+		IL_06c0: ldc.i4.1
+		IL_06c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_06c6: stloc.s 17
+		IL_06c8: ldloc.s 12
+		IL_06ca: ldstr "bind"
+		IL_06cf: ldloc.s 17
+		IL_06d1: ldc.r8 7
+		IL_06da: box [System.Runtime]System.Double
+		IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_06e4: stloc.s 13
+		IL_06e6: ldloc.s 13
+		IL_06e8: dup
+		IL_06e9: ldc.r8 8
+		IL_06f2: box [System.Runtime]System.Double
+		IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_06fc: stloc.s 14
+		IL_06fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0703: stloc.s 18
+		IL_0705: volatile.
+		IL_0707: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_070c: brfalse IL_0722
 
-		IL_06ea: ldloc.s 14
-		IL_06ec: ldstr "total"
-		IL_06f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06f6: br IL_0711
+		IL_0711: ldloc.s 14
+		IL_0713: ldstr "total"
+		IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_071d: br IL_0738
 
-		IL_06fb: ldloc.s 14
-		IL_06fd: ldstr "total"
-		IL_0702: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:199"
-		IL_0707: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0722: ldloc.s 14
+		IL_0724: ldstr "total"
+		IL_0729: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:199"
+		IL_072e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0711: stloc.s 23
-		IL_0713: volatile.
-		IL_0715: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_071a: brfalse IL_0730
+		IL_0738: stloc.s 23
+		IL_073a: volatile.
+		IL_073c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0741: brfalse IL_0757
 
-		IL_071f: ldloc.s 14
-		IL_0721: ldstr "seenNewTarget"
-		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_072b: br IL_0746
+		IL_0746: ldloc.s 14
+		IL_0748: ldstr "seenNewTarget"
+		IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0752: br IL_076d
 
-		IL_0730: ldloc.s 14
-		IL_0732: ldstr "seenNewTarget"
-		IL_0737: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:201"
-		IL_073c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0757: ldloc.s 14
+		IL_0759: ldstr "seenNewTarget"
+		IL_075e: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:201"
+		IL_0763: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0768: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0746: stloc.s 22
-		IL_0748: ldloc.s 22
-		IL_074a: ldloc.s 12
-		IL_074c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0751: stloc.s 28
-		IL_0753: ldloc.s 28
-		IL_0755: box [System.Runtime]System.Boolean
-		IL_075a: stloc.s 29
-		IL_075c: ldloc.s 14
-		IL_075e: ldloc.s 12
-		IL_0760: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0765: stloc.s 28
-		IL_0767: ldloc.s 28
-		IL_0769: box [System.Runtime]System.Boolean
-		IL_076e: stloc.s 27
-		IL_0770: ldloc.s 14
-		IL_0772: ldloc.s 13
-		IL_0774: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0779: stloc.s 28
-		IL_077b: ldloc.s 28
-		IL_077d: box [System.Runtime]System.Boolean
-		IL_0782: stloc.s 26
-		IL_0784: volatile.
-		IL_0786: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_078b: brfalse IL_07a1
+		IL_076d: stloc.s 22
+		IL_076f: ldloc.s 22
+		IL_0771: ldloc.s 12
+		IL_0773: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0778: stloc.s 28
+		IL_077a: ldloc.s 28
+		IL_077c: box [System.Runtime]System.Boolean
+		IL_0781: stloc.s 29
+		IL_0783: ldloc.s 14
+		IL_0785: ldloc.s 12
+		IL_0787: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_078c: stloc.s 28
+		IL_078e: ldloc.s 28
+		IL_0790: box [System.Runtime]System.Boolean
+		IL_0795: stloc.s 27
+		IL_0797: ldloc.s 14
+		IL_0799: ldloc.s 13
+		IL_079b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_07a0: stloc.s 28
+		IL_07a2: ldloc.s 28
+		IL_07a4: box [System.Runtime]System.Boolean
+		IL_07a9: stloc.s 26
+		IL_07ab: volatile.
+		IL_07ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_07b2: brfalse IL_07c8
 
-		IL_0790: ldloc.s 13
-		IL_0792: ldstr "name"
-		IL_0797: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_079c: br IL_07b7
+		IL_07b7: ldloc.s 13
+		IL_07b9: ldstr "name"
+		IL_07be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07c3: br IL_07de
 
-		IL_07a1: ldloc.s 13
-		IL_07a3: ldstr "name"
-		IL_07a8: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:209"
-		IL_07ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07c8: ldloc.s 13
+		IL_07ca: ldstr "name"
+		IL_07cf: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:209"
+		IL_07d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07b7: stloc.s 22
-		IL_07b9: volatile.
-		IL_07bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_07c0: brfalse IL_07d6
+		IL_07de: stloc.s 22
+		IL_07e0: volatile.
+		IL_07e2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_07e7: brfalse IL_07fd
 
-		IL_07c5: ldloc.s 13
-		IL_07c7: ldstr "length"
-		IL_07cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07d1: br IL_07ec
+		IL_07ec: ldloc.s 13
+		IL_07ee: ldstr "length"
+		IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07f8: br IL_0813
 
-		IL_07d6: ldloc.s 13
-		IL_07d8: ldstr "length"
-		IL_07dd: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:211"
-		IL_07e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_07e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07fd: ldloc.s 13
+		IL_07ff: ldstr "length"
+		IL_0804: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:211"
+		IL_0809: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_080e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07ec: stloc.s 20
-		IL_07ee: ldloc.s 13
-		IL_07f0: ldstr "prototype"
-		IL_07f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_07fa: box [System.Runtime]System.Boolean
-		IL_07ff: stloc.s 25
-		IL_0801: ldloc.s 18
-		IL_0803: ldc.i4.8
-		IL_0804: newarr [System.Runtime]System.Object
-		IL_0809: dup
-		IL_080a: ldc.i4.0
-		IL_080b: ldstr "class"
-		IL_0810: stelem.ref
-		IL_0811: dup
-		IL_0812: ldc.i4.1
-		IL_0813: ldloc.s 23
-		IL_0815: stelem.ref
-		IL_0816: dup
-		IL_0817: ldc.i4.2
-		IL_0818: ldloc.s 29
-		IL_081a: stelem.ref
-		IL_081b: dup
-		IL_081c: ldc.i4.3
-		IL_081d: ldloc.s 27
-		IL_081f: stelem.ref
-		IL_0820: dup
-		IL_0821: ldc.i4.4
-		IL_0822: ldloc.s 26
-		IL_0824: stelem.ref
-		IL_0825: dup
-		IL_0826: ldc.i4.5
-		IL_0827: ldloc.s 22
-		IL_0829: stelem.ref
-		IL_082a: dup
-		IL_082b: ldc.i4.6
-		IL_082c: ldloc.s 20
-		IL_082e: stelem.ref
-		IL_082f: dup
-		IL_0830: ldc.i4.7
-		IL_0831: ldloc.s 25
-		IL_0833: stelem.ref
-		IL_0834: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0839: pop
-		IL_083a: ldc.i4.1
-		IL_083b: newarr [System.Runtime]System.Object
-		IL_0840: dup
-		IL_0841: ldc.i4.0
-		IL_0842: ldloc.0
-		IL_0843: stelem.ref
-		IL_0844: stloc.s 16
-		IL_0846: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject::.ctor()
-		IL_084b: ldc.i4.0
-		IL_084c: conv.r8
-		IL_084d: ldstr ""
-		IL_0852: ldc.i4.0
-		IL_0853: ldc.i4.1
-		IL_0854: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0859: stloc.s 34
-		IL_085b: ldloc.2
-		IL_085c: ldstr "call"
-		IL_0861: ldloc.s 34
-		IL_0863: ldc.i4.1
-		IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0869: pop
-		IL_086a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_086f: stloc.s 18
-		IL_0871: ldloc.2
-		IL_0872: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0877: volatile.
-		IL_0879: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_087e: brfalse IL_0892
-
+		IL_0813: stloc.s 20
+		IL_0815: ldloc.s 13
+		IL_0817: ldstr "prototype"
+		IL_081c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0821: box [System.Runtime]System.Boolean
+		IL_0826: stloc.s 25
+		IL_0828: ldloc.s 18
+		IL_082a: ldc.i4.8
+		IL_082b: newarr [System.Runtime]System.Object
+		IL_0830: dup
+		IL_0831: ldc.i4.0
+		IL_0832: ldstr "class"
+		IL_0837: stelem.ref
+		IL_0838: dup
+		IL_0839: ldc.i4.1
+		IL_083a: ldloc.s 23
+		IL_083c: stelem.ref
+		IL_083d: dup
+		IL_083e: ldc.i4.2
+		IL_083f: ldloc.s 29
+		IL_0841: stelem.ref
+		IL_0842: dup
+		IL_0843: ldc.i4.3
+		IL_0844: ldloc.s 27
+		IL_0846: stelem.ref
+		IL_0847: dup
+		IL_0848: ldc.i4.4
+		IL_0849: ldloc.s 26
+		IL_084b: stelem.ref
+		IL_084c: dup
+		IL_084d: ldc.i4.5
+		IL_084e: ldloc.s 22
+		IL_0850: stelem.ref
+		IL_0851: dup
+		IL_0852: ldc.i4.6
+		IL_0853: ldloc.s 20
+		IL_0855: stelem.ref
+		IL_0856: dup
+		IL_0857: ldc.i4.7
+		IL_0858: ldloc.s 25
+		IL_085a: stelem.ref
+		IL_085b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0860: pop
+		IL_0861: ldc.i4.1
+		IL_0862: newarr [System.Runtime]System.Object
+		IL_0867: dup
+		IL_0868: ldc.i4.0
+		IL_0869: ldloc.0
+		IL_086a: stelem.ref
+		IL_086b: stloc.s 16
+		IL_086d: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject::.ctor()
+		IL_0872: ldc.i4.0
+		IL_0873: conv.r8
+		IL_0874: ldstr ""
+		IL_0879: ldc.i4.0
+		IL_087a: ldc.i4.1
+		IL_087b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0880: stloc.s 34
+		IL_0882: ldloc.2
 		IL_0883: ldstr "call"
-		IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_088d: br IL_08a6
+		IL_0888: ldloc.s 34
+		IL_088a: ldc.i4.1
+		IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0890: pop
+		IL_0891: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0896: stloc.s 18
+		IL_0898: ldloc.2
+		IL_0899: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_089e: volatile.
+		IL_08a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_08a5: brfalse IL_08b9
 
-		IL_0892: ldstr "call"
-		IL_0897: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:225"
-		IL_089c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_08a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_08aa: ldstr "call"
+		IL_08af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_08b4: br IL_08cd
 
-		IL_08a6: stloc.s 20
-		IL_08a8: ldloc.s 18
-		IL_08aa: ldstr "override"
-		IL_08af: ldloc.s 20
-		IL_08b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_08b6: pop
-		IL_08b7: ldnull
-		IL_08b8: stloc.s 15
-		IL_08ba: ret
+		IL_08b9: ldstr "call"
+		IL_08be: ldstr "Function_BoundFunctionObject_UnifiedTargets:Modules.Function_BoundFunctionObject_UnifiedTargets:__js_module_init__:225"
+		IL_08c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_08c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_08cd: stloc.s 20
+		IL_08cf: ldloc.s 18
+		IL_08d1: ldstr "override"
+		IL_08d6: ldloc.s 20
+		IL_08d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_08dd: pop
+		IL_08de: ldnull
+		IL_08df: stloc.s 15
+		IL_08e1: ret
 	} // end of method Function_BoundFunctionObject_UnifiedTargets::__js_module_init__
 
 } // end of class Modules.Function_BoundFunctionObject_UnifiedTargets
@@ -1712,6 +1724,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
 	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
@@ -229,7 +229,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -244,7 +244,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
 			IL_0036: ldstr "Function_CallableReflection_ProxyIntegration:<TwoPhaseDummy_M4>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -776,7 +776,7 @@
 			IL_002c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0031: stloc.2
 			IL_0032: volatile.
-			IL_0034: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0034: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0039: brfalse IL_004f
 
 			IL_003e: ldarg.s thisArgument
@@ -787,7 +787,7 @@
 			IL_004f: ldarg.s thisArgument
 			IL_0051: ldstr "base"
 			IL_0056: ldstr "Function_CallableReflection_ProxyIntegration:<TwoPhaseDummy_M8>:__js_call__:9"
-			IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0065: stloc.0
@@ -1873,7 +1873,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3572 (0xdf4)
+		// Code size: 3667 (0xe53)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallableReflection_ProxyIntegration/Scope,
@@ -2286,965 +2286,991 @@
 		IL_03cf: stloc.s 46
 		IL_03d1: ldloc.s 46
 		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d8: ldstr "join"
-		IL_03dd: ldstr ","
-		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03e7: stloc.s 46
-		IL_03e9: ldloc.0
-		IL_03ea: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_03ef: stloc.s 42
-		IL_03f1: ldloc.s 42
-		IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_03f8: stloc.s 42
-		IL_03fa: ldloc.s 42
-		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0401: stloc.s 42
-		IL_0403: ldc.i4.0
-		IL_0404: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0409: brfalse IL_0445
+		IL_03d8: volatile.
+		IL_03da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_03df: brfalse IL_03f8
 
-		IL_040e: ldloc.s 42
-		IL_0410: isinst [System.Runtime]System.String
-		IL_0415: dup
-		IL_0416: brtrue IL_042e
+		IL_03e4: ldstr "join"
+		IL_03e9: ldstr ","
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03f3: br IL_0411
 
-		IL_041b: pop
-		IL_041c: ldloc.s 42
-		IL_041e: ldstr "includes"
-		IL_0423: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_0428: dup
-		IL_0429: brfalse IL_0444
+		IL_03f8: ldstr "join"
+		IL_03fd: ldstr ","
+		IL_0402: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:94"
+		IL_0407: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_042e: ldstr "name"
-		IL_0433: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_0438: box [System.Runtime]System.Boolean
-		IL_043d: stloc.s 42
-		IL_043f: br IL_0458
+		IL_0411: stloc.s 46
+		IL_0413: ldloc.0
+		IL_0414: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0419: stloc.s 42
+		IL_041b: ldloc.s 42
+		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_0422: stloc.s 42
+		IL_0424: ldloc.s 42
+		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_042b: stloc.s 42
+		IL_042d: ldc.i4.0
+		IL_042e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0433: brfalse IL_046f
 
-		IL_0444: pop
+		IL_0438: ldloc.s 42
+		IL_043a: isinst [System.Runtime]System.String
+		IL_043f: dup
+		IL_0440: brtrue IL_0458
 
-		IL_0445: ldloc.s 42
-		IL_0447: ldstr "includes"
-		IL_044c: ldstr "name"
-		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0456: stloc.s 42
+		IL_0445: pop
+		IL_0446: ldloc.s 42
+		IL_0448: ldstr "includes"
+		IL_044d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0452: dup
+		IL_0453: brfalse IL_046e
 
-		IL_0458: ldloc.0
-		IL_0459: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_045e: stloc.s 36
-		IL_0460: ldloc.s 36
-		IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_0467: stloc.s 36
-		IL_0469: ldloc.s 36
-		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0470: stloc.s 36
-		IL_0472: ldc.i4.0
-		IL_0473: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0478: brfalse IL_04b4
+		IL_0458: ldstr "name"
+		IL_045d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_0462: box [System.Runtime]System.Boolean
+		IL_0467: stloc.s 42
+		IL_0469: br IL_0482
 
-		IL_047d: ldloc.s 36
-		IL_047f: isinst [System.Runtime]System.String
-		IL_0484: dup
-		IL_0485: brtrue IL_049d
+		IL_046e: pop
 
-		IL_048a: pop
-		IL_048b: ldloc.s 36
-		IL_048d: ldstr "includes"
-		IL_0492: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_0497: dup
-		IL_0498: brfalse IL_04b3
+		IL_046f: ldloc.s 42
+		IL_0471: ldstr "includes"
+		IL_0476: ldstr "name"
+		IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0480: stloc.s 42
 
-		IL_049d: ldstr "length"
-		IL_04a2: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_04a7: box [System.Runtime]System.Boolean
-		IL_04ac: stloc.s 36
-		IL_04ae: br IL_04c7
+		IL_0482: ldloc.0
+		IL_0483: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0488: stloc.s 36
+		IL_048a: ldloc.s 36
+		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_0491: stloc.s 36
+		IL_0493: ldloc.s 36
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_049a: stloc.s 36
+		IL_049c: ldc.i4.0
+		IL_049d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_04a2: brfalse IL_04de
 
-		IL_04b3: pop
+		IL_04a7: ldloc.s 36
+		IL_04a9: isinst [System.Runtime]System.String
+		IL_04ae: dup
+		IL_04af: brtrue IL_04c7
 
-		IL_04b4: ldloc.s 36
-		IL_04b6: ldstr "includes"
-		IL_04bb: ldstr "length"
-		IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04c5: stloc.s 36
+		IL_04b4: pop
+		IL_04b5: ldloc.s 36
+		IL_04b7: ldstr "includes"
+		IL_04bc: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_04c1: dup
+		IL_04c2: brfalse IL_04dd
 
-		IL_04c7: ldloc.s 40
-		IL_04c9: ldc.i4.4
-		IL_04ca: newarr [System.Runtime]System.Object
-		IL_04cf: dup
-		IL_04d0: ldc.i4.0
-		IL_04d1: ldstr "keys"
-		IL_04d6: stelem.ref
-		IL_04d7: dup
-		IL_04d8: ldc.i4.1
-		IL_04d9: ldloc.s 46
-		IL_04db: stelem.ref
-		IL_04dc: dup
-		IL_04dd: ldc.i4.2
-		IL_04de: ldloc.s 42
-		IL_04e0: stelem.ref
-		IL_04e1: dup
-		IL_04e2: ldc.i4.3
-		IL_04e3: ldloc.s 36
-		IL_04e5: stelem.ref
-		IL_04e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_04eb: pop
-		IL_04ec: ldloc.0
-		IL_04ed: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_04f2: stloc.s 36
-		IL_04f4: ldloc.s 36
-		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_04fb: pop
-		IL_04fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0501: stloc.s 40
-		IL_0503: ldloc.0
-		IL_0504: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0509: stloc.s 36
-		IL_050b: ldloc.s 36
-		IL_050d: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0512: box [System.Runtime]System.Boolean
-		IL_0517: stloc.s 45
-		IL_0519: volatile.
-		IL_051b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0520: brfalse IL_0535
+		IL_04c7: ldstr "length"
+		IL_04cc: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_04d1: box [System.Runtime]System.Boolean
+		IL_04d6: stloc.s 36
+		IL_04d8: br IL_04f1
 
-		IL_0525: ldloc.2
-		IL_0526: ldstr "get"
-		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0530: br IL_054a
+		IL_04dd: pop
 
-		IL_0535: ldloc.2
-		IL_0536: ldstr "get"
-		IL_053b: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:116"
-		IL_0540: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04de: ldloc.s 36
+		IL_04e0: ldstr "includes"
+		IL_04e5: ldstr "length"
+		IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04ef: stloc.s 36
 
-		IL_054a: stloc.s 36
-		IL_054c: ldloc.s 36
-		IL_054e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0553: box [System.Runtime]System.Boolean
-		IL_0558: stloc.s 44
-		IL_055a: ldloc.s 40
-		IL_055c: ldstr "integrity"
-		IL_0561: ldloc.s 45
-		IL_0563: ldloc.s 44
-		IL_0565: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_056a: pop
-		IL_056b: volatile.
-		IL_056d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0572: brfalse IL_0587
+		IL_04f1: ldloc.s 40
+		IL_04f3: ldc.i4.4
+		IL_04f4: newarr [System.Runtime]System.Object
+		IL_04f9: dup
+		IL_04fa: ldc.i4.0
+		IL_04fb: ldstr "keys"
+		IL_0500: stelem.ref
+		IL_0501: dup
+		IL_0502: ldc.i4.1
+		IL_0503: ldloc.s 46
+		IL_0505: stelem.ref
+		IL_0506: dup
+		IL_0507: ldc.i4.2
+		IL_0508: ldloc.s 42
+		IL_050a: stelem.ref
+		IL_050b: dup
+		IL_050c: ldc.i4.3
+		IL_050d: ldloc.s 36
+		IL_050f: stelem.ref
+		IL_0510: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0515: pop
+		IL_0516: ldloc.0
+		IL_0517: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_051c: stloc.s 36
+		IL_051e: ldloc.s 36
+		IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0525: pop
+		IL_0526: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_052b: stloc.s 40
+		IL_052d: ldloc.0
+		IL_052e: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0533: stloc.s 36
+		IL_0535: ldloc.s 36
+		IL_0537: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_053c: box [System.Runtime]System.Boolean
+		IL_0541: stloc.s 45
+		IL_0543: volatile.
+		IL_0545: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_054a: brfalse IL_055f
 
-		IL_0577: ldloc.2
-		IL_0578: ldstr "get"
-		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0582: br IL_059c
+		IL_054f: ldloc.2
+		IL_0550: ldstr "get"
+		IL_0555: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_055a: br IL_0574
 
-		IL_0587: ldloc.2
-		IL_0588: ldstr "get"
-		IL_058d: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:122"
-		IL_0592: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_055f: ldloc.2
+		IL_0560: ldstr "get"
+		IL_0565: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:116"
+		IL_056a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_059c: stloc.s 36
-		IL_059e: ldloc.s 36
-		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_05a5: pop
-		IL_05a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05ab: stloc.s 40
-		IL_05ad: volatile.
-		IL_05af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_05b4: brfalse IL_05c9
+		IL_0574: stloc.s 36
+		IL_0576: ldloc.s 36
+		IL_0578: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_057d: box [System.Runtime]System.Boolean
+		IL_0582: stloc.s 44
+		IL_0584: ldloc.s 40
+		IL_0586: ldstr "integrity"
+		IL_058b: ldloc.s 45
+		IL_058d: ldloc.s 44
+		IL_058f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0594: pop
+		IL_0595: volatile.
+		IL_0597: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_059c: brfalse IL_05b1
 
-		IL_05b9: ldloc.2
-		IL_05ba: ldstr "get"
-		IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05c4: br IL_05de
+		IL_05a1: ldloc.2
+		IL_05a2: ldstr "get"
+		IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ac: br IL_05c6
 
-		IL_05c9: ldloc.2
-		IL_05ca: ldstr "get"
-		IL_05cf: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:128"
-		IL_05d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05b1: ldloc.2
+		IL_05b2: ldstr "get"
+		IL_05b7: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:122"
+		IL_05bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05de: stloc.s 36
-		IL_05e0: ldloc.s 36
-		IL_05e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_05e7: box [System.Runtime]System.Boolean
-		IL_05ec: stloc.s 44
-		IL_05ee: ldloc.s 40
-		IL_05f0: ldstr "frozenFunction"
-		IL_05f5: ldloc.s 44
-		IL_05f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_05fc: pop
-		IL_05fd: nop
-		IL_05fe: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0603: dup
-		IL_0604: ldstr "marker"
-		IL_0609: ldstr "custom-function-prototype"
-		IL_060e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0613: stloc.s 4
-		IL_0615: ldloc.1
-		IL_0616: ldloc.s 4
-		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_061d: pop
-		IL_061e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0623: stloc.s 40
-		IL_0625: ldloc.1
-		IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_062b: stloc.s 36
-		IL_062d: ldloc.s 36
-		IL_062f: ldloc.s 4
-		IL_0631: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0636: stloc.s 43
-		IL_0638: ldloc.s 43
-		IL_063a: box [System.Runtime]System.Boolean
-		IL_063f: stloc.s 44
-		IL_0641: volatile.
-		IL_0643: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0648: brfalse IL_065d
+		IL_05c6: stloc.s 36
+		IL_05c8: ldloc.s 36
+		IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_05cf: pop
+		IL_05d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05d5: stloc.s 40
+		IL_05d7: volatile.
+		IL_05d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_05de: brfalse IL_05f3
 
-		IL_064d: ldloc.1
-		IL_064e: ldstr "marker"
-		IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0658: br IL_0672
+		IL_05e3: ldloc.2
+		IL_05e4: ldstr "get"
+		IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ee: br IL_0608
 
-		IL_065d: ldloc.1
-		IL_065e: ldstr "marker"
-		IL_0663: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:146"
-		IL_0668: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05f3: ldloc.2
+		IL_05f4: ldstr "get"
+		IL_05f9: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:128"
+		IL_05fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0603: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0672: stloc.s 36
-		IL_0674: ldloc.s 40
-		IL_0676: ldstr "prototypeMutation"
-		IL_067b: ldloc.s 44
-		IL_067d: ldloc.s 36
-		IL_067f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0684: pop
-		IL_0685: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_068a: stloc.s 40
-		IL_068c: ldloc.0
-		IL_068d: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0692: stloc.s 36
-		IL_0694: ldloc.s 36
-		IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_069b: stloc.s 36
-		IL_069d: ldloc.s 36
-		IL_069f: ldnull
-		IL_06a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_06a5: stloc.s 43
-		IL_06a7: ldloc.s 43
-		IL_06a9: box [System.Runtime]System.Boolean
-		IL_06ae: stloc.s 44
-		IL_06b0: ldloc.0
-		IL_06b1: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_06b6: stloc.s 36
-		IL_06b8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_06bd: dup
-		IL_06be: ldstr "target"
-		IL_06c3: ldloc.s 36
-		IL_06c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_06ca: stloc.s 37
-		IL_06cc: ldloc.s 37
-		IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_06d3: stloc.s 36
-		IL_06d5: ldloc.s 36
-		IL_06d7: ldstr "{}"
-		IL_06dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_06e1: stloc.s 43
-		IL_06e3: ldloc.s 43
-		IL_06e5: box [System.Runtime]System.Boolean
-		IL_06ea: stloc.s 45
-		IL_06ec: ldloc.s 40
-		IL_06ee: ldstr "json"
-		IL_06f3: ldloc.s 44
-		IL_06f5: ldloc.s 45
-		IL_06f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_06fc: pop
-		IL_06fd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0702: stloc.s 37
-		IL_0704: ldc.i4.1
-		IL_0705: newarr [System.Runtime]System.Object
-		IL_070a: dup
-		IL_070b: ldc.i4.0
-		IL_070c: ldloc.0
-		IL_070d: stelem.ref
-		IL_070e: stloc.s 33
-		IL_0710: ldloc.s 33
-		IL_0712: ldc.i4.0
-		IL_0713: ldelem.ref
-		IL_0714: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_0719: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
-		IL_071e: ldc.i4.3
-		IL_071f: conv.r8
-		IL_0720: ldstr ""
-		IL_0725: ldc.i4.0
-		IL_0726: ldc.i4.1
-		IL_0727: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_072c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0)
-		IL_0731: stloc.s 47
-		IL_0733: ldloc.s 37
-		IL_0735: ldstr "apply"
-		IL_073a: ldloc.s 47
-		IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0741: pop
-		IL_0742: ldloc.0
-		IL_0743: ldloc.s 37
-		IL_0745: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
-		IL_074a: ldloc.0
-		IL_074b: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0750: stloc.s 36
-		IL_0752: ldloc.0
-		IL_0753: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
-		IL_0758: ldstr "Cannot access 'applyHandler' before initialization"
-		IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0762: stloc.s 42
-		IL_0764: ldloc.s 36
-		IL_0766: ldloc.s 42
-		IL_0768: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_076d: stloc.s 5
-		IL_076f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0774: dup
-		IL_0775: ldstr "base"
-		IL_077a: ldc.r8 10
-		IL_0783: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0788: dup
-		IL_0789: ldstr "method"
-		IL_078e: ldloc.s 5
-		IL_0790: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0795: stloc.s 6
-		IL_0797: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_079c: stloc.s 40
-		IL_079e: ldloc.s 5
-		IL_07a0: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_07a5: stloc.s 41
-		IL_07a7: ldloc.s 6
-		IL_07a9: ldstr "method"
-		IL_07ae: ldc.r8 5
-		IL_07b7: box [System.Runtime]System.Double
-		IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07c1: stloc.s 42
-		IL_07c3: ldloc.0
-		IL_07c4: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_07c9: stloc.s 36
-		IL_07cb: ldloc.s 5
-		IL_07cd: ldloc.s 36
-		IL_07cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_07d4: stloc.s 43
-		IL_07d6: ldloc.s 43
-		IL_07d8: box [System.Runtime]System.Boolean
-		IL_07dd: stloc.s 45
-		IL_07df: ldloc.s 40
-		IL_07e1: ldc.i4.4
-		IL_07e2: newarr [System.Runtime]System.Object
-		IL_07e7: dup
-		IL_07e8: ldc.i4.0
-		IL_07e9: ldstr "apply"
-		IL_07ee: stelem.ref
-		IL_07ef: dup
-		IL_07f0: ldc.i4.1
-		IL_07f1: ldloc.s 41
-		IL_07f3: stelem.ref
-		IL_07f4: dup
-		IL_07f5: ldc.i4.2
-		IL_07f6: ldloc.s 42
-		IL_07f8: stelem.ref
-		IL_07f9: dup
-		IL_07fa: ldc.i4.3
-		IL_07fb: ldloc.s 45
-		IL_07fd: stelem.ref
-		IL_07fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0803: pop
-		IL_0804: ldloc.0
-		IL_0805: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_080a: stloc.s 42
-		IL_080c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0811: stloc.s 37
-		IL_0813: ldloc.s 42
-		IL_0815: ldloc.s 37
-		IL_0817: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_081c: stloc.s 7
-		IL_081e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0823: stloc.s 40
-		IL_0825: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_082a: dup
-		IL_082b: ldstr "base"
-		IL_0830: ldc.r8 20
-		IL_0839: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_083e: stloc.s 37
-		IL_0840: ldloc.s 7
-		IL_0842: ldstr "call"
-		IL_0847: ldloc.s 37
-		IL_0849: ldc.r8 2
-		IL_0852: box [System.Runtime]System.Double
-		IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_085c: stloc.s 42
-		IL_085e: ldloc.s 40
-		IL_0860: ldstr "fallback"
-		IL_0865: ldloc.s 42
-		IL_0867: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_086c: pop
-		IL_086d: nop
-		IL_086e: ldloc.0
-		IL_086f: ldnull
-		IL_0870: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_0875: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_087a: stloc.s 37
-		IL_087c: ldc.i4.1
-		IL_087d: newarr [System.Runtime]System.Object
-		IL_0882: dup
-		IL_0883: ldc.i4.0
-		IL_0884: ldloc.0
-		IL_0885: stelem.ref
-		IL_0886: stloc.s 33
-		IL_0888: ldloc.s 33
-		IL_088a: ldc.i4.0
-		IL_088b: ldelem.ref
-		IL_088c: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_0891: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
-		IL_0896: ldc.i4.3
-		IL_0897: conv.r8
-		IL_0898: ldstr ""
-		IL_089d: ldc.i4.0
-		IL_089e: ldc.i4.1
-		IL_089f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0)
-		IL_08a9: stloc.s 48
-		IL_08ab: ldloc.s 37
-		IL_08ad: ldstr "construct"
-		IL_08b2: ldloc.s 48
-		IL_08b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_08b9: pop
-		IL_08ba: ldloc.s 37
-		IL_08bc: stloc.s 8
-		IL_08be: ldloc.0
-		IL_08bf: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
-		IL_08c4: stloc.s 42
-		IL_08c6: ldloc.s 42
-		IL_08c8: ldloc.s 8
-		IL_08ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_08cf: stloc.s 49
-		IL_08d1: ldloc.0
-		IL_08d2: ldloc.s 49
-		IL_08d4: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_08d9: ldloc.0
-		IL_08da: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_08df: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
-		IL_08e4: stloc.s 49
-		IL_08e6: ldloc.s 49
-		IL_08e8: dup
-		IL_08e9: ldc.r8 12
-		IL_08f2: box [System.Runtime]System.Double
-		IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_08fc: stloc.s 9
-		IL_08fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0903: stloc.s 40
-		IL_0905: ldloc.0
-		IL_0906: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_090b: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
-		IL_0910: stloc.s 49
-		IL_0912: ldloc.s 49
-		IL_0914: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0919: stloc.s 41
-		IL_091b: volatile.
-		IL_091d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0922: brfalse IL_0938
+		IL_0608: stloc.s 36
+		IL_060a: ldloc.s 36
+		IL_060c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_0611: box [System.Runtime]System.Boolean
+		IL_0616: stloc.s 44
+		IL_0618: ldloc.s 40
+		IL_061a: ldstr "frozenFunction"
+		IL_061f: ldloc.s 44
+		IL_0621: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0626: pop
+		IL_0627: nop
+		IL_0628: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_062d: dup
+		IL_062e: ldstr "marker"
+		IL_0633: ldstr "custom-function-prototype"
+		IL_0638: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_063d: stloc.s 4
+		IL_063f: ldloc.1
+		IL_0640: ldloc.s 4
+		IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0647: pop
+		IL_0648: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_064d: stloc.s 40
+		IL_064f: ldloc.1
+		IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0655: stloc.s 36
+		IL_0657: ldloc.s 36
+		IL_0659: ldloc.s 4
+		IL_065b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0660: stloc.s 43
+		IL_0662: ldloc.s 43
+		IL_0664: box [System.Runtime]System.Boolean
+		IL_0669: stloc.s 44
+		IL_066b: volatile.
+		IL_066d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0672: brfalse IL_0687
 
-		IL_0927: ldloc.s 9
-		IL_0929: ldstr "targetMatches"
-		IL_092e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0933: br IL_094e
+		IL_0677: ldloc.1
+		IL_0678: ldstr "marker"
+		IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0682: br IL_069c
 
-		IL_0938: ldloc.s 9
-		IL_093a: ldstr "targetMatches"
-		IL_093f: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:231"
-		IL_0944: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0949: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0687: ldloc.1
+		IL_0688: ldstr "marker"
+		IL_068d: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:146"
+		IL_0692: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_094e: stloc.s 42
-		IL_0950: volatile.
-		IL_0952: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0957: brfalse IL_096d
+		IL_069c: stloc.s 36
+		IL_069e: ldloc.s 40
+		IL_06a0: ldstr "prototypeMutation"
+		IL_06a5: ldloc.s 44
+		IL_06a7: ldloc.s 36
+		IL_06a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_06ae: pop
+		IL_06af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06b4: stloc.s 40
+		IL_06b6: ldloc.0
+		IL_06b7: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_06bc: stloc.s 36
+		IL_06be: ldloc.s 36
+		IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_06c5: stloc.s 36
+		IL_06c7: ldloc.s 36
+		IL_06c9: ldnull
+		IL_06ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06cf: stloc.s 43
+		IL_06d1: ldloc.s 43
+		IL_06d3: box [System.Runtime]System.Boolean
+		IL_06d8: stloc.s 44
+		IL_06da: ldloc.0
+		IL_06db: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_06e0: stloc.s 36
+		IL_06e2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_06e7: dup
+		IL_06e8: ldstr "target"
+		IL_06ed: ldloc.s 36
+		IL_06ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_06f4: stloc.s 37
+		IL_06f6: ldloc.s 37
+		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_06fd: stloc.s 36
+		IL_06ff: ldloc.s 36
+		IL_0701: ldstr "{}"
+		IL_0706: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_070b: stloc.s 43
+		IL_070d: ldloc.s 43
+		IL_070f: box [System.Runtime]System.Boolean
+		IL_0714: stloc.s 45
+		IL_0716: ldloc.s 40
+		IL_0718: ldstr "json"
+		IL_071d: ldloc.s 44
+		IL_071f: ldloc.s 45
+		IL_0721: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0726: pop
+		IL_0727: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_072c: stloc.s 37
+		IL_072e: ldc.i4.1
+		IL_072f: newarr [System.Runtime]System.Object
+		IL_0734: dup
+		IL_0735: ldc.i4.0
+		IL_0736: ldloc.0
+		IL_0737: stelem.ref
+		IL_0738: stloc.s 33
+		IL_073a: ldloc.s 33
+		IL_073c: ldc.i4.0
+		IL_073d: ldelem.ref
+		IL_073e: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
+		IL_0743: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_0748: ldc.i4.3
+		IL_0749: conv.r8
+		IL_074a: ldstr ""
+		IL_074f: ldc.i4.0
+		IL_0750: ldc.i4.1
+		IL_0751: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0756: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0)
+		IL_075b: stloc.s 47
+		IL_075d: ldloc.s 37
+		IL_075f: ldstr "apply"
+		IL_0764: ldloc.s 47
+		IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_076b: pop
+		IL_076c: ldloc.0
+		IL_076d: ldloc.s 37
+		IL_076f: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
+		IL_0774: ldloc.0
+		IL_0775: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_077a: stloc.s 36
+		IL_077c: ldloc.0
+		IL_077d: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
+		IL_0782: ldstr "Cannot access 'applyHandler' before initialization"
+		IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_078c: stloc.s 42
+		IL_078e: ldloc.s 36
+		IL_0790: ldloc.s 42
+		IL_0792: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0797: stloc.s 5
+		IL_0799: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_079e: dup
+		IL_079f: ldstr "base"
+		IL_07a4: ldc.r8 10
+		IL_07ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_07b2: dup
+		IL_07b3: ldstr "method"
+		IL_07b8: ldloc.s 5
+		IL_07ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_07bf: stloc.s 6
+		IL_07c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07c6: stloc.s 40
+		IL_07c8: ldloc.s 5
+		IL_07ca: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_07cf: stloc.s 41
+		IL_07d1: volatile.
+		IL_07d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_07d8: brfalse IL_07fc
 
-		IL_095c: ldloc.s 9
-		IL_095e: ldstr "argument"
-		IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0968: br IL_0983
+		IL_07dd: ldloc.s 6
+		IL_07df: ldstr "method"
+		IL_07e4: ldc.r8 5
+		IL_07ed: box [System.Runtime]System.Double
+		IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07f7: br IL_0820
 
-		IL_096d: ldloc.s 9
-		IL_096f: ldstr "argument"
-		IL_0974: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:233"
-		IL_0979: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_097e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07fc: ldloc.s 6
+		IL_07fe: ldstr "method"
+		IL_0803: ldc.r8 5
+		IL_080c: box [System.Runtime]System.Double
+		IL_0811: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:185"
+		IL_0816: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_081b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0983: stloc.s 36
-		IL_0985: volatile.
-		IL_0987: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_098c: brfalse IL_09a2
+		IL_0820: stloc.s 42
+		IL_0822: ldloc.0
+		IL_0823: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0828: stloc.s 36
+		IL_082a: ldloc.s 5
+		IL_082c: ldloc.s 36
+		IL_082e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0833: stloc.s 43
+		IL_0835: ldloc.s 43
+		IL_0837: box [System.Runtime]System.Boolean
+		IL_083c: stloc.s 45
+		IL_083e: ldloc.s 40
+		IL_0840: ldc.i4.4
+		IL_0841: newarr [System.Runtime]System.Object
+		IL_0846: dup
+		IL_0847: ldc.i4.0
+		IL_0848: ldstr "apply"
+		IL_084d: stelem.ref
+		IL_084e: dup
+		IL_084f: ldc.i4.1
+		IL_0850: ldloc.s 41
+		IL_0852: stelem.ref
+		IL_0853: dup
+		IL_0854: ldc.i4.2
+		IL_0855: ldloc.s 42
+		IL_0857: stelem.ref
+		IL_0858: dup
+		IL_0859: ldc.i4.3
+		IL_085a: ldloc.s 45
+		IL_085c: stelem.ref
+		IL_085d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0862: pop
+		IL_0863: ldloc.0
+		IL_0864: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0869: stloc.s 42
+		IL_086b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0870: stloc.s 37
+		IL_0872: ldloc.s 42
+		IL_0874: ldloc.s 37
+		IL_0876: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_087b: stloc.s 7
+		IL_087d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0882: stloc.s 40
+		IL_0884: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0889: dup
+		IL_088a: ldstr "base"
+		IL_088f: ldc.r8 20
+		IL_0898: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_089d: stloc.s 37
+		IL_089f: ldloc.s 7
+		IL_08a1: ldstr "call"
+		IL_08a6: ldloc.s 37
+		IL_08a8: ldc.r8 2
+		IL_08b1: box [System.Runtime]System.Double
+		IL_08b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_08bb: stloc.s 42
+		IL_08bd: ldloc.s 40
+		IL_08bf: ldstr "fallback"
+		IL_08c4: ldloc.s 42
+		IL_08c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_08cb: pop
+		IL_08cc: nop
+		IL_08cd: ldloc.0
+		IL_08ce: ldnull
+		IL_08cf: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_08d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_08d9: stloc.s 37
+		IL_08db: ldc.i4.1
+		IL_08dc: newarr [System.Runtime]System.Object
+		IL_08e1: dup
+		IL_08e2: ldc.i4.0
+		IL_08e3: ldloc.0
+		IL_08e4: stelem.ref
+		IL_08e5: stloc.s 33
+		IL_08e7: ldloc.s 33
+		IL_08e9: ldc.i4.0
+		IL_08ea: ldelem.ref
+		IL_08eb: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
+		IL_08f0: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_08f5: ldc.i4.3
+		IL_08f6: conv.r8
+		IL_08f7: ldstr ""
+		IL_08fc: ldc.i4.0
+		IL_08fd: ldc.i4.1
+		IL_08fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0903: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0)
+		IL_0908: stloc.s 48
+		IL_090a: ldloc.s 37
+		IL_090c: ldstr "construct"
+		IL_0911: ldloc.s 48
+		IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0918: pop
+		IL_0919: ldloc.s 37
+		IL_091b: stloc.s 8
+		IL_091d: ldloc.0
+		IL_091e: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
+		IL_0923: stloc.s 42
+		IL_0925: ldloc.s 42
+		IL_0927: ldloc.s 8
+		IL_0929: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_092e: stloc.s 49
+		IL_0930: ldloc.0
+		IL_0931: ldloc.s 49
+		IL_0933: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_0938: ldloc.0
+		IL_0939: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_093e: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
+		IL_0943: stloc.s 49
+		IL_0945: ldloc.s 49
+		IL_0947: dup
+		IL_0948: ldc.r8 12
+		IL_0951: box [System.Runtime]System.Double
+		IL_0956: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_095b: stloc.s 9
+		IL_095d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0962: stloc.s 40
+		IL_0964: ldloc.0
+		IL_0965: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_096a: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
+		IL_096f: stloc.s 49
+		IL_0971: ldloc.s 49
+		IL_0973: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0978: stloc.s 41
+		IL_097a: volatile.
+		IL_097c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0981: brfalse IL_0997
 
-		IL_0991: ldloc.s 9
-		IL_0993: ldstr "newTargetMatches"
-		IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_099d: br IL_09b8
+		IL_0986: ldloc.s 9
+		IL_0988: ldstr "targetMatches"
+		IL_098d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0992: br IL_09ad
 
-		IL_09a2: ldloc.s 9
-		IL_09a4: ldstr "newTargetMatches"
-		IL_09a9: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:235"
-		IL_09ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_09b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0997: ldloc.s 9
+		IL_0999: ldstr "targetMatches"
+		IL_099e: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:231"
+		IL_09a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_09a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_09b8: stloc.s 46
-		IL_09ba: ldloc.s 40
-		IL_09bc: ldc.i4.5
-		IL_09bd: newarr [System.Runtime]System.Object
-		IL_09c2: dup
-		IL_09c3: ldc.i4.0
-		IL_09c4: ldstr "construct"
-		IL_09c9: stelem.ref
-		IL_09ca: dup
-		IL_09cb: ldc.i4.1
-		IL_09cc: ldloc.s 41
-		IL_09ce: stelem.ref
-		IL_09cf: dup
-		IL_09d0: ldc.i4.2
-		IL_09d1: ldloc.s 42
-		IL_09d3: stelem.ref
-		IL_09d4: dup
-		IL_09d5: ldc.i4.3
-		IL_09d6: ldloc.s 36
-		IL_09d8: stelem.ref
-		IL_09d9: dup
-		IL_09da: ldc.i4.4
-		IL_09db: ldloc.s 46
-		IL_09dd: stelem.ref
-		IL_09de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_09e3: pop
-		IL_09e4: ldloc.0
-		IL_09e5: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
-		IL_09ea: stloc.s 46
-		IL_09ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_09f1: stloc.s 37
-		IL_09f3: ldc.i4.1
-		IL_09f4: newarr [System.Runtime]System.Object
-		IL_09f9: dup
-		IL_09fa: ldc.i4.0
-		IL_09fb: ldloc.0
-		IL_09fc: stelem.ref
-		IL_09fd: stloc.s 33
-		IL_09ff: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject::.ctor()
-		IL_0a04: ldc.i4.0
-		IL_0a05: conv.r8
-		IL_0a06: ldstr ""
-		IL_0a0b: ldc.i4.0
-		IL_0a0c: ldc.i4.1
-		IL_0a0d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0a12: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0)
-		IL_0a17: stloc.s 50
-		IL_0a19: ldloc.s 37
-		IL_0a1b: ldstr "construct"
-		IL_0a20: ldloc.s 50
-		IL_0a22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0a27: pop
-		IL_0a28: ldloc.s 46
-		IL_0a2a: ldloc.s 37
-		IL_0a2c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0a31: stloc.s 10
-		IL_0a33: ldc.i4.0
-		IL_0a34: box [System.Runtime]System.Boolean
-		IL_0a39: stloc.s 11
+		IL_09ad: stloc.s 42
+		IL_09af: volatile.
+		IL_09b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_09b6: brfalse IL_09cc
+
+		IL_09bb: ldloc.s 9
+		IL_09bd: ldstr "argument"
+		IL_09c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09c7: br IL_09e2
+
+		IL_09cc: ldloc.s 9
+		IL_09ce: ldstr "argument"
+		IL_09d3: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:233"
+		IL_09d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_09dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_09e2: stloc.s 36
+		IL_09e4: volatile.
+		IL_09e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_09eb: brfalse IL_0a01
+
+		IL_09f0: ldloc.s 9
+		IL_09f2: ldstr "newTargetMatches"
+		IL_09f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09fc: br IL_0a17
+
+		IL_0a01: ldloc.s 9
+		IL_0a03: ldstr "newTargetMatches"
+		IL_0a08: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:235"
+		IL_0a0d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0a12: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0a17: stloc.s 46
+		IL_0a19: ldloc.s 40
+		IL_0a1b: ldc.i4.5
+		IL_0a1c: newarr [System.Runtime]System.Object
+		IL_0a21: dup
+		IL_0a22: ldc.i4.0
+		IL_0a23: ldstr "construct"
+		IL_0a28: stelem.ref
+		IL_0a29: dup
+		IL_0a2a: ldc.i4.1
+		IL_0a2b: ldloc.s 41
+		IL_0a2d: stelem.ref
+		IL_0a2e: dup
+		IL_0a2f: ldc.i4.2
+		IL_0a30: ldloc.s 42
+		IL_0a32: stelem.ref
+		IL_0a33: dup
+		IL_0a34: ldc.i4.3
+		IL_0a35: ldloc.s 36
+		IL_0a37: stelem.ref
+		IL_0a38: dup
+		IL_0a39: ldc.i4.4
+		IL_0a3a: ldloc.s 46
+		IL_0a3c: stelem.ref
+		IL_0a3d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0a42: pop
+		IL_0a43: ldloc.0
+		IL_0a44: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
+		IL_0a49: stloc.s 46
+		IL_0a4b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0a50: stloc.s 37
+		IL_0a52: ldc.i4.1
+		IL_0a53: newarr [System.Runtime]System.Object
+		IL_0a58: dup
+		IL_0a59: ldc.i4.0
+		IL_0a5a: ldloc.0
+		IL_0a5b: stelem.ref
+		IL_0a5c: stloc.s 33
+		IL_0a5e: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject::.ctor()
+		IL_0a63: ldc.i4.0
+		IL_0a64: conv.r8
+		IL_0a65: ldstr ""
+		IL_0a6a: ldc.i4.0
+		IL_0a6b: ldc.i4.1
+		IL_0a6c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a71: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0)
+		IL_0a76: stloc.s 50
+		IL_0a78: ldloc.s 37
+		IL_0a7a: ldstr "construct"
+		IL_0a7f: ldloc.s 50
+		IL_0a81: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0a86: pop
+		IL_0a87: ldloc.s 46
+		IL_0a89: ldloc.s 37
+		IL_0a8b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0a90: stloc.s 10
+		IL_0a92: ldc.i4.0
+		IL_0a93: box [System.Runtime]System.Boolean
+		IL_0a98: stloc.s 11
 		.try
 		{
-			IL_0a3b: nop
-			IL_0a3c: ldloc.s 10
-			IL_0a3e: dup
-			IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-			IL_0a44: pop
-			IL_0a45: leave IL_0aa9
+			IL_0a9a: nop
+			IL_0a9b: ldloc.s 10
+			IL_0a9d: dup
+			IL_0a9e: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+			IL_0aa3: pop
+			IL_0aa4: leave IL_0b08
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0a4a: stloc.s 12
-			IL_0a4c: ldloc.s 12
-			IL_0a4e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0a53: dup
-			IL_0a54: brtrue IL_0a6a
+			IL_0aa9: stloc.s 12
+			IL_0aab: ldloc.s 12
+			IL_0aad: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0ab2: dup
+			IL_0ab3: brtrue IL_0ac9
 
-			IL_0a59: pop
-			IL_0a5a: ldloc.s 12
-			IL_0a5c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0a61: dup
-			IL_0a62: brtrue IL_0a76
+			IL_0ab8: pop
+			IL_0ab9: ldloc.s 12
+			IL_0abb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0ac0: dup
+			IL_0ac1: brtrue IL_0ad5
 
-			IL_0a67: pop
-			IL_0a68: rethrow
+			IL_0ac6: pop
+			IL_0ac7: rethrow
 
-			IL_0a6a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0a6f: stloc.s 13
-			IL_0a71: br IL_0a78
+			IL_0ac9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0ace: stloc.s 13
+			IL_0ad0: br IL_0ad7
 
-			IL_0a76: stloc.s 13
+			IL_0ad5: stloc.s 13
 
-			IL_0a78: ldloc.s 13
-			IL_0a7a: stloc.s 14
-			IL_0a7c: ldloc.s 14
-			IL_0a7e: stloc.s 46
-			IL_0a80: ldstr "TypeError"
-			IL_0a85: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a8a: stloc.s 36
-			IL_0a8c: ldloc.s 46
-			IL_0a8e: ldloc.s 36
-			IL_0a90: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0a95: stloc.s 43
-			IL_0a97: ldloc.s 43
-			IL_0a99: box [System.Runtime]System.Boolean
-			IL_0a9e: stloc.s 45
-			IL_0aa0: ldloc.s 45
-			IL_0aa2: stloc.s 11
-			IL_0aa4: leave IL_0aa9
+			IL_0ad7: ldloc.s 13
+			IL_0ad9: stloc.s 14
+			IL_0adb: ldloc.s 14
+			IL_0add: stloc.s 46
+			IL_0adf: ldstr "TypeError"
+			IL_0ae4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ae9: stloc.s 36
+			IL_0aeb: ldloc.s 46
+			IL_0aed: ldloc.s 36
+			IL_0aef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0af4: stloc.s 43
+			IL_0af6: ldloc.s 43
+			IL_0af8: box [System.Runtime]System.Boolean
+			IL_0afd: stloc.s 45
+			IL_0aff: ldloc.s 45
+			IL_0b01: stloc.s 11
+			IL_0b03: leave IL_0b08
 		} // end handler
 
-		IL_0aa9: ldloc.0
-		IL_0aaa: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0aaf: stloc.s 36
-		IL_0ab1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0ab6: dup
-		IL_0ab7: ldstr "apply"
-		IL_0abc: ldc.r8 1
-		IL_0ac5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0aca: stloc.s 37
-		IL_0acc: ldloc.s 36
-		IL_0ace: ldloc.s 37
-		IL_0ad0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0ad5: stloc.s 15
-		IL_0ad7: ldc.i4.0
-		IL_0ad8: box [System.Runtime]System.Boolean
-		IL_0add: stloc.s 16
+		IL_0b08: ldloc.0
+		IL_0b09: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0b0e: stloc.s 36
+		IL_0b10: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0b15: dup
+		IL_0b16: ldstr "apply"
+		IL_0b1b: ldc.r8 1
+		IL_0b24: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0b29: stloc.s 37
+		IL_0b2b: ldloc.s 36
+		IL_0b2d: ldloc.s 37
+		IL_0b2f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0b34: stloc.s 15
+		IL_0b36: ldc.i4.0
+		IL_0b37: box [System.Runtime]System.Boolean
+		IL_0b3c: stloc.s 16
 		.try
 		{
-			IL_0adf: nop
-			IL_0ae0: ldloc.s 15
-			IL_0ae2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0ae7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0aec: pop
-			IL_0aed: leave IL_0b51
+			IL_0b3e: nop
+			IL_0b3f: ldloc.s 15
+			IL_0b41: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0b46: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0b4b: pop
+			IL_0b4c: leave IL_0bb0
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0af2: stloc.s 17
-			IL_0af4: ldloc.s 17
-			IL_0af6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0afb: dup
-			IL_0afc: brtrue IL_0b12
+			IL_0b51: stloc.s 17
+			IL_0b53: ldloc.s 17
+			IL_0b55: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0b5a: dup
+			IL_0b5b: brtrue IL_0b71
 
-			IL_0b01: pop
-			IL_0b02: ldloc.s 17
-			IL_0b04: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0b09: dup
-			IL_0b0a: brtrue IL_0b1e
+			IL_0b60: pop
+			IL_0b61: ldloc.s 17
+			IL_0b63: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0b68: dup
+			IL_0b69: brtrue IL_0b7d
 
-			IL_0b0f: pop
-			IL_0b10: rethrow
+			IL_0b6e: pop
+			IL_0b6f: rethrow
 
-			IL_0b12: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0b17: stloc.s 18
-			IL_0b19: br IL_0b20
+			IL_0b71: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b76: stloc.s 18
+			IL_0b78: br IL_0b7f
 
-			IL_0b1e: stloc.s 18
+			IL_0b7d: stloc.s 18
 
-			IL_0b20: ldloc.s 18
-			IL_0b22: stloc.s 19
-			IL_0b24: ldloc.s 19
-			IL_0b26: stloc.s 36
-			IL_0b28: ldstr "TypeError"
-			IL_0b2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b32: stloc.s 46
-			IL_0b34: ldloc.s 36
-			IL_0b36: ldloc.s 46
-			IL_0b38: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0b3d: stloc.s 43
-			IL_0b3f: ldloc.s 43
-			IL_0b41: box [System.Runtime]System.Boolean
-			IL_0b46: stloc.s 45
-			IL_0b48: ldloc.s 45
-			IL_0b4a: stloc.s 16
-			IL_0b4c: leave IL_0b51
+			IL_0b7f: ldloc.s 18
+			IL_0b81: stloc.s 19
+			IL_0b83: ldloc.s 19
+			IL_0b85: stloc.s 36
+			IL_0b87: ldstr "TypeError"
+			IL_0b8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b91: stloc.s 46
+			IL_0b93: ldloc.s 36
+			IL_0b95: ldloc.s 46
+			IL_0b97: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0b9c: stloc.s 43
+			IL_0b9e: ldloc.s 43
+			IL_0ba0: box [System.Runtime]System.Boolean
+			IL_0ba5: stloc.s 45
+			IL_0ba7: ldloc.s 45
+			IL_0ba9: stloc.s 16
+			IL_0bab: leave IL_0bb0
 		} // end handler
 
-		IL_0b51: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b56: stloc.s 40
-		IL_0b58: ldloc.s 40
-		IL_0b5a: ldstr "invalidTraps"
-		IL_0b5f: ldloc.s 11
-		IL_0b61: ldloc.s 16
-		IL_0b63: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0b68: pop
-		IL_0b69: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0b6e: stloc.s 20
-		IL_0b70: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0b75: stloc.s 37
-		IL_0b77: ldc.i4.1
-		IL_0b78: newarr [System.Runtime]System.Object
-		IL_0b7d: dup
-		IL_0b7e: ldc.i4.0
-		IL_0b7f: ldloc.0
-		IL_0b80: stelem.ref
-		IL_0b81: stloc.s 33
-		IL_0b83: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject::.ctor()
-		IL_0b88: ldc.i4.1
-		IL_0b89: conv.r8
-		IL_0b8a: ldstr ""
-		IL_0b8f: ldc.i4.0
-		IL_0b90: ldc.i4.1
-		IL_0b91: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b96: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0)
-		IL_0b9b: stloc.s 51
-		IL_0b9d: ldloc.s 37
-		IL_0b9f: ldstr "isExtensible"
-		IL_0ba4: ldloc.s 51
-		IL_0ba6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0bab: pop
-		IL_0bac: ldc.i4.1
-		IL_0bad: newarr [System.Runtime]System.Object
-		IL_0bb2: dup
-		IL_0bb3: ldc.i4.0
-		IL_0bb4: ldloc.0
-		IL_0bb5: stelem.ref
-		IL_0bb6: stloc.s 33
-		IL_0bb8: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject::.ctor()
-		IL_0bbd: ldc.i4.1
-		IL_0bbe: conv.r8
-		IL_0bbf: ldstr ""
-		IL_0bc4: ldc.i4.0
-		IL_0bc5: ldc.i4.1
-		IL_0bc6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0bcb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0)
-		IL_0bd0: stloc.s 52
-		IL_0bd2: ldloc.s 37
-		IL_0bd4: ldstr "preventExtensions"
-		IL_0bd9: ldloc.s 52
-		IL_0bdb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0be0: pop
-		IL_0be1: ldloc.s 37
-		IL_0be3: stloc.s 21
-		IL_0be5: ldloc.s 20
-		IL_0be7: ldloc.s 21
-		IL_0be9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0bee: stloc.s 22
-		IL_0bf0: ldloc.s 22
-		IL_0bf2: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0bf7: stloc.s 23
-		IL_0bf9: ldloc.s 22
-		IL_0bfb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_0c00: pop
-		IL_0c01: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0c06: stloc.s 40
-		IL_0c08: ldloc.s 23
-		IL_0c0a: box [System.Runtime]System.Boolean
-		IL_0c0f: stloc.s 45
-		IL_0c11: ldloc.s 22
-		IL_0c13: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0c18: box [System.Runtime]System.Boolean
-		IL_0c1d: stloc.s 44
-		IL_0c1f: ldloc.s 20
-		IL_0c21: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0c26: box [System.Runtime]System.Boolean
-		IL_0c2b: stloc.s 53
-		IL_0c2d: ldloc.s 40
-		IL_0c2f: ldc.i4.4
-		IL_0c30: newarr [System.Runtime]System.Object
-		IL_0c35: dup
-		IL_0c36: ldc.i4.0
-		IL_0c37: ldstr "proxyIntegrity"
-		IL_0c3c: stelem.ref
-		IL_0c3d: dup
-		IL_0c3e: ldc.i4.1
-		IL_0c3f: ldloc.s 45
-		IL_0c41: stelem.ref
-		IL_0c42: dup
-		IL_0c43: ldc.i4.2
-		IL_0c44: ldloc.s 44
-		IL_0c46: stelem.ref
-		IL_0c47: dup
-		IL_0c48: ldc.i4.3
-		IL_0c49: ldloc.s 53
-		IL_0c4b: stelem.ref
-		IL_0c4c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0c51: pop
-		IL_0c52: ldc.i4.0
-		IL_0c53: box [System.Runtime]System.Boolean
-		IL_0c58: stloc.s 24
+		IL_0bb0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0bb5: stloc.s 40
+		IL_0bb7: ldloc.s 40
+		IL_0bb9: ldstr "invalidTraps"
+		IL_0bbe: ldloc.s 11
+		IL_0bc0: ldloc.s 16
+		IL_0bc2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0bc7: pop
+		IL_0bc8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0bcd: stloc.s 20
+		IL_0bcf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0bd4: stloc.s 37
+		IL_0bd6: ldc.i4.1
+		IL_0bd7: newarr [System.Runtime]System.Object
+		IL_0bdc: dup
+		IL_0bdd: ldc.i4.0
+		IL_0bde: ldloc.0
+		IL_0bdf: stelem.ref
+		IL_0be0: stloc.s 33
+		IL_0be2: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject::.ctor()
+		IL_0be7: ldc.i4.1
+		IL_0be8: conv.r8
+		IL_0be9: ldstr ""
+		IL_0bee: ldc.i4.0
+		IL_0bef: ldc.i4.1
+		IL_0bf0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0bf5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0)
+		IL_0bfa: stloc.s 51
+		IL_0bfc: ldloc.s 37
+		IL_0bfe: ldstr "isExtensible"
+		IL_0c03: ldloc.s 51
+		IL_0c05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0c0a: pop
+		IL_0c0b: ldc.i4.1
+		IL_0c0c: newarr [System.Runtime]System.Object
+		IL_0c11: dup
+		IL_0c12: ldc.i4.0
+		IL_0c13: ldloc.0
+		IL_0c14: stelem.ref
+		IL_0c15: stloc.s 33
+		IL_0c17: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject::.ctor()
+		IL_0c1c: ldc.i4.1
+		IL_0c1d: conv.r8
+		IL_0c1e: ldstr ""
+		IL_0c23: ldc.i4.0
+		IL_0c24: ldc.i4.1
+		IL_0c25: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c2a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0)
+		IL_0c2f: stloc.s 52
+		IL_0c31: ldloc.s 37
+		IL_0c33: ldstr "preventExtensions"
+		IL_0c38: ldloc.s 52
+		IL_0c3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0c3f: pop
+		IL_0c40: ldloc.s 37
+		IL_0c42: stloc.s 21
+		IL_0c44: ldloc.s 20
+		IL_0c46: ldloc.s 21
+		IL_0c48: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0c4d: stloc.s 22
+		IL_0c4f: ldloc.s 22
+		IL_0c51: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0c56: stloc.s 23
+		IL_0c58: ldloc.s 22
+		IL_0c5a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_0c5f: pop
+		IL_0c60: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0c65: stloc.s 40
+		IL_0c67: ldloc.s 23
+		IL_0c69: box [System.Runtime]System.Boolean
+		IL_0c6e: stloc.s 45
+		IL_0c70: ldloc.s 22
+		IL_0c72: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0c77: box [System.Runtime]System.Boolean
+		IL_0c7c: stloc.s 44
+		IL_0c7e: ldloc.s 20
+		IL_0c80: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0c85: box [System.Runtime]System.Boolean
+		IL_0c8a: stloc.s 53
+		IL_0c8c: ldloc.s 40
+		IL_0c8e: ldc.i4.4
+		IL_0c8f: newarr [System.Runtime]System.Object
+		IL_0c94: dup
+		IL_0c95: ldc.i4.0
+		IL_0c96: ldstr "proxyIntegrity"
+		IL_0c9b: stelem.ref
+		IL_0c9c: dup
+		IL_0c9d: ldc.i4.1
+		IL_0c9e: ldloc.s 45
+		IL_0ca0: stelem.ref
+		IL_0ca1: dup
+		IL_0ca2: ldc.i4.2
+		IL_0ca3: ldloc.s 44
+		IL_0ca5: stelem.ref
+		IL_0ca6: dup
+		IL_0ca7: ldc.i4.3
+		IL_0ca8: ldloc.s 53
+		IL_0caa: stelem.ref
+		IL_0cab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0cb0: pop
+		IL_0cb1: ldc.i4.0
+		IL_0cb2: box [System.Runtime]System.Boolean
+		IL_0cb7: stloc.s 24
 		.try
 		{
-			IL_0c5a: nop
-			IL_0c5b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0c60: stloc.s 37
-			IL_0c62: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0c67: stloc.s 54
-			IL_0c69: ldc.i4.1
-			IL_0c6a: newarr [System.Runtime]System.Object
-			IL_0c6f: dup
-			IL_0c70: ldc.i4.0
-			IL_0c71: ldloc.0
-			IL_0c72: stelem.ref
-			IL_0c73: stloc.s 33
-			IL_0c75: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject::.ctor()
-			IL_0c7a: ldc.i4.0
-			IL_0c7b: conv.r8
-			IL_0c7c: ldstr ""
-			IL_0c81: ldc.i4.0
-			IL_0c82: ldc.i4.1
-			IL_0c83: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0c88: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0)
-			IL_0c8d: stloc.s 55
-			IL_0c8f: ldloc.s 54
-			IL_0c91: ldstr "isExtensible"
-			IL_0c96: ldloc.s 55
-			IL_0c98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0c9d: pop
-			IL_0c9e: ldloc.s 37
-			IL_0ca0: ldloc.s 54
-			IL_0ca2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-			IL_0ca7: stloc.s 49
-			IL_0ca9: ldloc.s 49
-			IL_0cab: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-			IL_0cb0: pop
-			IL_0cb1: leave IL_0d15
+			IL_0cb9: nop
+			IL_0cba: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0cbf: stloc.s 37
+			IL_0cc1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0cc6: stloc.s 54
+			IL_0cc8: ldc.i4.1
+			IL_0cc9: newarr [System.Runtime]System.Object
+			IL_0cce: dup
+			IL_0ccf: ldc.i4.0
+			IL_0cd0: ldloc.0
+			IL_0cd1: stelem.ref
+			IL_0cd2: stloc.s 33
+			IL_0cd4: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject::.ctor()
+			IL_0cd9: ldc.i4.0
+			IL_0cda: conv.r8
+			IL_0cdb: ldstr ""
+			IL_0ce0: ldc.i4.0
+			IL_0ce1: ldc.i4.1
+			IL_0ce2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0ce7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0)
+			IL_0cec: stloc.s 55
+			IL_0cee: ldloc.s 54
+			IL_0cf0: ldstr "isExtensible"
+			IL_0cf5: ldloc.s 55
+			IL_0cf7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0cfc: pop
+			IL_0cfd: ldloc.s 37
+			IL_0cff: ldloc.s 54
+			IL_0d01: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+			IL_0d06: stloc.s 49
+			IL_0d08: ldloc.s 49
+			IL_0d0a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+			IL_0d0f: pop
+			IL_0d10: leave IL_0d74
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0cb6: stloc.s 25
-			IL_0cb8: ldloc.s 25
-			IL_0cba: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0cbf: dup
-			IL_0cc0: brtrue IL_0cd6
+			IL_0d15: stloc.s 25
+			IL_0d17: ldloc.s 25
+			IL_0d19: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0d1e: dup
+			IL_0d1f: brtrue IL_0d35
 
-			IL_0cc5: pop
-			IL_0cc6: ldloc.s 25
-			IL_0cc8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0ccd: dup
-			IL_0cce: brtrue IL_0ce2
+			IL_0d24: pop
+			IL_0d25: ldloc.s 25
+			IL_0d27: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0d2c: dup
+			IL_0d2d: brtrue IL_0d41
 
-			IL_0cd3: pop
-			IL_0cd4: rethrow
+			IL_0d32: pop
+			IL_0d33: rethrow
 
-			IL_0cd6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0cdb: stloc.s 26
-			IL_0cdd: br IL_0ce4
+			IL_0d35: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0d3a: stloc.s 26
+			IL_0d3c: br IL_0d43
 
-			IL_0ce2: stloc.s 26
+			IL_0d41: stloc.s 26
 
-			IL_0ce4: ldloc.s 26
-			IL_0ce6: stloc.s 27
-			IL_0ce8: ldloc.s 27
-			IL_0cea: stloc.s 46
-			IL_0cec: ldstr "TypeError"
-			IL_0cf1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0cf6: stloc.s 36
-			IL_0cf8: ldloc.s 46
-			IL_0cfa: ldloc.s 36
-			IL_0cfc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0d01: stloc.s 43
-			IL_0d03: ldloc.s 43
-			IL_0d05: box [System.Runtime]System.Boolean
-			IL_0d0a: stloc.s 53
-			IL_0d0c: ldloc.s 53
-			IL_0d0e: stloc.s 24
-			IL_0d10: leave IL_0d15
+			IL_0d43: ldloc.s 26
+			IL_0d45: stloc.s 27
+			IL_0d47: ldloc.s 27
+			IL_0d49: stloc.s 46
+			IL_0d4b: ldstr "TypeError"
+			IL_0d50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0d55: stloc.s 36
+			IL_0d57: ldloc.s 46
+			IL_0d59: ldloc.s 36
+			IL_0d5b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0d60: stloc.s 43
+			IL_0d62: ldloc.s 43
+			IL_0d64: box [System.Runtime]System.Boolean
+			IL_0d69: stloc.s 53
+			IL_0d6b: ldloc.s 53
+			IL_0d6d: stloc.s 24
+			IL_0d6f: leave IL_0d74
 		} // end handler
 
-		IL_0d15: ldc.i4.0
-		IL_0d16: box [System.Runtime]System.Boolean
-		IL_0d1b: stloc.s 28
+		IL_0d74: ldc.i4.0
+		IL_0d75: box [System.Runtime]System.Boolean
+		IL_0d7a: stloc.s 28
 		.try
 		{
-			IL_0d1d: nop
-			IL_0d1e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0d23: stloc.s 54
-			IL_0d25: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0d2a: stloc.s 37
-			IL_0d2c: ldc.i4.1
-			IL_0d2d: newarr [System.Runtime]System.Object
-			IL_0d32: dup
-			IL_0d33: ldc.i4.0
-			IL_0d34: ldloc.0
-			IL_0d35: stelem.ref
-			IL_0d36: stloc.s 33
-			IL_0d38: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject::.ctor()
-			IL_0d3d: ldc.i4.0
-			IL_0d3e: conv.r8
-			IL_0d3f: ldstr ""
-			IL_0d44: ldc.i4.0
-			IL_0d45: ldc.i4.1
-			IL_0d46: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0d4b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0)
-			IL_0d50: stloc.s 56
-			IL_0d52: ldloc.s 37
-			IL_0d54: ldstr "preventExtensions"
-			IL_0d59: ldloc.s 56
-			IL_0d5b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0d60: pop
-			IL_0d61: ldloc.s 54
-			IL_0d63: ldloc.s 37
-			IL_0d65: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-			IL_0d6a: stloc.s 49
-			IL_0d6c: ldloc.s 49
-			IL_0d6e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-			IL_0d73: pop
-			IL_0d74: leave IL_0dd8
+			IL_0d7c: nop
+			IL_0d7d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0d82: stloc.s 54
+			IL_0d84: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0d89: stloc.s 37
+			IL_0d8b: ldc.i4.1
+			IL_0d8c: newarr [System.Runtime]System.Object
+			IL_0d91: dup
+			IL_0d92: ldc.i4.0
+			IL_0d93: ldloc.0
+			IL_0d94: stelem.ref
+			IL_0d95: stloc.s 33
+			IL_0d97: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject::.ctor()
+			IL_0d9c: ldc.i4.0
+			IL_0d9d: conv.r8
+			IL_0d9e: ldstr ""
+			IL_0da3: ldc.i4.0
+			IL_0da4: ldc.i4.1
+			IL_0da5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0daa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0)
+			IL_0daf: stloc.s 56
+			IL_0db1: ldloc.s 37
+			IL_0db3: ldstr "preventExtensions"
+			IL_0db8: ldloc.s 56
+			IL_0dba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0dbf: pop
+			IL_0dc0: ldloc.s 54
+			IL_0dc2: ldloc.s 37
+			IL_0dc4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+			IL_0dc9: stloc.s 49
+			IL_0dcb: ldloc.s 49
+			IL_0dcd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+			IL_0dd2: pop
+			IL_0dd3: leave IL_0e37
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0d79: stloc.s 29
-			IL_0d7b: ldloc.s 29
-			IL_0d7d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0d82: dup
-			IL_0d83: brtrue IL_0d99
+			IL_0dd8: stloc.s 29
+			IL_0dda: ldloc.s 29
+			IL_0ddc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0de1: dup
+			IL_0de2: brtrue IL_0df8
 
-			IL_0d88: pop
-			IL_0d89: ldloc.s 29
-			IL_0d8b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0d90: dup
-			IL_0d91: brtrue IL_0da5
+			IL_0de7: pop
+			IL_0de8: ldloc.s 29
+			IL_0dea: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0def: dup
+			IL_0df0: brtrue IL_0e04
 
-			IL_0d96: pop
-			IL_0d97: rethrow
+			IL_0df5: pop
+			IL_0df6: rethrow
 
-			IL_0d99: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0d9e: stloc.s 30
-			IL_0da0: br IL_0da7
+			IL_0df8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0dfd: stloc.s 30
+			IL_0dff: br IL_0e06
 
-			IL_0da5: stloc.s 30
+			IL_0e04: stloc.s 30
 
-			IL_0da7: ldloc.s 30
-			IL_0da9: stloc.s 31
-			IL_0dab: ldloc.s 31
-			IL_0dad: stloc.s 36
-			IL_0daf: ldstr "TypeError"
-			IL_0db4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0db9: stloc.s 46
-			IL_0dbb: ldloc.s 36
-			IL_0dbd: ldloc.s 46
-			IL_0dbf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0dc4: stloc.s 43
-			IL_0dc6: ldloc.s 43
-			IL_0dc8: box [System.Runtime]System.Boolean
-			IL_0dcd: stloc.s 53
-			IL_0dcf: ldloc.s 53
-			IL_0dd1: stloc.s 28
-			IL_0dd3: leave IL_0dd8
+			IL_0e06: ldloc.s 30
+			IL_0e08: stloc.s 31
+			IL_0e0a: ldloc.s 31
+			IL_0e0c: stloc.s 36
+			IL_0e0e: ldstr "TypeError"
+			IL_0e13: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0e18: stloc.s 46
+			IL_0e1a: ldloc.s 36
+			IL_0e1c: ldloc.s 46
+			IL_0e1e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0e23: stloc.s 43
+			IL_0e25: ldloc.s 43
+			IL_0e27: box [System.Runtime]System.Boolean
+			IL_0e2c: stloc.s 53
+			IL_0e2e: ldloc.s 53
+			IL_0e30: stloc.s 28
+			IL_0e32: leave IL_0e37
 		} // end handler
 
-		IL_0dd8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0ddd: stloc.s 40
-		IL_0ddf: ldloc.s 40
-		IL_0de1: ldstr "proxyIntegrityInvariants"
-		IL_0de6: ldloc.s 24
-		IL_0de8: ldloc.s 28
-		IL_0dea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0def: pop
-		IL_0df0: ldnull
-		IL_0df1: stloc.s 32
-		IL_0df3: ret
+		IL_0e37: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0e3c: stloc.s 40
+		IL_0e3e: ldloc.s 40
+		IL_0e40: ldstr "proxyIntegrityInvariants"
+		IL_0e45: ldloc.s 24
+		IL_0e47: ldloc.s 28
+		IL_0e49: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0e4e: pop
+		IL_0e4f: ldnull
+		IL_0e50: stloc.s 32
+		IL_0e52: ret
 	} // end of method Function_CallableReflection_ProxyIntegration::__js_module_init__
 
 } // end of class Modules.Function_CallableReflection_ProxyIntegration
@@ -3290,6 +3316,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_24
 	.field assembly static int32 __jroc_dynamicLookup_25
 	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
@@ -487,7 +487,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 218 (0xda)
+		// Code size: 320 (0x140)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope,
@@ -534,39 +534,65 @@
 		IL_0054: stloc.s 5
 		IL_0056: ldloc.2
 		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005c: ldstr "multiply"
-		IL_0061: ldc.r8 5
-		IL_006a: box [System.Runtime]System.Double
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0074: stloc.s 6
-		IL_0076: ldloc.s 5
-		IL_0078: ldstr "a.multiply(5):"
-		IL_007d: ldloc.s 6
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0084: pop
-		IL_0085: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008a: stloc.s 4
-		IL_008c: ldloc.1
-		IL_008d: ldloc.s 4
-		IL_008f: ldc.r8 3
-		IL_0098: box [System.Runtime]System.Double
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00a2: stloc.3
-		IL_00a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a8: stloc.s 5
-		IL_00aa: ldloc.3
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b0: ldstr "multiply"
-		IL_00b5: ldc.r8 7
-		IL_00be: box [System.Runtime]System.Double
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c8: stloc.s 6
-		IL_00ca: ldloc.s 5
-		IL_00cc: ldstr "b.multiply(7):"
-		IL_00d1: ldloc.s 6
-		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00d8: pop
-		IL_00d9: ret
+		IL_005c: volatile.
+		IL_005e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0063: brfalse IL_0085
+
+		IL_0068: ldstr "multiply"
+		IL_006d: ldc.r8 5
+		IL_0076: box [System.Runtime]System.Double
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: br IL_00a7
+
+		IL_0085: ldstr "multiply"
+		IL_008a: ldc.r8 5
+		IL_0093: box [System.Runtime]System.Double
+		IL_0098: ldstr "Function_ClosureEscapesScope_ObjectLiteralProperty:Modules.Function_ClosureEscapesScope_ObjectLiteralProperty:__js_module_init__:19"
+		IL_009d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a7: stloc.s 6
+		IL_00a9: ldloc.s 5
+		IL_00ab: ldstr "a.multiply(5):"
+		IL_00b0: ldloc.s 6
+		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00b7: pop
+		IL_00b8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00bd: stloc.s 4
+		IL_00bf: ldloc.1
+		IL_00c0: ldloc.s 4
+		IL_00c2: ldc.r8 3
+		IL_00cb: box [System.Runtime]System.Double
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00d5: stloc.3
+		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00db: stloc.s 5
+		IL_00dd: ldloc.3
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e3: volatile.
+		IL_00e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00ea: brfalse IL_010c
+
+		IL_00ef: ldstr "multiply"
+		IL_00f4: ldc.r8 7
+		IL_00fd: box [System.Runtime]System.Double
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0107: br IL_012e
+
+		IL_010c: ldstr "multiply"
+		IL_0111: ldc.r8 7
+		IL_011a: box [System.Runtime]System.Double
+		IL_011f: ldstr "Function_ClosureEscapesScope_ObjectLiteralProperty:Modules.Function_ClosureEscapesScope_ObjectLiteralProperty:__js_module_init__:33"
+		IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_012e: stloc.s 6
+		IL_0130: ldloc.s 5
+		IL_0132: ldstr "b.multiply(7):"
+		IL_0137: ldloc.s 6
+		IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_013e: pop
+		IL_013f: ret
 	} // end of method Function_ClosureEscapesScope_ObjectLiteralProperty::__js_module_init__
 
 } // end of class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty
@@ -591,4 +617,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -404,7 +404,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -419,12 +419,12 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "x"
 			IL_0036: ldstr "Function_ConstructedInstance_ObjectSemantics:<TwoPhaseDummy_M5>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
 			IL_0046: volatile.
-			IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_004d: brfalse IL_006c
 
 			IL_0052: ldarg.1
@@ -439,7 +439,7 @@
 			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0077: ldstr "y"
 			IL_007c: ldstr "Function_ConstructedInstance_ObjectSemantics:<TwoPhaseDummy_M5>:__js_call__:6"
-			IL_0081: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0081: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_008b: stloc.1
@@ -1814,7 +1814,7 @@
 			IL_0000: ldarg.0
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_000d: brfalse IL_0021
 
 			IL_0012: ldstr "sum"
@@ -1823,7 +1823,7 @@
 
 			IL_0021: ldstr "sum"
 			IL_0026: ldstr "Function_ConstructedInstance_ObjectSemantics:<TwoPhaseDummy_M14>:read:3"
-			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0035: stloc.0
@@ -1887,7 +1887,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2495 (0x9bf)
+		// Code size: 2662 (0xa66)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
@@ -2210,542 +2210,591 @@
 		IL_0318: ldloc.s 7
 		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0324: ldstr "join"
-		IL_0329: ldstr ","
-		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0333: stloc.s 24
-		IL_0335: ldloc.s 19
-		IL_0337: ldloc.s 24
-		IL_0339: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_033e: pop
-		IL_033f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0344: stloc.s 19
-		IL_0346: ldloc.s 7
-		IL_0348: ldstr "y"
-		IL_034d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_0352: stloc.s 20
-		IL_0354: ldloc.s 20
-		IL_0356: box [System.Runtime]System.Boolean
-		IL_035b: stloc.s 21
-		IL_035d: ldloc.s 19
-		IL_035f: ldloc.s 21
-		IL_0361: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0366: pop
-		IL_0367: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_036c: stloc.s 19
-		IL_036e: ldloc.s 7
-		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037a: ldstr "join"
-		IL_037f: ldstr ","
-		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0389: stloc.s 24
-		IL_038b: ldloc.s 19
-		IL_038d: ldloc.s 24
-		IL_038f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0394: pop
-		IL_0395: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_039a: stloc.s 19
-		IL_039c: volatile.
-		IL_039e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_03a3: brfalse IL_03b9
+		IL_0324: volatile.
+		IL_0326: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_032b: brfalse IL_0344
 
-		IL_03a8: ldloc.s 7
-		IL_03aa: ldstr "y"
-		IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03b4: br IL_03cf
+		IL_0330: ldstr "join"
+		IL_0335: ldstr ","
+		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_033f: br IL_035d
 
-		IL_03b9: ldloc.s 7
-		IL_03bb: ldstr "y"
-		IL_03c0: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:93"
-		IL_03c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0344: ldstr "join"
+		IL_0349: ldstr ","
+		IL_034e: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:74"
+		IL_0353: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03cf: stloc.s 24
-		IL_03d1: ldloc.s 24
-		IL_03d3: ldnull
-		IL_03d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03d9: stloc.s 20
-		IL_03db: ldloc.s 20
-		IL_03dd: box [System.Runtime]System.Boolean
-		IL_03e2: stloc.s 21
-		IL_03e4: ldloc.s 19
-		IL_03e6: ldloc.s 21
-		IL_03e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03ed: pop
-		IL_03ee: ldloc.s 7
-		IL_03f0: ldstr "y"
-		IL_03f5: ldc.r8 8
-		IL_03fe: ldc.i4.1
-		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0404: pop
-		IL_0405: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_040a: stloc.s 19
-		IL_040c: ldloc.s 7
-		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0418: ldstr "join"
-		IL_041d: ldstr ","
-		IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0427: stloc.s 24
-		IL_0429: ldloc.s 19
-		IL_042b: ldloc.s 24
-		IL_042d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0432: pop
-		IL_0433: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0438: stloc.s 19
-		IL_043a: ldloc.s 7
-		IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0441: stloc.s 24
-		IL_0443: volatile.
-		IL_0445: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_044a: brfalse IL_045f
+		IL_035d: stloc.s 24
+		IL_035f: ldloc.s 19
+		IL_0361: ldloc.s 24
+		IL_0363: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0368: pop
+		IL_0369: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_036e: stloc.s 19
+		IL_0370: ldloc.s 7
+		IL_0372: ldstr "y"
+		IL_0377: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_037c: stloc.s 20
+		IL_037e: ldloc.s 20
+		IL_0380: box [System.Runtime]System.Boolean
+		IL_0385: stloc.s 21
+		IL_0387: ldloc.s 19
+		IL_0389: ldloc.s 21
+		IL_038b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0390: pop
+		IL_0391: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0396: stloc.s 19
+		IL_0398: ldloc.s 7
+		IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03a4: volatile.
+		IL_03a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_03ab: brfalse IL_03c4
 
-		IL_044f: ldloc.1
-		IL_0450: ldstr "prototype"
-		IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_045a: br IL_0474
+		IL_03b0: ldstr "join"
+		IL_03b5: ldstr ","
+		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03bf: br IL_03dd
 
-		IL_045f: ldloc.1
-		IL_0460: ldstr "prototype"
-		IL_0465: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:113"
-		IL_046a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03c4: ldstr "join"
+		IL_03c9: ldstr ","
+		IL_03ce: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:88"
+		IL_03d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0474: stloc.s 23
-		IL_0476: ldloc.s 24
-		IL_0478: ldloc.s 23
-		IL_047a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_047f: stloc.s 20
-		IL_0481: ldloc.s 20
-		IL_0483: box [System.Runtime]System.Boolean
-		IL_0488: stloc.s 21
-		IL_048a: ldloc.s 19
-		IL_048c: ldloc.s 21
-		IL_048e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0493: pop
-		IL_0494: volatile.
-		IL_0496: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_049b: brfalse IL_04b0
+		IL_03dd: stloc.s 24
+		IL_03df: ldloc.s 19
+		IL_03e1: ldloc.s 24
+		IL_03e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03e8: pop
+		IL_03e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03ee: stloc.s 19
+		IL_03f0: volatile.
+		IL_03f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_03f7: brfalse IL_040d
 
-		IL_04a0: ldloc.1
-		IL_04a1: ldstr "prototype"
-		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ab: br IL_04c5
+		IL_03fc: ldloc.s 7
+		IL_03fe: ldstr "y"
+		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0408: br IL_0423
 
-		IL_04b0: ldloc.1
-		IL_04b1: ldstr "prototype"
-		IL_04b6: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:119"
-		IL_04bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_040d: ldloc.s 7
+		IL_040f: ldstr "y"
+		IL_0414: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:93"
+		IL_0419: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04c5: stloc.s 23
-		IL_04c7: ldloc.s 23
-		IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
-		IL_04ce: stloc.s 9
-		IL_04d0: ldloc.s 9
-		IL_04d2: ldstr "kind"
-		IL_04d7: ldstr "bridge"
-		IL_04dc: ldc.i4.1
-		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_04e2: pop
-		IL_04e3: ldloc.s 7
-		IL_04e5: ldloc.s 9
-		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_04ec: pop
-		IL_04ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04f2: stloc.s 19
-		IL_04f4: volatile.
-		IL_04f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_04fb: brfalse IL_0511
+		IL_0423: stloc.s 24
+		IL_0425: ldloc.s 24
+		IL_0427: ldnull
+		IL_0428: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_042d: stloc.s 20
+		IL_042f: ldloc.s 20
+		IL_0431: box [System.Runtime]System.Boolean
+		IL_0436: stloc.s 21
+		IL_0438: ldloc.s 19
+		IL_043a: ldloc.s 21
+		IL_043c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0441: pop
+		IL_0442: ldloc.s 7
+		IL_0444: ldstr "y"
+		IL_0449: ldc.r8 8
+		IL_0452: ldc.i4.1
+		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0458: pop
+		IL_0459: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_045e: stloc.s 19
+		IL_0460: ldloc.s 7
+		IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_046c: volatile.
+		IL_046e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0473: brfalse IL_048c
 
-		IL_0500: ldloc.s 7
-		IL_0502: ldstr "kind"
-		IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_050c: br IL_0527
+		IL_0478: ldstr "join"
+		IL_047d: ldstr ","
+		IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0487: br IL_04a5
 
-		IL_0511: ldloc.s 7
-		IL_0513: ldstr "kind"
-		IL_0518: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:131"
-		IL_051d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_048c: ldstr "join"
+		IL_0491: ldstr ","
+		IL_0496: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:107"
+		IL_049b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0527: stloc.s 23
-		IL_0529: ldloc.s 19
-		IL_052b: ldloc.s 23
-		IL_052d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0532: pop
-		IL_0533: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0538: stloc.s 19
-		IL_053a: ldloc.s 7
-		IL_053c: ldloc.1
-		IL_053d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0542: stloc.s 20
-		IL_0544: ldloc.s 20
-		IL_0546: box [System.Runtime]System.Boolean
-		IL_054b: stloc.s 21
-		IL_054d: ldloc.s 19
-		IL_054f: ldloc.s 21
-		IL_0551: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0556: pop
-		IL_0557: nop
-		IL_0558: nop
-		IL_0559: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_055e: stloc.s 19
-		IL_0560: ldloc.2
-		IL_0561: dup
-		IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_0567: stloc.s 23
-		IL_0569: volatile.
-		IL_056b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0570: brfalse IL_0586
+		IL_04a5: stloc.s 24
+		IL_04a7: ldloc.s 19
+		IL_04a9: ldloc.s 24
+		IL_04ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04b0: pop
+		IL_04b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04b6: stloc.s 19
+		IL_04b8: ldloc.s 7
+		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_04bf: stloc.s 24
+		IL_04c1: volatile.
+		IL_04c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_04c8: brfalse IL_04dd
 
-		IL_0575: ldloc.s 23
-		IL_0577: ldstr "override"
-		IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0581: br IL_059c
+		IL_04cd: ldloc.1
+		IL_04ce: ldstr "prototype"
+		IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04d8: br IL_04f2
 
-		IL_0586: ldloc.s 23
-		IL_0588: ldstr "override"
-		IL_058d: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:144"
-		IL_0592: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04dd: ldloc.1
+		IL_04de: ldstr "prototype"
+		IL_04e3: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:113"
+		IL_04e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_059c: stloc.s 23
-		IL_059e: ldloc.s 19
-		IL_05a0: ldloc.s 23
-		IL_05a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05a7: pop
-		IL_05a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05ad: stloc.s 19
-		IL_05af: ldloc.3
-		IL_05b0: dup
-		IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_05b6: stloc.s 23
-		IL_05b8: volatile.
-		IL_05ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_05bf: brfalse IL_05d5
+		IL_04f2: stloc.s 23
+		IL_04f4: ldloc.s 24
+		IL_04f6: ldloc.s 23
+		IL_04f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04fd: stloc.s 20
+		IL_04ff: ldloc.s 20
+		IL_0501: box [System.Runtime]System.Boolean
+		IL_0506: stloc.s 21
+		IL_0508: ldloc.s 19
+		IL_050a: ldloc.s 21
+		IL_050c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0511: pop
+		IL_0512: volatile.
+		IL_0514: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0519: brfalse IL_052e
 
-		IL_05c4: ldloc.s 23
-		IL_05c6: ldstr "kept"
-		IL_05cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05d0: br IL_05eb
+		IL_051e: ldloc.1
+		IL_051f: ldstr "prototype"
+		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0529: br IL_0543
 
-		IL_05d5: ldloc.s 23
-		IL_05d7: ldstr "kept"
-		IL_05dc: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:150"
-		IL_05e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_052e: ldloc.1
+		IL_052f: ldstr "prototype"
+		IL_0534: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:119"
+		IL_0539: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05eb: stloc.s 23
-		IL_05ed: ldloc.s 19
-		IL_05ef: ldloc.s 23
-		IL_05f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05f6: pop
-		IL_05f7: nop
-		IL_05f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05fd: stloc.s 16
-		IL_05ff: ldloc.s 4
-		IL_0601: ldloc.s 16
-		IL_0603: ldc.r8 10
-		IL_060c: box [System.Runtime]System.Double
-		IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0616: stloc.s 10
-		IL_0618: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_061d: stloc.s 19
-		IL_061f: ldloc.s 10
-		IL_0621: dup
-		IL_0622: ldc.r8 5
-		IL_062b: box [System.Runtime]System.Double
-		IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0635: stloc.s 23
-		IL_0637: volatile.
-		IL_0639: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_063e: brfalse IL_0654
+		IL_0543: stloc.s 23
+		IL_0545: ldloc.s 23
+		IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
+		IL_054c: stloc.s 9
+		IL_054e: ldloc.s 9
+		IL_0550: ldstr "kind"
+		IL_0555: ldstr "bridge"
+		IL_055a: ldc.i4.1
+		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0560: pop
+		IL_0561: ldloc.s 7
+		IL_0563: ldloc.s 9
+		IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_056a: pop
+		IL_056b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0570: stloc.s 19
+		IL_0572: volatile.
+		IL_0574: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0579: brfalse IL_058f
 
-		IL_0643: ldloc.s 23
-		IL_0645: ldstr "value"
-		IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_064f: br IL_066a
+		IL_057e: ldloc.s 7
+		IL_0580: ldstr "kind"
+		IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_058a: br IL_05a5
 
-		IL_0654: ldloc.s 23
-		IL_0656: ldstr "value"
-		IL_065b: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:165"
-		IL_0660: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0665: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_058f: ldloc.s 7
+		IL_0591: ldstr "kind"
+		IL_0596: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:131"
+		IL_059b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_066a: stloc.s 23
-		IL_066c: ldloc.s 19
-		IL_066e: ldloc.s 23
-		IL_0670: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0675: pop
-		IL_0676: ldloc.1
-		IL_0677: ldstr "bind"
-		IL_067c: ldc.i4.0
-		IL_067d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0682: ldc.r8 10
-		IL_068b: box [System.Runtime]System.Double
-		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0695: stloc.s 11
-		IL_0697: ldloc.s 11
-		IL_0699: dup
-		IL_069a: ldc.r8 5
-		IL_06a3: box [System.Runtime]System.Double
-		IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_06ad: stloc.s 12
-		IL_06af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06b4: stloc.s 19
-		IL_06b6: ldloc.s 12
-		IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06bd: volatile.
-		IL_06bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_06c4: brfalse IL_06d8
+		IL_05a5: stloc.s 23
+		IL_05a7: ldloc.s 19
+		IL_05a9: ldloc.s 23
+		IL_05ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05b0: pop
+		IL_05b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05b6: stloc.s 19
+		IL_05b8: ldloc.s 7
+		IL_05ba: ldloc.1
+		IL_05bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_05c0: stloc.s 20
+		IL_05c2: ldloc.s 20
+		IL_05c4: box [System.Runtime]System.Boolean
+		IL_05c9: stloc.s 21
+		IL_05cb: ldloc.s 19
+		IL_05cd: ldloc.s 21
+		IL_05cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05d4: pop
+		IL_05d5: nop
+		IL_05d6: nop
+		IL_05d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05dc: stloc.s 19
+		IL_05de: ldloc.2
+		IL_05df: dup
+		IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_05e5: stloc.s 23
+		IL_05e7: volatile.
+		IL_05e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_05ee: brfalse IL_0604
 
-		IL_06c9: ldstr "sum"
-		IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_06d3: br IL_06ec
+		IL_05f3: ldloc.s 23
+		IL_05f5: ldstr "override"
+		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ff: br IL_061a
 
-		IL_06d8: ldstr "sum"
-		IL_06dd: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:182"
-		IL_06e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0604: ldloc.s 23
+		IL_0606: ldstr "override"
+		IL_060b: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:144"
+		IL_0610: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06ec: stloc.s 23
-		IL_06ee: ldloc.s 19
-		IL_06f0: ldloc.s 23
-		IL_06f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06f7: pop
-		IL_06f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06fd: stloc.s 19
-		IL_06ff: ldloc.s 12
-		IL_0701: ldloc.1
-		IL_0702: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0707: stloc.s 20
-		IL_0709: ldloc.s 20
-		IL_070b: box [System.Runtime]System.Boolean
-		IL_0710: stloc.s 21
-		IL_0712: ldloc.s 19
-		IL_0714: ldloc.s 21
-		IL_0716: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_071b: pop
-		IL_071c: ldc.i4.1
-		IL_071d: newarr [System.Runtime]System.Object
-		IL_0722: dup
-		IL_0723: ldc.i4.0
-		IL_0724: ldloc.0
-		IL_0725: stelem.ref
-		IL_0726: stloc.s 16
-		IL_0728: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject::.ctor()
-		IL_072d: ldc.i4.1
-		IL_072e: conv.r8
-		IL_072f: ldstr ""
-		IL_0734: ldc.i4.0
-		IL_0735: ldc.i4.0
-		IL_0736: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_073b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0)
-		IL_0740: stloc.s 13
-		IL_0742: ldloc.s 13
-		IL_0744: dup
-		IL_0745: ldc.r8 9
-		IL_074e: box [System.Runtime]System.Double
-		IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0758: stloc.s 14
-		IL_075a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_075f: stloc.s 19
-		IL_0761: volatile.
-		IL_0763: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0768: brfalse IL_077e
+		IL_061a: stloc.s 23
+		IL_061c: ldloc.s 19
+		IL_061e: ldloc.s 23
+		IL_0620: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0625: pop
+		IL_0626: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_062b: stloc.s 19
+		IL_062d: ldloc.3
+		IL_062e: dup
+		IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0634: stloc.s 23
+		IL_0636: volatile.
+		IL_0638: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_063d: brfalse IL_0653
 
-		IL_076d: ldloc.s 14
-		IL_076f: ldstr "value"
-		IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0779: br IL_0794
+		IL_0642: ldloc.s 23
+		IL_0644: ldstr "kept"
+		IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_064e: br IL_0669
 
-		IL_077e: ldloc.s 14
-		IL_0780: ldstr "value"
-		IL_0785: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:201"
-		IL_078a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_078f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0653: ldloc.s 23
+		IL_0655: ldstr "kept"
+		IL_065a: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:150"
+		IL_065f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0664: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0794: stloc.s 23
-		IL_0796: ldloc.s 19
-		IL_0798: ldloc.s 23
-		IL_079a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_079f: pop
-		IL_07a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07a5: stloc.s 19
-		IL_07a7: ldloc.s 14
-		IL_07a9: ldloc.s 13
-		IL_07ab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_07b0: stloc.s 20
-		IL_07b2: ldloc.s 20
-		IL_07b4: box [System.Runtime]System.Boolean
-		IL_07b9: stloc.s 21
-		IL_07bb: ldloc.s 19
-		IL_07bd: ldloc.s 21
-		IL_07bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07c4: pop
-		IL_07c5: nop
-		IL_07c6: ldloc.s 5
-		IL_07c8: ldstr "prototype"
-		IL_07cd: ldc.r8 3
-		IL_07d6: ldc.i4.1
-		IL_07d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_07dc: pop
-		IL_07dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07e2: stloc.s 19
-		IL_07e4: ldloc.s 5
-		IL_07e6: dup
-		IL_07e7: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_07ec: stloc.s 23
-		IL_07ee: ldloc.s 23
-		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_07f5: stloc.s 23
-		IL_07f7: ldstr "Object"
-		IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0801: volatile.
-		IL_0803: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0808: brfalse IL_081c
+		IL_0669: stloc.s 23
+		IL_066b: ldloc.s 19
+		IL_066d: ldloc.s 23
+		IL_066f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0674: pop
+		IL_0675: nop
+		IL_0676: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_067b: stloc.s 16
+		IL_067d: ldloc.s 4
+		IL_067f: ldloc.s 16
+		IL_0681: ldc.r8 10
+		IL_068a: box [System.Runtime]System.Double
+		IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0694: stloc.s 10
+		IL_0696: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_069b: stloc.s 19
+		IL_069d: ldloc.s 10
+		IL_069f: dup
+		IL_06a0: ldc.r8 5
+		IL_06a9: box [System.Runtime]System.Double
+		IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_06b3: stloc.s 23
+		IL_06b5: volatile.
+		IL_06b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_06bc: brfalse IL_06d2
 
-		IL_080d: ldstr "prototype"
-		IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0817: br IL_0830
+		IL_06c1: ldloc.s 23
+		IL_06c3: ldstr "value"
+		IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06cd: br IL_06e8
 
-		IL_081c: ldstr "prototype"
-		IL_0821: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:220"
-		IL_0826: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_082b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06d2: ldloc.s 23
+		IL_06d4: ldstr "value"
+		IL_06d9: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:165"
+		IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0830: stloc.s 24
-		IL_0832: ldloc.s 23
-		IL_0834: ldloc.s 24
-		IL_0836: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_083b: stloc.s 20
-		IL_083d: ldloc.s 20
-		IL_083f: box [System.Runtime]System.Boolean
-		IL_0844: stloc.s 21
-		IL_0846: ldloc.s 19
-		IL_0848: ldloc.s 21
-		IL_084a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_084f: pop
-		IL_0850: nop
-		IL_0851: ldloc.s 6
-		IL_0853: ldstr "prototype"
-		IL_0858: ldc.i4.0
-		IL_0859: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_085e: ldc.i4.1
-		IL_085f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0864: pop
-		IL_0865: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_086a: stloc.s 19
-		IL_086c: ldloc.s 6
-		IL_086e: dup
-		IL_086f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_0874: stloc.s 24
-		IL_0876: ldloc.s 24
-		IL_0878: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_087d: stloc.s 24
-		IL_087f: ldstr "Object"
-		IL_0884: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0889: volatile.
-		IL_088b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0890: brfalse IL_08a4
+		IL_06e8: stloc.s 23
+		IL_06ea: ldloc.s 19
+		IL_06ec: ldloc.s 23
+		IL_06ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06f3: pop
+		IL_06f4: ldloc.1
+		IL_06f5: ldstr "bind"
+		IL_06fa: ldc.i4.0
+		IL_06fb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0700: ldc.r8 10
+		IL_0709: box [System.Runtime]System.Double
+		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0713: stloc.s 11
+		IL_0715: ldloc.s 11
+		IL_0717: dup
+		IL_0718: ldc.r8 5
+		IL_0721: box [System.Runtime]System.Double
+		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_072b: stloc.s 12
+		IL_072d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0732: stloc.s 19
+		IL_0734: ldloc.s 12
+		IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_073b: volatile.
+		IL_073d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0742: brfalse IL_0756
 
-		IL_0895: ldstr "prototype"
-		IL_089a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_089f: br IL_08b8
+		IL_0747: ldstr "sum"
+		IL_074c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0751: br IL_076a
 
-		IL_08a4: ldstr "prototype"
-		IL_08a9: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:237"
-		IL_08ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_08b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0756: ldstr "sum"
+		IL_075b: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:182"
+		IL_0760: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_08b8: stloc.s 23
-		IL_08ba: ldloc.s 24
-		IL_08bc: ldloc.s 23
-		IL_08be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_08c3: stloc.s 20
-		IL_08c5: ldloc.s 20
-		IL_08c7: box [System.Runtime]System.Boolean
-		IL_08cc: stloc.s 21
-		IL_08ce: ldloc.s 19
-		IL_08d0: ldloc.s 21
-		IL_08d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08d7: pop
-		IL_08d8: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_08dd: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_08e2: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_08e7: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_08ec: stloc.s 25
-		IL_08ee: volatile.
-		IL_08f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_08f5: brfalse IL_090b
+		IL_076a: stloc.s 23
+		IL_076c: ldloc.s 19
+		IL_076e: ldloc.s 23
+		IL_0770: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0775: pop
+		IL_0776: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_077b: stloc.s 19
+		IL_077d: ldloc.s 12
+		IL_077f: ldloc.1
+		IL_0780: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0785: stloc.s 20
+		IL_0787: ldloc.s 20
+		IL_0789: box [System.Runtime]System.Boolean
+		IL_078e: stloc.s 21
+		IL_0790: ldloc.s 19
+		IL_0792: ldloc.s 21
+		IL_0794: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0799: pop
+		IL_079a: ldc.i4.1
+		IL_079b: newarr [System.Runtime]System.Object
+		IL_07a0: dup
+		IL_07a1: ldc.i4.0
+		IL_07a2: ldloc.0
+		IL_07a3: stelem.ref
+		IL_07a4: stloc.s 16
+		IL_07a6: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject::.ctor()
+		IL_07ab: ldc.i4.1
+		IL_07ac: conv.r8
+		IL_07ad: ldstr ""
+		IL_07b2: ldc.i4.0
+		IL_07b3: ldc.i4.0
+		IL_07b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0)
+		IL_07be: stloc.s 13
+		IL_07c0: ldloc.s 13
+		IL_07c2: dup
+		IL_07c3: ldc.r8 9
+		IL_07cc: box [System.Runtime]System.Double
+		IL_07d1: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_07d6: stloc.s 14
+		IL_07d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07dd: stloc.s 19
+		IL_07df: volatile.
+		IL_07e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_07e6: brfalse IL_07fc
 
-		IL_08fa: ldloc.s 25
-		IL_08fc: ldstr "prototype"
-		IL_0901: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0906: br IL_0921
+		IL_07eb: ldloc.s 14
+		IL_07ed: ldstr "value"
+		IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07f7: br IL_0812
 
-		IL_090b: ldloc.s 25
-		IL_090d: ldstr "prototype"
-		IL_0912: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:244"
-		IL_0917: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_091c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07fc: ldloc.s 14
+		IL_07fe: ldstr "value"
+		IL_0803: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:201"
+		IL_0808: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_080d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0921: pop
-		IL_0922: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0927: stloc.s 16
-		IL_0929: ldloc.s 25
-		IL_092b: ldstr "read"
-		IL_0930: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject::.ctor()
-		IL_0935: ldc.i4.1
-		IL_0936: conv.r8
-		IL_0937: ldstr "read"
-		IL_093c: ldc.i4.0
-		IL_093d: ldc.i4.1
-		IL_093e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0943: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0)
-		IL_0948: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_094d: pop
-		IL_094e: ldc.i4.1
-		IL_094f: newarr [System.Runtime]System.Object
-		IL_0954: dup
-		IL_0955: ldc.i4.0
-		IL_0956: ldloc.0
-		IL_0957: stelem.ref
-		IL_0958: stloc.s 16
-		IL_095a: ldloc.s 16
-		IL_095c: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject::.ctor(object[])
-		IL_0961: ldloc.s 25
-		IL_0963: ldloc.s 16
-		IL_0965: ldc.i4.0
-		IL_0966: conv.r8
-		IL_0967: ldc.i4.0
-		IL_0968: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_096d: castclass Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
-		IL_0972: stloc.s 26
-		IL_0974: ldloc.s 26
-		IL_0976: stloc.s 15
-		IL_0978: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_097d: stloc.s 19
-		IL_097f: ldloc.1
-		IL_0980: dup
-		IL_0981: ldc.r8 6
-		IL_098a: box [System.Runtime]System.Double
-		IL_098f: ldc.r8 1
-		IL_0998: box [System.Runtime]System.Double
-		IL_099d: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_09a2: stloc.s 23
-		IL_09a4: ldloc.s 15
-		IL_09a6: ldstr "read"
-		IL_09ab: ldloc.s 23
-		IL_09ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_09b2: stloc.s 23
-		IL_09b4: ldloc.s 19
-		IL_09b6: ldloc.s 23
-		IL_09b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_09bd: pop
-		IL_09be: ret
+		IL_0812: stloc.s 23
+		IL_0814: ldloc.s 19
+		IL_0816: ldloc.s 23
+		IL_0818: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_081d: pop
+		IL_081e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0823: stloc.s 19
+		IL_0825: ldloc.s 14
+		IL_0827: ldloc.s 13
+		IL_0829: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_082e: stloc.s 20
+		IL_0830: ldloc.s 20
+		IL_0832: box [System.Runtime]System.Boolean
+		IL_0837: stloc.s 21
+		IL_0839: ldloc.s 19
+		IL_083b: ldloc.s 21
+		IL_083d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0842: pop
+		IL_0843: nop
+		IL_0844: ldloc.s 5
+		IL_0846: ldstr "prototype"
+		IL_084b: ldc.r8 3
+		IL_0854: ldc.i4.1
+		IL_0855: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_085a: pop
+		IL_085b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0860: stloc.s 19
+		IL_0862: ldloc.s 5
+		IL_0864: dup
+		IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_086a: stloc.s 23
+		IL_086c: ldloc.s 23
+		IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0873: stloc.s 23
+		IL_0875: ldstr "Object"
+		IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_087f: volatile.
+		IL_0881: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0886: brfalse IL_089a
+
+		IL_088b: ldstr "prototype"
+		IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0895: br IL_08ae
+
+		IL_089a: ldstr "prototype"
+		IL_089f: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:220"
+		IL_08a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_08a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_08ae: stloc.s 24
+		IL_08b0: ldloc.s 23
+		IL_08b2: ldloc.s 24
+		IL_08b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_08b9: stloc.s 20
+		IL_08bb: ldloc.s 20
+		IL_08bd: box [System.Runtime]System.Boolean
+		IL_08c2: stloc.s 21
+		IL_08c4: ldloc.s 19
+		IL_08c6: ldloc.s 21
+		IL_08c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08cd: pop
+		IL_08ce: nop
+		IL_08cf: ldloc.s 6
+		IL_08d1: ldstr "prototype"
+		IL_08d6: ldc.i4.0
+		IL_08d7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_08dc: ldc.i4.1
+		IL_08dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_08e2: pop
+		IL_08e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08e8: stloc.s 19
+		IL_08ea: ldloc.s 6
+		IL_08ec: dup
+		IL_08ed: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_08f2: stloc.s 24
+		IL_08f4: ldloc.s 24
+		IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_08fb: stloc.s 24
+		IL_08fd: ldstr "Object"
+		IL_0902: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0907: volatile.
+		IL_0909: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_090e: brfalse IL_0922
+
+		IL_0913: ldstr "prototype"
+		IL_0918: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_091d: br IL_0936
+
+		IL_0922: ldstr "prototype"
+		IL_0927: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:237"
+		IL_092c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0931: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0936: stloc.s 23
+		IL_0938: ldloc.s 24
+		IL_093a: ldloc.s 23
+		IL_093c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0941: stloc.s 20
+		IL_0943: ldloc.s 20
+		IL_0945: box [System.Runtime]System.Boolean
+		IL_094a: stloc.s 21
+		IL_094c: ldloc.s 19
+		IL_094e: ldloc.s 21
+		IL_0950: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0955: pop
+		IL_0956: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_095b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0960: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_0965: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_096a: stloc.s 25
+		IL_096c: volatile.
+		IL_096e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0973: brfalse IL_0989
+
+		IL_0978: ldloc.s 25
+		IL_097a: ldstr "prototype"
+		IL_097f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0984: br IL_099f
+
+		IL_0989: ldloc.s 25
+		IL_098b: ldstr "prototype"
+		IL_0990: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:244"
+		IL_0995: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_099a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_099f: pop
+		IL_09a0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_09a5: stloc.s 16
+		IL_09a7: ldloc.s 25
+		IL_09a9: ldstr "read"
+		IL_09ae: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject::.ctor()
+		IL_09b3: ldc.i4.1
+		IL_09b4: conv.r8
+		IL_09b5: ldstr "read"
+		IL_09ba: ldc.i4.0
+		IL_09bb: ldc.i4.1
+		IL_09bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_09c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0)
+		IL_09c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_09cb: pop
+		IL_09cc: ldc.i4.1
+		IL_09cd: newarr [System.Runtime]System.Object
+		IL_09d2: dup
+		IL_09d3: ldc.i4.0
+		IL_09d4: ldloc.0
+		IL_09d5: stelem.ref
+		IL_09d6: stloc.s 16
+		IL_09d8: ldloc.s 16
+		IL_09da: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject::.ctor(object[])
+		IL_09df: ldloc.s 25
+		IL_09e1: ldloc.s 16
+		IL_09e3: ldc.i4.0
+		IL_09e4: conv.r8
+		IL_09e5: ldc.i4.0
+		IL_09e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_09eb: castclass Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
+		IL_09f0: stloc.s 26
+		IL_09f2: ldloc.s 26
+		IL_09f4: stloc.s 15
+		IL_09f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_09fb: stloc.s 19
+		IL_09fd: ldloc.1
+		IL_09fe: dup
+		IL_09ff: ldc.r8 6
+		IL_0a08: box [System.Runtime]System.Double
+		IL_0a0d: ldc.r8 1
+		IL_0a16: box [System.Runtime]System.Double
+		IL_0a1b: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+		IL_0a20: stloc.s 23
+		IL_0a22: volatile.
+		IL_0a24: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0a29: brfalse IL_0a41
+
+		IL_0a2e: ldloc.s 15
+		IL_0a30: ldstr "read"
+		IL_0a35: ldloc.s 23
+		IL_0a37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a3c: br IL_0a59
+
+		IL_0a41: ldloc.s 15
+		IL_0a43: ldstr "read"
+		IL_0a48: ldloc.s 23
+		IL_0a4a: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:260"
+		IL_0a4f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0a54: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0a59: stloc.s 23
+		IL_0a5b: ldloc.s 19
+		IL_0a5d: ldloc.s 23
+		IL_0a5f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0a64: pop
+		IL_0a65: ret
 	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
 
 } // end of class Modules.Function_ConstructedInstance_ObjectSemantics
@@ -2796,6 +2845,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_31
 	.field assembly static int32 __jroc_dynamicLookup_32
 	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
+	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
+	.field assembly static int32 __jroc_dynamicLookup_37
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
@@ -234,7 +234,7 @@
 				IL_002e: ldstr "globalThis"
 				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 				IL_0038: volatile.
-				IL_003a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+				IL_003a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 				IL_003f: brfalse IL_0053
 
 				IL_0044: ldstr "dynamicFnVisible"
@@ -243,7 +243,7 @@
 
 				IL_0053: ldstr "dynamicFnVisible"
 				IL_0058: ldstr "Function_Constructor_GlobalScope_NoClosure:<TwoPhaseDummy_M5>:__js_call__:13"
-				IL_005d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+				IL_005d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0067: stloc.1
@@ -391,7 +391,7 @@
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
 			// Header size: 12
-			// Code size: 135 (0x87)
+			// Code size: 176 (0xb0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Constructor_GlobalScope_NoClosure/outer/Scope,
@@ -442,13 +442,26 @@
 			IL_006e: stelem.ref
 			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 			IL_0074: stloc.s 5
-			IL_0076: ldloc.s 4
-			IL_0078: ldstr "log"
-			IL_007d: ldloc.s 5
-			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0084: pop
-			IL_0085: ldnull
-			IL_0086: ret
+			IL_0076: volatile.
+			IL_0078: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_007d: brfalse IL_0095
+
+			IL_0082: ldloc.s 4
+			IL_0084: ldstr "log"
+			IL_0089: ldloc.s 5
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0090: br IL_00ad
+
+			IL_0095: ldloc.s 4
+			IL_0097: ldstr "log"
+			IL_009c: ldloc.s 5
+			IL_009e: ldstr "Function_Constructor_GlobalScope_NoClosure:<TwoPhaseDummy_M4>:__js_call__:20"
+			IL_00a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00ad: pop
+			IL_00ae: ldnull
+			IL_00af: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -562,6 +575,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ExplicitReceiverAbi.verified.txt
@@ -243,7 +243,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -258,7 +258,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
 			IL_0036: ldstr "Function_ExplicitReceiverAbi:<TwoPhaseDummy_M4>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -536,7 +536,7 @@
 			IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.ArgumentsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateArgumentsObject(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object, string[], bool, bool)
 			IL_0011: stfld object Modules.Function_ExplicitReceiverAbi/variadicSum/Scope::arguments
 			IL_0016: volatile.
-			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_001d: brfalse IL_003c
 
 			IL_0022: ldarg.2
@@ -551,7 +551,7 @@
 			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0047: ldstr "base"
 			IL_004c: ldstr "Function_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0051: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0051: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_005b: stloc.1
@@ -864,7 +864,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3251 (0xcb3)
+		// Code size: 3485 (0xd9d)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_ExplicitReceiverAbi/Scope,
@@ -998,954 +998,1027 @@
 		IL_013a: ldc.r8 100
 		IL_0143: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_0148: stloc.s 24
-		IL_014a: ldloc.1
-		IL_014b: ldstr "bind"
-		IL_0150: ldloc.s 24
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0157: stloc.s 26
-		IL_0159: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_015e: stloc.s 22
-		IL_0160: ldloc.s 26
-		IL_0162: ldloc.s 22
-		IL_0164: ldc.r8 1
-		IL_016d: box [System.Runtime]System.Double
-		IL_0172: ldc.r8 2
-		IL_017b: box [System.Runtime]System.Double
-		IL_0180: ldc.r8 3
-		IL_0189: box [System.Runtime]System.Double
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0193: stloc.s 26
-		IL_0195: ldloc.s 23
-		IL_0197: ldloc.s 26
-		IL_0199: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019e: pop
-		IL_019f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a4: stloc.s 23
-		IL_01a6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01ab: dup
-		IL_01ac: ldstr "base"
-		IL_01b1: ldc.r8 100
-		IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_01bf: stloc.s 24
-		IL_01c1: ldloc.1
-		IL_01c2: ldstr "bind"
-		IL_01c7: ldloc.s 24
-		IL_01c9: ldc.r8 1
-		IL_01d2: box [System.Runtime]System.Double
-		IL_01d7: ldc.r8 2
-		IL_01e0: box [System.Runtime]System.Double
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_01ea: stloc.s 26
-		IL_01ec: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01f1: stloc.s 22
-		IL_01f3: ldloc.s 26
-		IL_01f5: ldloc.s 22
-		IL_01f7: ldc.r8 3
-		IL_0200: box [System.Runtime]System.Double
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_020a: stloc.s 26
-		IL_020c: ldloc.s 23
-		IL_020e: ldloc.s 26
-		IL_0210: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0215: pop
-		IL_0216: nop
-		IL_0217: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021c: stloc.s 23
-		IL_021e: ldloc.2
-		IL_021f: ldstr "call"
-		IL_0224: ldc.i4.8
-		IL_0225: newarr [System.Runtime]System.Object
-		IL_022a: dup
-		IL_022b: ldc.i4.0
-		IL_022c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0231: dup
-		IL_0232: ldstr "base"
-		IL_0237: ldc.r8 0.0
-		IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0245: stelem.ref
-		IL_0246: dup
-		IL_0247: ldc.i4.1
-		IL_0248: ldc.r8 1
-		IL_0251: box [System.Runtime]System.Double
-		IL_0256: stelem.ref
-		IL_0257: dup
-		IL_0258: ldc.i4.2
-		IL_0259: ldc.r8 2
-		IL_0262: box [System.Runtime]System.Double
-		IL_0267: stelem.ref
-		IL_0268: dup
-		IL_0269: ldc.i4.3
-		IL_026a: ldc.r8 3
-		IL_0273: box [System.Runtime]System.Double
-		IL_0278: stelem.ref
-		IL_0279: dup
-		IL_027a: ldc.i4.4
-		IL_027b: ldc.r8 4
-		IL_0284: box [System.Runtime]System.Double
-		IL_0289: stelem.ref
-		IL_028a: dup
-		IL_028b: ldc.i4.5
-		IL_028c: ldc.r8 5
-		IL_0295: box [System.Runtime]System.Double
-		IL_029a: stelem.ref
-		IL_029b: dup
-		IL_029c: ldc.i4.6
-		IL_029d: ldc.r8 6
-		IL_02a6: box [System.Runtime]System.Double
-		IL_02ab: stelem.ref
-		IL_02ac: dup
-		IL_02ad: ldc.i4.7
-		IL_02ae: ldc.r8 7
-		IL_02b7: box [System.Runtime]System.Double
-		IL_02bc: stelem.ref
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_02c2: stloc.s 26
-		IL_02c4: ldloc.s 23
-		IL_02c6: ldloc.s 26
-		IL_02c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02cd: pop
-		IL_02ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02d3: stloc.s 23
-		IL_02d5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02da: dup
-		IL_02db: ldstr "base"
-		IL_02e0: ldc.r8 0.0
-		IL_02e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_02ee: stloc.s 24
-		IL_02f0: ldc.i4.8
-		IL_02f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02f6: dup
-		IL_02f7: ldc.r8 1
-		IL_0300: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0305: dup
-		IL_0306: ldc.r8 2
-		IL_030f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0314: dup
-		IL_0315: ldc.r8 3
-		IL_031e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0323: dup
-		IL_0324: ldc.r8 4
-		IL_032d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0332: dup
-		IL_0333: ldc.r8 5
-		IL_033c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0341: dup
-		IL_0342: ldc.r8 6
-		IL_034b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0350: dup
-		IL_0351: ldc.r8 7
-		IL_035a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_035f: dup
-		IL_0360: ldc.r8 8
-		IL_0369: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_036e: stloc.s 25
-		IL_0370: ldloc.2
-		IL_0371: ldstr "apply"
-		IL_0376: ldloc.s 24
-		IL_0378: ldloc.s 25
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_037f: stloc.s 26
-		IL_0381: ldloc.s 23
-		IL_0383: ldloc.s 26
-		IL_0385: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_038a: pop
-		IL_038b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0390: stloc.s 23
-		IL_0392: ldstr "Function"
-		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_039c: volatile.
-		IL_039e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_03a3: brfalse IL_03b7
+		IL_014a: volatile.
+		IL_014c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0151: brfalse IL_0168
 
-		IL_03a8: ldstr "prototype"
-		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03b2: br IL_03cb
+		IL_0156: ldloc.1
+		IL_0157: ldstr "bind"
+		IL_015c: ldloc.s 24
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0163: br IL_017f
 
-		IL_03b7: ldstr "prototype"
-		IL_03bc: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:102"
-		IL_03c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0168: ldloc.1
+		IL_0169: ldstr "bind"
+		IL_016e: ldloc.s 24
+		IL_0170: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:36"
+		IL_0175: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03cb: stloc.s 26
-		IL_03cd: volatile.
-		IL_03cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_03d4: brfalse IL_03ea
+		IL_017f: stloc.s 26
+		IL_0181: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0186: stloc.s 22
+		IL_0188: ldloc.s 26
+		IL_018a: ldloc.s 22
+		IL_018c: ldc.r8 1
+		IL_0195: box [System.Runtime]System.Double
+		IL_019a: ldc.r8 2
+		IL_01a3: box [System.Runtime]System.Double
+		IL_01a8: ldc.r8 3
+		IL_01b1: box [System.Runtime]System.Double
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_01bb: stloc.s 26
+		IL_01bd: ldloc.s 23
+		IL_01bf: ldloc.s 26
+		IL_01c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c6: pop
+		IL_01c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cc: stloc.s 23
+		IL_01ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01d3: dup
+		IL_01d4: ldstr "base"
+		IL_01d9: ldc.r8 100
+		IL_01e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_01e7: stloc.s 24
+		IL_01e9: ldloc.1
+		IL_01ea: ldstr "bind"
+		IL_01ef: ldloc.s 24
+		IL_01f1: ldc.r8 1
+		IL_01fa: box [System.Runtime]System.Double
+		IL_01ff: ldc.r8 2
+		IL_0208: box [System.Runtime]System.Double
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0212: stloc.s 26
+		IL_0214: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0219: stloc.s 22
+		IL_021b: ldloc.s 26
+		IL_021d: ldloc.s 22
+		IL_021f: ldc.r8 3
+		IL_0228: box [System.Runtime]System.Double
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0232: stloc.s 26
+		IL_0234: ldloc.s 23
+		IL_0236: ldloc.s 26
+		IL_0238: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_023d: pop
+		IL_023e: nop
+		IL_023f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0244: stloc.s 23
+		IL_0246: ldloc.2
+		IL_0247: ldstr "call"
+		IL_024c: ldc.i4.8
+		IL_024d: newarr [System.Runtime]System.Object
+		IL_0252: dup
+		IL_0253: ldc.i4.0
+		IL_0254: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0259: dup
+		IL_025a: ldstr "base"
+		IL_025f: ldc.r8 0.0
+		IL_0268: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_026d: stelem.ref
+		IL_026e: dup
+		IL_026f: ldc.i4.1
+		IL_0270: ldc.r8 1
+		IL_0279: box [System.Runtime]System.Double
+		IL_027e: stelem.ref
+		IL_027f: dup
+		IL_0280: ldc.i4.2
+		IL_0281: ldc.r8 2
+		IL_028a: box [System.Runtime]System.Double
+		IL_028f: stelem.ref
+		IL_0290: dup
+		IL_0291: ldc.i4.3
+		IL_0292: ldc.r8 3
+		IL_029b: box [System.Runtime]System.Double
+		IL_02a0: stelem.ref
+		IL_02a1: dup
+		IL_02a2: ldc.i4.4
+		IL_02a3: ldc.r8 4
+		IL_02ac: box [System.Runtime]System.Double
+		IL_02b1: stelem.ref
+		IL_02b2: dup
+		IL_02b3: ldc.i4.5
+		IL_02b4: ldc.r8 5
+		IL_02bd: box [System.Runtime]System.Double
+		IL_02c2: stelem.ref
+		IL_02c3: dup
+		IL_02c4: ldc.i4.6
+		IL_02c5: ldc.r8 6
+		IL_02ce: box [System.Runtime]System.Double
+		IL_02d3: stelem.ref
+		IL_02d4: dup
+		IL_02d5: ldc.i4.7
+		IL_02d6: ldc.r8 7
+		IL_02df: box [System.Runtime]System.Double
+		IL_02e4: stelem.ref
+		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_02ea: stloc.s 26
+		IL_02ec: ldloc.s 23
+		IL_02ee: ldloc.s 26
+		IL_02f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02f5: pop
+		IL_02f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02fb: stloc.s 23
+		IL_02fd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0302: dup
+		IL_0303: ldstr "base"
+		IL_0308: ldc.r8 0.0
+		IL_0311: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0316: stloc.s 24
+		IL_0318: ldc.i4.8
+		IL_0319: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_031e: dup
+		IL_031f: ldc.r8 1
+		IL_0328: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_032d: dup
+		IL_032e: ldc.r8 2
+		IL_0337: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_033c: dup
+		IL_033d: ldc.r8 3
+		IL_0346: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_034b: dup
+		IL_034c: ldc.r8 4
+		IL_0355: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_035a: dup
+		IL_035b: ldc.r8 5
+		IL_0364: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0369: dup
+		IL_036a: ldc.r8 6
+		IL_0373: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0378: dup
+		IL_0379: ldc.r8 7
+		IL_0382: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0387: dup
+		IL_0388: ldc.r8 8
+		IL_0391: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0396: stloc.s 25
+		IL_0398: ldloc.2
+		IL_0399: ldstr "apply"
+		IL_039e: ldloc.s 24
+		IL_03a0: ldloc.s 25
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03a7: stloc.s 26
+		IL_03a9: ldloc.s 23
+		IL_03ab: ldloc.s 26
+		IL_03ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03b2: pop
+		IL_03b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03b8: stloc.s 23
+		IL_03ba: ldstr "Function"
+		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c4: volatile.
+		IL_03c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_03cb: brfalse IL_03df
 
-		IL_03d9: ldloc.s 26
-		IL_03db: ldstr "toString"
-		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03e5: br IL_0400
+		IL_03d0: ldstr "prototype"
+		IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03da: br IL_03f3
 
-		IL_03ea: ldloc.s 26
-		IL_03ec: ldstr "toString"
-		IL_03f1: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:104"
-		IL_03f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03df: ldstr "prototype"
+		IL_03e4: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:102"
+		IL_03e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0400: stloc.s 26
-		IL_0402: ldloc.s 26
-		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0409: ldstr "call"
-		IL_040e: ldloc.1
-		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0414: stloc.s 26
-		IL_0416: ldloc.s 26
-		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_041d: stloc.s 26
-		IL_041f: ldc.i4.0
-		IL_0420: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0425: brfalse IL_0461
+		IL_03f3: stloc.s 26
+		IL_03f5: volatile.
+		IL_03f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_03fc: brfalse IL_0412
 
+		IL_0401: ldloc.s 26
+		IL_0403: ldstr "toString"
+		IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_040d: br IL_0428
+
+		IL_0412: ldloc.s 26
+		IL_0414: ldstr "toString"
+		IL_0419: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:104"
+		IL_041e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0428: stloc.s 26
 		IL_042a: ldloc.s 26
-		IL_042c: isinst [System.Runtime]System.String
-		IL_0431: dup
-		IL_0432: brtrue IL_044a
+		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0431: volatile.
+		IL_0433: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0438: brfalse IL_044d
 
-		IL_0437: pop
-		IL_0438: ldloc.s 26
-		IL_043a: ldstr "indexOf"
-		IL_043f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_0444: dup
-		IL_0445: brfalse IL_0460
+		IL_043d: ldstr "call"
+		IL_0442: ldloc.1
+		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0448: br IL_0462
 
-		IL_044a: ldstr "function"
-		IL_044f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_0454: box [System.Runtime]System.Double
-		IL_0459: stloc.s 26
-		IL_045b: br IL_0474
+		IL_044d: ldstr "call"
+		IL_0452: ldloc.1
+		IL_0453: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:106"
+		IL_0458: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0460: pop
+		IL_0462: stloc.s 26
+		IL_0464: ldloc.s 26
+		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_046b: stloc.s 26
+		IL_046d: ldc.i4.0
+		IL_046e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0473: brfalse IL_04af
 
-		IL_0461: ldloc.s 26
-		IL_0463: ldstr "indexOf"
-		IL_0468: ldstr "function"
-		IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0472: stloc.s 26
+		IL_0478: ldloc.s 26
+		IL_047a: isinst [System.Runtime]System.String
+		IL_047f: dup
+		IL_0480: brtrue IL_0498
 
-		IL_0474: ldloc.s 26
-		IL_0476: ldc.r8 0.0
-		IL_047f: box [System.Runtime]System.Double
-		IL_0484: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0489: stloc.s 27
-		IL_048b: ldloc.s 27
-		IL_048d: box [System.Runtime]System.Boolean
-		IL_0492: stloc.s 28
-		IL_0494: ldloc.s 23
-		IL_0496: ldloc.s 28
-		IL_0498: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_049d: pop
+		IL_0485: pop
+		IL_0486: ldloc.s 26
+		IL_0488: ldstr "indexOf"
+		IL_048d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0492: dup
+		IL_0493: brfalse IL_04ae
+
+		IL_0498: ldstr "function"
+		IL_049d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_04a2: box [System.Runtime]System.Double
+		IL_04a7: stloc.s 26
+		IL_04a9: br IL_04c2
+
+		IL_04ae: pop
+
+		IL_04af: ldloc.s 26
+		IL_04b1: ldstr "indexOf"
+		IL_04b6: ldstr "function"
+		IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04c0: stloc.s 26
+
+		IL_04c2: ldloc.s 26
+		IL_04c4: ldc.r8 0.0
+		IL_04cd: box [System.Runtime]System.Double
+		IL_04d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04d7: stloc.s 27
+		IL_04d9: ldloc.s 27
+		IL_04db: box [System.Runtime]System.Boolean
+		IL_04e0: stloc.s 28
+		IL_04e2: ldloc.s 23
+		IL_04e4: ldloc.s 28
+		IL_04e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04eb: pop
 		.try
 		{
-			IL_049e: nop
-			IL_049f: ldstr "Function"
-			IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04a9: volatile.
-			IL_04ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-			IL_04b0: brfalse IL_04c4
+			IL_04ec: nop
+			IL_04ed: ldstr "Function"
+			IL_04f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04f7: volatile.
+			IL_04f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_04fe: brfalse IL_0512
 
-			IL_04b5: ldstr "prototype"
-			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04bf: br IL_04d8
+			IL_0503: ldstr "prototype"
+			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_050d: br IL_0526
 
-			IL_04c4: ldstr "prototype"
-			IL_04c9: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:122"
-			IL_04ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-			IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0512: ldstr "prototype"
+			IL_0517: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:122"
+			IL_051c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04d8: stloc.s 26
-			IL_04da: volatile.
-			IL_04dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_04e1: brfalse IL_04f7
+			IL_0526: stloc.s 26
+			IL_0528: volatile.
+			IL_052a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_052f: brfalse IL_0545
 
-			IL_04e6: ldloc.s 26
-			IL_04e8: ldstr "apply"
-			IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04f2: br IL_050d
+			IL_0534: ldloc.s 26
+			IL_0536: ldstr "apply"
+			IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0540: br IL_055b
 
-			IL_04f7: ldloc.s 26
-			IL_04f9: ldstr "apply"
-			IL_04fe: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:124"
-			IL_0503: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0545: ldloc.s 26
+			IL_0547: ldstr "apply"
+			IL_054c: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:124"
+			IL_0551: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_050d: stloc.s 26
-			IL_050f: ldloc.s 26
-			IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0516: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_051b: stloc.s 24
-			IL_051d: ldstr "call"
-			IL_0522: ldloc.s 24
-			IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0529: pop
-			IL_052a: leave IL_0598
+			IL_055b: stloc.s 26
+			IL_055d: ldloc.s 26
+			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0564: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0569: stloc.s 24
+			IL_056b: volatile.
+			IL_056d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0572: brfalse IL_0588
+
+			IL_0577: ldstr "call"
+			IL_057c: ldloc.s 24
+			IL_057e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0583: br IL_059e
+
+			IL_0588: ldstr "call"
+			IL_058d: ldloc.s 24
+			IL_058f: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:127"
+			IL_0594: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_059e: pop
+			IL_059f: leave IL_060d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_052f: stloc.3
-			IL_0530: ldloc.3
-			IL_0531: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0536: dup
-			IL_0537: brtrue IL_054c
+			IL_05a4: stloc.3
+			IL_05a5: ldloc.3
+			IL_05a6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05ab: dup
+			IL_05ac: brtrue IL_05c1
 
-			IL_053c: pop
-			IL_053d: ldloc.3
-			IL_053e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0543: dup
-			IL_0544: brtrue IL_0558
+			IL_05b1: pop
+			IL_05b2: ldloc.3
+			IL_05b3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_05b8: dup
+			IL_05b9: brtrue IL_05cd
 
-			IL_0549: pop
-			IL_054a: rethrow
+			IL_05be: pop
+			IL_05bf: rethrow
 
-			IL_054c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0551: stloc.s 4
-			IL_0553: br IL_055a
+			IL_05c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_05c6: stloc.s 4
+			IL_05c8: br IL_05cf
 
-			IL_0558: stloc.s 4
+			IL_05cd: stloc.s 4
 
-			IL_055a: ldloc.s 4
-			IL_055c: stloc.s 5
-			IL_055e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0563: stloc.s 23
-			IL_0565: ldloc.s 5
-			IL_0567: stloc.s 26
-			IL_0569: ldstr "TypeError"
-			IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0573: stloc.s 29
-			IL_0575: ldloc.s 26
-			IL_0577: ldloc.s 29
-			IL_0579: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_057e: stloc.s 27
-			IL_0580: ldloc.s 27
-			IL_0582: box [System.Runtime]System.Boolean
-			IL_0587: stloc.s 28
-			IL_0589: ldloc.s 23
-			IL_058b: ldloc.s 28
-			IL_058d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0592: pop
-			IL_0593: leave IL_0598
+			IL_05cf: ldloc.s 4
+			IL_05d1: stloc.s 5
+			IL_05d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05d8: stloc.s 23
+			IL_05da: ldloc.s 5
+			IL_05dc: stloc.s 26
+			IL_05de: ldstr "TypeError"
+			IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05e8: stloc.s 29
+			IL_05ea: ldloc.s 26
+			IL_05ec: ldloc.s 29
+			IL_05ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_05f3: stloc.s 27
+			IL_05f5: ldloc.s 27
+			IL_05f7: box [System.Runtime]System.Boolean
+			IL_05fc: stloc.s 28
+			IL_05fe: ldloc.s 23
+			IL_0600: ldloc.s 28
+			IL_0602: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0607: pop
+			IL_0608: leave IL_060d
 		} // end handler
 		.try
 		{
-			IL_0598: nop
-			IL_0599: ldstr "Function"
-			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05a3: volatile.
-			IL_05a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_05aa: brfalse IL_05be
+			IL_060d: nop
+			IL_060e: ldstr "Function"
+			IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0618: volatile.
+			IL_061a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_061f: brfalse IL_0633
 
-			IL_05af: ldstr "prototype"
-			IL_05b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05b9: br IL_05d2
+			IL_0624: ldstr "prototype"
+			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_062e: br IL_0647
 
-			IL_05be: ldstr "prototype"
-			IL_05c3: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:154"
-			IL_05c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_05cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0633: ldstr "prototype"
+			IL_0638: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:154"
+			IL_063d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_05d2: stloc.s 29
-			IL_05d4: volatile.
-			IL_05d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_05db: brfalse IL_05f1
+			IL_0647: stloc.s 29
+			IL_0649: volatile.
+			IL_064b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0650: brfalse IL_0666
 
-			IL_05e0: ldloc.s 29
-			IL_05e2: ldstr "call"
-			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ec: br IL_0607
+			IL_0655: ldloc.s 29
+			IL_0657: ldstr "call"
+			IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0661: br IL_067c
 
-			IL_05f1: ldloc.s 29
-			IL_05f3: ldstr "call"
-			IL_05f8: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:156"
-			IL_05fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0666: ldloc.s 29
+			IL_0668: ldstr "call"
+			IL_066d: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:156"
+			IL_0672: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0607: stloc.s 29
-			IL_0609: ldloc.s 29
-			IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0610: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0615: stloc.s 24
-			IL_0617: ldstr "call"
-			IL_061c: ldloc.s 24
-			IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0623: pop
-			IL_0624: leave IL_0695
+			IL_067c: stloc.s 29
+			IL_067e: ldloc.s 29
+			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0685: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_068a: stloc.s 24
+			IL_068c: volatile.
+			IL_068e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0693: brfalse IL_06a9
+
+			IL_0698: ldstr "call"
+			IL_069d: ldloc.s 24
+			IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06a4: br IL_06bf
+
+			IL_06a9: ldstr "call"
+			IL_06ae: ldloc.s 24
+			IL_06b0: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:159"
+			IL_06b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_06bf: pop
+			IL_06c0: leave IL_0731
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0629: stloc.s 6
-			IL_062b: ldloc.s 6
-			IL_062d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0632: dup
-			IL_0633: brtrue IL_0649
+			IL_06c5: stloc.s 6
+			IL_06c7: ldloc.s 6
+			IL_06c9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06ce: dup
+			IL_06cf: brtrue IL_06e5
 
-			IL_0638: pop
-			IL_0639: ldloc.s 6
-			IL_063b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0640: dup
-			IL_0641: brtrue IL_0655
+			IL_06d4: pop
+			IL_06d5: ldloc.s 6
+			IL_06d7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06dc: dup
+			IL_06dd: brtrue IL_06f1
 
-			IL_0646: pop
-			IL_0647: rethrow
+			IL_06e2: pop
+			IL_06e3: rethrow
 
-			IL_0649: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_064e: stloc.s 7
-			IL_0650: br IL_0657
+			IL_06e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_06ea: stloc.s 7
+			IL_06ec: br IL_06f3
 
-			IL_0655: stloc.s 7
+			IL_06f1: stloc.s 7
 
-			IL_0657: ldloc.s 7
-			IL_0659: stloc.s 8
-			IL_065b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0660: stloc.s 23
-			IL_0662: ldloc.s 8
-			IL_0664: stloc.s 29
-			IL_0666: ldstr "TypeError"
-			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0670: stloc.s 26
-			IL_0672: ldloc.s 29
-			IL_0674: ldloc.s 26
-			IL_0676: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_067b: stloc.s 27
-			IL_067d: ldloc.s 27
-			IL_067f: box [System.Runtime]System.Boolean
-			IL_0684: stloc.s 28
-			IL_0686: ldloc.s 23
-			IL_0688: ldloc.s 28
-			IL_068a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_068f: pop
-			IL_0690: leave IL_0695
+			IL_06f3: ldloc.s 7
+			IL_06f5: stloc.s 8
+			IL_06f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06fc: stloc.s 23
+			IL_06fe: ldloc.s 8
+			IL_0700: stloc.s 29
+			IL_0702: ldstr "TypeError"
+			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_070c: stloc.s 26
+			IL_070e: ldloc.s 29
+			IL_0710: ldloc.s 26
+			IL_0712: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0717: stloc.s 27
+			IL_0719: ldloc.s 27
+			IL_071b: box [System.Runtime]System.Boolean
+			IL_0720: stloc.s 28
+			IL_0722: ldloc.s 23
+			IL_0724: ldloc.s 28
+			IL_0726: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_072b: pop
+			IL_072c: leave IL_0731
 		} // end handler
 		.try
 		{
-			IL_0695: nop
-			IL_0696: ldstr "Function"
-			IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06a0: volatile.
-			IL_06a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_06a7: brfalse IL_06bb
+			IL_0731: nop
+			IL_0732: ldstr "Function"
+			IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_073c: volatile.
+			IL_073e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0743: brfalse IL_0757
 
-			IL_06ac: ldstr "prototype"
-			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06b6: br IL_06cf
+			IL_0748: ldstr "prototype"
+			IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0752: br IL_076b
 
-			IL_06bb: ldstr "prototype"
-			IL_06c0: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:186"
-			IL_06c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0757: ldstr "prototype"
+			IL_075c: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:186"
+			IL_0761: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06cf: stloc.s 26
-			IL_06d1: volatile.
-			IL_06d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_06d8: brfalse IL_06ee
+			IL_076b: stloc.s 26
+			IL_076d: volatile.
+			IL_076f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0774: brfalse IL_078a
 
-			IL_06dd: ldloc.s 26
-			IL_06df: ldstr "bind"
-			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06e9: br IL_0704
+			IL_0779: ldloc.s 26
+			IL_077b: ldstr "bind"
+			IL_0780: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0785: br IL_07a0
 
-			IL_06ee: ldloc.s 26
-			IL_06f0: ldstr "bind"
-			IL_06f5: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:188"
-			IL_06fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_078a: ldloc.s 26
+			IL_078c: ldstr "bind"
+			IL_0791: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:188"
+			IL_0796: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_079b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0704: stloc.s 26
-			IL_0706: ldloc.s 26
-			IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_070d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0712: stloc.s 24
-			IL_0714: ldstr "call"
-			IL_0719: ldloc.s 24
-			IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0720: pop
-			IL_0721: leave IL_0792
+			IL_07a0: stloc.s 26
+			IL_07a2: ldloc.s 26
+			IL_07a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07a9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_07ae: stloc.s 24
+			IL_07b0: volatile.
+			IL_07b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_07b7: brfalse IL_07cd
+
+			IL_07bc: ldstr "call"
+			IL_07c1: ldloc.s 24
+			IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_07c8: br IL_07e3
+
+			IL_07cd: ldstr "call"
+			IL_07d2: ldloc.s 24
+			IL_07d4: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:191"
+			IL_07d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_07de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_07e3: pop
+			IL_07e4: leave IL_0855
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0726: stloc.s 9
-			IL_0728: ldloc.s 9
-			IL_072a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_072f: dup
-			IL_0730: brtrue IL_0746
+			IL_07e9: stloc.s 9
+			IL_07eb: ldloc.s 9
+			IL_07ed: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_07f2: dup
+			IL_07f3: brtrue IL_0809
 
-			IL_0735: pop
-			IL_0736: ldloc.s 9
-			IL_0738: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_073d: dup
-			IL_073e: brtrue IL_0752
+			IL_07f8: pop
+			IL_07f9: ldloc.s 9
+			IL_07fb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0800: dup
+			IL_0801: brtrue IL_0815
 
-			IL_0743: pop
-			IL_0744: rethrow
+			IL_0806: pop
+			IL_0807: rethrow
 
-			IL_0746: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_074b: stloc.s 10
-			IL_074d: br IL_0754
+			IL_0809: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_080e: stloc.s 10
+			IL_0810: br IL_0817
 
-			IL_0752: stloc.s 10
+			IL_0815: stloc.s 10
 
-			IL_0754: ldloc.s 10
-			IL_0756: stloc.s 11
-			IL_0758: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_075d: stloc.s 23
-			IL_075f: ldloc.s 11
-			IL_0761: stloc.s 26
-			IL_0763: ldstr "TypeError"
-			IL_0768: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_076d: stloc.s 29
-			IL_076f: ldloc.s 26
-			IL_0771: ldloc.s 29
-			IL_0773: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0778: stloc.s 27
-			IL_077a: ldloc.s 27
-			IL_077c: box [System.Runtime]System.Boolean
-			IL_0781: stloc.s 28
-			IL_0783: ldloc.s 23
-			IL_0785: ldloc.s 28
-			IL_0787: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_078c: pop
-			IL_078d: leave IL_0792
+			IL_0817: ldloc.s 10
+			IL_0819: stloc.s 11
+			IL_081b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0820: stloc.s 23
+			IL_0822: ldloc.s 11
+			IL_0824: stloc.s 26
+			IL_0826: ldstr "TypeError"
+			IL_082b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0830: stloc.s 29
+			IL_0832: ldloc.s 26
+			IL_0834: ldloc.s 29
+			IL_0836: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_083b: stloc.s 27
+			IL_083d: ldloc.s 27
+			IL_083f: box [System.Runtime]System.Boolean
+			IL_0844: stloc.s 28
+			IL_0846: ldloc.s 23
+			IL_0848: ldloc.s 28
+			IL_084a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_084f: pop
+			IL_0850: leave IL_0855
 		} // end handler
 		.try
 		{
-			IL_0792: nop
-			IL_0793: ldstr "Function"
-			IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_079d: volatile.
-			IL_079f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_07a4: brfalse IL_07b8
+			IL_0855: nop
+			IL_0856: ldstr "Function"
+			IL_085b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0860: volatile.
+			IL_0862: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0867: brfalse IL_087b
 
-			IL_07a9: ldstr "prototype"
-			IL_07ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07b3: br IL_07cc
+			IL_086c: ldstr "prototype"
+			IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0876: br IL_088f
 
-			IL_07b8: ldstr "prototype"
-			IL_07bd: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:218"
-			IL_07c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_07c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_087b: ldstr "prototype"
+			IL_0880: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:218"
+			IL_0885: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_088a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07cc: stloc.s 29
-			IL_07ce: volatile.
-			IL_07d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_07d5: brfalse IL_07eb
+			IL_088f: stloc.s 29
+			IL_0891: volatile.
+			IL_0893: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0898: brfalse IL_08ae
 
-			IL_07da: ldloc.s 29
-			IL_07dc: ldstr "toString"
-			IL_07e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07e6: br IL_0801
+			IL_089d: ldloc.s 29
+			IL_089f: ldstr "toString"
+			IL_08a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08a9: br IL_08c4
 
-			IL_07eb: ldloc.s 29
-			IL_07ed: ldstr "toString"
-			IL_07f2: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:220"
-			IL_07f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_08ae: ldloc.s 29
+			IL_08b0: ldstr "toString"
+			IL_08b5: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:220"
+			IL_08ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_08bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0801: stloc.s 29
-			IL_0803: ldloc.s 29
-			IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_080a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_080f: stloc.s 24
-			IL_0811: ldstr "call"
-			IL_0816: ldloc.s 24
-			IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_081d: pop
-			IL_081e: leave IL_088f
+			IL_08c4: stloc.s 29
+			IL_08c6: ldloc.s 29
+			IL_08c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08cd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_08d2: stloc.s 24
+			IL_08d4: volatile.
+			IL_08d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_08db: brfalse IL_08f1
+
+			IL_08e0: ldstr "call"
+			IL_08e5: ldloc.s 24
+			IL_08e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_08ec: br IL_0907
+
+			IL_08f1: ldstr "call"
+			IL_08f6: ldloc.s 24
+			IL_08f8: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:223"
+			IL_08fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0902: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0907: pop
+			IL_0908: leave IL_0979
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0823: stloc.s 12
-			IL_0825: ldloc.s 12
-			IL_0827: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_082c: dup
-			IL_082d: brtrue IL_0843
+			IL_090d: stloc.s 12
+			IL_090f: ldloc.s 12
+			IL_0911: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0916: dup
+			IL_0917: brtrue IL_092d
 
-			IL_0832: pop
-			IL_0833: ldloc.s 12
-			IL_0835: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_083a: dup
-			IL_083b: brtrue IL_084f
+			IL_091c: pop
+			IL_091d: ldloc.s 12
+			IL_091f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0924: dup
+			IL_0925: brtrue IL_0939
 
-			IL_0840: pop
-			IL_0841: rethrow
+			IL_092a: pop
+			IL_092b: rethrow
 
-			IL_0843: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0848: stloc.s 13
-			IL_084a: br IL_0851
+			IL_092d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0932: stloc.s 13
+			IL_0934: br IL_093b
 
-			IL_084f: stloc.s 13
+			IL_0939: stloc.s 13
 
-			IL_0851: ldloc.s 13
-			IL_0853: stloc.s 14
-			IL_0855: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_085a: stloc.s 23
-			IL_085c: ldloc.s 14
-			IL_085e: stloc.s 29
-			IL_0860: ldstr "TypeError"
-			IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_086a: stloc.s 26
-			IL_086c: ldloc.s 29
-			IL_086e: ldloc.s 26
-			IL_0870: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0875: stloc.s 27
-			IL_0877: ldloc.s 27
-			IL_0879: box [System.Runtime]System.Boolean
-			IL_087e: stloc.s 28
-			IL_0880: ldloc.s 23
-			IL_0882: ldloc.s 28
-			IL_0884: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0889: pop
-			IL_088a: leave IL_088f
+			IL_093b: ldloc.s 13
+			IL_093d: stloc.s 14
+			IL_093f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0944: stloc.s 23
+			IL_0946: ldloc.s 14
+			IL_0948: stloc.s 29
+			IL_094a: ldstr "TypeError"
+			IL_094f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0954: stloc.s 26
+			IL_0956: ldloc.s 29
+			IL_0958: ldloc.s 26
+			IL_095a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_095f: stloc.s 27
+			IL_0961: ldloc.s 27
+			IL_0963: box [System.Runtime]System.Boolean
+			IL_0968: stloc.s 28
+			IL_096a: ldloc.s 23
+			IL_096c: ldloc.s 28
+			IL_096e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0973: pop
+			IL_0974: leave IL_0979
 		} // end handler
 		.try
 		{
-			IL_088f: nop
-			IL_0890: volatile.
-			IL_0892: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0897: brfalse IL_08ac
+			IL_0979: nop
+			IL_097a: volatile.
+			IL_097c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0981: brfalse IL_0996
 
-			IL_089c: ldloc.1
-			IL_089d: ldstr "caller"
-			IL_08a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a7: br IL_08c1
+			IL_0986: ldloc.1
+			IL_0987: ldstr "caller"
+			IL_098c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0991: br IL_09ab
 
-			IL_08ac: ldloc.1
-			IL_08ad: ldstr "caller"
-			IL_08b2: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:248"
-			IL_08b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_08bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0996: ldloc.1
+			IL_0997: ldstr "caller"
+			IL_099c: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:248"
+			IL_09a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_09a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08c1: pop
-			IL_08c2: leave IL_0933
+			IL_09ab: pop
+			IL_09ac: leave IL_0a1d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_08c7: stloc.s 15
-			IL_08c9: ldloc.s 15
-			IL_08cb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_08d0: dup
-			IL_08d1: brtrue IL_08e7
+			IL_09b1: stloc.s 15
+			IL_09b3: ldloc.s 15
+			IL_09b5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_09ba: dup
+			IL_09bb: brtrue IL_09d1
 
-			IL_08d6: pop
-			IL_08d7: ldloc.s 15
-			IL_08d9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_08de: dup
-			IL_08df: brtrue IL_08f3
+			IL_09c0: pop
+			IL_09c1: ldloc.s 15
+			IL_09c3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_09c8: dup
+			IL_09c9: brtrue IL_09dd
 
-			IL_08e4: pop
-			IL_08e5: rethrow
+			IL_09ce: pop
+			IL_09cf: rethrow
 
-			IL_08e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_08ec: stloc.s 16
-			IL_08ee: br IL_08f5
+			IL_09d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_09d6: stloc.s 16
+			IL_09d8: br IL_09df
 
-			IL_08f3: stloc.s 16
+			IL_09dd: stloc.s 16
 
-			IL_08f5: ldloc.s 16
-			IL_08f7: stloc.s 17
-			IL_08f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08fe: stloc.s 23
-			IL_0900: ldloc.s 17
-			IL_0902: stloc.s 26
-			IL_0904: ldstr "TypeError"
-			IL_0909: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_090e: stloc.s 29
-			IL_0910: ldloc.s 26
-			IL_0912: ldloc.s 29
-			IL_0914: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0919: stloc.s 27
-			IL_091b: ldloc.s 27
-			IL_091d: box [System.Runtime]System.Boolean
-			IL_0922: stloc.s 28
-			IL_0924: ldloc.s 23
-			IL_0926: ldloc.s 28
-			IL_0928: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_092d: pop
-			IL_092e: leave IL_0933
+			IL_09df: ldloc.s 16
+			IL_09e1: stloc.s 17
+			IL_09e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09e8: stloc.s 23
+			IL_09ea: ldloc.s 17
+			IL_09ec: stloc.s 26
+			IL_09ee: ldstr "TypeError"
+			IL_09f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09f8: stloc.s 29
+			IL_09fa: ldloc.s 26
+			IL_09fc: ldloc.s 29
+			IL_09fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0a03: stloc.s 27
+			IL_0a05: ldloc.s 27
+			IL_0a07: box [System.Runtime]System.Boolean
+			IL_0a0c: stloc.s 28
+			IL_0a0e: ldloc.s 23
+			IL_0a10: ldloc.s 28
+			IL_0a12: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a17: pop
+			IL_0a18: leave IL_0a1d
 		} // end handler
 		.try
 		{
-			IL_0933: nop
-			IL_0934: volatile.
-			IL_0936: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_093b: brfalse IL_0950
+			IL_0a1d: nop
+			IL_0a1e: volatile.
+			IL_0a20: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0a25: brfalse IL_0a3a
 
-			IL_0940: ldloc.1
-			IL_0941: ldstr "arguments"
-			IL_0946: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_094b: br IL_0965
+			IL_0a2a: ldloc.1
+			IL_0a2b: ldstr "arguments"
+			IL_0a30: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a35: br IL_0a4f
 
-			IL_0950: ldloc.1
-			IL_0951: ldstr "arguments"
-			IL_0956: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:273"
-			IL_095b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0960: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0a3a: ldloc.1
+			IL_0a3b: ldstr "arguments"
+			IL_0a40: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:273"
+			IL_0a45: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0a4a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0965: pop
-			IL_0966: leave IL_09d7
+			IL_0a4f: pop
+			IL_0a50: leave IL_0ac1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_096b: stloc.s 18
-			IL_096d: ldloc.s 18
-			IL_096f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0974: dup
-			IL_0975: brtrue IL_098b
+			IL_0a55: stloc.s 18
+			IL_0a57: ldloc.s 18
+			IL_0a59: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0a5e: dup
+			IL_0a5f: brtrue IL_0a75
 
-			IL_097a: pop
-			IL_097b: ldloc.s 18
-			IL_097d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0982: dup
-			IL_0983: brtrue IL_0997
+			IL_0a64: pop
+			IL_0a65: ldloc.s 18
+			IL_0a67: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0a6c: dup
+			IL_0a6d: brtrue IL_0a81
 
-			IL_0988: pop
-			IL_0989: rethrow
+			IL_0a72: pop
+			IL_0a73: rethrow
 
-			IL_098b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0990: stloc.s 19
-			IL_0992: br IL_0999
+			IL_0a75: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0a7a: stloc.s 19
+			IL_0a7c: br IL_0a83
 
-			IL_0997: stloc.s 19
+			IL_0a81: stloc.s 19
 
-			IL_0999: ldloc.s 19
-			IL_099b: stloc.s 20
-			IL_099d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09a2: stloc.s 23
-			IL_09a4: ldloc.s 20
-			IL_09a6: stloc.s 29
-			IL_09a8: ldstr "TypeError"
-			IL_09ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09b2: stloc.s 26
-			IL_09b4: ldloc.s 29
-			IL_09b6: ldloc.s 26
-			IL_09b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_09bd: stloc.s 27
-			IL_09bf: ldloc.s 27
-			IL_09c1: box [System.Runtime]System.Boolean
-			IL_09c6: stloc.s 28
-			IL_09c8: ldloc.s 23
-			IL_09ca: ldloc.s 28
-			IL_09cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_09d1: pop
-			IL_09d2: leave IL_09d7
+			IL_0a83: ldloc.s 19
+			IL_0a85: stloc.s 20
+			IL_0a87: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a8c: stloc.s 23
+			IL_0a8e: ldloc.s 20
+			IL_0a90: stloc.s 29
+			IL_0a92: ldstr "TypeError"
+			IL_0a97: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a9c: stloc.s 26
+			IL_0a9e: ldloc.s 29
+			IL_0aa0: ldloc.s 26
+			IL_0aa2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0aa7: stloc.s 27
+			IL_0aa9: ldloc.s 27
+			IL_0aab: box [System.Runtime]System.Boolean
+			IL_0ab0: stloc.s 28
+			IL_0ab2: ldloc.s 23
+			IL_0ab4: ldloc.s 28
+			IL_0ab6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0abb: pop
+			IL_0abc: leave IL_0ac1
 		} // end handler
 
-		IL_09d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09dc: stloc.s 23
-		IL_09de: ldstr "Function"
-		IL_09e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_09e8: volatile.
-		IL_09ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_09ef: brfalse IL_0a03
+		IL_0ac1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ac6: stloc.s 23
+		IL_0ac8: ldstr "Function"
+		IL_0acd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0ad2: volatile.
+		IL_0ad4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0ad9: brfalse IL_0aed
 
-		IL_09f4: ldstr "prototype"
-		IL_09f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09fe: br IL_0a17
+		IL_0ade: ldstr "prototype"
+		IL_0ae3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ae8: br IL_0b01
 
-		IL_0a03: ldstr "prototype"
-		IL_0a08: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:298"
-		IL_0a0d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0a12: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0aed: ldstr "prototype"
+		IL_0af2: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:298"
+		IL_0af7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0afc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a17: stloc.s 26
-		IL_0a19: volatile.
-		IL_0a1b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0a20: brfalse IL_0a36
+		IL_0b01: stloc.s 26
+		IL_0b03: volatile.
+		IL_0b05: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0b0a: brfalse IL_0b20
 
-		IL_0a25: ldloc.s 26
-		IL_0a27: ldstr "apply"
-		IL_0a2c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a31: br IL_0a4c
+		IL_0b0f: ldloc.s 26
+		IL_0b11: ldstr "apply"
+		IL_0b16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b1b: br IL_0b36
 
-		IL_0a36: ldloc.s 26
-		IL_0a38: ldstr "apply"
-		IL_0a3d: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:300"
-		IL_0a42: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0a47: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0b20: ldloc.s 26
+		IL_0b22: ldstr "apply"
+		IL_0b27: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:300"
+		IL_0b2c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0b31: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a4c: stloc.s 26
-		IL_0a4e: volatile.
-		IL_0a50: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0a55: brfalse IL_0a6b
+		IL_0b36: stloc.s 26
+		IL_0b38: volatile.
+		IL_0b3a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0b3f: brfalse IL_0b55
 
-		IL_0a5a: ldloc.s 26
-		IL_0a5c: ldstr "length"
-		IL_0a61: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a66: br IL_0a81
+		IL_0b44: ldloc.s 26
+		IL_0b46: ldstr "length"
+		IL_0b4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b50: br IL_0b6b
 
-		IL_0a6b: ldloc.s 26
-		IL_0a6d: ldstr "length"
-		IL_0a72: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:302"
-		IL_0a77: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0a7c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0b55: ldloc.s 26
+		IL_0b57: ldstr "length"
+		IL_0b5c: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:302"
+		IL_0b61: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0b66: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a81: stloc.s 26
-		IL_0a83: ldloc.s 23
-		IL_0a85: ldloc.s 26
-		IL_0a87: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0a8c: pop
-		IL_0a8d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0a92: stloc.s 23
-		IL_0a94: ldstr "Function"
-		IL_0a99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0a9e: volatile.
-		IL_0aa0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0aa5: brfalse IL_0ab9
+		IL_0b6b: stloc.s 26
+		IL_0b6d: ldloc.s 23
+		IL_0b6f: ldloc.s 26
+		IL_0b71: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b76: pop
+		IL_0b77: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b7c: stloc.s 23
+		IL_0b7e: ldstr "Function"
+		IL_0b83: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b88: volatile.
+		IL_0b8a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0b8f: brfalse IL_0ba3
 
-		IL_0aaa: ldstr "prototype"
-		IL_0aaf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ab4: br IL_0acd
+		IL_0b94: ldstr "prototype"
+		IL_0b99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b9e: br IL_0bb7
 
-		IL_0ab9: ldstr "prototype"
-		IL_0abe: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:309"
-		IL_0ac3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0ac8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ba3: ldstr "prototype"
+		IL_0ba8: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:309"
+		IL_0bad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0bb2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0acd: stloc.s 26
-		IL_0acf: volatile.
-		IL_0ad1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0ad6: brfalse IL_0aec
+		IL_0bb7: stloc.s 26
+		IL_0bb9: volatile.
+		IL_0bbb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0bc0: brfalse IL_0bd6
 
-		IL_0adb: ldloc.s 26
-		IL_0add: ldstr "call"
-		IL_0ae2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ae7: br IL_0b02
+		IL_0bc5: ldloc.s 26
+		IL_0bc7: ldstr "call"
+		IL_0bcc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0bd1: br IL_0bec
 
-		IL_0aec: ldloc.s 26
-		IL_0aee: ldstr "call"
-		IL_0af3: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:311"
-		IL_0af8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0afd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0bd6: ldloc.s 26
+		IL_0bd8: ldstr "call"
+		IL_0bdd: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:311"
+		IL_0be2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0be7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0b02: stloc.s 26
-		IL_0b04: volatile.
-		IL_0b06: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0b0b: brfalse IL_0b21
+		IL_0bec: stloc.s 26
+		IL_0bee: volatile.
+		IL_0bf0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0bf5: brfalse IL_0c0b
 
-		IL_0b10: ldloc.s 26
-		IL_0b12: ldstr "length"
-		IL_0b17: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b1c: br IL_0b37
+		IL_0bfa: ldloc.s 26
+		IL_0bfc: ldstr "length"
+		IL_0c01: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c06: br IL_0c21
 
-		IL_0b21: ldloc.s 26
-		IL_0b23: ldstr "length"
-		IL_0b28: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:313"
-		IL_0b2d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0b32: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0c0b: ldloc.s 26
+		IL_0c0d: ldstr "length"
+		IL_0c12: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:313"
+		IL_0c17: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0c1c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0b37: stloc.s 26
-		IL_0b39: ldloc.s 23
-		IL_0b3b: ldloc.s 26
-		IL_0b3d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0b42: pop
-		IL_0b43: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b48: stloc.s 23
-		IL_0b4a: ldstr "Function"
-		IL_0b4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b54: volatile.
-		IL_0b56: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0b5b: brfalse IL_0b6f
+		IL_0c21: stloc.s 26
+		IL_0c23: ldloc.s 23
+		IL_0c25: ldloc.s 26
+		IL_0c27: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0c2c: pop
+		IL_0c2d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0c32: stloc.s 23
+		IL_0c34: ldstr "Function"
+		IL_0c39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0c3e: volatile.
+		IL_0c40: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0c45: brfalse IL_0c59
 
-		IL_0b60: ldstr "prototype"
-		IL_0b65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b6a: br IL_0b83
+		IL_0c4a: ldstr "prototype"
+		IL_0c4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c54: br IL_0c6d
 
-		IL_0b6f: ldstr "prototype"
-		IL_0b74: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:320"
-		IL_0b79: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0b7e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0c59: ldstr "prototype"
+		IL_0c5e: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:320"
+		IL_0c63: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0c68: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0b83: stloc.s 26
-		IL_0b85: volatile.
-		IL_0b87: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0b8c: brfalse IL_0ba2
+		IL_0c6d: stloc.s 26
+		IL_0c6f: volatile.
+		IL_0c71: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0c76: brfalse IL_0c8c
 
-		IL_0b91: ldloc.s 26
-		IL_0b93: ldstr "bind"
-		IL_0b98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b9d: br IL_0bb8
+		IL_0c7b: ldloc.s 26
+		IL_0c7d: ldstr "bind"
+		IL_0c82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c87: br IL_0ca2
 
-		IL_0ba2: ldloc.s 26
-		IL_0ba4: ldstr "bind"
-		IL_0ba9: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:322"
-		IL_0bae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0bb3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0c8c: ldloc.s 26
+		IL_0c8e: ldstr "bind"
+		IL_0c93: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:322"
+		IL_0c98: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0c9d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0bb8: stloc.s 26
-		IL_0bba: volatile.
-		IL_0bbc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0bc1: brfalse IL_0bd7
+		IL_0ca2: stloc.s 26
+		IL_0ca4: volatile.
+		IL_0ca6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0cab: brfalse IL_0cc1
 
-		IL_0bc6: ldloc.s 26
-		IL_0bc8: ldstr "length"
-		IL_0bcd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0bd2: br IL_0bed
+		IL_0cb0: ldloc.s 26
+		IL_0cb2: ldstr "length"
+		IL_0cb7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0cbc: br IL_0cd7
 
-		IL_0bd7: ldloc.s 26
-		IL_0bd9: ldstr "length"
-		IL_0bde: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:324"
-		IL_0be3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0be8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0cc1: ldloc.s 26
+		IL_0cc3: ldstr "length"
+		IL_0cc8: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:324"
+		IL_0ccd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0cd2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0bed: stloc.s 26
-		IL_0bef: ldloc.s 23
-		IL_0bf1: ldloc.s 26
-		IL_0bf3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0bf8: pop
-		IL_0bf9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0bfe: stloc.s 23
-		IL_0c00: ldstr "Function"
-		IL_0c05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0c0a: volatile.
-		IL_0c0c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0c11: brfalse IL_0c25
+		IL_0cd7: stloc.s 26
+		IL_0cd9: ldloc.s 23
+		IL_0cdb: ldloc.s 26
+		IL_0cdd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0ce2: pop
+		IL_0ce3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ce8: stloc.s 23
+		IL_0cea: ldstr "Function"
+		IL_0cef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0cf4: volatile.
+		IL_0cf6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0cfb: brfalse IL_0d0f
 
-		IL_0c16: ldstr "prototype"
-		IL_0c1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c20: br IL_0c39
+		IL_0d00: ldstr "prototype"
+		IL_0d05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d0a: br IL_0d23
 
-		IL_0c25: ldstr "prototype"
-		IL_0c2a: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:331"
-		IL_0c2f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0c34: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0d0f: ldstr "prototype"
+		IL_0d14: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:331"
+		IL_0d19: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0d1e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0c39: stloc.s 26
-		IL_0c3b: volatile.
-		IL_0c3d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0c42: brfalse IL_0c58
+		IL_0d23: stloc.s 26
+		IL_0d25: volatile.
+		IL_0d27: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0d2c: brfalse IL_0d42
 
-		IL_0c47: ldloc.s 26
-		IL_0c49: ldstr "toString"
-		IL_0c4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c53: br IL_0c6e
+		IL_0d31: ldloc.s 26
+		IL_0d33: ldstr "toString"
+		IL_0d38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d3d: br IL_0d58
 
-		IL_0c58: ldloc.s 26
-		IL_0c5a: ldstr "toString"
-		IL_0c5f: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:333"
-		IL_0c64: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0c69: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0d42: ldloc.s 26
+		IL_0d44: ldstr "toString"
+		IL_0d49: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:333"
+		IL_0d4e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0d53: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0c6e: stloc.s 26
-		IL_0c70: volatile.
-		IL_0c72: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0c77: brfalse IL_0c8d
+		IL_0d58: stloc.s 26
+		IL_0d5a: volatile.
+		IL_0d5c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0d61: brfalse IL_0d77
 
-		IL_0c7c: ldloc.s 26
-		IL_0c7e: ldstr "length"
-		IL_0c83: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c88: br IL_0ca3
+		IL_0d66: ldloc.s 26
+		IL_0d68: ldstr "length"
+		IL_0d6d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d72: br IL_0d8d
 
-		IL_0c8d: ldloc.s 26
-		IL_0c8f: ldstr "length"
-		IL_0c94: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:335"
-		IL_0c99: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0c9e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0d77: ldloc.s 26
+		IL_0d79: ldstr "length"
+		IL_0d7e: ldstr "Function_ExplicitReceiverAbi:Modules.Function_ExplicitReceiverAbi:__js_module_init__:335"
+		IL_0d83: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0d88: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0ca3: stloc.s 26
-		IL_0ca5: ldloc.s 23
-		IL_0ca7: ldloc.s 26
-		IL_0ca9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0cae: pop
-		IL_0caf: ldnull
-		IL_0cb0: stloc.s 21
-		IL_0cb2: ret
+		IL_0d8d: stloc.s 26
+		IL_0d8f: ldloc.s 23
+		IL_0d91: ldloc.s 26
+		IL_0d93: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0d98: pop
+		IL_0d99: ldnull
+		IL_0d9a: stloc.s 21
+		IL_0d9c: ret
 	} // end of method Function_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.Function_ExplicitReceiverAbi
@@ -2001,6 +2074,12 @@
 	.field assembly static int32 __jroc_dynamicLookup_28
 	.field assembly static int32 __jroc_dynamicLookup_29
 	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
+	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -317,7 +317,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 161 (0xa1)
+		// Code size: 203 (0xcb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithArrayIteration/Scope,
@@ -372,15 +372,27 @@
 		IL_007d: stloc.s 5
 		IL_007f: ldloc.3
 		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0085: ldstr "join"
-		IL_008a: ldstr ","
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0094: stloc.s 6
-		IL_0096: ldloc.s 5
-		IL_0098: ldloc.s 6
-		IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009f: pop
-		IL_00a0: ret
+		IL_0085: volatile.
+		IL_0087: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_008c: brfalse IL_00a5
+
+		IL_0091: ldstr "join"
+		IL_0096: ldstr ","
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a0: br IL_00be
+
+		IL_00a5: ldstr "join"
+		IL_00aa: ldstr ","
+		IL_00af: ldstr "Function_GlobalFunctionWithArrayIteration:Modules.Function_GlobalFunctionWithArrayIteration:__js_module_init__:22"
+		IL_00b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00be: stloc.s 6
+		IL_00c0: ldloc.s 5
+		IL_00c2: ldloc.s 6
+		IL_00c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c9: pop
+		IL_00ca: ret
 	} // end of method Function_GlobalFunctionWithArrayIteration::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithArrayIteration
@@ -405,4 +417,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
@@ -229,7 +229,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -244,7 +244,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "prefix"
 			IL_0036: ldstr "Function_ObjectLiteralMethod_ThisBinding:<TwoPhaseDummy_M4>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -289,7 +289,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 117 (0x75)
+		// Code size: 169 (0xa9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ObjectLiteralMethod_ThisBinding/Scope,
@@ -330,17 +330,31 @@
 		IL_0047: stloc.1
 		IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_004d: stloc.s 4
-		IL_004f: ldloc.1
-		IL_0050: ldstr "format"
-		IL_0055: ldc.r8 42
-		IL_005e: box [System.Runtime]System.Double
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0068: stloc.s 5
-		IL_006a: ldloc.s 4
-		IL_006c: ldloc.s 5
-		IL_006e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0073: pop
-		IL_0074: ret
+		IL_004f: volatile.
+		IL_0051: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0056: brfalse IL_0079
+
+		IL_005b: ldloc.1
+		IL_005c: ldstr "format"
+		IL_0061: ldc.r8 42
+		IL_006a: box [System.Runtime]System.Double
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0074: br IL_009c
+
+		IL_0079: ldloc.1
+		IL_007a: ldstr "format"
+		IL_007f: ldc.r8 42
+		IL_0088: box [System.Runtime]System.Double
+		IL_008d: ldstr "Function_ObjectLiteralMethod_ThisBinding:Modules.Function_ObjectLiteralMethod_ThisBinding:__js_module_init__:13"
+		IL_0092: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009c: stloc.s 5
+		IL_009e: ldloc.s 4
+		IL_00a0: ldloc.s 5
+		IL_00a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a7: pop
+		IL_00a8: ret
 	} // end of method Function_ObjectLiteralMethod_ThisBinding::__js_module_init__
 
 } // end of class Modules.Function_ObjectLiteralMethod_ThisBinding
@@ -371,6 +385,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralValueFunction_ForEachCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralValueFunction_ForEachCapturesOuter.verified.txt
@@ -224,7 +224,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 36 (0x24)
+				// Code size: 75 (0x4b)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -240,13 +240,26 @@
 				IL_000a: castclass Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope
 				IL_000f: ldfld object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope::toBeRemoved
 				IL_0014: stloc.1
-				IL_0015: ldloc.0
-				IL_0016: ldstr "_preremove"
-				IL_001b: ldloc.1
-				IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0021: pop
-				IL_0022: ldnull
-				IL_0023: ret
+				IL_0015: volatile.
+				IL_0017: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+				IL_001c: brfalse IL_0032
+
+				IL_0021: ldloc.0
+				IL_0022: ldstr "_preremove"
+				IL_0027: ldloc.1
+				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_002d: br IL_0048
+
+				IL_0032: ldloc.0
+				IL_0033: ldstr "_preremove"
+				IL_0038: ldloc.1
+				IL_0039: ldstr "Function_ObjectLiteralValueFunction_ForEachCapturesOuter:<TwoPhaseDummy_M6>:__js_call__:4"
+				IL_003e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0048: pop
+				IL_0049: ldnull
+				IL_004a: ret
 			} // end of method FunctionExpression_DocumentLike::__js_call__
 
 		} // end of class FunctionExpression_DocumentLike
@@ -440,7 +453,7 @@
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
 			// Header size: 12
-			// Code size: 234 (0xea)
+			// Code size: 274 (0x112)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope,
@@ -479,7 +492,7 @@
 			IL_0054: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0059: stloc.2
 			IL_005a: ldloc.2
-			IL_005b: brfalse IL_00e8
+			IL_005b: brfalse IL_0110
 
 			IL_0060: volatile.
 			IL_0062: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
@@ -528,14 +541,27 @@
 			IL_00d2: ldc.i4.1
 			IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00d8: stloc.s 4
-			IL_00da: ldloc.1
-			IL_00db: ldstr "forEach"
-			IL_00e0: ldloc.s 4
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00e7: pop
+			IL_00da: volatile.
+			IL_00dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_00e1: brfalse IL_00f8
 
-			IL_00e8: ldnull
-			IL_00e9: ret
+			IL_00e6: ldloc.1
+			IL_00e7: ldstr "forEach"
+			IL_00ec: ldloc.s 4
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00f3: br IL_010f
+
+			IL_00f8: ldloc.1
+			IL_00f9: ldstr "forEach"
+			IL_00fe: ldloc.s 4
+			IL_0100: ldstr "Function_ObjectLiteralValueFunction_ForEachCapturesOuter:<TwoPhaseDummy_M4>:__js_call__:16"
+			IL_0105: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_010f: pop
+
+			IL_0110: ldnull
+			IL_0111: ret
 		} // end of method FunctionExpression_DocumentLike::__js_call__
 
 	} // end of class FunctionExpression_DocumentLike
@@ -930,6 +956,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
@@ -263,7 +263,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 480 (0x1e0)
+		// Code size: 518 (0x206)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Prototype_ToString_Basic/Scope,
@@ -330,116 +330,128 @@
 		IL_0095: stloc.s 4
 		IL_0097: ldloc.s 4
 		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: ldstr "call"
-		IL_00a3: ldloc.1
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a9: stloc.2
-		IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00af: stloc.s 5
-		IL_00b1: ldloc.2
-		IL_00b2: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_00b7: stloc.s 6
-		IL_00b9: ldloc.s 5
-		IL_00bb: ldloc.s 6
-		IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c2: pop
-		IL_00c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c8: stloc.s 5
-		IL_00ca: ldloc.2
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d0: stloc.s 4
-		IL_00d2: ldc.i4.0
-		IL_00d3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_00d8: brfalse IL_0114
+		IL_009e: volatile.
+		IL_00a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a5: brfalse IL_00ba
 
-		IL_00dd: ldloc.s 4
-		IL_00df: isinst [System.Runtime]System.String
-		IL_00e4: dup
-		IL_00e5: brtrue IL_00fd
+		IL_00aa: ldstr "call"
+		IL_00af: ldloc.1
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b5: br IL_00cf
 
-		IL_00ea: pop
-		IL_00eb: ldloc.s 4
-		IL_00ed: ldstr "indexOf"
-		IL_00f2: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_00f7: dup
-		IL_00f8: brfalse IL_0113
+		IL_00ba: ldstr "call"
+		IL_00bf: ldloc.1
+		IL_00c0: ldstr "Function_Prototype_ToString_Basic:Modules.Function_Prototype_ToString_Basic:__js_module_init__:15"
+		IL_00c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00fd: ldstr "function"
-		IL_0102: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_0107: box [System.Runtime]System.Double
-		IL_010c: stloc.s 4
-		IL_010e: br IL_0127
+		IL_00cf: stloc.2
+		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d5: stloc.s 5
+		IL_00d7: ldloc.2
+		IL_00d8: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_00dd: stloc.s 6
+		IL_00df: ldloc.s 5
+		IL_00e1: ldloc.s 6
+		IL_00e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e8: pop
+		IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ee: stloc.s 5
+		IL_00f0: ldloc.2
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f6: stloc.s 4
+		IL_00f8: ldc.i4.0
+		IL_00f9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00fe: brfalse IL_013a
 
-		IL_0113: pop
+		IL_0103: ldloc.s 4
+		IL_0105: isinst [System.Runtime]System.String
+		IL_010a: dup
+		IL_010b: brtrue IL_0123
 
-		IL_0114: ldloc.s 4
-		IL_0116: ldstr "indexOf"
-		IL_011b: ldstr "function"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0125: stloc.s 4
+		IL_0110: pop
+		IL_0111: ldloc.s 4
+		IL_0113: ldstr "indexOf"
+		IL_0118: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_011d: dup
+		IL_011e: brfalse IL_0139
 
-		IL_0127: ldloc.s 4
-		IL_0129: ldc.r8 0.0
-		IL_0132: box [System.Runtime]System.Double
-		IL_0137: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_013c: stloc.s 7
-		IL_013e: ldloc.s 7
-		IL_0140: box [System.Runtime]System.Boolean
-		IL_0145: stloc.s 8
-		IL_0147: ldloc.s 5
-		IL_0149: ldloc.s 8
-		IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0150: pop
-		IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0156: stloc.s 5
-		IL_0158: ldloc.2
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015e: stloc.s 4
-		IL_0160: ldc.i4.0
-		IL_0161: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0166: brfalse IL_01a2
+		IL_0123: ldstr "function"
+		IL_0128: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_012d: box [System.Runtime]System.Double
+		IL_0132: stloc.s 4
+		IL_0134: br IL_014d
 
-		IL_016b: ldloc.s 4
-		IL_016d: isinst [System.Runtime]System.String
-		IL_0172: dup
-		IL_0173: brtrue IL_018b
+		IL_0139: pop
 
-		IL_0178: pop
-		IL_0179: ldloc.s 4
-		IL_017b: ldstr "indexOf"
-		IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_0185: dup
-		IL_0186: brfalse IL_01a1
+		IL_013a: ldloc.s 4
+		IL_013c: ldstr "indexOf"
+		IL_0141: ldstr "function"
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014b: stloc.s 4
 
-		IL_018b: ldstr "[native code]"
-		IL_0190: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_0195: box [System.Runtime]System.Double
-		IL_019a: stloc.s 4
-		IL_019c: br IL_01b5
+		IL_014d: ldloc.s 4
+		IL_014f: ldc.r8 0.0
+		IL_0158: box [System.Runtime]System.Double
+		IL_015d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0162: stloc.s 7
+		IL_0164: ldloc.s 7
+		IL_0166: box [System.Runtime]System.Boolean
+		IL_016b: stloc.s 8
+		IL_016d: ldloc.s 5
+		IL_016f: ldloc.s 8
+		IL_0171: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0176: pop
+		IL_0177: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017c: stloc.s 5
+		IL_017e: ldloc.2
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0184: stloc.s 4
+		IL_0186: ldc.i4.0
+		IL_0187: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_018c: brfalse IL_01c8
 
-		IL_01a1: pop
+		IL_0191: ldloc.s 4
+		IL_0193: isinst [System.Runtime]System.String
+		IL_0198: dup
+		IL_0199: brtrue IL_01b1
 
-		IL_01a2: ldloc.s 4
-		IL_01a4: ldstr "indexOf"
-		IL_01a9: ldstr "[native code]"
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b3: stloc.s 4
+		IL_019e: pop
+		IL_019f: ldloc.s 4
+		IL_01a1: ldstr "indexOf"
+		IL_01a6: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_01ab: dup
+		IL_01ac: brfalse IL_01c7
 
-		IL_01b5: ldloc.s 4
-		IL_01b7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01bc: ldc.r8 0.0
-		IL_01c5: clt
-		IL_01c7: ldc.i4.0
-		IL_01c8: ceq
-		IL_01ca: stloc.s 7
-		IL_01cc: ldloc.s 7
-		IL_01ce: box [System.Runtime]System.Boolean
-		IL_01d3: stloc.s 8
-		IL_01d5: ldloc.s 5
-		IL_01d7: ldloc.s 8
-		IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01de: pop
-		IL_01df: ret
+		IL_01b1: ldstr "[native code]"
+		IL_01b6: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_01bb: box [System.Runtime]System.Double
+		IL_01c0: stloc.s 4
+		IL_01c2: br IL_01db
+
+		IL_01c7: pop
+
+		IL_01c8: ldloc.s 4
+		IL_01ca: ldstr "indexOf"
+		IL_01cf: ldstr "[native code]"
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d9: stloc.s 4
+
+		IL_01db: ldloc.s 4
+		IL_01dd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01e2: ldc.r8 0.0
+		IL_01eb: clt
+		IL_01ed: ldc.i4.0
+		IL_01ee: ceq
+		IL_01f0: stloc.s 7
+		IL_01f2: ldloc.s 7
+		IL_01f4: box [System.Runtime]System.Boolean
+		IL_01f9: stloc.s 8
+		IL_01fb: ldloc.s 5
+		IL_01fd: ldloc.s 8
+		IL_01ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0204: pop
+		IL_0205: ret
 	} // end of method Function_Prototype_ToString_Basic::__js_module_init__
 
 } // end of class Modules.Function_Prototype_ToString_Basic
@@ -471,6 +483,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
@@ -495,7 +495,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 291 (0x123)
+		// Code size: 393 (0x189)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnObjectWithClosure/Scope,
@@ -542,62 +542,88 @@
 		IL_0054: stloc.s 5
 		IL_0056: ldloc.2
 		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005c: ldstr "multiply"
-		IL_0061: ldc.r8 5
-		IL_006a: box [System.Runtime]System.Double
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0074: stloc.s 6
-		IL_0076: ldloc.s 5
-		IL_0078: ldstr "multiply(5):"
-		IL_007d: ldloc.s 6
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0084: pop
-		IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008a: stloc.s 5
-		IL_008c: volatile.
-		IL_008e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0093: brfalse IL_00a8
+		IL_005c: volatile.
+		IL_005e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0063: brfalse IL_0085
 
-		IL_0098: ldloc.2
-		IL_0099: ldstr "factor"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a3: br IL_00bd
+		IL_0068: ldstr "multiply"
+		IL_006d: ldc.r8 5
+		IL_0076: box [System.Runtime]System.Double
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: br IL_00a7
 
-		IL_00a8: ldloc.2
-		IL_00a9: ldstr "factor"
-		IL_00ae: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:25"
-		IL_00b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0085: ldstr "multiply"
+		IL_008a: ldc.r8 5
+		IL_0093: box [System.Runtime]System.Double
+		IL_0098: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:19"
+		IL_009d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00bd: stloc.s 6
-		IL_00bf: ldloc.s 5
-		IL_00c1: ldstr "factor:"
-		IL_00c6: ldloc.s 6
-		IL_00c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00cd: pop
-		IL_00ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00d3: stloc.s 4
-		IL_00d5: ldloc.1
-		IL_00d6: ldloc.s 4
-		IL_00d8: ldc.r8 3
-		IL_00e1: box [System.Runtime]System.Double
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00eb: stloc.3
-		IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f1: stloc.s 5
-		IL_00f3: ldloc.3
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f9: ldstr "multiply"
-		IL_00fe: ldc.r8 7
-		IL_0107: box [System.Runtime]System.Double
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0111: stloc.s 6
-		IL_0113: ldloc.s 5
-		IL_0115: ldstr "calc2.multiply(7):"
-		IL_011a: ldloc.s 6
-		IL_011c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0121: pop
-		IL_0122: ret
+		IL_00a7: stloc.s 6
+		IL_00a9: ldloc.s 5
+		IL_00ab: ldstr "multiply(5):"
+		IL_00b0: ldloc.s 6
+		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00b7: pop
+		IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bd: stloc.s 5
+		IL_00bf: volatile.
+		IL_00c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00c6: brfalse IL_00db
+
+		IL_00cb: ldloc.2
+		IL_00cc: ldstr "factor"
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d6: br IL_00f0
+
+		IL_00db: ldloc.2
+		IL_00dc: ldstr "factor"
+		IL_00e1: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:25"
+		IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_00f0: stloc.s 6
+		IL_00f2: ldloc.s 5
+		IL_00f4: ldstr "factor:"
+		IL_00f9: ldloc.s 6
+		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0100: pop
+		IL_0101: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0106: stloc.s 4
+		IL_0108: ldloc.1
+		IL_0109: ldloc.s 4
+		IL_010b: ldc.r8 3
+		IL_0114: box [System.Runtime]System.Double
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_011e: stloc.3
+		IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0124: stloc.s 5
+		IL_0126: ldloc.3
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012c: volatile.
+		IL_012e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0133: brfalse IL_0155
+
+		IL_0138: ldstr "multiply"
+		IL_013d: ldc.r8 7
+		IL_0146: box [System.Runtime]System.Double
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0150: br IL_0177
+
+		IL_0155: ldstr "multiply"
+		IL_015a: ldc.r8 7
+		IL_0163: box [System.Runtime]System.Double
+		IL_0168: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:39"
+		IL_016d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0177: stloc.s 6
+		IL_0179: ldloc.s 5
+		IL_017b: ldstr "calc2.multiply(7):"
+		IL_0180: ldloc.s 6
+		IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0187: pop
+		IL_0188: ret
 	} // end of method Function_ReturnObjectWithClosure::__js_module_init__
 
 } // end of class Modules.Function_ReturnObjectWithClosure
@@ -628,6 +654,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
@@ -812,7 +812,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.1
@@ -823,7 +823,7 @@
 			IL_002c: ldarg.1
 			IL_002d: ldstr "length"
 			IL_0032: ldstr "Function_SchedulerConversionsStableLoads:<TwoPhaseDummy_M8>:__js_call__:6"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
@@ -1228,7 +1228,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1056 (0x420)
+		// Code size: 1098 (0x44a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerConversionsStableLoads/Scope,
@@ -1504,141 +1504,153 @@
 		IL_02a6: stloc.s 16
 		IL_02a8: ldloc.s 16
 		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02af: ldstr "join"
-		IL_02b4: ldstr ","
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02be: stloc.s 16
-		IL_02c0: ldloc.s 17
-		IL_02c2: ldloc.s 16
-		IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c9: pop
-		IL_02ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02cf: stloc.s 17
-		IL_02d1: volatile.
-		IL_02d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02d8: brfalse IL_02ee
+		IL_02af: volatile.
+		IL_02b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02b6: brfalse IL_02cf
 
-		IL_02dd: ldloc.s 7
-		IL_02df: ldstr "x"
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e9: br IL_0304
+		IL_02bb: ldstr "join"
+		IL_02c0: ldstr ","
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ca: br IL_02e8
 
-		IL_02ee: ldloc.s 7
-		IL_02f0: ldstr "x"
-		IL_02f5: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:92"
-		IL_02fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02cf: ldstr "join"
+		IL_02d4: ldstr ","
+		IL_02d9: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:87"
+		IL_02de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0304: stloc.s 16
-		IL_0306: volatile.
-		IL_0308: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_030d: brfalse IL_0323
+		IL_02e8: stloc.s 16
+		IL_02ea: ldloc.s 17
+		IL_02ec: ldloc.s 16
+		IL_02ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02f3: pop
+		IL_02f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02f9: stloc.s 17
+		IL_02fb: volatile.
+		IL_02fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0302: brfalse IL_0318
 
-		IL_0312: ldloc.s 7
-		IL_0314: ldstr "x"
-		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_031e: br IL_0339
+		IL_0307: ldloc.s 7
+		IL_0309: ldstr "x"
+		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0313: br IL_032e
 
-		IL_0323: ldloc.s 7
-		IL_0325: ldstr "x"
-		IL_032a: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:94"
-		IL_032f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0318: ldloc.s 7
+		IL_031a: ldstr "x"
+		IL_031f: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:92"
+		IL_0324: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0339: stloc.s 20
-		IL_033b: ldloc.s 16
-		IL_033d: ldloc.s 20
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0344: stloc.s 21
-		IL_0346: ldloc.0
-		IL_0347: ldfld object Modules.Function_SchedulerConversionsStableLoads/Scope::getterCount
-		IL_034c: stloc.s 20
-		IL_034e: ldloc.s 17
-		IL_0350: ldloc.s 21
-		IL_0352: ldloc.s 20
-		IL_0354: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0359: pop
+		IL_032e: stloc.s 16
+		IL_0330: volatile.
+		IL_0332: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0337: brfalse IL_034d
+
+		IL_033c: ldloc.s 7
+		IL_033e: ldstr "x"
+		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0348: br IL_0363
+
+		IL_034d: ldloc.s 7
+		IL_034f: ldstr "x"
+		IL_0354: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:94"
+		IL_0359: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0363: stloc.s 20
+		IL_0365: ldloc.s 16
+		IL_0367: ldloc.s 20
+		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_036e: stloc.s 21
+		IL_0370: ldloc.0
+		IL_0371: ldfld object Modules.Function_SchedulerConversionsStableLoads/Scope::getterCount
+		IL_0376: stloc.s 20
+		IL_0378: ldloc.s 17
+		IL_037a: ldloc.s 21
+		IL_037c: ldloc.s 20
+		IL_037e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0383: pop
 		.try
 		{
-			IL_035a: nop
-			IL_035b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0360: stloc.s 17
-			IL_0362: ldstr "Cannot access 'tdzValue' before initialization"
-			IL_0367: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_036c: stloc.s 22
-			IL_036e: ldloc.s 22
-			IL_0370: isinst [System.Runtime]System.Exception
-			IL_0375: dup
-			IL_0376: brtrue IL_0384
+			IL_0384: nop
+			IL_0385: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_038a: stloc.s 17
+			IL_038c: ldstr "Cannot access 'tdzValue' before initialization"
+			IL_0391: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_0396: stloc.s 22
+			IL_0398: ldloc.s 22
+			IL_039a: isinst [System.Runtime]System.Exception
+			IL_039f: dup
+			IL_03a0: brtrue IL_03ae
 
-			IL_037b: pop
-			IL_037c: ldloc.s 22
-			IL_037e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0383: throw
+			IL_03a5: pop
+			IL_03a6: ldloc.s 22
+			IL_03a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03ad: throw
 
-			IL_0384: throw
+			IL_03ae: throw
 
-			IL_0385: ldnull
-			IL_0386: ldc.r8 1
-			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0394: stloc.s 21
-			IL_0396: ldloc.s 17
-			IL_0398: ldloc.s 21
-			IL_039a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_039f: pop
-			IL_03a0: leave IL_0411
+			IL_03af: ldnull
+			IL_03b0: ldc.r8 1
+			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_03be: stloc.s 21
+			IL_03c0: ldloc.s 17
+			IL_03c2: ldloc.s 21
+			IL_03c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03c9: pop
+			IL_03ca: leave IL_043b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03a5: stloc.s 8
-			IL_03a7: ldloc.s 8
-			IL_03a9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03ae: dup
-			IL_03af: brtrue IL_03c5
+			IL_03cf: stloc.s 8
+			IL_03d1: ldloc.s 8
+			IL_03d3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03d8: dup
+			IL_03d9: brtrue IL_03ef
 
-			IL_03b4: pop
-			IL_03b5: ldloc.s 8
-			IL_03b7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03bc: dup
-			IL_03bd: brtrue IL_03d1
+			IL_03de: pop
+			IL_03df: ldloc.s 8
+			IL_03e1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03e6: dup
+			IL_03e7: brtrue IL_03fb
 
-			IL_03c2: pop
-			IL_03c3: rethrow
+			IL_03ec: pop
+			IL_03ed: rethrow
 
-			IL_03c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03ca: stloc.s 9
-			IL_03cc: br IL_03d3
+			IL_03ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03f4: stloc.s 9
+			IL_03f6: br IL_03fd
 
-			IL_03d1: stloc.s 9
+			IL_03fb: stloc.s 9
 
-			IL_03d3: ldloc.s 9
-			IL_03d5: stloc.s 10
-			IL_03d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03dc: stloc.s 17
-			IL_03de: ldloc.s 10
-			IL_03e0: stloc.s 20
-			IL_03e2: ldstr "ReferenceError"
-			IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03ec: stloc.s 16
-			IL_03ee: ldloc.s 20
-			IL_03f0: ldloc.s 16
-			IL_03f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_03f7: stloc.s 23
-			IL_03f9: ldloc.s 23
-			IL_03fb: box [System.Runtime]System.Boolean
-			IL_0400: stloc.s 24
-			IL_0402: ldloc.s 17
-			IL_0404: ldloc.s 24
-			IL_0406: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_040b: pop
-			IL_040c: leave IL_0411
+			IL_03fd: ldloc.s 9
+			IL_03ff: stloc.s 10
+			IL_0401: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0406: stloc.s 17
+			IL_0408: ldloc.s 10
+			IL_040a: stloc.s 20
+			IL_040c: ldstr "ReferenceError"
+			IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0416: stloc.s 16
+			IL_0418: ldloc.s 20
+			IL_041a: ldloc.s 16
+			IL_041c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0421: stloc.s 23
+			IL_0423: ldloc.s 23
+			IL_0425: box [System.Runtime]System.Boolean
+			IL_042a: stloc.s 24
+			IL_042c: ldloc.s 17
+			IL_042e: ldloc.s 24
+			IL_0430: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0435: pop
+			IL_0436: leave IL_043b
 		} // end handler
 
-		IL_0411: ldc.r8 2
-		IL_041a: stloc.s 11
-		IL_041c: ldnull
-		IL_041d: stloc.s 12
-		IL_041f: ret
+		IL_043b: ldc.r8 2
+		IL_0444: stloc.s 11
+		IL_0446: ldnull
+		IL_0447: stloc.s 12
+		IL_0449: ret
 	} // end of method Function_SchedulerConversionsStableLoads::__js_module_init__
 
 } // end of class Modules.Function_SchedulerConversionsStableLoads
@@ -1671,6 +1683,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
@@ -1146,7 +1146,7 @@
 				IL_0022: ldloc.1
 				IL_0023: stfld object Modules.Function_SchedulerGeneralRegions/Scope::order
 				IL_0028: volatile.
-				IL_002a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_002a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_002f: brfalse IL_004e
 
 				IL_0034: ldarg.2
@@ -1161,7 +1161,7 @@
 				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0059: ldstr "_x"
 				IL_005e: ldstr "Function_SchedulerGeneralRegions:<TwoPhaseDummy_M11>:__js_call__:8"
-				IL_0063: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_0063: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_006d: stloc.0
@@ -1569,7 +1569,7 @@
 			IL_00ca: ldloc.3
 			IL_00cb: stloc.1
 			IL_00cc: volatile.
-			IL_00ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_00ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_00d3: brfalse IL_00e8
 
 			IL_00d8: ldloc.1
@@ -1580,7 +1580,7 @@
 			IL_00e8: ldloc.1
 			IL_00e9: ldstr "x"
 			IL_00ee: ldstr "Function_SchedulerGeneralRegions:<TwoPhaseDummy_M9>:__js_call__:26"
-			IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00fd: stloc.s 6
@@ -1595,7 +1595,7 @@
 			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_011f: stloc.s 8
 			IL_0121: volatile.
-			IL_0123: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0123: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_0128: brfalse IL_013d
 
 			IL_012d: ldloc.1
@@ -1606,7 +1606,7 @@
 			IL_013d: ldloc.1
 			IL_013e: ldstr "x"
 			IL_0143: ldstr "Function_SchedulerGeneralRegions:<TwoPhaseDummy_M9>:__js_call__:32"
-			IL_0148: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0148: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0152: stloc.s 7
@@ -1972,7 +1972,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 761 (0x2f9)
+		// Code size: 803 (0x323)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerGeneralRegions/Scope,
@@ -2192,73 +2192,85 @@
 		IL_0218: stloc.s 11
 		IL_021a: ldloc.s 11
 		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0221: ldstr "join"
-		IL_0226: ldstr ","
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0230: stloc.s 11
-		IL_0232: ldloc.s 11
-		IL_0234: ldstr ":"
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_023e: stloc.s 12
-		IL_0240: volatile.
-		IL_0242: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0247: brfalse IL_025d
+		IL_0221: volatile.
+		IL_0223: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0228: brfalse IL_0241
 
-		IL_024c: ldloc.s 6
-		IL_024e: ldstr "y"
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0258: br IL_0273
+		IL_022d: ldstr "join"
+		IL_0232: ldstr ","
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023c: br IL_025a
 
-		IL_025d: ldloc.s 6
-		IL_025f: ldstr "y"
-		IL_0264: ldstr "Function_SchedulerGeneralRegions:Modules.Function_SchedulerGeneralRegions:__js_module_init__:69"
-		IL_0269: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0241: ldstr "join"
+		IL_0246: ldstr ","
+		IL_024b: ldstr "Function_SchedulerGeneralRegions:Modules.Function_SchedulerGeneralRegions:__js_module_init__:65"
+		IL_0250: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0273: stloc.s 11
-		IL_0275: ldloc.s 12
-		IL_0277: ldloc.s 11
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_027e: stloc.s 12
-		IL_0280: ldloc.s 10
-		IL_0282: ldloc.s 12
-		IL_0284: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0289: pop
-		IL_028a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_028f: stloc.s 10
-		IL_0291: ldloc.3
-		IL_0292: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_029c: stloc.s 11
-		IL_029e: ldloc.s 10
-		IL_02a0: ldloc.s 11
-		IL_02a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02a7: pop
-		IL_02a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ad: stloc.s 10
-		IL_02af: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02b4: stloc.s 7
-		IL_02b6: ldloc.s 4
-		IL_02b8: ldloc.s 7
-		IL_02ba: ldc.r8 1
-		IL_02c3: box [System.Runtime]System.Double
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02cd: stloc.s 11
-		IL_02cf: ldloc.s 10
-		IL_02d1: ldloc.s 11
-		IL_02d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d8: pop
-		IL_02d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02de: stloc.s 10
-		IL_02e0: ldloc.s 5
-		IL_02e2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_02ec: stloc.s 11
-		IL_02ee: ldloc.s 10
-		IL_02f0: ldloc.s 11
-		IL_02f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02f7: pop
-		IL_02f8: ret
+		IL_025a: stloc.s 11
+		IL_025c: ldloc.s 11
+		IL_025e: ldstr ":"
+		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0268: stloc.s 12
+		IL_026a: volatile.
+		IL_026c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0271: brfalse IL_0287
+
+		IL_0276: ldloc.s 6
+		IL_0278: ldstr "y"
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0282: br IL_029d
+
+		IL_0287: ldloc.s 6
+		IL_0289: ldstr "y"
+		IL_028e: ldstr "Function_SchedulerGeneralRegions:Modules.Function_SchedulerGeneralRegions:__js_module_init__:69"
+		IL_0293: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_029d: stloc.s 11
+		IL_029f: ldloc.s 12
+		IL_02a1: ldloc.s 11
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02a8: stloc.s 12
+		IL_02aa: ldloc.s 10
+		IL_02ac: ldloc.s 12
+		IL_02ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02b3: pop
+		IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02b9: stloc.s 10
+		IL_02bb: ldloc.3
+		IL_02bc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_02c6: stloc.s 11
+		IL_02c8: ldloc.s 10
+		IL_02ca: ldloc.s 11
+		IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d1: pop
+		IL_02d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d7: stloc.s 10
+		IL_02d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02de: stloc.s 7
+		IL_02e0: ldloc.s 4
+		IL_02e2: ldloc.s 7
+		IL_02e4: ldc.r8 1
+		IL_02ed: box [System.Runtime]System.Double
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_02f7: stloc.s 11
+		IL_02f9: ldloc.s 10
+		IL_02fb: ldloc.s 11
+		IL_02fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0302: pop
+		IL_0303: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0308: stloc.s 10
+		IL_030a: ldloc.s 5
+		IL_030c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0316: stloc.s 11
+		IL_0318: ldloc.s 10
+		IL_031a: ldloc.s 11
+		IL_031c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0321: pop
+		IL_0322: ret
 	} // end of method Function_SchedulerGeneralRegions::__js_module_init__
 
 } // end of class Modules.Function_SchedulerGeneralRegions
@@ -2293,6 +2305,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_22
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
@@ -1602,7 +1602,7 @@
 			IL_006b: ldloc.s 4
 			IL_006d: stloc.0
 			IL_006e: volatile.
-			IL_0070: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0070: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0075: brfalse IL_008a
 
 			IL_007a: ldloc.0
@@ -1613,7 +1613,7 @@
 			IL_008a: ldloc.0
 			IL_008b: ldstr "k"
 			IL_0090: ldstr "Function_SchedulerLiteralArguments:<TwoPhaseDummy_M11>:__js_call__:20"
-			IL_0095: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0095: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_009f: stloc.3
@@ -1622,7 +1622,7 @@
 			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_00ab: stloc.s 5
 			IL_00ad: volatile.
-			IL_00af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_00af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_00b4: brfalse IL_00c9
 
 			IL_00b9: ldloc.0
@@ -1633,7 +1633,7 @@
 			IL_00c9: ldloc.0
 			IL_00ca: ldstr "order"
 			IL_00cf: ldstr "Function_SchedulerLiteralArguments:<TwoPhaseDummy_M11>:__js_call__:24"
-			IL_00d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_00d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00de: stloc.3
@@ -2542,7 +2542,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1434 (0x59a)
+		// Code size: 1476 (0x5c4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerLiteralArguments/Scope,
@@ -2847,226 +2847,238 @@
 		IL_02a0: stloc.s 15
 		IL_02a2: ldloc.s 15
 		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a9: ldstr "join"
-		IL_02ae: ldstr ","
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b8: stloc.s 15
-		IL_02ba: ldloc.s 17
-		IL_02bc: ldloc.s 15
-		IL_02be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c3: pop
-		IL_02c4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02c9: stloc.s 12
-		IL_02cb: ldloc.3
-		IL_02cc: ldloc.s 12
-		IL_02ce: ldc.r8 2
-		IL_02d7: box [System.Runtime]System.Double
-		IL_02dc: ldc.r8 4
-		IL_02e5: box [System.Runtime]System.Double
-		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02ef: stloc.s 10
-		IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f6: stloc.s 17
-		IL_02f8: volatile.
-		IL_02fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_02ff: brfalse IL_0315
+		IL_02a9: volatile.
+		IL_02ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_02b0: brfalse IL_02c9
 
-		IL_0304: ldloc.s 10
-		IL_0306: ldstr "x"
-		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0310: br IL_032b
+		IL_02b5: ldstr "join"
+		IL_02ba: ldstr ","
+		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c4: br IL_02e2
 
-		IL_0315: ldloc.s 10
-		IL_0317: ldstr "x"
-		IL_031c: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:90"
-		IL_0321: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02c9: ldstr "join"
+		IL_02ce: ldstr ","
+		IL_02d3: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:77"
+		IL_02d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_032b: stloc.s 15
-		IL_032d: ldloc.s 15
-		IL_032f: ldstr ","
-		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0339: stloc.s 18
-		IL_033b: volatile.
-		IL_033d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0342: brfalse IL_0358
+		IL_02e2: stloc.s 15
+		IL_02e4: ldloc.s 17
+		IL_02e6: ldloc.s 15
+		IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ed: pop
+		IL_02ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02f3: stloc.s 12
+		IL_02f5: ldloc.3
+		IL_02f6: ldloc.s 12
+		IL_02f8: ldc.r8 2
+		IL_0301: box [System.Runtime]System.Double
+		IL_0306: ldc.r8 4
+		IL_030f: box [System.Runtime]System.Double
+		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0319: stloc.s 10
+		IL_031b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0320: stloc.s 17
+		IL_0322: volatile.
+		IL_0324: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0329: brfalse IL_033f
 
-		IL_0347: ldloc.s 10
-		IL_0349: ldstr "y"
-		IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0353: br IL_036e
+		IL_032e: ldloc.s 10
+		IL_0330: ldstr "x"
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_033a: br IL_0355
 
-		IL_0358: ldloc.s 10
-		IL_035a: ldstr "y"
-		IL_035f: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:94"
-		IL_0364: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_033f: ldloc.s 10
+		IL_0341: ldstr "x"
+		IL_0346: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:90"
+		IL_034b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_036e: stloc.s 15
-		IL_0370: ldloc.s 18
-		IL_0372: ldloc.s 15
-		IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0379: stloc.s 18
-		IL_037b: ldloc.s 17
-		IL_037d: ldloc.s 18
-		IL_037f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0384: pop
-		IL_0385: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_038a: stloc.s 12
-		IL_038c: ldloc.s 4
-		IL_038e: ldloc.s 12
-		IL_0390: ldc.r8 2
-		IL_0399: box [System.Runtime]System.Double
-		IL_039e: ldc.r8 4
-		IL_03a7: box [System.Runtime]System.Double
-		IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_03b1: stloc.s 11
-		IL_03b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03b8: stloc.s 17
-		IL_03ba: ldloc.s 11
-		IL_03bc: ldc.r8 0.0
-		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03ca: stloc.s 15
-		IL_03cc: ldloc.s 15
-		IL_03ce: ldc.r8 0.0
-		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03dc: stloc.s 15
-		IL_03de: ldloc.s 15
-		IL_03e0: ldstr ","
-		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_03ea: stloc.s 18
-		IL_03ec: ldloc.s 11
-		IL_03ee: ldc.r8 1
-		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03fc: stloc.s 15
-		IL_03fe: volatile.
-		IL_0400: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0405: brfalse IL_041b
+		IL_0355: stloc.s 15
+		IL_0357: ldloc.s 15
+		IL_0359: ldstr ","
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0363: stloc.s 18
+		IL_0365: volatile.
+		IL_0367: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_036c: brfalse IL_0382
 
-		IL_040a: ldloc.s 15
-		IL_040c: ldstr "y"
-		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0416: br IL_0431
+		IL_0371: ldloc.s 10
+		IL_0373: ldstr "y"
+		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_037d: br IL_0398
 
-		IL_041b: ldloc.s 15
-		IL_041d: ldstr "y"
-		IL_0422: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:116"
-		IL_0427: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0382: ldloc.s 10
+		IL_0384: ldstr "y"
+		IL_0389: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:94"
+		IL_038e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0431: stloc.s 15
-		IL_0433: ldloc.s 18
-		IL_0435: ldloc.s 15
-		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_043c: stloc.s 18
-		IL_043e: ldloc.s 17
-		IL_0440: ldloc.s 18
-		IL_0442: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0447: pop
-		IL_0448: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_044d: stloc.s 17
-		IL_044f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0454: stloc.s 12
-		IL_0456: ldloc.s 5
-		IL_0458: ldloc.s 12
-		IL_045a: ldc.i4.s 9
-		IL_045c: newarr [System.Runtime]System.Object
-		IL_0461: dup
-		IL_0462: ldc.i4.0
-		IL_0463: ldc.r8 1
-		IL_046c: box [System.Runtime]System.Double
-		IL_0471: stelem.ref
-		IL_0472: dup
-		IL_0473: ldc.i4.1
-		IL_0474: ldc.r8 2
-		IL_047d: box [System.Runtime]System.Double
-		IL_0482: stelem.ref
-		IL_0483: dup
-		IL_0484: ldc.i4.2
-		IL_0485: ldc.r8 3
-		IL_048e: box [System.Runtime]System.Double
-		IL_0493: stelem.ref
-		IL_0494: dup
-		IL_0495: ldc.i4.3
-		IL_0496: ldc.r8 4
-		IL_049f: box [System.Runtime]System.Double
-		IL_04a4: stelem.ref
-		IL_04a5: dup
-		IL_04a6: ldc.i4.4
-		IL_04a7: ldc.r8 5
-		IL_04b0: box [System.Runtime]System.Double
-		IL_04b5: stelem.ref
-		IL_04b6: dup
-		IL_04b7: ldc.i4.5
-		IL_04b8: ldc.r8 6
-		IL_04c1: box [System.Runtime]System.Double
-		IL_04c6: stelem.ref
-		IL_04c7: dup
-		IL_04c8: ldc.i4.6
-		IL_04c9: ldc.r8 7
-		IL_04d2: box [System.Runtime]System.Double
-		IL_04d7: stelem.ref
-		IL_04d8: dup
-		IL_04d9: ldc.i4.7
-		IL_04da: ldc.r8 8
-		IL_04e3: box [System.Runtime]System.Double
-		IL_04e8: stelem.ref
-		IL_04e9: dup
-		IL_04ea: ldc.i4.8
-		IL_04eb: ldc.r8 9
-		IL_04f4: box [System.Runtime]System.Double
-		IL_04f9: stelem.ref
-		IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_04ff: stloc.s 15
-		IL_0501: ldloc.s 15
-		IL_0503: ldc.r8 0.0
-		IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0511: stloc.s 15
-		IL_0513: ldloc.s 17
-		IL_0515: ldloc.s 15
-		IL_0517: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_051c: pop
-		IL_051d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0522: stloc.s 17
-		IL_0524: ldloc.s 6
-		IL_0526: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0530: stloc.s 15
-		IL_0532: ldloc.s 17
-		IL_0534: ldloc.s 15
-		IL_0536: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_053b: pop
-		IL_053c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0541: stloc.s 17
-		IL_0543: ldloc.s 7
-		IL_0545: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_054f: stloc.s 15
-		IL_0551: ldloc.s 17
-		IL_0553: ldloc.s 15
-		IL_0555: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_055a: pop
-		IL_055b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0560: stloc.s 17
-		IL_0562: ldloc.s 8
-		IL_0564: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0569: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_056e: stloc.s 15
-		IL_0570: ldloc.s 17
-		IL_0572: ldloc.s 15
-		IL_0574: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0579: pop
-		IL_057a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_057f: stloc.s 17
-		IL_0581: ldloc.s 9
-		IL_0583: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_058d: stloc.s 15
-		IL_058f: ldloc.s 17
-		IL_0591: ldloc.s 15
-		IL_0593: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0598: pop
-		IL_0599: ret
+		IL_0398: stloc.s 15
+		IL_039a: ldloc.s 18
+		IL_039c: ldloc.s 15
+		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03a3: stloc.s 18
+		IL_03a5: ldloc.s 17
+		IL_03a7: ldloc.s 18
+		IL_03a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03ae: pop
+		IL_03af: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03b4: stloc.s 12
+		IL_03b6: ldloc.s 4
+		IL_03b8: ldloc.s 12
+		IL_03ba: ldc.r8 2
+		IL_03c3: box [System.Runtime]System.Double
+		IL_03c8: ldc.r8 4
+		IL_03d1: box [System.Runtime]System.Double
+		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_03db: stloc.s 11
+		IL_03dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03e2: stloc.s 17
+		IL_03e4: ldloc.s 11
+		IL_03e6: ldc.r8 0.0
+		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03f4: stloc.s 15
+		IL_03f6: ldloc.s 15
+		IL_03f8: ldc.r8 0.0
+		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0406: stloc.s 15
+		IL_0408: ldloc.s 15
+		IL_040a: ldstr ","
+		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0414: stloc.s 18
+		IL_0416: ldloc.s 11
+		IL_0418: ldc.r8 1
+		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0426: stloc.s 15
+		IL_0428: volatile.
+		IL_042a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_042f: brfalse IL_0445
+
+		IL_0434: ldloc.s 15
+		IL_0436: ldstr "y"
+		IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0440: br IL_045b
+
+		IL_0445: ldloc.s 15
+		IL_0447: ldstr "y"
+		IL_044c: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:116"
+		IL_0451: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_045b: stloc.s 15
+		IL_045d: ldloc.s 18
+		IL_045f: ldloc.s 15
+		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0466: stloc.s 18
+		IL_0468: ldloc.s 17
+		IL_046a: ldloc.s 18
+		IL_046c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0471: pop
+		IL_0472: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0477: stloc.s 17
+		IL_0479: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_047e: stloc.s 12
+		IL_0480: ldloc.s 5
+		IL_0482: ldloc.s 12
+		IL_0484: ldc.i4.s 9
+		IL_0486: newarr [System.Runtime]System.Object
+		IL_048b: dup
+		IL_048c: ldc.i4.0
+		IL_048d: ldc.r8 1
+		IL_0496: box [System.Runtime]System.Double
+		IL_049b: stelem.ref
+		IL_049c: dup
+		IL_049d: ldc.i4.1
+		IL_049e: ldc.r8 2
+		IL_04a7: box [System.Runtime]System.Double
+		IL_04ac: stelem.ref
+		IL_04ad: dup
+		IL_04ae: ldc.i4.2
+		IL_04af: ldc.r8 3
+		IL_04b8: box [System.Runtime]System.Double
+		IL_04bd: stelem.ref
+		IL_04be: dup
+		IL_04bf: ldc.i4.3
+		IL_04c0: ldc.r8 4
+		IL_04c9: box [System.Runtime]System.Double
+		IL_04ce: stelem.ref
+		IL_04cf: dup
+		IL_04d0: ldc.i4.4
+		IL_04d1: ldc.r8 5
+		IL_04da: box [System.Runtime]System.Double
+		IL_04df: stelem.ref
+		IL_04e0: dup
+		IL_04e1: ldc.i4.5
+		IL_04e2: ldc.r8 6
+		IL_04eb: box [System.Runtime]System.Double
+		IL_04f0: stelem.ref
+		IL_04f1: dup
+		IL_04f2: ldc.i4.6
+		IL_04f3: ldc.r8 7
+		IL_04fc: box [System.Runtime]System.Double
+		IL_0501: stelem.ref
+		IL_0502: dup
+		IL_0503: ldc.i4.7
+		IL_0504: ldc.r8 8
+		IL_050d: box [System.Runtime]System.Double
+		IL_0512: stelem.ref
+		IL_0513: dup
+		IL_0514: ldc.i4.8
+		IL_0515: ldc.r8 9
+		IL_051e: box [System.Runtime]System.Double
+		IL_0523: stelem.ref
+		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0529: stloc.s 15
+		IL_052b: ldloc.s 15
+		IL_052d: ldc.r8 0.0
+		IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_053b: stloc.s 15
+		IL_053d: ldloc.s 17
+		IL_053f: ldloc.s 15
+		IL_0541: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0546: pop
+		IL_0547: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_054c: stloc.s 17
+		IL_054e: ldloc.s 6
+		IL_0550: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0555: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_055a: stloc.s 15
+		IL_055c: ldloc.s 17
+		IL_055e: ldloc.s 15
+		IL_0560: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0565: pop
+		IL_0566: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_056b: stloc.s 17
+		IL_056d: ldloc.s 7
+		IL_056f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0579: stloc.s 15
+		IL_057b: ldloc.s 17
+		IL_057d: ldloc.s 15
+		IL_057f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0584: pop
+		IL_0585: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_058a: stloc.s 17
+		IL_058c: ldloc.s 8
+		IL_058e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0598: stloc.s 15
+		IL_059a: ldloc.s 17
+		IL_059c: ldloc.s 15
+		IL_059e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05a3: pop
+		IL_05a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05a9: stloc.s 17
+		IL_05ab: ldloc.s 9
+		IL_05ad: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_05b7: stloc.s 15
+		IL_05b9: ldloc.s 17
+		IL_05bb: ldloc.s 15
+		IL_05bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05c2: pop
+		IL_05c3: ret
 	} // end of method Function_SchedulerLiteralArguments::__js_module_init__
 
 } // end of class Modules.Function_SchedulerLiteralArguments
@@ -3101,6 +3113,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_25
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Direct.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Direct.verified.txt
@@ -1861,7 +1861,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 				IL_0007: brfalse IL_0026
 
 				IL_000c: ldarg.1
@@ -1876,7 +1876,7 @@
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0031: ldstr "value"
 				IL_0036: ldstr "Function_StableConstCallable_Direct:<TwoPhaseDummy_M18>:__js_call__:2"
-				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0045: stloc.0
@@ -2622,7 +2622,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_0007: brfalse IL_0026
 
 				IL_000c: ldarg.1
@@ -2637,7 +2637,7 @@
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0031: ldstr "value"
 				IL_0036: ldstr "Function_StableConstCallable_Direct:<TwoPhaseDummy_M20>:__js_call__:3"
-				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0045: stloc.0
@@ -2966,7 +2966,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 				IL_0007: brfalse IL_001c
 
 				IL_000c: ldarg.0
@@ -2977,7 +2977,7 @@
 				IL_001c: ldarg.0
 				IL_001d: ldstr "value"
 				IL_0022: ldstr "Function_StableConstCallable_Direct:<TwoPhaseDummy_M22>:read:3"
-				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0031: stloc.0
@@ -3140,7 +3140,7 @@
 			IL_0015: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_001a: stloc.2
 			IL_001b: volatile.
-			IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0022: brfalse IL_0037
 
 			IL_0027: ldloc.2
@@ -3151,7 +3151,7 @@
 			IL_0037: ldloc.2
 			IL_0038: ldstr "prototype"
 			IL_003d: ldstr "Function_StableConstCallable_Direct:<TwoPhaseDummy_M17>:__js_call__:4"
-			IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004c: stloc.3
@@ -3251,7 +3251,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1047 (0x417)
+		// Code size: 1087 (0x43f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_StableConstCallable_Direct/Scope,
@@ -3651,27 +3651,40 @@
 		IL_03ce: ldc.r8 9
 		IL_03d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_03dc: stloc.s 23
-		IL_03de: ldloc.3
-		IL_03df: ldstr "call"
-		IL_03e4: ldloc.s 23
-		IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03eb: stloc.s 17
-		IL_03ed: ldloc.s 11
-		IL_03ef: ldstr "log"
-		IL_03f4: ldstr "context"
-		IL_03f9: ldloc.s 19
-		IL_03fb: ldloc.s 18
-		IL_03fd: ldloc.s 17
-		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember4(object, string, object, object, object, object)
-		IL_0404: pop
-		IL_0405: ldloc.0
-		IL_0406: ldfld object Modules.Function_StableConstCallable_Direct/Scope::ReadsNestedArrowNewTarget
-		IL_040b: stloc.s 17
-		IL_040d: ldloc.s 17
-		IL_040f: dup
-		IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_0415: pop
-		IL_0416: ret
+		IL_03de: volatile.
+		IL_03e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_03e5: brfalse IL_03fc
+
+		IL_03ea: ldloc.3
+		IL_03eb: ldstr "call"
+		IL_03f0: ldloc.s 23
+		IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03f7: br IL_0413
+
+		IL_03fc: ldloc.3
+		IL_03fd: ldstr "call"
+		IL_0402: ldloc.s 23
+		IL_0404: ldstr "Function_StableConstCallable_Direct:Modules.Function_StableConstCallable_Direct:__js_module_init__:118"
+		IL_0409: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0413: stloc.s 17
+		IL_0415: ldloc.s 11
+		IL_0417: ldstr "log"
+		IL_041c: ldstr "context"
+		IL_0421: ldloc.s 19
+		IL_0423: ldloc.s 18
+		IL_0425: ldloc.s 17
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember4(object, string, object, object, object, object)
+		IL_042c: pop
+		IL_042d: ldloc.0
+		IL_042e: ldfld object Modules.Function_StableConstCallable_Direct/Scope::ReadsNestedArrowNewTarget
+		IL_0433: stloc.s 17
+		IL_0435: ldloc.s 17
+		IL_0437: dup
+		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_043d: pop
+		IL_043e: ret
 	} // end of method Function_StableConstCallable_Direct::__js_module_init__
 
 } // end of class Modules.Function_StableConstCallable_Direct
@@ -3707,6 +3720,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
 	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Fallbacks.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Fallbacks.verified.txt
@@ -235,7 +235,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -250,7 +250,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "stableConstMarker"
 			IL_0036: ldstr "Function_StableConstCallable_Fallbacks:<TwoPhaseDummy_M4>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -647,7 +647,7 @@
 			IL_0030: ldloc.0
 			IL_0031: ldfld object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments/Scope::arguments
 			IL_0036: volatile.
-			IL_0038: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_0038: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_003d: brfalse IL_0051
 
 			IL_0042: ldstr "length"
@@ -656,7 +656,7 @@
 
 			IL_0051: ldstr "length"
 			IL_0056: ldstr "Function_StableConstCallable_Fallbacks:<TwoPhaseDummy_M6>:__js_call__:6"
-			IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0065: stloc.1
@@ -1500,7 +1500,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
 				IL_0007: brfalse IL_0026
 
 				IL_000c: ldarg.1
@@ -1515,7 +1515,7 @@
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0031: ldstr "value"
 				IL_0036: ldstr "Function_StableConstCallable_Fallbacks:<TwoPhaseDummy_M18>:__js_call__:2"
-				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0045: stloc.0
@@ -2638,7 +2638,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 				IL_0007: brfalse IL_0026
 
 				IL_000c: ldarg.1
@@ -2653,7 +2653,7 @@
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0031: ldstr "stableConstMarker"
 				IL_0036: ldstr "Function_StableConstCallable_Fallbacks:<TwoPhaseDummy_M21>:__js_call__:2"
-				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0045: stloc.0
@@ -3366,7 +3366,7 @@
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 58 (0x3a)
+			// Code size: 100 (0x64)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3379,18 +3379,30 @@
 			IL_000f: stloc.0
 			IL_0010: ldarg.2
 			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0016: ldstr "join"
-			IL_001b: ldstr ","
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0025: stloc.1
-			IL_0026: ldloc.0
-			IL_0027: ldstr "log"
-			IL_002c: ldstr "async"
-			IL_0031: ldloc.1
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0037: pop
-			IL_0038: ldnull
-			IL_0039: ret
+			IL_0016: volatile.
+			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_001d: brfalse IL_0036
+
+			IL_0022: ldstr "join"
+			IL_0027: ldstr ","
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0031: br IL_004f
+
+			IL_0036: ldstr "join"
+			IL_003b: ldstr ","
+			IL_0040: ldstr "Function_StableConstCallable_Fallbacks:<TwoPhaseDummy_M17>:__js_call__:8"
+			IL_0045: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_004f: stloc.1
+			IL_0050: ldloc.0
+			IL_0051: ldstr "log"
+			IL_0056: ldstr "async"
+			IL_005b: ldloc.1
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0061: pop
+			IL_0062: ldnull
+			IL_0063: ret
 		} // end of method ArrowFunction_L76C55::__js_call__
 
 	} // end of class ArrowFunction_L76C55
@@ -4047,7 +4059,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2068 (0x814)
+		// Code size: 2109 (0x83d)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_StableConstCallable_Fallbacks/Scope,
@@ -4783,12 +4795,25 @@
 		IL_07f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/ArrowFunction_L76C55/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_07fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StableConstCallable_Fallbacks/ArrowFunction_L76C55/FunctionObject>(!!0)
 		IL_0802: stloc.s 36
-		IL_0804: ldloc.s 26
-		IL_0806: ldstr "then"
-		IL_080b: ldloc.s 36
-		IL_080d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0812: pop
-		IL_0813: ret
+		IL_0804: volatile.
+		IL_0806: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_080b: brfalse IL_0823
+
+		IL_0810: ldloc.s 26
+		IL_0812: ldstr "then"
+		IL_0817: ldloc.s 36
+		IL_0819: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_081e: br IL_083b
+
+		IL_0823: ldloc.s 26
+		IL_0825: ldstr "then"
+		IL_082a: ldloc.s 36
+		IL_082c: ldstr "Function_StableConstCallable_Fallbacks:Modules.Function_StableConstCallable_Fallbacks:__js_module_init__:194"
+		IL_0831: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_0836: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_083b: pop
+		IL_083c: ret
 	} // end of method Function_StableConstCallable_Fallbacks::__js_module_init__
 
 } // end of class Modules.Function_StableConstCallable_Fallbacks
@@ -4828,6 +4853,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_45
 	.field assembly static int32 __jroc_dynamicLookup_46
 	.field assembly static int32 __jroc_dynamicLookup_47
+	.field assembly static int32 __jroc_dynamicLookup_48
+	.field assembly static int32 __jroc_dynamicLookup_49
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_BasicNext.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_BasicNext.verified.txt
@@ -481,7 +481,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 837 (0x345)
+		// Code size: 888 (0x378)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_BasicNext/Scope,
@@ -650,116 +650,129 @@
 		IL_01d4: pop
 		IL_01d5: ldloc.2
 		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01db: ldstr "next"
-		IL_01e0: ldc.r8 42
-		IL_01e9: box [System.Runtime]System.Double
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f3: stloc.s 5
-		IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fa: stloc.s 8
-		IL_01fc: volatile.
-		IL_01fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0203: brfalse IL_0219
+		IL_01db: volatile.
+		IL_01dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_01e2: brfalse IL_0204
 
-		IL_0208: ldloc.s 5
-		IL_020a: ldstr "value"
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0214: br IL_022f
+		IL_01e7: ldstr "next"
+		IL_01ec: ldc.r8 42
+		IL_01f5: box [System.Runtime]System.Double
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ff: br IL_0226
 
-		IL_0219: ldloc.s 5
-		IL_021b: ldstr "value"
-		IL_0220: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:52"
-		IL_0225: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0204: ldstr "next"
+		IL_0209: ldc.r8 42
+		IL_0212: box [System.Runtime]System.Double
+		IL_0217: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:47"
+		IL_021c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_022f: stloc.s 9
-		IL_0231: ldloc.s 8
-		IL_0233: ldloc.s 9
-		IL_0235: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023a: pop
-		IL_023b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0240: stloc.s 8
-		IL_0242: volatile.
-		IL_0244: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0249: brfalse IL_025f
+		IL_0226: stloc.s 5
+		IL_0228: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_022d: stloc.s 8
+		IL_022f: volatile.
+		IL_0231: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0236: brfalse IL_024c
 
-		IL_024e: ldloc.s 5
-		IL_0250: ldstr "done"
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_025a: br IL_0275
+		IL_023b: ldloc.s 5
+		IL_023d: ldstr "value"
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0247: br IL_0262
 
-		IL_025f: ldloc.s 5
-		IL_0261: ldstr "done"
-		IL_0266: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:57"
-		IL_026b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_024c: ldloc.s 5
+		IL_024e: ldstr "value"
+		IL_0253: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:52"
+		IL_0258: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0275: stloc.s 9
-		IL_0277: ldloc.s 8
-		IL_0279: ldloc.s 9
-		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0280: pop
-		IL_0281: ldloc.2
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0287: volatile.
-		IL_0289: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_028e: brfalse IL_02a2
+		IL_0262: stloc.s 9
+		IL_0264: ldloc.s 8
+		IL_0266: ldloc.s 9
+		IL_0268: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_026d: pop
+		IL_026e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0273: stloc.s 8
+		IL_0275: volatile.
+		IL_0277: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_027c: brfalse IL_0292
 
-		IL_0293: ldstr "next"
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_029d: br IL_02b6
+		IL_0281: ldloc.s 5
+		IL_0283: ldstr "done"
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028d: br IL_02a8
 
-		IL_02a2: ldstr "next"
-		IL_02a7: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:61"
-		IL_02ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0292: ldloc.s 5
+		IL_0294: ldstr "done"
+		IL_0299: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:57"
+		IL_029e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02b6: stloc.s 6
-		IL_02b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02bd: stloc.s 8
-		IL_02bf: volatile.
-		IL_02c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_02c6: brfalse IL_02dc
+		IL_02a8: stloc.s 9
+		IL_02aa: ldloc.s 8
+		IL_02ac: ldloc.s 9
+		IL_02ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02b3: pop
+		IL_02b4: ldloc.2
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ba: volatile.
+		IL_02bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02c1: brfalse IL_02d5
 
-		IL_02cb: ldloc.s 6
-		IL_02cd: ldstr "value"
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d7: br IL_02f2
+		IL_02c6: ldstr "next"
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02d0: br IL_02e9
 
-		IL_02dc: ldloc.s 6
-		IL_02de: ldstr "value"
-		IL_02e3: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:66"
-		IL_02e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02d5: ldstr "next"
+		IL_02da: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:61"
+		IL_02df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_02f2: stloc.s 9
-		IL_02f4: ldloc.s 8
-		IL_02f6: ldloc.s 9
-		IL_02f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02fd: pop
-		IL_02fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0303: stloc.s 8
-		IL_0305: volatile.
-		IL_0307: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_030c: brfalse IL_0322
+		IL_02e9: stloc.s 6
+		IL_02eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02f0: stloc.s 8
+		IL_02f2: volatile.
+		IL_02f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_02f9: brfalse IL_030f
 
-		IL_0311: ldloc.s 6
-		IL_0313: ldstr "done"
-		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_031d: br IL_0338
+		IL_02fe: ldloc.s 6
+		IL_0300: ldstr "value"
+		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_030a: br IL_0325
 
-		IL_0322: ldloc.s 6
-		IL_0324: ldstr "done"
-		IL_0329: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:71"
-		IL_032e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_030f: ldloc.s 6
+		IL_0311: ldstr "value"
+		IL_0316: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:66"
+		IL_031b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0338: stloc.s 9
-		IL_033a: ldloc.s 8
-		IL_033c: ldloc.s 9
-		IL_033e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0343: pop
-		IL_0344: ret
+		IL_0325: stloc.s 9
+		IL_0327: ldloc.s 8
+		IL_0329: ldloc.s 9
+		IL_032b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0330: pop
+		IL_0331: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0336: stloc.s 8
+		IL_0338: volatile.
+		IL_033a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_033f: brfalse IL_0355
+
+		IL_0344: ldloc.s 6
+		IL_0346: ldstr "done"
+		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0350: br IL_036b
+
+		IL_0355: ldloc.s 6
+		IL_0357: ldstr "done"
+		IL_035c: ldstr "Generator_BasicNext:Modules.Generator_BasicNext:__js_module_init__:71"
+		IL_0361: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_036b: stloc.s 9
+		IL_036d: ldloc.s 8
+		IL_036f: ldloc.s 9
+		IL_0371: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0376: pop
+		IL_0377: ret
 	} // end of method Generator_BasicNext::__js_module_init__
 
 } // end of class Modules.Generator_BasicNext
@@ -800,6 +813,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
@@ -512,7 +512,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 866 (0x362)
+		// Code size: 917 (0x395)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_ClassMethod_YieldAssign/Scope,
@@ -690,142 +690,155 @@
 		IL_01cf: pop
 		IL_01d0: ldloc.3
 		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d6: ldstr "next"
-		IL_01db: ldc.r8 42
-		IL_01e4: box [System.Runtime]System.Double
-		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ee: stloc.s 11
-		IL_01f0: ldloc.s 11
-		IL_01f2: stloc.s 4
-		IL_01f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f9: stloc.s 10
-		IL_01fb: volatile.
-		IL_01fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0202: brfalse IL_0218
+		IL_01d6: volatile.
+		IL_01d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01dd: brfalse IL_01ff
 
-		IL_0207: ldloc.s 4
-		IL_0209: ldstr "value"
-		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0213: br IL_022e
+		IL_01e2: ldstr "next"
+		IL_01e7: ldc.r8 42
+		IL_01f0: box [System.Runtime]System.Double
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01fa: br IL_0221
 
-		IL_0218: ldloc.s 4
-		IL_021a: ldstr "value"
-		IL_021f: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:50"
-		IL_0224: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01ff: ldstr "next"
+		IL_0204: ldc.r8 42
+		IL_020d: box [System.Runtime]System.Double
+		IL_0212: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:43"
+		IL_0217: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_022e: stloc.s 11
-		IL_0230: volatile.
-		IL_0232: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0237: brfalse IL_024d
+		IL_0221: stloc.s 11
+		IL_0223: ldloc.s 11
+		IL_0225: stloc.s 4
+		IL_0227: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_022c: stloc.s 10
+		IL_022e: volatile.
+		IL_0230: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0235: brfalse IL_024b
 
-		IL_023c: ldloc.s 4
-		IL_023e: ldstr "done"
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0248: br IL_0263
+		IL_023a: ldloc.s 4
+		IL_023c: ldstr "value"
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0246: br IL_0261
 
-		IL_024d: ldloc.s 4
-		IL_024f: ldstr "done"
-		IL_0254: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:53"
-		IL_0259: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_024b: ldloc.s 4
+		IL_024d: ldstr "value"
+		IL_0252: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:50"
+		IL_0257: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0263: stloc.s 6
-		IL_0265: ldloc.s 10
-		IL_0267: ldc.i4.4
-		IL_0268: newarr [System.Runtime]System.Object
-		IL_026d: dup
-		IL_026e: ldc.i4.0
-		IL_026f: ldstr "y2:"
-		IL_0274: stelem.ref
-		IL_0275: dup
-		IL_0276: ldc.i4.1
-		IL_0277: ldloc.s 11
-		IL_0279: stelem.ref
-		IL_027a: dup
-		IL_027b: ldc.i4.2
-		IL_027c: ldstr "done:"
-		IL_0281: stelem.ref
-		IL_0282: dup
-		IL_0283: ldc.i4.3
-		IL_0284: ldloc.s 6
-		IL_0286: stelem.ref
-		IL_0287: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_028c: pop
-		IL_028d: ldloc.3
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0293: volatile.
-		IL_0295: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_029a: brfalse IL_02ae
+		IL_0261: stloc.s 11
+		IL_0263: volatile.
+		IL_0265: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_026a: brfalse IL_0280
 
-		IL_029f: ldstr "next"
-		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02a9: br IL_02c2
+		IL_026f: ldloc.s 4
+		IL_0271: ldstr "done"
+		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_027b: br IL_0296
 
-		IL_02ae: ldstr "next"
-		IL_02b3: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:57"
-		IL_02b8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0280: ldloc.s 4
+		IL_0282: ldstr "done"
+		IL_0287: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:53"
+		IL_028c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02c2: stloc.s 6
-		IL_02c4: ldloc.s 6
-		IL_02c6: stloc.s 4
-		IL_02c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02cd: stloc.s 10
-		IL_02cf: volatile.
-		IL_02d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02d6: brfalse IL_02ec
+		IL_0296: stloc.s 6
+		IL_0298: ldloc.s 10
+		IL_029a: ldc.i4.4
+		IL_029b: newarr [System.Runtime]System.Object
+		IL_02a0: dup
+		IL_02a1: ldc.i4.0
+		IL_02a2: ldstr "y2:"
+		IL_02a7: stelem.ref
+		IL_02a8: dup
+		IL_02a9: ldc.i4.1
+		IL_02aa: ldloc.s 11
+		IL_02ac: stelem.ref
+		IL_02ad: dup
+		IL_02ae: ldc.i4.2
+		IL_02af: ldstr "done:"
+		IL_02b4: stelem.ref
+		IL_02b5: dup
+		IL_02b6: ldc.i4.3
+		IL_02b7: ldloc.s 6
+		IL_02b9: stelem.ref
+		IL_02ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_02bf: pop
+		IL_02c0: ldloc.3
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c6: volatile.
+		IL_02c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02cd: brfalse IL_02e1
 
-		IL_02db: ldloc.s 4
-		IL_02dd: ldstr "value"
-		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e7: br IL_0302
+		IL_02d2: ldstr "next"
+		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02dc: br IL_02f5
 
-		IL_02ec: ldloc.s 4
-		IL_02ee: ldstr "value"
-		IL_02f3: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:64"
-		IL_02f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02e1: ldstr "next"
+		IL_02e6: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:57"
+		IL_02eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0302: stloc.s 6
-		IL_0304: volatile.
-		IL_0306: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_030b: brfalse IL_0321
+		IL_02f5: stloc.s 6
+		IL_02f7: ldloc.s 6
+		IL_02f9: stloc.s 4
+		IL_02fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0300: stloc.s 10
+		IL_0302: volatile.
+		IL_0304: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0309: brfalse IL_031f
 
-		IL_0310: ldloc.s 4
-		IL_0312: ldstr "done"
-		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_031c: br IL_0337
+		IL_030e: ldloc.s 4
+		IL_0310: ldstr "value"
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_031a: br IL_0335
 
-		IL_0321: ldloc.s 4
-		IL_0323: ldstr "done"
-		IL_0328: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:67"
-		IL_032d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_031f: ldloc.s 4
+		IL_0321: ldstr "value"
+		IL_0326: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:64"
+		IL_032b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0337: stloc.s 11
-		IL_0339: ldloc.s 10
-		IL_033b: ldc.i4.4
-		IL_033c: newarr [System.Runtime]System.Object
-		IL_0341: dup
-		IL_0342: ldc.i4.0
-		IL_0343: ldstr "y3:"
-		IL_0348: stelem.ref
-		IL_0349: dup
-		IL_034a: ldc.i4.1
-		IL_034b: ldloc.s 6
-		IL_034d: stelem.ref
-		IL_034e: dup
-		IL_034f: ldc.i4.2
-		IL_0350: ldstr "done:"
-		IL_0355: stelem.ref
-		IL_0356: dup
-		IL_0357: ldc.i4.3
-		IL_0358: ldloc.s 11
-		IL_035a: stelem.ref
-		IL_035b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0360: pop
-		IL_0361: ret
+		IL_0335: stloc.s 6
+		IL_0337: volatile.
+		IL_0339: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_033e: brfalse IL_0354
+
+		IL_0343: ldloc.s 4
+		IL_0345: ldstr "done"
+		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_034f: br IL_036a
+
+		IL_0354: ldloc.s 4
+		IL_0356: ldstr "done"
+		IL_035b: ldstr "Generator_ClassMethod_YieldAssign:Modules.Generator_ClassMethod_YieldAssign:__js_module_init__:67"
+		IL_0360: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_036a: stloc.s 11
+		IL_036c: ldloc.s 10
+		IL_036e: ldc.i4.4
+		IL_036f: newarr [System.Runtime]System.Object
+		IL_0374: dup
+		IL_0375: ldc.i4.0
+		IL_0376: ldstr "y3:"
+		IL_037b: stelem.ref
+		IL_037c: dup
+		IL_037d: ldc.i4.1
+		IL_037e: ldloc.s 6
+		IL_0380: stelem.ref
+		IL_0381: dup
+		IL_0382: ldc.i4.2
+		IL_0383: ldstr "done:"
+		IL_0388: stelem.ref
+		IL_0389: dup
+		IL_038a: ldc.i4.3
+		IL_038b: ldloc.s 11
+		IL_038d: stelem.ref
+		IL_038e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0393: pop
+		IL_0394: ret
 	} // end of method Generator_ClassMethod_YieldAssign::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_YieldAssign
@@ -864,6 +877,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ExplicitReceiverAbi.verified.txt
@@ -912,7 +912,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2213 (0x8a5)
+		// Code size: 2407 (0x967)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_ExplicitReceiverAbi/Scope,
@@ -997,682 +997,742 @@
 		IL_008b: stloc.s 21
 		IL_008d: ldloc.s 21
 		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0094: ldstr "call"
-		IL_0099: ldloc.3
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009f: stloc.s 4
-		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a6: stloc.s 22
-		IL_00a8: volatile.
-		IL_00aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_00af: brfalse IL_00c5
+		IL_0094: volatile.
+		IL_0096: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_009b: brfalse IL_00b0
 
-		IL_00b4: ldloc.s 4
-		IL_00b6: ldstr "value"
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c0: br IL_00db
+		IL_00a0: ldstr "call"
+		IL_00a5: ldloc.3
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ab: br IL_00c5
 
-		IL_00c5: ldloc.s 4
-		IL_00c7: ldstr "value"
-		IL_00cc: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:26"
-		IL_00d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00b0: ldstr "call"
+		IL_00b5: ldloc.3
+		IL_00b6: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:20"
+		IL_00bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00db: stloc.s 21
-		IL_00dd: ldloc.s 21
-		IL_00df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00e4: stloc.s 23
-		IL_00e6: ldstr "r1: "
-		IL_00eb: ldloc.s 23
-		IL_00ed: call string [System.Runtime]System.String::Concat(string, string)
-		IL_00f2: ldstr " done: "
-		IL_00f7: call string [System.Runtime]System.String::Concat(string, string)
-		IL_00fc: volatile.
-		IL_00fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0103: brfalse IL_0119
+		IL_00c5: stloc.s 4
+		IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00cc: stloc.s 22
+		IL_00ce: volatile.
+		IL_00d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00d5: brfalse IL_00eb
 
-		IL_0108: ldloc.s 4
-		IL_010a: ldstr "done"
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0114: br IL_012f
+		IL_00da: ldloc.s 4
+		IL_00dc: ldstr "value"
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e6: br IL_0101
 
-		IL_0119: ldloc.s 4
-		IL_011b: ldstr "done"
-		IL_0120: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:32"
-		IL_0125: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00eb: ldloc.s 4
+		IL_00ed: ldstr "value"
+		IL_00f2: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:26"
+		IL_00f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_012f: stloc.s 21
-		IL_0131: ldloc.s 21
-		IL_0133: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0138: stloc.s 23
-		IL_013a: ldloc.s 23
-		IL_013c: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0141: stloc.s 23
-		IL_0143: ldloc.s 22
-		IL_0145: ldloc.s 23
-		IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_014c: pop
-		IL_014d: volatile.
-		IL_014f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0154: brfalse IL_0169
+		IL_0101: stloc.s 21
+		IL_0103: ldloc.s 21
+		IL_0105: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_010a: stloc.s 23
+		IL_010c: ldstr "r1: "
+		IL_0111: ldloc.s 23
+		IL_0113: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0118: ldstr " done: "
+		IL_011d: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0122: volatile.
+		IL_0124: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0129: brfalse IL_013f
 
-		IL_0159: ldloc.2
-		IL_015a: ldstr "next"
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0164: br IL_017e
+		IL_012e: ldloc.s 4
+		IL_0130: ldstr "done"
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013a: br IL_0155
 
-		IL_0169: ldloc.2
-		IL_016a: ldstr "next"
-		IL_016f: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:38"
-		IL_0174: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_013f: ldloc.s 4
+		IL_0141: ldstr "done"
+		IL_0146: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:32"
+		IL_014b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_017e: stloc.s 21
-		IL_0180: ldloc.s 21
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0187: ldstr "call"
-		IL_018c: ldloc.3
-		IL_018d: ldc.r8 10
-		IL_0196: box [System.Runtime]System.Double
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01a0: stloc.s 5
-		IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a7: stloc.s 22
-		IL_01a9: volatile.
-		IL_01ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01b0: brfalse IL_01c6
+		IL_0155: stloc.s 21
+		IL_0157: ldloc.s 21
+		IL_0159: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_015e: stloc.s 23
+		IL_0160: ldloc.s 23
+		IL_0162: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0167: stloc.s 23
+		IL_0169: ldloc.s 22
+		IL_016b: ldloc.s 23
+		IL_016d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0172: pop
+		IL_0173: volatile.
+		IL_0175: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_017a: brfalse IL_018f
 
-		IL_01b5: ldloc.s 5
-		IL_01b7: ldstr "value"
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c1: br IL_01dc
+		IL_017f: ldloc.2
+		IL_0180: ldstr "next"
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018a: br IL_01a4
 
-		IL_01c6: ldloc.s 5
-		IL_01c8: ldstr "value"
-		IL_01cd: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:48"
-		IL_01d2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_018f: ldloc.2
+		IL_0190: ldstr "next"
+		IL_0195: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:38"
+		IL_019a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01dc: stloc.s 21
-		IL_01de: ldloc.s 21
-		IL_01e0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_01e5: stloc.s 23
-		IL_01e7: ldstr "r2: "
-		IL_01ec: ldloc.s 23
-		IL_01ee: call string [System.Runtime]System.String::Concat(string, string)
-		IL_01f3: ldstr " done: "
-		IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
-		IL_01fd: volatile.
-		IL_01ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0204: brfalse IL_021a
+		IL_01a4: stloc.s 21
+		IL_01a6: ldloc.s 21
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ad: ldstr "call"
+		IL_01b2: ldloc.3
+		IL_01b3: ldc.r8 10
+		IL_01bc: box [System.Runtime]System.Double
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01c6: stloc.s 5
+		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cd: stloc.s 22
+		IL_01cf: volatile.
+		IL_01d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01d6: brfalse IL_01ec
 
-		IL_0209: ldloc.s 5
-		IL_020b: ldstr "done"
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0215: br IL_0230
+		IL_01db: ldloc.s 5
+		IL_01dd: ldstr "value"
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e7: br IL_0202
 
-		IL_021a: ldloc.s 5
-		IL_021c: ldstr "done"
-		IL_0221: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:54"
-		IL_0226: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01ec: ldloc.s 5
+		IL_01ee: ldstr "value"
+		IL_01f3: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:48"
+		IL_01f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0230: stloc.s 21
-		IL_0232: ldloc.s 21
-		IL_0234: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0239: stloc.s 23
-		IL_023b: ldloc.s 23
-		IL_023d: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0242: stloc.s 23
-		IL_0244: ldloc.s 22
-		IL_0246: ldloc.s 23
-		IL_0248: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024d: pop
-		IL_024e: ldloc.1
-		IL_024f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0259: stloc.s 6
-		IL_025b: volatile.
-		IL_025d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0262: brfalse IL_0277
+		IL_0202: stloc.s 21
+		IL_0204: ldloc.s 21
+		IL_0206: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_020b: stloc.s 23
+		IL_020d: ldstr "r2: "
+		IL_0212: ldloc.s 23
+		IL_0214: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0219: ldstr " done: "
+		IL_021e: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0223: volatile.
+		IL_0225: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_022a: brfalse IL_0240
 
-		IL_0267: ldloc.2
-		IL_0268: ldstr "next"
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0272: br IL_028c
+		IL_022f: ldloc.s 5
+		IL_0231: ldstr "done"
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023b: br IL_0256
 
-		IL_0277: ldloc.2
-		IL_0278: ldstr "next"
-		IL_027d: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:64"
-		IL_0282: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0240: ldloc.s 5
+		IL_0242: ldstr "done"
+		IL_0247: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:54"
+		IL_024c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_028c: stloc.s 21
-		IL_028e: ldloc.s 21
-		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0295: ldstr "call"
-		IL_029a: ldloc.s 6
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a1: pop
-		IL_02a2: volatile.
-		IL_02a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02a9: brfalse IL_02be
+		IL_0256: stloc.s 21
+		IL_0258: ldloc.s 21
+		IL_025a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_025f: stloc.s 23
+		IL_0261: ldloc.s 23
+		IL_0263: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0268: stloc.s 23
+		IL_026a: ldloc.s 22
+		IL_026c: ldloc.s 23
+		IL_026e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0273: pop
+		IL_0274: ldloc.1
+		IL_0275: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_027f: stloc.s 6
+		IL_0281: volatile.
+		IL_0283: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0288: brfalse IL_029d
 
-		IL_02ae: ldloc.2
-		IL_02af: ldstr "throw"
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b9: br IL_02d3
+		IL_028d: ldloc.2
+		IL_028e: ldstr "next"
+		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0298: br IL_02b2
 
-		IL_02be: ldloc.2
-		IL_02bf: ldstr "throw"
-		IL_02c4: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:69"
-		IL_02c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_029d: ldloc.2
+		IL_029e: ldstr "next"
+		IL_02a3: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:64"
+		IL_02a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02d3: stloc.s 21
-		IL_02d5: ldloc.s 21
-		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02dc: ldstr "call"
-		IL_02e1: ldloc.s 6
-		IL_02e3: ldstr "boom"
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02ed: stloc.s 7
-		IL_02ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f4: stloc.s 22
-		IL_02f6: volatile.
-		IL_02f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02fd: brfalse IL_0313
+		IL_02b2: stloc.s 21
+		IL_02b4: ldloc.s 21
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02bb: volatile.
+		IL_02bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02c2: brfalse IL_02d8
 
-		IL_0302: ldloc.s 7
-		IL_0304: ldstr "value"
-		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_030e: br IL_0329
+		IL_02c7: ldstr "call"
+		IL_02cc: ldloc.s 6
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d3: br IL_02ee
 
-		IL_0313: ldloc.s 7
-		IL_0315: ldstr "value"
-		IL_031a: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:78"
-		IL_031f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02d8: ldstr "call"
+		IL_02dd: ldloc.s 6
+		IL_02df: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:66"
+		IL_02e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0329: stloc.s 21
-		IL_032b: ldloc.s 21
-		IL_032d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0332: stloc.s 23
-		IL_0334: ldstr "r3: "
-		IL_0339: ldloc.s 23
-		IL_033b: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0340: ldstr " done: "
-		IL_0345: call string [System.Runtime]System.String::Concat(string, string)
-		IL_034a: volatile.
-		IL_034c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0351: brfalse IL_0367
+		IL_02ee: pop
+		IL_02ef: volatile.
+		IL_02f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_02f6: brfalse IL_030b
 
-		IL_0356: ldloc.s 7
-		IL_0358: ldstr "done"
-		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0362: br IL_037d
+		IL_02fb: ldloc.2
+		IL_02fc: ldstr "throw"
+		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0306: br IL_0320
 
-		IL_0367: ldloc.s 7
-		IL_0369: ldstr "done"
-		IL_036e: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:84"
-		IL_0373: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_030b: ldloc.2
+		IL_030c: ldstr "throw"
+		IL_0311: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:69"
+		IL_0316: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_037d: stloc.s 21
-		IL_037f: ldloc.s 21
-		IL_0381: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0386: stloc.s 23
-		IL_0388: ldloc.s 23
-		IL_038a: call string [System.Runtime]System.String::Concat(string, string)
-		IL_038f: stloc.s 23
-		IL_0391: ldloc.s 22
-		IL_0393: ldloc.s 23
-		IL_0395: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_039a: pop
-		IL_039b: ldloc.1
-		IL_039c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_03a6: stloc.s 8
-		IL_03a8: volatile.
-		IL_03aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_03af: brfalse IL_03c4
+		IL_0320: stloc.s 21
+		IL_0322: ldloc.s 21
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0329: ldstr "call"
+		IL_032e: ldloc.s 6
+		IL_0330: ldstr "boom"
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_033a: stloc.s 7
+		IL_033c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0341: stloc.s 22
+		IL_0343: volatile.
+		IL_0345: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_034a: brfalse IL_0360
 
-		IL_03b4: ldloc.2
-		IL_03b5: ldstr "next"
-		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03bf: br IL_03d9
+		IL_034f: ldloc.s 7
+		IL_0351: ldstr "value"
+		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_035b: br IL_0376
 
-		IL_03c4: ldloc.2
-		IL_03c5: ldstr "next"
-		IL_03ca: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:94"
-		IL_03cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0360: ldloc.s 7
+		IL_0362: ldstr "value"
+		IL_0367: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:78"
+		IL_036c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03d9: stloc.s 21
-		IL_03db: ldloc.s 21
-		IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e2: ldstr "call"
-		IL_03e7: ldloc.s 8
-		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03ee: pop
-		IL_03ef: volatile.
-		IL_03f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_03f6: brfalse IL_040b
+		IL_0376: stloc.s 21
+		IL_0378: ldloc.s 21
+		IL_037a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_037f: stloc.s 23
+		IL_0381: ldstr "r3: "
+		IL_0386: ldloc.s 23
+		IL_0388: call string [System.Runtime]System.String::Concat(string, string)
+		IL_038d: ldstr " done: "
+		IL_0392: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0397: volatile.
+		IL_0399: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_039e: brfalse IL_03b4
 
-		IL_03fb: ldloc.2
-		IL_03fc: ldstr "return"
-		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0406: br IL_0420
+		IL_03a3: ldloc.s 7
+		IL_03a5: ldstr "done"
+		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03af: br IL_03ca
 
-		IL_040b: ldloc.2
-		IL_040c: ldstr "return"
-		IL_0411: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:99"
-		IL_0416: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03b4: ldloc.s 7
+		IL_03b6: ldstr "done"
+		IL_03bb: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:84"
+		IL_03c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0420: stloc.s 21
-		IL_0422: ldloc.s 21
-		IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0429: ldstr "call"
-		IL_042e: ldloc.s 8
-		IL_0430: ldc.r8 99
-		IL_0439: box [System.Runtime]System.Double
-		IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0443: stloc.s 9
-		IL_0445: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_044a: stloc.s 22
-		IL_044c: volatile.
-		IL_044e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0453: brfalse IL_0469
+		IL_03ca: stloc.s 21
+		IL_03cc: ldloc.s 21
+		IL_03ce: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_03d3: stloc.s 23
+		IL_03d5: ldloc.s 23
+		IL_03d7: call string [System.Runtime]System.String::Concat(string, string)
+		IL_03dc: stloc.s 23
+		IL_03de: ldloc.s 22
+		IL_03e0: ldloc.s 23
+		IL_03e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03e7: pop
+		IL_03e8: ldloc.1
+		IL_03e9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_03f3: stloc.s 8
+		IL_03f5: volatile.
+		IL_03f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_03fc: brfalse IL_0411
 
-		IL_0458: ldloc.s 9
-		IL_045a: ldstr "value"
-		IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0464: br IL_047f
+		IL_0401: ldloc.2
+		IL_0402: ldstr "next"
+		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_040c: br IL_0426
 
-		IL_0469: ldloc.s 9
-		IL_046b: ldstr "value"
-		IL_0470: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:109"
-		IL_0475: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0411: ldloc.2
+		IL_0412: ldstr "next"
+		IL_0417: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:94"
+		IL_041c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_047f: stloc.s 21
-		IL_0481: ldloc.s 21
-		IL_0483: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0488: stloc.s 23
-		IL_048a: ldstr "r4: "
-		IL_048f: ldloc.s 23
-		IL_0491: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0496: ldstr " done: "
-		IL_049b: call string [System.Runtime]System.String::Concat(string, string)
-		IL_04a0: volatile.
-		IL_04a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_04a7: brfalse IL_04bd
+		IL_0426: stloc.s 21
+		IL_0428: ldloc.s 21
+		IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_042f: volatile.
+		IL_0431: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0436: brfalse IL_044c
 
-		IL_04ac: ldloc.s 9
-		IL_04ae: ldstr "done"
-		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04b8: br IL_04d3
+		IL_043b: ldstr "call"
+		IL_0440: ldloc.s 8
+		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0447: br IL_0462
 
-		IL_04bd: ldloc.s 9
-		IL_04bf: ldstr "done"
-		IL_04c4: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:115"
-		IL_04c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_044c: ldstr "call"
+		IL_0451: ldloc.s 8
+		IL_0453: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:96"
+		IL_0458: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_04d3: stloc.s 21
-		IL_04d5: ldloc.s 21
-		IL_04d7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_04dc: stloc.s 23
-		IL_04de: ldloc.s 23
-		IL_04e0: call string [System.Runtime]System.String::Concat(string, string)
-		IL_04e5: stloc.s 23
-		IL_04e7: ldloc.s 22
-		IL_04e9: ldloc.s 23
-		IL_04eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04f0: pop
+		IL_0462: pop
+		IL_0463: volatile.
+		IL_0465: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_046a: brfalse IL_047f
+
+		IL_046f: ldloc.2
+		IL_0470: ldstr "return"
+		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_047a: br IL_0494
+
+		IL_047f: ldloc.2
+		IL_0480: ldstr "return"
+		IL_0485: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:99"
+		IL_048a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0494: stloc.s 21
+		IL_0496: ldloc.s 21
+		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_049d: ldstr "call"
+		IL_04a2: ldloc.s 8
+		IL_04a4: ldc.r8 99
+		IL_04ad: box [System.Runtime]System.Double
+		IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04b7: stloc.s 9
+		IL_04b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04be: stloc.s 22
+		IL_04c0: volatile.
+		IL_04c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_04c7: brfalse IL_04dd
+
+		IL_04cc: ldloc.s 9
+		IL_04ce: ldstr "value"
+		IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04d8: br IL_04f3
+
+		IL_04dd: ldloc.s 9
+		IL_04df: ldstr "value"
+		IL_04e4: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:109"
+		IL_04e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_04ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04f3: stloc.s 21
+		IL_04f5: ldloc.s 21
+		IL_04f7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_04fc: stloc.s 23
+		IL_04fe: ldstr "r4: "
+		IL_0503: ldloc.s 23
+		IL_0505: call string [System.Runtime]System.String::Concat(string, string)
+		IL_050a: ldstr " done: "
+		IL_050f: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0514: volatile.
+		IL_0516: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_051b: brfalse IL_0531
+
+		IL_0520: ldloc.s 9
+		IL_0522: ldstr "done"
+		IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_052c: br IL_0547
+
+		IL_0531: ldloc.s 9
+		IL_0533: ldstr "done"
+		IL_0538: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:115"
+		IL_053d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0542: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0547: stloc.s 21
+		IL_0549: ldloc.s 21
+		IL_054b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0550: stloc.s 23
+		IL_0552: ldloc.s 23
+		IL_0554: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0559: stloc.s 23
+		IL_055b: ldloc.s 22
+		IL_055d: ldloc.s 23
+		IL_055f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0564: pop
 		.try
 		{
-			IL_04f1: nop
-			IL_04f2: volatile.
-			IL_04f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_04f9: brfalse IL_050e
+			IL_0565: nop
+			IL_0566: volatile.
+			IL_0568: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_056d: brfalse IL_0582
 
-			IL_04fe: ldloc.2
-			IL_04ff: ldstr "next"
-			IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0509: br IL_0523
+			IL_0572: ldloc.2
+			IL_0573: ldstr "next"
+			IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057d: br IL_0597
 
-			IL_050e: ldloc.2
-			IL_050f: ldstr "next"
-			IL_0514: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:124"
-			IL_0519: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0582: ldloc.2
+			IL_0583: ldstr "next"
+			IL_0588: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:124"
+			IL_058d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0523: stloc.s 21
-			IL_0525: ldloc.s 21
-			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_052c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0531: stloc.s 24
-			IL_0533: ldstr "call"
-			IL_0538: ldloc.s 24
-			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_053f: pop
-			IL_0540: leave IL_05b1
+			IL_0597: stloc.s 21
+			IL_0599: ldloc.s 21
+			IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05a0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05a5: stloc.s 24
+			IL_05a7: volatile.
+			IL_05a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_05ae: brfalse IL_05c4
+
+			IL_05b3: ldstr "call"
+			IL_05b8: ldloc.s 24
+			IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05bf: br IL_05da
+
+			IL_05c4: ldstr "call"
+			IL_05c9: ldloc.s 24
+			IL_05cb: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:127"
+			IL_05d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_05da: pop
+			IL_05db: leave IL_064c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0545: stloc.s 10
-			IL_0547: ldloc.s 10
-			IL_0549: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_054e: dup
-			IL_054f: brtrue IL_0565
+			IL_05e0: stloc.s 10
+			IL_05e2: ldloc.s 10
+			IL_05e4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05e9: dup
+			IL_05ea: brtrue IL_0600
 
-			IL_0554: pop
-			IL_0555: ldloc.s 10
-			IL_0557: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_055c: dup
-			IL_055d: brtrue IL_0571
+			IL_05ef: pop
+			IL_05f0: ldloc.s 10
+			IL_05f2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_05f7: dup
+			IL_05f8: brtrue IL_060c
 
-			IL_0562: pop
-			IL_0563: rethrow
+			IL_05fd: pop
+			IL_05fe: rethrow
 
-			IL_0565: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_056a: stloc.s 11
-			IL_056c: br IL_0573
+			IL_0600: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0605: stloc.s 11
+			IL_0607: br IL_060e
 
-			IL_0571: stloc.s 11
+			IL_060c: stloc.s 11
 
-			IL_0573: ldloc.s 11
-			IL_0575: stloc.s 12
-			IL_0577: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_057c: stloc.s 22
-			IL_057e: ldloc.s 12
-			IL_0580: stloc.s 21
-			IL_0582: ldstr "TypeError"
-			IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_058c: stloc.s 25
-			IL_058e: ldloc.s 21
-			IL_0590: ldloc.s 25
-			IL_0592: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0597: stloc.s 26
-			IL_0599: ldloc.s 26
-			IL_059b: box [System.Runtime]System.Boolean
-			IL_05a0: stloc.s 27
-			IL_05a2: ldloc.s 22
-			IL_05a4: ldloc.s 27
-			IL_05a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05ab: pop
-			IL_05ac: leave IL_05b1
+			IL_060e: ldloc.s 11
+			IL_0610: stloc.s 12
+			IL_0612: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0617: stloc.s 22
+			IL_0619: ldloc.s 12
+			IL_061b: stloc.s 21
+			IL_061d: ldstr "TypeError"
+			IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0627: stloc.s 25
+			IL_0629: ldloc.s 21
+			IL_062b: ldloc.s 25
+			IL_062d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0632: stloc.s 26
+			IL_0634: ldloc.s 26
+			IL_0636: box [System.Runtime]System.Boolean
+			IL_063b: stloc.s 27
+			IL_063d: ldloc.s 22
+			IL_063f: ldloc.s 27
+			IL_0641: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0646: pop
+			IL_0647: leave IL_064c
 		} // end handler
 		.try
 		{
-			IL_05b1: nop
-			IL_05b2: volatile.
-			IL_05b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_05b9: brfalse IL_05ce
+			IL_064c: nop
+			IL_064d: volatile.
+			IL_064f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0654: brfalse IL_0669
 
-			IL_05be: ldloc.2
-			IL_05bf: ldstr "return"
-			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05c9: br IL_05e3
+			IL_0659: ldloc.2
+			IL_065a: ldstr "return"
+			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0664: br IL_067e
 
-			IL_05ce: ldloc.2
-			IL_05cf: ldstr "return"
-			IL_05d4: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:152"
-			IL_05d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0669: ldloc.2
+			IL_066a: ldstr "return"
+			IL_066f: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:152"
+			IL_0674: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0679: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_05e3: stloc.s 25
-			IL_05e5: ldloc.s 25
-			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05f1: stloc.s 24
-			IL_05f3: ldstr "call"
-			IL_05f8: ldloc.s 24
-			IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05ff: pop
-			IL_0600: leave IL_0671
+			IL_067e: stloc.s 25
+			IL_0680: ldloc.s 25
+			IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0687: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_068c: stloc.s 24
+			IL_068e: volatile.
+			IL_0690: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0695: brfalse IL_06ab
+
+			IL_069a: ldstr "call"
+			IL_069f: ldloc.s 24
+			IL_06a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06a6: br IL_06c1
+
+			IL_06ab: ldstr "call"
+			IL_06b0: ldloc.s 24
+			IL_06b2: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:155"
+			IL_06b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_06c1: pop
+			IL_06c2: leave IL_0733
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0605: stloc.s 13
-			IL_0607: ldloc.s 13
-			IL_0609: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_060e: dup
-			IL_060f: brtrue IL_0625
+			IL_06c7: stloc.s 13
+			IL_06c9: ldloc.s 13
+			IL_06cb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06d0: dup
+			IL_06d1: brtrue IL_06e7
 
-			IL_0614: pop
-			IL_0615: ldloc.s 13
-			IL_0617: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_061c: dup
-			IL_061d: brtrue IL_0631
+			IL_06d6: pop
+			IL_06d7: ldloc.s 13
+			IL_06d9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06de: dup
+			IL_06df: brtrue IL_06f3
 
-			IL_0622: pop
-			IL_0623: rethrow
+			IL_06e4: pop
+			IL_06e5: rethrow
 
-			IL_0625: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_062a: stloc.s 14
-			IL_062c: br IL_0633
+			IL_06e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_06ec: stloc.s 14
+			IL_06ee: br IL_06f5
 
-			IL_0631: stloc.s 14
+			IL_06f3: stloc.s 14
 
-			IL_0633: ldloc.s 14
-			IL_0635: stloc.s 15
-			IL_0637: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_063c: stloc.s 22
-			IL_063e: ldloc.s 15
-			IL_0640: stloc.s 25
-			IL_0642: ldstr "TypeError"
-			IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_064c: stloc.s 21
-			IL_064e: ldloc.s 25
-			IL_0650: ldloc.s 21
-			IL_0652: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0657: stloc.s 26
-			IL_0659: ldloc.s 26
-			IL_065b: box [System.Runtime]System.Boolean
-			IL_0660: stloc.s 27
-			IL_0662: ldloc.s 22
-			IL_0664: ldloc.s 27
-			IL_0666: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_066b: pop
-			IL_066c: leave IL_0671
+			IL_06f5: ldloc.s 14
+			IL_06f7: stloc.s 15
+			IL_06f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06fe: stloc.s 22
+			IL_0700: ldloc.s 15
+			IL_0702: stloc.s 25
+			IL_0704: ldstr "TypeError"
+			IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_070e: stloc.s 21
+			IL_0710: ldloc.s 25
+			IL_0712: ldloc.s 21
+			IL_0714: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0719: stloc.s 26
+			IL_071b: ldloc.s 26
+			IL_071d: box [System.Runtime]System.Boolean
+			IL_0722: stloc.s 27
+			IL_0724: ldloc.s 22
+			IL_0726: ldloc.s 27
+			IL_0728: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_072d: pop
+			IL_072e: leave IL_0733
 		} // end handler
 		.try
 		{
-			IL_0671: nop
-			IL_0672: volatile.
-			IL_0674: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_0679: brfalse IL_068e
+			IL_0733: nop
+			IL_0734: volatile.
+			IL_0736: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_073b: brfalse IL_0750
 
-			IL_067e: ldloc.2
-			IL_067f: ldstr "throw"
-			IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0689: br IL_06a3
+			IL_0740: ldloc.2
+			IL_0741: ldstr "throw"
+			IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_074b: br IL_0765
 
-			IL_068e: ldloc.2
-			IL_068f: ldstr "throw"
-			IL_0694: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:180"
-			IL_0699: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_069e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0750: ldloc.2
+			IL_0751: ldstr "throw"
+			IL_0756: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:180"
+			IL_075b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06a3: stloc.s 21
-			IL_06a5: ldloc.s 21
-			IL_06a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06b1: stloc.s 24
-			IL_06b3: ldstr "call"
-			IL_06b8: ldloc.s 24
-			IL_06ba: ldstr "x"
-			IL_06bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_06c4: pop
-			IL_06c5: leave IL_0736
+			IL_0765: stloc.s 21
+			IL_0767: ldloc.s 21
+			IL_0769: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_076e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0773: stloc.s 24
+			IL_0775: ldstr "call"
+			IL_077a: ldloc.s 24
+			IL_077c: ldstr "x"
+			IL_0781: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0786: pop
+			IL_0787: leave IL_07f8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06ca: stloc.s 16
-			IL_06cc: ldloc.s 16
-			IL_06ce: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_06d3: dup
-			IL_06d4: brtrue IL_06ea
+			IL_078c: stloc.s 16
+			IL_078e: ldloc.s 16
+			IL_0790: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0795: dup
+			IL_0796: brtrue IL_07ac
 
-			IL_06d9: pop
-			IL_06da: ldloc.s 16
-			IL_06dc: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_06e1: dup
-			IL_06e2: brtrue IL_06f6
+			IL_079b: pop
+			IL_079c: ldloc.s 16
+			IL_079e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_07a3: dup
+			IL_07a4: brtrue IL_07b8
 
-			IL_06e7: pop
-			IL_06e8: rethrow
+			IL_07a9: pop
+			IL_07aa: rethrow
 
-			IL_06ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_06ef: stloc.s 17
-			IL_06f1: br IL_06f8
+			IL_07ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07b1: stloc.s 17
+			IL_07b3: br IL_07ba
 
-			IL_06f6: stloc.s 17
+			IL_07b8: stloc.s 17
 
-			IL_06f8: ldloc.s 17
-			IL_06fa: stloc.s 18
-			IL_06fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0701: stloc.s 22
-			IL_0703: ldloc.s 18
-			IL_0705: stloc.s 21
-			IL_0707: ldstr "TypeError"
-			IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0711: stloc.s 25
-			IL_0713: ldloc.s 21
-			IL_0715: ldloc.s 25
-			IL_0717: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_071c: stloc.s 26
-			IL_071e: ldloc.s 26
-			IL_0720: box [System.Runtime]System.Boolean
-			IL_0725: stloc.s 27
-			IL_0727: ldloc.s 22
-			IL_0729: ldloc.s 27
-			IL_072b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0730: pop
-			IL_0731: leave IL_0736
+			IL_07ba: ldloc.s 17
+			IL_07bc: stloc.s 18
+			IL_07be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07c3: stloc.s 22
+			IL_07c5: ldloc.s 18
+			IL_07c7: stloc.s 21
+			IL_07c9: ldstr "TypeError"
+			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07d3: stloc.s 25
+			IL_07d5: ldloc.s 21
+			IL_07d7: ldloc.s 25
+			IL_07d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_07de: stloc.s 26
+			IL_07e0: ldloc.s 26
+			IL_07e2: box [System.Runtime]System.Boolean
+			IL_07e7: stloc.s 27
+			IL_07e9: ldloc.s 22
+			IL_07eb: ldloc.s 27
+			IL_07ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07f2: pop
+			IL_07f3: leave IL_07f8
 		} // end handler
 
-		IL_0736: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_073b: stloc.s 22
-		IL_073d: volatile.
-		IL_073f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0744: brfalse IL_0759
+		IL_07f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07fd: stloc.s 22
+		IL_07ff: volatile.
+		IL_0801: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0806: brfalse IL_081b
 
-		IL_0749: ldloc.2
-		IL_074a: ldstr "next"
-		IL_074f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0754: br IL_076e
+		IL_080b: ldloc.2
+		IL_080c: ldstr "next"
+		IL_0811: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0816: br IL_0830
 
-		IL_0759: ldloc.2
-		IL_075a: ldstr "next"
-		IL_075f: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:207"
-		IL_0764: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0769: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_081b: ldloc.2
+		IL_081c: ldstr "next"
+		IL_0821: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:207"
+		IL_0826: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_082b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_076e: stloc.s 25
-		IL_0770: volatile.
-		IL_0772: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0777: brfalse IL_078d
+		IL_0830: stloc.s 25
+		IL_0832: volatile.
+		IL_0834: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0839: brfalse IL_084f
 
-		IL_077c: ldloc.s 25
-		IL_077e: ldstr "length"
-		IL_0783: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0788: br IL_07a3
+		IL_083e: ldloc.s 25
+		IL_0840: ldstr "length"
+		IL_0845: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_084a: br IL_0865
 
-		IL_078d: ldloc.s 25
-		IL_078f: ldstr "length"
-		IL_0794: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:209"
-		IL_0799: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_084f: ldloc.s 25
+		IL_0851: ldstr "length"
+		IL_0856: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:209"
+		IL_085b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0860: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07a3: stloc.s 25
-		IL_07a5: ldloc.s 22
-		IL_07a7: ldloc.s 25
-		IL_07a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07ae: pop
-		IL_07af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07b4: stloc.s 22
-		IL_07b6: volatile.
-		IL_07b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_07bd: brfalse IL_07d2
+		IL_0865: stloc.s 25
+		IL_0867: ldloc.s 22
+		IL_0869: ldloc.s 25
+		IL_086b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0870: pop
+		IL_0871: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0876: stloc.s 22
+		IL_0878: volatile.
+		IL_087a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_087f: brfalse IL_0894
 
-		IL_07c2: ldloc.2
-		IL_07c3: ldstr "return"
-		IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07cd: br IL_07e7
+		IL_0884: ldloc.2
+		IL_0885: ldstr "return"
+		IL_088a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_088f: br IL_08a9
 
-		IL_07d2: ldloc.2
-		IL_07d3: ldstr "return"
-		IL_07d8: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:214"
-		IL_07dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0894: ldloc.2
+		IL_0895: ldstr "return"
+		IL_089a: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:214"
+		IL_089f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_08a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07e7: stloc.s 25
-		IL_07e9: volatile.
-		IL_07eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_07f0: brfalse IL_0806
+		IL_08a9: stloc.s 25
+		IL_08ab: volatile.
+		IL_08ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_08b2: brfalse IL_08c8
 
-		IL_07f5: ldloc.s 25
-		IL_07f7: ldstr "length"
-		IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0801: br IL_081c
+		IL_08b7: ldloc.s 25
+		IL_08b9: ldstr "length"
+		IL_08be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08c3: br IL_08de
 
-		IL_0806: ldloc.s 25
-		IL_0808: ldstr "length"
-		IL_080d: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:216"
-		IL_0812: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_08c8: ldloc.s 25
+		IL_08ca: ldstr "length"
+		IL_08cf: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:216"
+		IL_08d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_08d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_081c: stloc.s 25
-		IL_081e: ldloc.s 22
-		IL_0820: ldloc.s 25
-		IL_0822: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0827: pop
-		IL_0828: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_082d: stloc.s 22
-		IL_082f: volatile.
-		IL_0831: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0836: brfalse IL_084b
+		IL_08de: stloc.s 25
+		IL_08e0: ldloc.s 22
+		IL_08e2: ldloc.s 25
+		IL_08e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08e9: pop
+		IL_08ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08ef: stloc.s 22
+		IL_08f1: volatile.
+		IL_08f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_08f8: brfalse IL_090d
 
-		IL_083b: ldloc.2
-		IL_083c: ldstr "throw"
-		IL_0841: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0846: br IL_0860
+		IL_08fd: ldloc.2
+		IL_08fe: ldstr "throw"
+		IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0908: br IL_0922
 
-		IL_084b: ldloc.2
-		IL_084c: ldstr "throw"
-		IL_0851: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:221"
-		IL_0856: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_085b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_090d: ldloc.2
+		IL_090e: ldstr "throw"
+		IL_0913: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:221"
+		IL_0918: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_091d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0860: stloc.s 25
-		IL_0862: volatile.
-		IL_0864: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0869: brfalse IL_087f
+		IL_0922: stloc.s 25
+		IL_0924: volatile.
+		IL_0926: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_092b: brfalse IL_0941
 
-		IL_086e: ldloc.s 25
-		IL_0870: ldstr "length"
-		IL_0875: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_087a: br IL_0895
+		IL_0930: ldloc.s 25
+		IL_0932: ldstr "length"
+		IL_0937: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_093c: br IL_0957
 
-		IL_087f: ldloc.s 25
-		IL_0881: ldstr "length"
-		IL_0886: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:223"
-		IL_088b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0941: ldloc.s 25
+		IL_0943: ldstr "length"
+		IL_0948: ldstr "Generator_ExplicitReceiverAbi:Modules.Generator_ExplicitReceiverAbi:__js_module_init__:223"
+		IL_094d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0952: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0895: stloc.s 25
-		IL_0897: ldloc.s 22
-		IL_0899: ldloc.s 25
-		IL_089b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08a0: pop
-		IL_08a1: ldnull
-		IL_08a2: stloc.s 19
-		IL_08a4: ret
+		IL_0957: stloc.s 25
+		IL_0959: ldloc.s 22
+		IL_095b: ldloc.s 25
+		IL_095d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0962: pop
+		IL_0963: ldnull
+		IL_0964: stloc.s 19
+		IL_0966: ret
 	} // end of method Generator_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.Generator_ExplicitReceiverAbi
@@ -1725,6 +1785,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
 	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_GeneratedFunctionObject_Semantics.verified.txt
@@ -315,7 +315,7 @@
 			IL_00d1: switch (IL_00e2, IL_016f, IL_024b)
 
 			IL_00e2: volatile.
-			IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_00e9: brfalse IL_0107
 
 			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
@@ -328,7 +328,7 @@
 			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0111: ldstr "base"
 			IL_0116: ldstr "Generator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M4>:__js_call__:18"
-			IL_011b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_011b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0125: stloc.3
@@ -398,7 +398,7 @@
 			IL_01ab: throw
 
 			IL_01ac: volatile.
-			IL_01ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_01ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_01b3: brfalse IL_01d1
 
 			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
@@ -411,7 +411,7 @@
 			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_01db: ldstr "base"
 			IL_01e0: ldstr "Generator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M4>:__js_call__:25"
-			IL_01e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_01e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01ef: stloc.s 4
@@ -2191,7 +2191,7 @@
 			IL_00d1: switch (IL_00de, IL_016b)
 
 			IL_00de: volatile.
-			IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_00e5: brfalse IL_0103
 
 			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
@@ -2204,7 +2204,7 @@
 			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_010d: ldstr "base"
 			IL_0112: ldstr "Generator_GeneratedFunctionObject_Semantics:<TwoPhaseDummy_M8>:__js_call__:18"
-			IL_0117: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0117: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0121: stloc.3
@@ -4006,7 +4006,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 4773 (0x12a5)
+		// Code size: 4826 (0x12da)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_GeneratedFunctionObject_Semantics/Scope,
@@ -5183,450 +5183,464 @@
 		IL_0d4b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0d50: stloc.s 35
-		IL_0d52: ldloc.s 44
-		IL_0d54: ldstr "twice"
-		IL_0d59: ldc.r8 5
-		IL_0d62: box [System.Runtime]System.Double
-		IL_0d67: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0d6c: stloc.s 33
-		IL_0d6e: ldloc.s 33
-		IL_0d70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0d75: volatile.
-		IL_0d77: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-		IL_0d7c: brfalse IL_0d90
+		IL_0d52: volatile.
+		IL_0d54: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_0d59: brfalse IL_0d7d
 
-		IL_0d81: ldstr "next"
-		IL_0d86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0d8b: br IL_0da4
+		IL_0d5e: ldloc.s 44
+		IL_0d60: ldstr "twice"
+		IL_0d65: ldc.r8 5
+		IL_0d6e: box [System.Runtime]System.Double
+		IL_0d73: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0d78: br IL_0da1
 
-		IL_0d90: ldstr "next"
-		IL_0d95: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:252"
-		IL_0d9a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-		IL_0d9f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0d7d: ldloc.s 44
+		IL_0d7f: ldstr "twice"
+		IL_0d84: ldc.r8 5
+		IL_0d8d: box [System.Runtime]System.Double
+		IL_0d92: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:250"
+		IL_0d97: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_0d9c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0da4: stloc.s 33
-		IL_0da6: volatile.
-		IL_0da8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_0dad: brfalse IL_0dc3
+		IL_0da1: stloc.s 33
+		IL_0da3: ldloc.s 33
+		IL_0da5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0daa: volatile.
+		IL_0dac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_0db1: brfalse IL_0dc5
 
-		IL_0db2: ldloc.s 33
-		IL_0db4: ldstr "value"
-		IL_0db9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0dbe: br IL_0dd9
+		IL_0db6: ldstr "next"
+		IL_0dbb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0dc0: br IL_0dd9
 
-		IL_0dc3: ldloc.s 33
-		IL_0dc5: ldstr "value"
-		IL_0dca: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:254"
+		IL_0dc5: ldstr "next"
+		IL_0dca: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:252"
 		IL_0dcf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_0dd4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0dd4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 		IL_0dd9: stloc.s 33
 		IL_0ddb: volatile.
 		IL_0ddd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 		IL_0de2: brfalse IL_0df8
 
-		IL_0de7: ldloc.s 16
-		IL_0de9: ldstr "run"
+		IL_0de7: ldloc.s 33
+		IL_0de9: ldstr "value"
 		IL_0dee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0df3: br IL_0e0e
 
-		IL_0df8: ldloc.s 16
-		IL_0dfa: ldstr "run"
-		IL_0dff: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:256"
+		IL_0df8: ldloc.s 33
+		IL_0dfa: ldstr "value"
+		IL_0dff: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:254"
 		IL_0e04: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 		IL_0e09: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0e0e: stloc.s 32
-		IL_0e10: ldloc.s 32
-		IL_0e12: ldstr "prototype"
-		IL_0e17: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0e1c: box [System.Runtime]System.Boolean
-		IL_0e21: stloc.s 40
-		IL_0e23: volatile.
-		IL_0e25: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-		IL_0e2a: brfalse IL_0e40
+		IL_0e0e: stloc.s 33
+		IL_0e10: volatile.
+		IL_0e12: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+		IL_0e17: brfalse IL_0e2d
 
-		IL_0e2f: ldloc.s 44
-		IL_0e31: ldstr "prototype"
-		IL_0e36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0e3b: br IL_0e56
+		IL_0e1c: ldloc.s 16
+		IL_0e1e: ldstr "run"
+		IL_0e23: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0e28: br IL_0e43
 
-		IL_0e40: ldloc.s 44
-		IL_0e42: ldstr "prototype"
-		IL_0e47: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:261"
-		IL_0e4c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-		IL_0e51: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0e2d: ldloc.s 16
+		IL_0e2f: ldstr "run"
+		IL_0e34: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:256"
+		IL_0e39: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+		IL_0e3e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0e56: stloc.s 32
+		IL_0e43: stloc.s 32
+		IL_0e45: ldloc.s 32
+		IL_0e47: ldstr "prototype"
+		IL_0e4c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0e51: box [System.Runtime]System.Boolean
+		IL_0e56: stloc.s 40
 		IL_0e58: volatile.
 		IL_0e5a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 		IL_0e5f: brfalse IL_0e75
 
-		IL_0e64: ldloc.s 32
-		IL_0e66: ldstr "run"
+		IL_0e64: ldloc.s 44
+		IL_0e66: ldstr "prototype"
 		IL_0e6b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0e70: br IL_0e8b
 
-		IL_0e75: ldloc.s 32
-		IL_0e77: ldstr "run"
-		IL_0e7c: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:263"
+		IL_0e75: ldloc.s 44
+		IL_0e77: ldstr "prototype"
+		IL_0e7c: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:261"
 		IL_0e81: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 		IL_0e86: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0e8b: stloc.s 32
-		IL_0e8d: ldloc.s 32
-		IL_0e8f: ldstr "prototype"
-		IL_0e94: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0e99: box [System.Runtime]System.Boolean
-		IL_0e9e: stloc.s 38
-		IL_0ea0: volatile.
-		IL_0ea2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-		IL_0ea7: brfalse IL_0ebd
+		IL_0e8d: volatile.
+		IL_0e8f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+		IL_0e94: brfalse IL_0eaa
 
-		IL_0eac: ldloc.s 44
-		IL_0eae: ldstr "twice"
-		IL_0eb3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0eb8: br IL_0ed3
+		IL_0e99: ldloc.s 32
+		IL_0e9b: ldstr "run"
+		IL_0ea0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ea5: br IL_0ec0
 
-		IL_0ebd: ldloc.s 44
-		IL_0ebf: ldstr "twice"
-		IL_0ec4: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:268"
-		IL_0ec9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-		IL_0ece: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0eaa: ldloc.s 32
+		IL_0eac: ldstr "run"
+		IL_0eb1: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:263"
+		IL_0eb6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+		IL_0ebb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0ed3: stloc.s 32
-		IL_0ed5: ldloc.s 32
-		IL_0ed7: ldstr "prototype"
-		IL_0edc: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0ee1: box [System.Runtime]System.Boolean
-		IL_0ee6: stloc.s 37
-		IL_0ee8: ldloc.s 30
-		IL_0eea: ldc.i4.7
-		IL_0eeb: newarr [System.Runtime]System.Object
-		IL_0ef0: dup
-		IL_0ef1: ldc.i4.0
-		IL_0ef2: ldstr "methods"
-		IL_0ef7: stelem.ref
-		IL_0ef8: dup
-		IL_0ef9: ldc.i4.1
-		IL_0efa: ldloc.s 34
-		IL_0efc: stelem.ref
-		IL_0efd: dup
-		IL_0efe: ldc.i4.2
-		IL_0eff: ldloc.s 35
-		IL_0f01: stelem.ref
-		IL_0f02: dup
-		IL_0f03: ldc.i4.3
-		IL_0f04: ldloc.s 33
-		IL_0f06: stelem.ref
-		IL_0f07: dup
-		IL_0f08: ldc.i4.4
-		IL_0f09: ldloc.s 40
-		IL_0f0b: stelem.ref
-		IL_0f0c: dup
-		IL_0f0d: ldc.i4.5
-		IL_0f0e: ldloc.s 38
-		IL_0f10: stelem.ref
-		IL_0f11: dup
-		IL_0f12: ldc.i4.6
-		IL_0f13: ldloc.s 37
-		IL_0f15: stelem.ref
-		IL_0f16: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0f1b: pop
-		IL_0f1c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0f21: stloc.s 18
-		IL_0f23: volatile.
-		IL_0f25: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_0f2a: brfalse IL_0f40
+		IL_0ec0: stloc.s 32
+		IL_0ec2: ldloc.s 32
+		IL_0ec4: ldstr "prototype"
+		IL_0ec9: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0ece: box [System.Runtime]System.Boolean
+		IL_0ed3: stloc.s 38
+		IL_0ed5: volatile.
+		IL_0ed7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_0edc: brfalse IL_0ef2
 
-		IL_0f2f: ldloc.s 44
-		IL_0f31: ldstr "prototype"
-		IL_0f36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0f3b: br IL_0f56
+		IL_0ee1: ldloc.s 44
+		IL_0ee3: ldstr "twice"
+		IL_0ee8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0eed: br IL_0f08
 
-		IL_0f40: ldloc.s 44
-		IL_0f42: ldstr "prototype"
-		IL_0f47: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:278"
-		IL_0f4c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_0f51: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ef2: ldloc.s 44
+		IL_0ef4: ldstr "twice"
+		IL_0ef9: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:268"
+		IL_0efe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_0f03: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0f56: stloc.s 33
+		IL_0f08: stloc.s 32
+		IL_0f0a: ldloc.s 32
+		IL_0f0c: ldstr "prototype"
+		IL_0f11: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0f16: box [System.Runtime]System.Boolean
+		IL_0f1b: stloc.s 37
+		IL_0f1d: ldloc.s 30
+		IL_0f1f: ldc.i4.7
+		IL_0f20: newarr [System.Runtime]System.Object
+		IL_0f25: dup
+		IL_0f26: ldc.i4.0
+		IL_0f27: ldstr "methods"
+		IL_0f2c: stelem.ref
+		IL_0f2d: dup
+		IL_0f2e: ldc.i4.1
+		IL_0f2f: ldloc.s 34
+		IL_0f31: stelem.ref
+		IL_0f32: dup
+		IL_0f33: ldc.i4.2
+		IL_0f34: ldloc.s 35
+		IL_0f36: stelem.ref
+		IL_0f37: dup
+		IL_0f38: ldc.i4.3
+		IL_0f39: ldloc.s 33
+		IL_0f3b: stelem.ref
+		IL_0f3c: dup
+		IL_0f3d: ldc.i4.4
+		IL_0f3e: ldloc.s 40
+		IL_0f40: stelem.ref
+		IL_0f41: dup
+		IL_0f42: ldc.i4.5
+		IL_0f43: ldloc.s 38
+		IL_0f45: stelem.ref
+		IL_0f46: dup
+		IL_0f47: ldc.i4.6
+		IL_0f48: ldloc.s 37
+		IL_0f4a: stelem.ref
+		IL_0f4b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0f50: pop
+		IL_0f51: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0f56: stloc.s 18
 		IL_0f58: volatile.
 		IL_0f5a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 		IL_0f5f: brfalse IL_0f75
 
-		IL_0f64: ldloc.s 33
-		IL_0f66: ldstr "run"
+		IL_0f64: ldloc.s 44
+		IL_0f66: ldstr "prototype"
 		IL_0f6b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0f70: br IL_0f8b
 
-		IL_0f75: ldloc.s 33
-		IL_0f77: ldstr "run"
-		IL_0f7c: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:280"
+		IL_0f75: ldloc.s 44
+		IL_0f77: ldstr "prototype"
+		IL_0f7c: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:278"
 		IL_0f81: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 		IL_0f86: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0f8b: stloc.s 33
-		IL_0f8d: ldloc.s 33
-		IL_0f8f: ldstr "prototype"
-		IL_0f94: ldloc.s 18
-		IL_0f96: ldc.i4.0
-		IL_0f97: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0f9c: pop
-		IL_0f9d: ldc.i4.1
-		IL_0f9e: newarr [System.Runtime]System.Object
-		IL_0fa3: dup
-		IL_0fa4: ldc.i4.0
-		IL_0fa5: ldc.r8 50
-		IL_0fae: box [System.Runtime]System.Double
-		IL_0fb3: stelem.ref
-		IL_0fb4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0fb9: ldc.r8 50
-		IL_0fc2: box [System.Runtime]System.Double
-		IL_0fc7: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::.ctor(object)
-		IL_0fcc: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_0fd1: stloc.s 19
-		IL_0fd3: ldloc.s 19
-		IL_0fd5: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
-		IL_0fda: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0fdf: ldstr "prototype"
-		IL_0fe4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0fe9: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0fee: ldc.i4.1
-		IL_0fef: newarr [System.Runtime]System.Object
-		IL_0ff4: dup
-		IL_0ff5: ldc.i4.0
-		IL_0ff6: ldloc.0
-		IL_0ff7: stelem.ref
-		IL_0ff8: stloc.s 28
-		IL_0ffa: ldloc.s 28
-		IL_0ffc: ldc.i4.1
-		IL_0ffd: newarr [System.Runtime]System.Object
-		IL_1002: dup
-		IL_1003: ldc.i4.0
-		IL_1004: ldc.r8 60
-		IL_100d: box [System.Runtime]System.Double
-		IL_1012: stelem.ref
-		IL_1013: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_1018: ldloc.s 17
-		IL_101a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_101f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_1024: ldc.r8 60
-		IL_102d: box [System.Runtime]System.Double
-		IL_1032: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::.ctor(object[], object)
-		IL_1037: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_103c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_1041: dup
-		IL_1042: ldloc.s 17
-		IL_1044: ldstr "prototype"
-		IL_1049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_104e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_1053: stloc.s 20
-		IL_1055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_105a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_105f: stloc.s 20
-		IL_1061: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_1066: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_106b: stloc.s 30
-		IL_106d: ldloc.s 19
-		IL_106f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass>(!!0)
-		IL_1074: stloc.s 46
-		IL_1076: ldloc.s 46
-		IL_1078: ldc.r8 6
-		IL_1081: box [System.Runtime]System.Double
-		IL_1086: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::callRun(object)
-		IL_108b: stloc.s 33
-		IL_108d: ldloc.s 33
-		IL_108f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_1094: stloc.s 33
-		IL_1096: ldloc.s 33
-		IL_1098: ldloc.s 18
-		IL_109a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_109f: stloc.s 36
-		IL_10a1: ldloc.s 36
-		IL_10a3: box [System.Runtime]System.Boolean
-		IL_10a8: stloc.s 37
-		IL_10aa: ldloc.s 20
-		IL_10ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_10b1: stloc.s 33
-		IL_10b3: ldloc.s 33
-		IL_10b5: isinst Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
-		IL_10ba: dup
-		IL_10bb: brfalse IL_10da
+		IL_0f8d: volatile.
+		IL_0f8f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+		IL_0f94: brfalse IL_0faa
 
-		IL_10c0: ldc.r8 7
-		IL_10c9: box [System.Runtime]System.Double
-		IL_10ce: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::callSuper(object)
-		IL_10d3: stloc.s 33
-		IL_10d5: br IL_10f7
+		IL_0f99: ldloc.s 33
+		IL_0f9b: ldstr "run"
+		IL_0fa0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0fa5: br IL_0fc0
 
-		IL_10da: pop
-		IL_10db: ldloc.s 33
-		IL_10dd: ldstr "callSuper"
-		IL_10e2: ldc.r8 7
-		IL_10eb: box [System.Runtime]System.Double
-		IL_10f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_10f5: stloc.s 33
+		IL_0faa: ldloc.s 33
+		IL_0fac: ldstr "run"
+		IL_0fb1: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:280"
+		IL_0fb6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+		IL_0fbb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_10f7: ldloc.s 33
-		IL_10f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_10fe: stloc.s 33
-		IL_1100: ldloc.s 33
-		IL_1102: ldloc.s 18
-		IL_1104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_1109: stloc.s 36
-		IL_110b: ldloc.s 36
-		IL_110d: box [System.Runtime]System.Boolean
-		IL_1112: stloc.s 38
-		IL_1114: ldloc.s 30
-		IL_1116: ldstr "internalMethods"
-		IL_111b: ldloc.s 37
-		IL_111d: ldloc.s 38
-		IL_111f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_1124: pop
-		IL_1125: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_112a: stloc.s 21
-		IL_112c: ldloc.0
-		IL_112d: ldfld object Modules.Generator_GeneratedFunctionObject_Semantics/Scope::expression
-		IL_1132: ldstr "Cannot access 'expression' before initialization"
-		IL_1137: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_113c: stloc.s 33
-		IL_113e: ldloc.s 33
-		IL_1140: ldstr "prototype"
-		IL_1145: ldloc.s 21
-		IL_1147: ldc.i4.0
-		IL_1148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_114d: pop
-		IL_114e: nop
-		IL_114f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_1154: stloc.s 30
-		IL_1156: ldloc.0
-		IL_1157: castclass Modules.Generator_GeneratedFunctionObject_Semantics/Scope
-		IL_115c: ldnull
-		IL_115d: call object Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator::__js_call__(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, object)
-		IL_1162: stloc.s 33
-		IL_1164: ldloc.s 33
-		IL_1166: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_116b: stloc.s 33
-		IL_116d: ldloc.s 33
-		IL_116f: ldloc.s 21
-		IL_1171: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_1176: stloc.s 36
-		IL_1178: ldloc.s 36
-		IL_117a: box [System.Runtime]System.Boolean
-		IL_117f: stloc.s 38
-		IL_1181: ldloc.s 30
-		IL_1183: ldstr "tail"
-		IL_1188: ldloc.s 38
-		IL_118a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_118f: pop
-		IL_1190: nop
-		IL_1191: ldc.i4.0
-		IL_1192: stloc.s 22
-		IL_1194: ldc.i4.0
-		IL_1195: box [System.Runtime]System.Boolean
-		IL_119a: stloc.s 23
+		IL_0fc0: stloc.s 33
+		IL_0fc2: ldloc.s 33
+		IL_0fc4: ldstr "prototype"
+		IL_0fc9: ldloc.s 18
+		IL_0fcb: ldc.i4.0
+		IL_0fcc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0fd1: pop
+		IL_0fd2: ldc.i4.1
+		IL_0fd3: newarr [System.Runtime]System.Object
+		IL_0fd8: dup
+		IL_0fd9: ldc.i4.0
+		IL_0fda: ldc.r8 50
+		IL_0fe3: box [System.Runtime]System.Double
+		IL_0fe8: stelem.ref
+		IL_0fe9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0fee: ldc.r8 50
+		IL_0ff7: box [System.Runtime]System.Double
+		IL_0ffc: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::.ctor(object)
+		IL_1001: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_1006: stloc.s 19
+		IL_1008: ldloc.s 19
+		IL_100a: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
+		IL_100f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_1014: ldstr "prototype"
+		IL_1019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_101e: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_1023: ldc.i4.1
+		IL_1024: newarr [System.Runtime]System.Object
+		IL_1029: dup
+		IL_102a: ldc.i4.0
+		IL_102b: ldloc.0
+		IL_102c: stelem.ref
+		IL_102d: stloc.s 28
+		IL_102f: ldloc.s 28
+		IL_1031: ldc.i4.1
+		IL_1032: newarr [System.Runtime]System.Object
+		IL_1037: dup
+		IL_1038: ldc.i4.0
+		IL_1039: ldc.r8 60
+		IL_1042: box [System.Runtime]System.Double
+		IL_1047: stelem.ref
+		IL_1048: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_104d: ldloc.s 17
+		IL_104f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_1054: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_1059: ldc.r8 60
+		IL_1062: box [System.Runtime]System.Double
+		IL_1067: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::.ctor(object[], object)
+		IL_106c: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_1071: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_1076: dup
+		IL_1077: ldloc.s 17
+		IL_1079: ldstr "prototype"
+		IL_107e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_1083: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_1088: stloc.s 20
+		IL_108a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_108f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_1094: stloc.s 20
+		IL_1096: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_109b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_10a0: stloc.s 30
+		IL_10a2: ldloc.s 19
+		IL_10a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass>(!!0)
+		IL_10a9: stloc.s 46
+		IL_10ab: ldloc.s 46
+		IL_10ad: ldc.r8 6
+		IL_10b6: box [System.Runtime]System.Double
+		IL_10bb: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::callRun(object)
+		IL_10c0: stloc.s 33
+		IL_10c2: ldloc.s 33
+		IL_10c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_10c9: stloc.s 33
+		IL_10cb: ldloc.s 33
+		IL_10cd: ldloc.s 18
+		IL_10cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_10d4: stloc.s 36
+		IL_10d6: ldloc.s 36
+		IL_10d8: box [System.Runtime]System.Boolean
+		IL_10dd: stloc.s 37
+		IL_10df: ldloc.s 20
+		IL_10e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_10e6: stloc.s 33
+		IL_10e8: ldloc.s 33
+		IL_10ea: isinst Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
+		IL_10ef: dup
+		IL_10f0: brfalse IL_110f
+
+		IL_10f5: ldc.r8 7
+		IL_10fe: box [System.Runtime]System.Double
+		IL_1103: callvirt instance object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::callSuper(object)
+		IL_1108: stloc.s 33
+		IL_110a: br IL_112c
+
+		IL_110f: pop
+		IL_1110: ldloc.s 33
+		IL_1112: ldstr "callSuper"
+		IL_1117: ldc.r8 7
+		IL_1120: box [System.Runtime]System.Double
+		IL_1125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_112a: stloc.s 33
+
+		IL_112c: ldloc.s 33
+		IL_112e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_1133: stloc.s 33
+		IL_1135: ldloc.s 33
+		IL_1137: ldloc.s 18
+		IL_1139: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_113e: stloc.s 36
+		IL_1140: ldloc.s 36
+		IL_1142: box [System.Runtime]System.Boolean
+		IL_1147: stloc.s 38
+		IL_1149: ldloc.s 30
+		IL_114b: ldstr "internalMethods"
+		IL_1150: ldloc.s 37
+		IL_1152: ldloc.s 38
+		IL_1154: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_1159: pop
+		IL_115a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_115f: stloc.s 21
+		IL_1161: ldloc.0
+		IL_1162: ldfld object Modules.Generator_GeneratedFunctionObject_Semantics/Scope::expression
+		IL_1167: ldstr "Cannot access 'expression' before initialization"
+		IL_116c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_1171: stloc.s 33
+		IL_1173: ldloc.s 33
+		IL_1175: ldstr "prototype"
+		IL_117a: ldloc.s 21
+		IL_117c: ldc.i4.0
+		IL_117d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_1182: pop
+		IL_1183: nop
+		IL_1184: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_1189: stloc.s 30
+		IL_118b: ldloc.0
+		IL_118c: castclass Modules.Generator_GeneratedFunctionObject_Semantics/Scope
+		IL_1191: ldnull
+		IL_1192: call object Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator::__js_call__(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, object)
+		IL_1197: stloc.s 33
+		IL_1199: ldloc.s 33
+		IL_119b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_11a0: stloc.s 33
+		IL_11a2: ldloc.s 33
+		IL_11a4: ldloc.s 21
+		IL_11a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_11ab: stloc.s 36
+		IL_11ad: ldloc.s 36
+		IL_11af: box [System.Runtime]System.Boolean
+		IL_11b4: stloc.s 38
+		IL_11b6: ldloc.s 30
+		IL_11b8: ldstr "tail"
+		IL_11bd: ldloc.s 38
+		IL_11bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_11c4: pop
+		IL_11c5: nop
+		IL_11c6: ldc.i4.0
+		IL_11c7: stloc.s 22
+		IL_11c9: ldc.i4.0
+		IL_11ca: box [System.Runtime]System.Boolean
+		IL_11cf: stloc.s 23
 		.try
 		{
-			IL_119c: nop
-			IL_119d: ldloc.s 5
-			IL_119f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_11a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_11a9: stloc.s 33
-			IL_11ab: ldloc.s 33
-			IL_11ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_11b2: volatile.
-			IL_11b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_11b9: brfalse IL_11cd
+			IL_11d1: nop
+			IL_11d2: ldloc.s 5
+			IL_11d4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_11d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_11de: stloc.s 33
+			IL_11e0: ldloc.s 33
+			IL_11e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_11e7: volatile.
+			IL_11e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_11ee: brfalse IL_1202
 
-			IL_11be: ldstr "next"
-			IL_11c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_11c8: br IL_11e1
+			IL_11f3: ldstr "next"
+			IL_11f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_11fd: br IL_1216
 
-			IL_11cd: ldstr "next"
-			IL_11d2: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:344"
-			IL_11d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_11dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_1202: ldstr "next"
+			IL_1207: ldstr "Generator_GeneratedFunctionObject_Semantics:Modules.Generator_GeneratedFunctionObject_Semantics:__js_module_init__:344"
+			IL_120c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_1211: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_11e1: pop
-			IL_11e2: leave IL_1246
+			IL_1216: pop
+			IL_1217: leave IL_127b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_11e7: stloc.s 24
-			IL_11e9: ldloc.s 24
-			IL_11eb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_11f0: dup
-			IL_11f1: brtrue IL_1207
+			IL_121c: stloc.s 24
+			IL_121e: ldloc.s 24
+			IL_1220: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_1225: dup
+			IL_1226: brtrue IL_123c
 
-			IL_11f6: pop
-			IL_11f7: ldloc.s 24
-			IL_11f9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_11fe: dup
-			IL_11ff: brtrue IL_1213
+			IL_122b: pop
+			IL_122c: ldloc.s 24
+			IL_122e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_1233: dup
+			IL_1234: brtrue IL_1248
 
-			IL_1204: pop
-			IL_1205: rethrow
+			IL_1239: pop
+			IL_123a: rethrow
 
-			IL_1207: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_120c: stloc.s 25
-			IL_120e: br IL_1215
+			IL_123c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_1241: stloc.s 25
+			IL_1243: br IL_124a
 
-			IL_1213: stloc.s 25
+			IL_1248: stloc.s 25
 
-			IL_1215: ldloc.s 25
-			IL_1217: stloc.s 26
-			IL_1219: ldloc.s 26
-			IL_121b: stloc.s 33
-			IL_121d: ldstr "ReferenceError"
-			IL_1222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_1227: stloc.s 35
-			IL_1229: ldloc.s 33
-			IL_122b: ldloc.s 35
-			IL_122d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_1232: stloc.s 36
-			IL_1234: ldloc.s 36
-			IL_1236: box [System.Runtime]System.Boolean
-			IL_123b: stloc.s 38
-			IL_123d: ldloc.s 38
-			IL_123f: stloc.s 23
-			IL_1241: leave IL_1246
+			IL_124a: ldloc.s 25
+			IL_124c: stloc.s 26
+			IL_124e: ldloc.s 26
+			IL_1250: stloc.s 33
+			IL_1252: ldstr "ReferenceError"
+			IL_1257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_125c: stloc.s 35
+			IL_125e: ldloc.s 33
+			IL_1260: ldloc.s 35
+			IL_1262: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_1267: stloc.s 36
+			IL_1269: ldloc.s 36
+			IL_126b: box [System.Runtime]System.Boolean
+			IL_1270: stloc.s 38
+			IL_1272: ldloc.s 38
+			IL_1274: stloc.s 23
+			IL_1276: leave IL_127b
 		} // end handler
 
-		IL_1246: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_124b: stloc.s 30
-		IL_124d: ldloc.s 22
-		IL_124f: box [System.Runtime]System.Boolean
-		IL_1254: stloc.s 38
-		IL_1256: ldloc.s 30
-		IL_1258: ldstr "parameterSetup"
-		IL_125d: ldloc.s 38
-		IL_125f: ldloc.s 23
-		IL_1261: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_1266: pop
-		IL_1267: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_126c: stloc.s 30
-		IL_126e: ldnull
-		IL_126f: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
-		IL_1274: stloc.s 35
-		IL_1276: ldnull
-		IL_1277: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
-		IL_127c: stloc.s 33
-		IL_127e: ldloc.s 35
-		IL_1280: ldloc.s 33
-		IL_1282: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_1287: stloc.s 36
-		IL_1289: ldloc.s 36
-		IL_128b: box [System.Runtime]System.Boolean
-		IL_1290: stloc.s 38
-		IL_1292: ldloc.s 30
-		IL_1294: ldstr "identity"
-		IL_1299: ldloc.s 38
-		IL_129b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_12a0: pop
-		IL_12a1: ldnull
-		IL_12a2: stloc.s 27
-		IL_12a4: ret
+		IL_127b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_1280: stloc.s 30
+		IL_1282: ldloc.s 22
+		IL_1284: box [System.Runtime]System.Boolean
+		IL_1289: stloc.s 38
+		IL_128b: ldloc.s 30
+		IL_128d: ldstr "parameterSetup"
+		IL_1292: ldloc.s 38
+		IL_1294: ldloc.s 23
+		IL_1296: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_129b: pop
+		IL_129c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_12a1: stloc.s 30
+		IL_12a3: ldnull
+		IL_12a4: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
+		IL_12a9: stloc.s 35
+		IL_12ab: ldnull
+		IL_12ac: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
+		IL_12b1: stloc.s 33
+		IL_12b3: ldloc.s 35
+		IL_12b5: ldloc.s 33
+		IL_12b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_12bc: stloc.s 36
+		IL_12be: ldloc.s 36
+		IL_12c0: box [System.Runtime]System.Boolean
+		IL_12c5: stloc.s 38
+		IL_12c7: ldloc.s 30
+		IL_12c9: ldstr "identity"
+		IL_12ce: ldloc.s 38
+		IL_12d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_12d5: pop
+		IL_12d6: ldnull
+		IL_12d7: stloc.s 27
+		IL_12d9: ret
 	} // end of method Generator_GeneratedFunctionObject_Semantics::__js_module_init__
 
 } // end of class Modules.Generator_GeneratedFunctionObject_Semantics
@@ -5698,6 +5712,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_72
 	.field assembly static int32 __jroc_dynamicLookup_73
 	.field assembly static int32 __jroc_dynamicLookup_74
+	.field assembly static int32 __jroc_dynamicLookup_75
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_ToStringTag.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_ToStringTag.verified.txt
@@ -362,7 +362,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 635 (0x27b)
+		// Code size: 751 (0x2ef)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_Prototype_ToStringTag/Scope,
@@ -435,141 +435,177 @@
 		IL_00ae: stloc.s 6
 		IL_00b0: ldloc.s 6
 		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b7: ldstr "call"
-		IL_00bc: ldloc.2
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c2: stloc.3
-		IL_00c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c8: stloc.s 7
-		IL_00ca: ldloc.s 7
-		IL_00cc: ldloc.3
-		IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d2: pop
-		IL_00d3: ldloc.1
-		IL_00d4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00de: stloc.s 4
-		IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e5: stloc.s 7
-		IL_00e7: ldstr "Object"
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f1: volatile.
-		IL_00f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_00f8: brfalse IL_010c
+		IL_00b7: volatile.
+		IL_00b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00be: brfalse IL_00d3
 
-		IL_00fd: ldstr "prototype"
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0107: br IL_0120
+		IL_00c3: ldstr "call"
+		IL_00c8: ldloc.2
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ce: br IL_00e8
 
-		IL_010c: ldstr "prototype"
-		IL_0111: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:33"
-		IL_0116: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00d3: ldstr "call"
+		IL_00d8: ldloc.2
+		IL_00d9: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:19"
+		IL_00de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0120: stloc.s 6
-		IL_0122: volatile.
-		IL_0124: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0129: brfalse IL_013f
+		IL_00e8: stloc.3
+		IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ee: stloc.s 7
+		IL_00f0: ldloc.s 7
+		IL_00f2: ldloc.3
+		IL_00f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f8: pop
+		IL_00f9: ldloc.1
+		IL_00fa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0104: stloc.s 4
+		IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010b: stloc.s 7
+		IL_010d: ldstr "Object"
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0117: volatile.
+		IL_0119: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_011e: brfalse IL_0132
 
-		IL_012e: ldloc.s 6
-		IL_0130: ldstr "toString"
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013a: br IL_0155
+		IL_0123: ldstr "prototype"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012d: br IL_0146
 
-		IL_013f: ldloc.s 6
-		IL_0141: ldstr "toString"
-		IL_0146: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:35"
-		IL_014b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0132: ldstr "prototype"
+		IL_0137: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:33"
+		IL_013c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0155: stloc.s 6
-		IL_0157: ldloc.s 6
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015e: ldstr "call"
-		IL_0163: ldloc.s 4
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016a: stloc.s 6
-		IL_016c: ldloc.s 7
-		IL_016e: ldloc.s 6
-		IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0175: pop
-		IL_0176: ldloc.s 4
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017d: volatile.
-		IL_017f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0184: brfalse IL_0198
+		IL_0146: stloc.s 6
+		IL_0148: volatile.
+		IL_014a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_014f: brfalse IL_0165
 
-		IL_0189: ldstr "next"
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0193: br IL_01ac
+		IL_0154: ldloc.s 6
+		IL_0156: ldstr "toString"
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0160: br IL_017b
 
-		IL_0198: ldstr "next"
-		IL_019d: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:41"
-		IL_01a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0165: ldloc.s 6
+		IL_0167: ldstr "toString"
+		IL_016c: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:35"
+		IL_0171: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01ac: pop
-		IL_01ad: ldloc.s 4
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b4: volatile.
-		IL_01b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_01bb: brfalse IL_01cf
+		IL_017b: stloc.s 6
+		IL_017d: ldloc.s 6
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0184: volatile.
+		IL_0186: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_018b: brfalse IL_01a1
 
-		IL_01c0: ldstr "next"
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01ca: br IL_01e3
+		IL_0190: ldstr "call"
+		IL_0195: ldloc.s 4
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019c: br IL_01b7
 
-		IL_01cf: ldstr "next"
-		IL_01d4: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:44"
-		IL_01d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01a1: ldstr "call"
+		IL_01a6: ldloc.s 4
+		IL_01a8: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:37"
+		IL_01ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01e3: pop
-		IL_01e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e9: stloc.s 7
-		IL_01eb: ldstr "Object"
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f5: volatile.
-		IL_01f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_01fc: brfalse IL_0210
+		IL_01b7: stloc.s 6
+		IL_01b9: ldloc.s 7
+		IL_01bb: ldloc.s 6
+		IL_01bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c2: pop
+		IL_01c3: ldloc.s 4
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ca: volatile.
+		IL_01cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01d1: brfalse IL_01e5
 
-		IL_0201: ldstr "prototype"
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020b: br IL_0224
+		IL_01d6: ldstr "next"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01e0: br IL_01f9
 
-		IL_0210: ldstr "prototype"
-		IL_0215: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:50"
-		IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01e5: ldstr "next"
+		IL_01ea: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:41"
+		IL_01ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0224: stloc.s 6
-		IL_0226: volatile.
-		IL_0228: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_022d: brfalse IL_0243
+		IL_01f9: pop
+		IL_01fa: ldloc.s 4
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0201: volatile.
+		IL_0203: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0208: brfalse IL_021c
 
-		IL_0232: ldloc.s 6
-		IL_0234: ldstr "toString"
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_023e: br IL_0259
+		IL_020d: ldstr "next"
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0217: br IL_0230
 
-		IL_0243: ldloc.s 6
-		IL_0245: ldstr "toString"
-		IL_024a: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:52"
-		IL_024f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_021c: ldstr "next"
+		IL_0221: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:44"
+		IL_0226: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0259: stloc.s 6
-		IL_025b: ldloc.s 6
-		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0262: ldstr "call"
-		IL_0267: ldloc.s 4
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026e: stloc.s 6
-		IL_0270: ldloc.s 7
-		IL_0272: ldloc.s 6
-		IL_0274: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0279: pop
-		IL_027a: ret
+		IL_0230: pop
+		IL_0231: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0236: stloc.s 7
+		IL_0238: ldstr "Object"
+		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0242: volatile.
+		IL_0244: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0249: brfalse IL_025d
+
+		IL_024e: ldstr "prototype"
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0258: br IL_0271
+
+		IL_025d: ldstr "prototype"
+		IL_0262: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:50"
+		IL_0267: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0271: stloc.s 6
+		IL_0273: volatile.
+		IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_027a: brfalse IL_0290
+
+		IL_027f: ldloc.s 6
+		IL_0281: ldstr "toString"
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028b: br IL_02a6
+
+		IL_0290: ldloc.s 6
+		IL_0292: ldstr "toString"
+		IL_0297: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:52"
+		IL_029c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02a6: stloc.s 6
+		IL_02a8: ldloc.s 6
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02af: volatile.
+		IL_02b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02b6: brfalse IL_02cc
+
+		IL_02bb: ldstr "call"
+		IL_02c0: ldloc.s 4
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c7: br IL_02e2
+
+		IL_02cc: ldstr "call"
+		IL_02d1: ldloc.s 4
+		IL_02d3: ldstr "Generator_Prototype_ToStringTag:Modules.Generator_Prototype_ToStringTag:__js_module_init__:54"
+		IL_02d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02e2: stloc.s 6
+		IL_02e4: ldloc.s 7
+		IL_02e6: ldloc.s 6
+		IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ed: pop
+		IL_02ee: ret
 	} // end of method Generator_Prototype_ToStringTag::__js_module_init__
 
 } // end of class Modules.Generator_Prototype_ToStringTag
@@ -607,6 +643,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_SchedulerLocalsAcrossYield.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_SchedulerLocalsAcrossYield.verified.txt
@@ -440,7 +440,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 306 (0x132)
+		// Code size: 357 (0x165)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_SchedulerLocalsAcrossYield/Scope,
@@ -523,32 +523,45 @@
 		IL_00d0: stloc.s 4
 		IL_00d2: ldloc.2
 		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d8: ldstr "next"
-		IL_00dd: ldc.r8 10
-		IL_00e6: box [System.Runtime]System.Double
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f0: stloc.s 5
-		IL_00f2: volatile.
-		IL_00f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_00f9: brfalse IL_010f
+		IL_00d8: volatile.
+		IL_00da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00df: brfalse IL_0101
 
-		IL_00fe: ldloc.s 5
-		IL_0100: ldstr "value"
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010a: br IL_0125
+		IL_00e4: ldstr "next"
+		IL_00e9: ldc.r8 10
+		IL_00f2: box [System.Runtime]System.Double
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fc: br IL_0123
 
-		IL_010f: ldloc.s 5
-		IL_0111: ldstr "value"
-		IL_0116: ldstr "Generator_SchedulerLocalsAcrossYield:Modules.Generator_SchedulerLocalsAcrossYield:__js_module_init__:27"
-		IL_011b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0101: ldstr "next"
+		IL_0106: ldc.r8 10
+		IL_010f: box [System.Runtime]System.Double
+		IL_0114: ldstr "Generator_SchedulerLocalsAcrossYield:Modules.Generator_SchedulerLocalsAcrossYield:__js_module_init__:25"
+		IL_0119: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0125: stloc.s 5
-		IL_0127: ldloc.s 4
-		IL_0129: ldloc.s 5
-		IL_012b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0130: pop
-		IL_0131: ret
+		IL_0123: stloc.s 5
+		IL_0125: volatile.
+		IL_0127: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_012c: brfalse IL_0142
+
+		IL_0131: ldloc.s 5
+		IL_0133: ldstr "value"
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013d: br IL_0158
+
+		IL_0142: ldloc.s 5
+		IL_0144: ldstr "value"
+		IL_0149: ldstr "Generator_SchedulerLocalsAcrossYield:Modules.Generator_SchedulerLocalsAcrossYield:__js_module_init__:27"
+		IL_014e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0158: stloc.s 5
+		IL_015a: ldloc.s 4
+		IL_015c: ldloc.s 5
+		IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0163: pop
+		IL_0164: ret
 	} // end of method Generator_SchedulerLocalsAcrossYield::__js_module_init__
 
 } // end of class Modules.Generator_SchedulerLocalsAcrossYield
@@ -581,6 +594,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
@@ -1263,7 +1263,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1592 (0x638)
+		// Code size: 1718 (0x6b6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/Scope,
@@ -1398,254 +1398,252 @@
 		IL_014a: pop
 		IL_014b: ldloc.3
 		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0151: ldstr "return"
-		IL_0156: ldstr "R1"
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0160: stloc.s 5
-		IL_0162: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0167: stloc.s 13
-		IL_0169: volatile.
-		IL_016b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0170: brfalse IL_0186
+		IL_0151: volatile.
+		IL_0153: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0158: brfalse IL_0171
 
-		IL_0175: ldloc.s 5
-		IL_0177: ldstr "value"
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0181: br IL_019c
+		IL_015d: ldstr "return"
+		IL_0162: ldstr "R1"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016c: br IL_018a
 
-		IL_0186: ldloc.s 5
-		IL_0188: ldstr "value"
-		IL_018d: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:41"
-		IL_0192: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0171: ldstr "return"
+		IL_0176: ldstr "R1"
+		IL_017b: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:35"
+		IL_0180: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_019c: stloc.s 14
-		IL_019e: ldstr "it1.r2.value="
-		IL_01a3: ldloc.s 14
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01aa: stloc.s 15
-		IL_01ac: ldloc.s 13
-		IL_01ae: ldloc.s 15
-		IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b5: pop
-		IL_01b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01bb: stloc.s 13
-		IL_01bd: volatile.
-		IL_01bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_01c4: brfalse IL_01da
+		IL_018a: stloc.s 5
+		IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0191: stloc.s 13
+		IL_0193: volatile.
+		IL_0195: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_019a: brfalse IL_01b0
 
-		IL_01c9: ldloc.s 5
-		IL_01cb: ldstr "done"
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d5: br IL_01f0
+		IL_019f: ldloc.s 5
+		IL_01a1: ldstr "value"
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ab: br IL_01c6
 
-		IL_01da: ldloc.s 5
-		IL_01dc: ldstr "done"
-		IL_01e1: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:48"
-		IL_01e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01b0: ldloc.s 5
+		IL_01b2: ldstr "value"
+		IL_01b7: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:41"
+		IL_01bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01f0: stloc.s 14
-		IL_01f2: ldstr "it1.r2.done="
-		IL_01f7: ldloc.s 14
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01fe: stloc.s 15
-		IL_0200: ldloc.s 13
-		IL_0202: ldloc.s 15
-		IL_0204: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0209: pop
-		IL_020a: ldloc.3
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0210: volatile.
-		IL_0212: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0217: brfalse IL_022b
+		IL_01c6: stloc.s 14
+		IL_01c8: ldstr "it1.r2.value="
+		IL_01cd: ldloc.s 14
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01d4: stloc.s 15
+		IL_01d6: ldloc.s 13
+		IL_01d8: ldloc.s 15
+		IL_01da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01df: pop
+		IL_01e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e5: stloc.s 13
+		IL_01e7: volatile.
+		IL_01e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_01ee: brfalse IL_0204
 
-		IL_021c: ldstr "next"
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0226: br IL_023f
+		IL_01f3: ldloc.s 5
+		IL_01f5: ldstr "done"
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ff: br IL_021a
 
-		IL_022b: ldstr "next"
-		IL_0230: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:53"
-		IL_0235: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0204: ldloc.s 5
+		IL_0206: ldstr "done"
+		IL_020b: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:48"
+		IL_0210: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_023f: stloc.s 6
-		IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0246: stloc.s 13
-		IL_0248: volatile.
-		IL_024a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_024f: brfalse IL_0265
+		IL_021a: stloc.s 14
+		IL_021c: ldstr "it1.r2.done="
+		IL_0221: ldloc.s 14
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0228: stloc.s 15
+		IL_022a: ldloc.s 13
+		IL_022c: ldloc.s 15
+		IL_022e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0233: pop
+		IL_0234: ldloc.3
+		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023a: volatile.
+		IL_023c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0241: brfalse IL_0255
 
-		IL_0254: ldloc.s 6
-		IL_0256: ldstr "value"
-		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0260: br IL_027b
+		IL_0246: ldstr "next"
+		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0250: br IL_0269
 
-		IL_0265: ldloc.s 6
-		IL_0267: ldstr "value"
-		IL_026c: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:59"
-		IL_0271: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0255: ldstr "next"
+		IL_025a: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:53"
+		IL_025f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_027b: stloc.s 14
-		IL_027d: ldstr "it1.r3.value="
-		IL_0282: ldloc.s 14
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0289: stloc.s 15
-		IL_028b: ldloc.s 13
-		IL_028d: ldloc.s 15
-		IL_028f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0294: pop
-		IL_0295: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_029a: stloc.s 13
-		IL_029c: volatile.
-		IL_029e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_02a3: brfalse IL_02b9
+		IL_0269: stloc.s 6
+		IL_026b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0270: stloc.s 13
+		IL_0272: volatile.
+		IL_0274: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0279: brfalse IL_028f
 
-		IL_02a8: ldloc.s 6
-		IL_02aa: ldstr "done"
-		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b4: br IL_02cf
+		IL_027e: ldloc.s 6
+		IL_0280: ldstr "value"
+		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028a: br IL_02a5
 
-		IL_02b9: ldloc.s 6
-		IL_02bb: ldstr "done"
-		IL_02c0: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:66"
-		IL_02c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_028f: ldloc.s 6
+		IL_0291: ldstr "value"
+		IL_0296: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:59"
+		IL_029b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02cf: stloc.s 14
-		IL_02d1: ldstr "it1.r3.done="
-		IL_02d6: ldloc.s 14
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02dd: stloc.s 15
-		IL_02df: ldloc.s 13
-		IL_02e1: ldloc.s 15
-		IL_02e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02e8: pop
-		IL_02e9: nop
-		IL_02ea: ldloc.2
-		IL_02eb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_02f5: stloc.s 7
-		IL_02f7: ldloc.s 7
-		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02fe: volatile.
-		IL_0300: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0305: brfalse IL_0319
+		IL_02a5: stloc.s 14
+		IL_02a7: ldstr "it1.r3.value="
+		IL_02ac: ldloc.s 14
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02b3: stloc.s 15
+		IL_02b5: ldloc.s 13
+		IL_02b7: ldloc.s 15
+		IL_02b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02be: pop
+		IL_02bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c4: stloc.s 13
+		IL_02c6: volatile.
+		IL_02c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02cd: brfalse IL_02e3
 
-		IL_030a: ldstr "next"
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0314: br IL_032d
+		IL_02d2: ldloc.s 6
+		IL_02d4: ldstr "done"
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02de: br IL_02f9
 
-		IL_0319: ldstr "next"
-		IL_031e: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:76"
-		IL_0323: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_02e3: ldloc.s 6
+		IL_02e5: ldstr "done"
+		IL_02ea: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:66"
+		IL_02ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_032d: stloc.s 8
-		IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0334: stloc.s 13
-		IL_0336: volatile.
-		IL_0338: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_033d: brfalse IL_0353
+		IL_02f9: stloc.s 14
+		IL_02fb: ldstr "it1.r3.done="
+		IL_0300: ldloc.s 14
+		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0307: stloc.s 15
+		IL_0309: ldloc.s 13
+		IL_030b: ldloc.s 15
+		IL_030d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0312: pop
+		IL_0313: nop
+		IL_0314: ldloc.2
+		IL_0315: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_031f: stloc.s 7
+		IL_0321: ldloc.s 7
+		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0328: volatile.
+		IL_032a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_032f: brfalse IL_0343
 
-		IL_0342: ldloc.s 8
-		IL_0344: ldstr "value"
-		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_034e: br IL_0369
+		IL_0334: ldstr "next"
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_033e: br IL_0357
 
-		IL_0353: ldloc.s 8
-		IL_0355: ldstr "value"
-		IL_035a: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:82"
-		IL_035f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0343: ldstr "next"
+		IL_0348: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:76"
+		IL_034d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0369: stloc.s 14
-		IL_036b: ldstr "it2.r1.value="
-		IL_0370: ldloc.s 14
-		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0377: stloc.s 15
-		IL_0379: ldloc.s 13
-		IL_037b: ldloc.s 15
-		IL_037d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0382: pop
-		IL_0383: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0388: stloc.s 13
-		IL_038a: volatile.
-		IL_038c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0391: brfalse IL_03a7
+		IL_0357: stloc.s 8
+		IL_0359: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_035e: stloc.s 13
+		IL_0360: volatile.
+		IL_0362: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0367: brfalse IL_037d
 
-		IL_0396: ldloc.s 8
-		IL_0398: ldstr "done"
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03a2: br IL_03bd
+		IL_036c: ldloc.s 8
+		IL_036e: ldstr "value"
+		IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0378: br IL_0393
 
-		IL_03a7: ldloc.s 8
-		IL_03a9: ldstr "done"
-		IL_03ae: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:89"
-		IL_03b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_037d: ldloc.s 8
+		IL_037f: ldstr "value"
+		IL_0384: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:82"
+		IL_0389: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03bd: stloc.s 14
-		IL_03bf: ldstr "it2.r1.done="
-		IL_03c4: ldloc.s 14
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_03cb: stloc.s 15
-		IL_03cd: ldloc.s 13
-		IL_03cf: ldloc.s 15
-		IL_03d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03d6: pop
-		IL_03d7: ldloc.s 7
-		IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03de: ldstr "throw"
-		IL_03e3: ldstr "E2"
-		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03ed: stloc.s 9
-		IL_03ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03f4: stloc.s 13
-		IL_03f6: volatile.
-		IL_03f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_03fd: brfalse IL_0413
+		IL_0393: stloc.s 14
+		IL_0395: ldstr "it2.r1.value="
+		IL_039a: ldloc.s 14
+		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03a1: stloc.s 15
+		IL_03a3: ldloc.s 13
+		IL_03a5: ldloc.s 15
+		IL_03a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03ac: pop
+		IL_03ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03b2: stloc.s 13
+		IL_03b4: volatile.
+		IL_03b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_03bb: brfalse IL_03d1
 
-		IL_0402: ldloc.s 9
-		IL_0404: ldstr "value"
-		IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_040e: br IL_0429
+		IL_03c0: ldloc.s 8
+		IL_03c2: ldstr "done"
+		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03cc: br IL_03e7
 
-		IL_0413: ldloc.s 9
-		IL_0415: ldstr "value"
-		IL_041a: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:101"
-		IL_041f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03d1: ldloc.s 8
+		IL_03d3: ldstr "done"
+		IL_03d8: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:89"
+		IL_03dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0429: stloc.s 14
-		IL_042b: ldstr "it2.r2.value="
-		IL_0430: ldloc.s 14
-		IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0437: stloc.s 15
-		IL_0439: ldloc.s 13
-		IL_043b: ldloc.s 15
-		IL_043d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0442: pop
+		IL_03e7: stloc.s 14
+		IL_03e9: ldstr "it2.r1.done="
+		IL_03ee: ldloc.s 14
+		IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03f5: stloc.s 15
+		IL_03f7: ldloc.s 13
+		IL_03f9: ldloc.s 15
+		IL_03fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0400: pop
+		IL_0401: ldloc.s 7
+		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0408: volatile.
+		IL_040a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_040f: brfalse IL_0428
+
+		IL_0414: ldstr "throw"
+		IL_0419: ldstr "E2"
+		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0423: br IL_0441
+
+		IL_0428: ldstr "throw"
+		IL_042d: ldstr "E2"
+		IL_0432: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:95"
+		IL_0437: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0441: stloc.s 9
 		IL_0443: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0448: stloc.s 13
 		IL_044a: volatile.
-		IL_044c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_044c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 		IL_0451: brfalse IL_0467
 
 		IL_0456: ldloc.s 9
-		IL_0458: ldstr "done"
+		IL_0458: ldstr "value"
 		IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0462: br IL_047d
 
 		IL_0467: ldloc.s 9
-		IL_0469: ldstr "done"
-		IL_046e: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:108"
-		IL_0473: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0469: ldstr "value"
+		IL_046e: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:101"
+		IL_0473: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 		IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_047d: stloc.s 14
-		IL_047f: ldstr "it2.r2.done="
+		IL_047f: ldstr "it2.r2.value="
 		IL_0484: ldloc.s 14
 		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 		IL_048b: stloc.s 15
@@ -1653,133 +1651,171 @@
 		IL_048f: ldloc.s 15
 		IL_0491: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0496: pop
-		IL_0497: ldloc.s 7
-		IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_049e: ldstr "return"
-		IL_04a3: ldstr "R2"
-		IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04ad: stloc.s 10
-		IL_04af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04b4: stloc.s 13
-		IL_04b6: volatile.
-		IL_04b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_04bd: brfalse IL_04d3
+		IL_0497: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_049c: stloc.s 13
+		IL_049e: volatile.
+		IL_04a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_04a5: brfalse IL_04bb
 
-		IL_04c2: ldloc.s 10
-		IL_04c4: ldstr "value"
-		IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ce: br IL_04e9
+		IL_04aa: ldloc.s 9
+		IL_04ac: ldstr "done"
+		IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04b6: br IL_04d1
 
-		IL_04d3: ldloc.s 10
-		IL_04d5: ldstr "value"
-		IL_04da: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:120"
-		IL_04df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_04e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04bb: ldloc.s 9
+		IL_04bd: ldstr "done"
+		IL_04c2: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:108"
+		IL_04c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04e9: stloc.s 14
-		IL_04eb: ldstr "it2.r3.value="
-		IL_04f0: ldloc.s 14
-		IL_04f2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_04f7: stloc.s 15
-		IL_04f9: ldloc.s 13
-		IL_04fb: ldloc.s 15
-		IL_04fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0502: pop
-		IL_0503: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0508: stloc.s 13
-		IL_050a: volatile.
-		IL_050c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0511: brfalse IL_0527
+		IL_04d1: stloc.s 14
+		IL_04d3: ldstr "it2.r2.done="
+		IL_04d8: ldloc.s 14
+		IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_04df: stloc.s 15
+		IL_04e1: ldloc.s 13
+		IL_04e3: ldloc.s 15
+		IL_04e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04ea: pop
+		IL_04eb: ldloc.s 7
+		IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04f2: volatile.
+		IL_04f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_04f9: brfalse IL_0512
 
-		IL_0516: ldloc.s 10
-		IL_0518: ldstr "done"
-		IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0522: br IL_053d
+		IL_04fe: ldstr "return"
+		IL_0503: ldstr "R2"
+		IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_050d: br IL_052b
 
-		IL_0527: ldloc.s 10
-		IL_0529: ldstr "done"
-		IL_052e: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:127"
-		IL_0533: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0512: ldstr "return"
+		IL_0517: ldstr "R2"
+		IL_051c: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:114"
+		IL_0521: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_053d: stloc.s 14
-		IL_053f: ldstr "it2.r3.done="
-		IL_0544: ldloc.s 14
-		IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_054b: stloc.s 15
-		IL_054d: ldloc.s 13
-		IL_054f: ldloc.s 15
-		IL_0551: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0556: pop
-		IL_0557: ldloc.s 7
-		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_055e: volatile.
-		IL_0560: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0565: brfalse IL_0579
+		IL_052b: stloc.s 10
+		IL_052d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0532: stloc.s 13
+		IL_0534: volatile.
+		IL_0536: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_053b: brfalse IL_0551
 
-		IL_056a: ldstr "next"
-		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0574: br IL_058d
+		IL_0540: ldloc.s 10
+		IL_0542: ldstr "value"
+		IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_054c: br IL_0567
 
-		IL_0579: ldstr "next"
-		IL_057e: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:132"
-		IL_0583: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0551: ldloc.s 10
+		IL_0553: ldstr "value"
+		IL_0558: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:120"
+		IL_055d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_058d: stloc.s 11
-		IL_058f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0594: stloc.s 13
-		IL_0596: volatile.
-		IL_0598: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_059d: brfalse IL_05b3
+		IL_0567: stloc.s 14
+		IL_0569: ldstr "it2.r3.value="
+		IL_056e: ldloc.s 14
+		IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0575: stloc.s 15
+		IL_0577: ldloc.s 13
+		IL_0579: ldloc.s 15
+		IL_057b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0580: pop
+		IL_0581: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0586: stloc.s 13
+		IL_0588: volatile.
+		IL_058a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_058f: brfalse IL_05a5
 
-		IL_05a2: ldloc.s 11
-		IL_05a4: ldstr "value"
-		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ae: br IL_05c9
+		IL_0594: ldloc.s 10
+		IL_0596: ldstr "done"
+		IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05a0: br IL_05bb
 
-		IL_05b3: ldloc.s 11
-		IL_05b5: ldstr "value"
-		IL_05ba: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:138"
-		IL_05bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05a5: ldloc.s 10
+		IL_05a7: ldstr "done"
+		IL_05ac: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:127"
+		IL_05b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05c9: stloc.s 14
-		IL_05cb: ldstr "it2.r4.value="
-		IL_05d0: ldloc.s 14
-		IL_05d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_05d7: stloc.s 15
-		IL_05d9: ldloc.s 13
-		IL_05db: ldloc.s 15
-		IL_05dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05e2: pop
-		IL_05e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05e8: stloc.s 13
-		IL_05ea: volatile.
-		IL_05ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_05f1: brfalse IL_0607
+		IL_05bb: stloc.s 14
+		IL_05bd: ldstr "it2.r3.done="
+		IL_05c2: ldloc.s 14
+		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_05c9: stloc.s 15
+		IL_05cb: ldloc.s 13
+		IL_05cd: ldloc.s 15
+		IL_05cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05d4: pop
+		IL_05d5: ldloc.s 7
+		IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05dc: volatile.
+		IL_05de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_05e3: brfalse IL_05f7
 
-		IL_05f6: ldloc.s 11
-		IL_05f8: ldstr "done"
-		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0602: br IL_061d
+		IL_05e8: ldstr "next"
+		IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05f2: br IL_060b
 
-		IL_0607: ldloc.s 11
-		IL_0609: ldstr "done"
-		IL_060e: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:145"
-		IL_0613: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05f7: ldstr "next"
+		IL_05fc: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:132"
+		IL_0601: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_061d: stloc.s 14
-		IL_061f: ldstr "it2.r4.done="
-		IL_0624: ldloc.s 14
-		IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_062b: stloc.s 15
-		IL_062d: ldloc.s 13
-		IL_062f: ldloc.s 15
-		IL_0631: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0636: pop
-		IL_0637: ret
+		IL_060b: stloc.s 11
+		IL_060d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0612: stloc.s 13
+		IL_0614: volatile.
+		IL_0616: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_061b: brfalse IL_0631
+
+		IL_0620: ldloc.s 11
+		IL_0622: ldstr "value"
+		IL_0627: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_062c: br IL_0647
+
+		IL_0631: ldloc.s 11
+		IL_0633: ldstr "value"
+		IL_0638: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:138"
+		IL_063d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0647: stloc.s 14
+		IL_0649: ldstr "it2.r4.value="
+		IL_064e: ldloc.s 14
+		IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0655: stloc.s 15
+		IL_0657: ldloc.s 13
+		IL_0659: ldloc.s 15
+		IL_065b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0660: pop
+		IL_0661: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0666: stloc.s 13
+		IL_0668: volatile.
+		IL_066a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_066f: brfalse IL_0685
+
+		IL_0674: ldloc.s 11
+		IL_0676: ldstr "done"
+		IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0680: br IL_069b
+
+		IL_0685: ldloc.s 11
+		IL_0687: ldstr "done"
+		IL_068c: ldstr "Generator_TryCatchFinally_ReturnWhileSuspended:Modules.Generator_TryCatchFinally_ReturnWhileSuspended:__js_module_init__:145"
+		IL_0691: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_069b: stloc.s 14
+		IL_069d: ldstr "it2.r4.done="
+		IL_06a2: ldloc.s 14
+		IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_06a9: stloc.s 15
+		IL_06ab: ldloc.s 13
+		IL_06ad: ldloc.s 15
+		IL_06af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06b4: pop
+		IL_06b5: ret
 	} // end of method Generator_TryCatchFinally_ReturnWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ReturnWhileSuspended
@@ -1827,6 +1863,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_20
 	.field assembly static int32 __jroc_dynamicLookup_21
 	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
@@ -691,7 +691,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 920 (0x398)
+		// Code size: 962 (0x3c2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/Scope,
@@ -803,199 +803,211 @@
 		IL_0119: pop
 		IL_011a: ldloc.2
 		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0120: ldstr "throw"
-		IL_0125: ldstr "boom"
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012f: stloc.s 4
-		IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0136: stloc.s 8
-		IL_0138: volatile.
-		IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_013f: brfalse IL_0155
+		IL_0120: volatile.
+		IL_0122: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0127: brfalse IL_0140
 
-		IL_0144: ldloc.s 4
-		IL_0146: ldstr "value"
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0150: br IL_016b
+		IL_012c: ldstr "throw"
+		IL_0131: ldstr "boom"
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013b: br IL_0159
 
-		IL_0155: ldloc.s 4
-		IL_0157: ldstr "value"
-		IL_015c: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:38"
-		IL_0161: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0140: ldstr "throw"
+		IL_0145: ldstr "boom"
+		IL_014a: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:32"
+		IL_014f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_016b: stloc.s 9
-		IL_016d: ldstr "r2.value="
-		IL_0172: ldloc.s 9
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0179: stloc.s 10
-		IL_017b: ldloc.s 8
-		IL_017d: ldloc.s 10
-		IL_017f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0184: pop
-		IL_0185: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018a: stloc.s 8
-		IL_018c: volatile.
-		IL_018e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0193: brfalse IL_01a9
+		IL_0159: stloc.s 4
+		IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0160: stloc.s 8
+		IL_0162: volatile.
+		IL_0164: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0169: brfalse IL_017f
 
-		IL_0198: ldloc.s 4
-		IL_019a: ldstr "done"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a4: br IL_01bf
+		IL_016e: ldloc.s 4
+		IL_0170: ldstr "value"
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_017a: br IL_0195
 
-		IL_01a9: ldloc.s 4
-		IL_01ab: ldstr "done"
-		IL_01b0: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:45"
-		IL_01b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_017f: ldloc.s 4
+		IL_0181: ldstr "value"
+		IL_0186: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:38"
+		IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01bf: stloc.s 9
-		IL_01c1: ldstr "r2.done="
-		IL_01c6: ldloc.s 9
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01cd: stloc.s 10
-		IL_01cf: ldloc.s 8
-		IL_01d1: ldloc.s 10
-		IL_01d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d8: pop
-		IL_01d9: ldloc.2
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01df: volatile.
-		IL_01e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_01e6: brfalse IL_01fa
+		IL_0195: stloc.s 9
+		IL_0197: ldstr "r2.value="
+		IL_019c: ldloc.s 9
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01a3: stloc.s 10
+		IL_01a5: ldloc.s 8
+		IL_01a7: ldloc.s 10
+		IL_01a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ae: pop
+		IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b4: stloc.s 8
+		IL_01b6: volatile.
+		IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01bd: brfalse IL_01d3
 
-		IL_01eb: ldstr "next"
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01f5: br IL_020e
+		IL_01c2: ldloc.s 4
+		IL_01c4: ldstr "done"
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ce: br IL_01e9
 
-		IL_01fa: ldstr "next"
-		IL_01ff: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:50"
-		IL_0204: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01d3: ldloc.s 4
+		IL_01d5: ldstr "done"
+		IL_01da: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:45"
+		IL_01df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_020e: stloc.s 5
-		IL_0210: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0215: stloc.s 8
-		IL_0217: volatile.
-		IL_0219: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_021e: brfalse IL_0234
+		IL_01e9: stloc.s 9
+		IL_01eb: ldstr "r2.done="
+		IL_01f0: ldloc.s 9
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01f7: stloc.s 10
+		IL_01f9: ldloc.s 8
+		IL_01fb: ldloc.s 10
+		IL_01fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0202: pop
+		IL_0203: ldloc.2
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0209: volatile.
+		IL_020b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0210: brfalse IL_0224
 
-		IL_0223: ldloc.s 5
-		IL_0225: ldstr "value"
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022f: br IL_024a
+		IL_0215: ldstr "next"
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_021f: br IL_0238
 
-		IL_0234: ldloc.s 5
-		IL_0236: ldstr "value"
-		IL_023b: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:56"
-		IL_0240: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0224: ldstr "next"
+		IL_0229: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:50"
+		IL_022e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_024a: stloc.s 9
-		IL_024c: ldstr "r3.value="
-		IL_0251: ldloc.s 9
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0258: stloc.s 10
-		IL_025a: ldloc.s 8
-		IL_025c: ldloc.s 10
-		IL_025e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0263: pop
-		IL_0264: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0269: stloc.s 8
-		IL_026b: volatile.
-		IL_026d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0272: brfalse IL_0288
+		IL_0238: stloc.s 5
+		IL_023a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023f: stloc.s 8
+		IL_0241: volatile.
+		IL_0243: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0248: brfalse IL_025e
 
-		IL_0277: ldloc.s 5
-		IL_0279: ldstr "done"
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0283: br IL_029e
+		IL_024d: ldloc.s 5
+		IL_024f: ldstr "value"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0259: br IL_0274
 
-		IL_0288: ldloc.s 5
-		IL_028a: ldstr "done"
-		IL_028f: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:63"
-		IL_0294: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_025e: ldloc.s 5
+		IL_0260: ldstr "value"
+		IL_0265: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:56"
+		IL_026a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_029e: stloc.s 9
-		IL_02a0: ldstr "r3.done="
-		IL_02a5: ldloc.s 9
-		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02ac: stloc.s 10
-		IL_02ae: ldloc.s 8
-		IL_02b0: ldloc.s 10
-		IL_02b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b7: pop
-		IL_02b8: ldloc.2
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02be: volatile.
-		IL_02c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02c5: brfalse IL_02d9
+		IL_0274: stloc.s 9
+		IL_0276: ldstr "r3.value="
+		IL_027b: ldloc.s 9
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0282: stloc.s 10
+		IL_0284: ldloc.s 8
+		IL_0286: ldloc.s 10
+		IL_0288: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_028d: pop
+		IL_028e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0293: stloc.s 8
+		IL_0295: volatile.
+		IL_0297: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_029c: brfalse IL_02b2
 
-		IL_02ca: ldstr "next"
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02d4: br IL_02ed
+		IL_02a1: ldloc.s 5
+		IL_02a3: ldstr "done"
+		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ad: br IL_02c8
 
-		IL_02d9: ldstr "next"
-		IL_02de: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:68"
-		IL_02e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_02b2: ldloc.s 5
+		IL_02b4: ldstr "done"
+		IL_02b9: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:63"
+		IL_02be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02ed: stloc.s 6
-		IL_02ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f4: stloc.s 8
-		IL_02f6: volatile.
-		IL_02f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_02fd: brfalse IL_0313
+		IL_02c8: stloc.s 9
+		IL_02ca: ldstr "r3.done="
+		IL_02cf: ldloc.s 9
+		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02d6: stloc.s 10
+		IL_02d8: ldloc.s 8
+		IL_02da: ldloc.s 10
+		IL_02dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e1: pop
+		IL_02e2: ldloc.2
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e8: volatile.
+		IL_02ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_02ef: brfalse IL_0303
 
-		IL_0302: ldloc.s 6
-		IL_0304: ldstr "value"
-		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_030e: br IL_0329
+		IL_02f4: ldstr "next"
+		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02fe: br IL_0317
 
-		IL_0313: ldloc.s 6
-		IL_0315: ldstr "value"
-		IL_031a: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:74"
-		IL_031f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0303: ldstr "next"
+		IL_0308: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:68"
+		IL_030d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0329: stloc.s 9
-		IL_032b: ldstr "r4.value="
-		IL_0330: ldloc.s 9
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0337: stloc.s 10
-		IL_0339: ldloc.s 8
-		IL_033b: ldloc.s 10
-		IL_033d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0342: pop
-		IL_0343: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0348: stloc.s 8
-		IL_034a: volatile.
-		IL_034c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0351: brfalse IL_0367
+		IL_0317: stloc.s 6
+		IL_0319: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_031e: stloc.s 8
+		IL_0320: volatile.
+		IL_0322: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0327: brfalse IL_033d
 
-		IL_0356: ldloc.s 6
-		IL_0358: ldstr "done"
-		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0362: br IL_037d
+		IL_032c: ldloc.s 6
+		IL_032e: ldstr "value"
+		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0338: br IL_0353
 
-		IL_0367: ldloc.s 6
-		IL_0369: ldstr "done"
-		IL_036e: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:81"
-		IL_0373: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_033d: ldloc.s 6
+		IL_033f: ldstr "value"
+		IL_0344: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:74"
+		IL_0349: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_037d: stloc.s 9
-		IL_037f: ldstr "r4.done="
-		IL_0384: ldloc.s 9
-		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_038b: stloc.s 10
-		IL_038d: ldloc.s 8
-		IL_038f: ldloc.s 10
-		IL_0391: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0396: pop
-		IL_0397: ret
+		IL_0353: stloc.s 9
+		IL_0355: ldstr "r4.value="
+		IL_035a: ldloc.s 9
+		IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0361: stloc.s 10
+		IL_0363: ldloc.s 8
+		IL_0365: ldloc.s 10
+		IL_0367: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_036c: pop
+		IL_036d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0372: stloc.s 8
+		IL_0374: volatile.
+		IL_0376: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_037b: brfalse IL_0391
+
+		IL_0380: ldloc.s 6
+		IL_0382: ldstr "done"
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_038c: br IL_03a7
+
+		IL_0391: ldloc.s 6
+		IL_0393: ldstr "done"
+		IL_0398: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields:__js_module_init__:81"
+		IL_039d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_03a7: stloc.s 9
+		IL_03a9: ldstr "r4.done="
+		IL_03ae: ldloc.s 9
+		IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03b5: stloc.s 10
+		IL_03b7: ldloc.s 8
+		IL_03b9: ldloc.s 10
+		IL_03bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03c0: pop
+		IL_03c1: ret
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields
@@ -1036,6 +1048,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
@@ -777,7 +777,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 697 (0x2b9)
+		// Code size: 739 (0x2e3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/Scope,
@@ -888,131 +888,143 @@
 		IL_0119: pop
 		IL_011a: ldloc.2
 		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0120: ldstr "throw"
-		IL_0125: ldstr "boom"
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012f: stloc.s 4
-		IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0136: stloc.s 7
-		IL_0138: volatile.
-		IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_013f: brfalse IL_0155
+		IL_0120: volatile.
+		IL_0122: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0127: brfalse IL_0140
 
-		IL_0144: ldloc.s 4
-		IL_0146: ldstr "value"
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0150: br IL_016b
+		IL_012c: ldstr "throw"
+		IL_0131: ldstr "boom"
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013b: br IL_0159
 
-		IL_0155: ldloc.s 4
-		IL_0157: ldstr "value"
-		IL_015c: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:38"
-		IL_0161: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0140: ldstr "throw"
+		IL_0145: ldstr "boom"
+		IL_014a: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:32"
+		IL_014f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_016b: stloc.s 8
-		IL_016d: ldstr "r2.value="
-		IL_0172: ldloc.s 8
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0179: stloc.s 9
-		IL_017b: ldloc.s 7
-		IL_017d: ldloc.s 9
-		IL_017f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0184: pop
-		IL_0185: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018a: stloc.s 7
-		IL_018c: volatile.
-		IL_018e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0193: brfalse IL_01a9
+		IL_0159: stloc.s 4
+		IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0160: stloc.s 7
+		IL_0162: volatile.
+		IL_0164: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0169: brfalse IL_017f
 
-		IL_0198: ldloc.s 4
-		IL_019a: ldstr "done"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a4: br IL_01bf
+		IL_016e: ldloc.s 4
+		IL_0170: ldstr "value"
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_017a: br IL_0195
 
-		IL_01a9: ldloc.s 4
-		IL_01ab: ldstr "done"
-		IL_01b0: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:45"
-		IL_01b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_017f: ldloc.s 4
+		IL_0181: ldstr "value"
+		IL_0186: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:38"
+		IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01bf: stloc.s 8
-		IL_01c1: ldstr "r2.done="
-		IL_01c6: ldloc.s 8
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01cd: stloc.s 9
-		IL_01cf: ldloc.s 7
-		IL_01d1: ldloc.s 9
-		IL_01d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d8: pop
-		IL_01d9: ldloc.2
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01df: volatile.
-		IL_01e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_01e6: brfalse IL_01fa
+		IL_0195: stloc.s 8
+		IL_0197: ldstr "r2.value="
+		IL_019c: ldloc.s 8
+		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01a3: stloc.s 9
+		IL_01a5: ldloc.s 7
+		IL_01a7: ldloc.s 9
+		IL_01a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ae: pop
+		IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b4: stloc.s 7
+		IL_01b6: volatile.
+		IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01bd: brfalse IL_01d3
 
-		IL_01eb: ldstr "next"
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01f5: br IL_020e
+		IL_01c2: ldloc.s 4
+		IL_01c4: ldstr "done"
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ce: br IL_01e9
 
-		IL_01fa: ldstr "next"
-		IL_01ff: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:50"
-		IL_0204: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01d3: ldloc.s 4
+		IL_01d5: ldstr "done"
+		IL_01da: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:45"
+		IL_01df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_020e: stloc.s 5
-		IL_0210: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0215: stloc.s 7
-		IL_0217: volatile.
-		IL_0219: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_021e: brfalse IL_0234
+		IL_01e9: stloc.s 8
+		IL_01eb: ldstr "r2.done="
+		IL_01f0: ldloc.s 8
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01f7: stloc.s 9
+		IL_01f9: ldloc.s 7
+		IL_01fb: ldloc.s 9
+		IL_01fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0202: pop
+		IL_0203: ldloc.2
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0209: volatile.
+		IL_020b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0210: brfalse IL_0224
 
-		IL_0223: ldloc.s 5
-		IL_0225: ldstr "value"
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022f: br IL_024a
+		IL_0215: ldstr "next"
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_021f: br IL_0238
 
-		IL_0234: ldloc.s 5
-		IL_0236: ldstr "value"
-		IL_023b: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:56"
-		IL_0240: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0224: ldstr "next"
+		IL_0229: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:50"
+		IL_022e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_024a: stloc.s 8
-		IL_024c: ldstr "r3.value="
-		IL_0251: ldloc.s 8
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0258: stloc.s 9
-		IL_025a: ldloc.s 7
-		IL_025c: ldloc.s 9
-		IL_025e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0263: pop
-		IL_0264: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0269: stloc.s 7
-		IL_026b: volatile.
-		IL_026d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0272: brfalse IL_0288
+		IL_0238: stloc.s 5
+		IL_023a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023f: stloc.s 7
+		IL_0241: volatile.
+		IL_0243: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0248: brfalse IL_025e
 
-		IL_0277: ldloc.s 5
-		IL_0279: ldstr "done"
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0283: br IL_029e
+		IL_024d: ldloc.s 5
+		IL_024f: ldstr "value"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0259: br IL_0274
 
-		IL_0288: ldloc.s 5
-		IL_028a: ldstr "done"
-		IL_028f: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:63"
-		IL_0294: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_025e: ldloc.s 5
+		IL_0260: ldstr "value"
+		IL_0265: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:56"
+		IL_026a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_029e: stloc.s 8
-		IL_02a0: ldstr "r3.done="
-		IL_02a5: ldloc.s 8
-		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02ac: stloc.s 9
-		IL_02ae: ldloc.s 7
-		IL_02b0: ldloc.s 9
-		IL_02b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b7: pop
-		IL_02b8: ret
+		IL_0274: stloc.s 8
+		IL_0276: ldstr "r3.value="
+		IL_027b: ldloc.s 8
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0282: stloc.s 9
+		IL_0284: ldloc.s 7
+		IL_0286: ldloc.s 9
+		IL_0288: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_028d: pop
+		IL_028e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0293: stloc.s 7
+		IL_0295: volatile.
+		IL_0297: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_029c: brfalse IL_02b2
+
+		IL_02a1: ldloc.s 5
+		IL_02a3: ldstr "done"
+		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ad: br IL_02c8
+
+		IL_02b2: ldloc.s 5
+		IL_02b4: ldstr "done"
+		IL_02b9: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Nested:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested:__js_module_init__:63"
+		IL_02be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02c8: stloc.s 8
+		IL_02ca: ldstr "r3.done="
+		IL_02cf: ldloc.s 8
+		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02d6: stloc.s 9
+		IL_02d8: ldloc.s 7
+		IL_02da: ldloc.s 9
+		IL_02dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e1: pop
+		IL_02e2: ret
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_Nested::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested
@@ -1050,6 +1062,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
@@ -642,7 +642,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 643 (0x283)
+		// Code size: 685 (0x2ad)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope,
@@ -759,127 +759,139 @@
 			IL_011a: nop
 			IL_011b: ldloc.2
 			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0121: ldstr "throw"
-			IL_0126: ldstr "boom"
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0130: pop
-			IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0136: stloc.s 10
-			IL_0138: ldloc.s 10
-			IL_013a: ldstr "throw-returned"
-			IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0144: pop
-			IL_0145: leave IL_01a0
+			IL_0121: volatile.
+			IL_0123: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0128: brfalse IL_0141
+
+			IL_012d: ldstr "throw"
+			IL_0132: ldstr "boom"
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_013c: br IL_015a
+
+			IL_0141: ldstr "throw"
+			IL_0146: ldstr "boom"
+			IL_014b: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:__js_module_init__:35"
+			IL_0150: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_015a: pop
+			IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0160: stloc.s 10
+			IL_0162: ldloc.s 10
+			IL_0164: ldstr "throw-returned"
+			IL_0169: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_016e: pop
+			IL_016f: leave IL_01ca
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_014a: stloc.s 4
-			IL_014c: ldloc.s 4
-			IL_014e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0153: dup
-			IL_0154: brtrue IL_016a
+			IL_0174: stloc.s 4
+			IL_0176: ldloc.s 4
+			IL_0178: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_017d: dup
+			IL_017e: brtrue IL_0194
 
-			IL_0159: pop
-			IL_015a: ldloc.s 4
-			IL_015c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0161: dup
-			IL_0162: brtrue IL_0176
+			IL_0183: pop
+			IL_0184: ldloc.s 4
+			IL_0186: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_018b: dup
+			IL_018c: brtrue IL_01a0
 
-			IL_0167: pop
-			IL_0168: rethrow
+			IL_0191: pop
+			IL_0192: rethrow
 
-			IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_016f: stloc.s 5
-			IL_0171: br IL_0178
+			IL_0194: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0199: stloc.s 5
+			IL_019b: br IL_01a2
 
-			IL_0176: stloc.s 5
+			IL_01a0: stloc.s 5
 
-			IL_0178: ldloc.s 5
-			IL_017a: stloc.s 6
-			IL_017c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0181: stloc.s 10
-			IL_0183: ldstr "caught="
-			IL_0188: ldloc.s 6
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_018f: stloc.s 12
-			IL_0191: ldloc.s 10
-			IL_0193: ldloc.s 12
-			IL_0195: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_019a: pop
-			IL_019b: leave IL_01a0
+			IL_01a2: ldloc.s 5
+			IL_01a4: stloc.s 6
+			IL_01a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01ab: stloc.s 10
+			IL_01ad: ldstr "caught="
+			IL_01b2: ldloc.s 6
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01b9: stloc.s 12
+			IL_01bb: ldloc.s 10
+			IL_01bd: ldloc.s 12
+			IL_01bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01c4: pop
+			IL_01c5: leave IL_01ca
 		} // end handler
 
-		IL_01a0: ldloc.2
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a6: volatile.
-		IL_01a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01ad: brfalse IL_01c1
+		IL_01ca: ldloc.2
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d0: volatile.
+		IL_01d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01d7: brfalse IL_01eb
 
-		IL_01b2: ldstr "next"
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01bc: br IL_01d5
+		IL_01dc: ldstr "next"
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01e6: br IL_01ff
 
-		IL_01c1: ldstr "next"
-		IL_01c6: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:__js_module_init__:58"
-		IL_01cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01eb: ldstr "next"
+		IL_01f0: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:__js_module_init__:58"
+		IL_01f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_01d5: stloc.s 7
-		IL_01d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01dc: stloc.s 10
-		IL_01de: volatile.
-		IL_01e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01e5: brfalse IL_01fb
+		IL_01ff: stloc.s 7
+		IL_0201: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0206: stloc.s 10
+		IL_0208: volatile.
+		IL_020a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_020f: brfalse IL_0225
 
-		IL_01ea: ldloc.s 7
-		IL_01ec: ldstr "value"
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f6: br IL_0211
+		IL_0214: ldloc.s 7
+		IL_0216: ldstr "value"
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0220: br IL_023b
 
-		IL_01fb: ldloc.s 7
-		IL_01fd: ldstr "value"
-		IL_0202: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:__js_module_init__:64"
-		IL_0207: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0225: ldloc.s 7
+		IL_0227: ldstr "value"
+		IL_022c: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:__js_module_init__:64"
+		IL_0231: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0211: stloc.s 11
-		IL_0213: ldstr "r2.value="
-		IL_0218: ldloc.s 11
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_021f: stloc.s 12
-		IL_0221: ldloc.s 10
-		IL_0223: ldloc.s 12
-		IL_0225: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_022a: pop
-		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0230: stloc.s 10
-		IL_0232: volatile.
-		IL_0234: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0239: brfalse IL_024f
+		IL_023b: stloc.s 11
+		IL_023d: ldstr "r2.value="
+		IL_0242: ldloc.s 11
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0249: stloc.s 12
+		IL_024b: ldloc.s 10
+		IL_024d: ldloc.s 12
+		IL_024f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0254: pop
+		IL_0255: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025a: stloc.s 10
+		IL_025c: volatile.
+		IL_025e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0263: brfalse IL_0279
 
-		IL_023e: ldloc.s 7
-		IL_0240: ldstr "done"
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_024a: br IL_0265
+		IL_0268: ldloc.s 7
+		IL_026a: ldstr "done"
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0274: br IL_028f
 
-		IL_024f: ldloc.s 7
-		IL_0251: ldstr "done"
-		IL_0256: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:__js_module_init__:71"
-		IL_025b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0279: ldloc.s 7
+		IL_027b: ldstr "done"
+		IL_0280: ldstr "Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow:__js_module_init__:71"
+		IL_0285: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0265: stloc.s 11
-		IL_0267: ldstr "r2.done="
-		IL_026c: ldloc.s 11
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0273: stloc.s 12
-		IL_0275: ldloc.s 10
-		IL_0277: ldloc.s 12
-		IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_027e: pop
-		IL_027f: ldnull
-		IL_0280: stloc.s 8
-		IL_0282: ret
+		IL_028f: stloc.s 11
+		IL_0291: ldstr "r2.done="
+		IL_0296: ldloc.s 11
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_029d: stloc.s 12
+		IL_029f: ldloc.s 10
+		IL_02a1: ldloc.s 12
+		IL_02a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a8: pop
+		IL_02a9: ldnull
+		IL_02aa: stloc.s 8
+		IL_02ac: ret
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow
@@ -915,6 +927,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_Nested_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_Nested_ReturnWhileSuspended.verified.txt
@@ -702,7 +702,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 929 (0x3a1)
+		// Code size: 980 (0x3d4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/Scope,
@@ -882,132 +882,145 @@
 		IL_01f8: pop
 		IL_01f9: ldloc.2
 		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ff: ldstr "return"
-		IL_0204: ldc.r8 99
-		IL_020d: box [System.Runtime]System.Double
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0217: stloc.s 5
-		IL_0219: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021e: stloc.s 8
-		IL_0220: volatile.
-		IL_0222: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0227: brfalse IL_023d
+		IL_01ff: volatile.
+		IL_0201: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0206: brfalse IL_0228
 
-		IL_022c: ldloc.s 5
-		IL_022e: ldstr "value"
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0238: br IL_0253
+		IL_020b: ldstr "return"
+		IL_0210: ldc.r8 99
+		IL_0219: box [System.Runtime]System.Double
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0223: br IL_024a
 
-		IL_023d: ldloc.s 5
-		IL_023f: ldstr "value"
-		IL_0244: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:57"
-		IL_0249: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0228: ldstr "return"
+		IL_022d: ldc.r8 99
+		IL_0236: box [System.Runtime]System.Double
+		IL_023b: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:51"
+		IL_0240: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0253: stloc.s 9
-		IL_0255: ldstr "r3.value="
-		IL_025a: ldloc.s 9
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0261: stloc.s 10
-		IL_0263: ldloc.s 8
-		IL_0265: ldloc.s 10
-		IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026c: pop
-		IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0272: stloc.s 8
-		IL_0274: volatile.
-		IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_027b: brfalse IL_0291
+		IL_024a: stloc.s 5
+		IL_024c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0251: stloc.s 8
+		IL_0253: volatile.
+		IL_0255: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_025a: brfalse IL_0270
 
-		IL_0280: ldloc.s 5
-		IL_0282: ldstr "done"
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028c: br IL_02a7
+		IL_025f: ldloc.s 5
+		IL_0261: ldstr "value"
+		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026b: br IL_0286
 
-		IL_0291: ldloc.s 5
-		IL_0293: ldstr "done"
-		IL_0298: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:64"
-		IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0270: ldloc.s 5
+		IL_0272: ldstr "value"
+		IL_0277: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:57"
+		IL_027c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02a7: stloc.s 9
-		IL_02a9: ldstr "r3.done="
-		IL_02ae: ldloc.s 9
-		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02b5: stloc.s 10
-		IL_02b7: ldloc.s 8
-		IL_02b9: ldloc.s 10
-		IL_02bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c0: pop
-		IL_02c1: ldloc.2
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c7: volatile.
-		IL_02c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02ce: brfalse IL_02e2
+		IL_0286: stloc.s 9
+		IL_0288: ldstr "r3.value="
+		IL_028d: ldloc.s 9
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0294: stloc.s 10
+		IL_0296: ldloc.s 8
+		IL_0298: ldloc.s 10
+		IL_029a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029f: pop
+		IL_02a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a5: stloc.s 8
+		IL_02a7: volatile.
+		IL_02a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02ae: brfalse IL_02c4
 
-		IL_02d3: ldstr "next"
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02dd: br IL_02f6
+		IL_02b3: ldloc.s 5
+		IL_02b5: ldstr "done"
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02bf: br IL_02da
 
-		IL_02e2: ldstr "next"
-		IL_02e7: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:69"
-		IL_02ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_02c4: ldloc.s 5
+		IL_02c6: ldstr "done"
+		IL_02cb: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:64"
+		IL_02d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02f6: stloc.s 6
-		IL_02f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02fd: stloc.s 8
-		IL_02ff: volatile.
-		IL_0301: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0306: brfalse IL_031c
+		IL_02da: stloc.s 9
+		IL_02dc: ldstr "r3.done="
+		IL_02e1: ldloc.s 9
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02e8: stloc.s 10
+		IL_02ea: ldloc.s 8
+		IL_02ec: ldloc.s 10
+		IL_02ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02f3: pop
+		IL_02f4: ldloc.2
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fa: volatile.
+		IL_02fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0301: brfalse IL_0315
 
-		IL_030b: ldloc.s 6
-		IL_030d: ldstr "value"
-		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0317: br IL_0332
+		IL_0306: ldstr "next"
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0310: br IL_0329
 
-		IL_031c: ldloc.s 6
-		IL_031e: ldstr "value"
-		IL_0323: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:75"
-		IL_0328: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0315: ldstr "next"
+		IL_031a: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:69"
+		IL_031f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0332: stloc.s 9
-		IL_0334: ldstr "r4.value="
-		IL_0339: ldloc.s 9
-		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0340: stloc.s 10
-		IL_0342: ldloc.s 8
-		IL_0344: ldloc.s 10
-		IL_0346: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_034b: pop
-		IL_034c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0351: stloc.s 8
-		IL_0353: volatile.
-		IL_0355: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_035a: brfalse IL_0370
+		IL_0329: stloc.s 6
+		IL_032b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0330: stloc.s 8
+		IL_0332: volatile.
+		IL_0334: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0339: brfalse IL_034f
 
-		IL_035f: ldloc.s 6
-		IL_0361: ldstr "done"
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_036b: br IL_0386
+		IL_033e: ldloc.s 6
+		IL_0340: ldstr "value"
+		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_034a: br IL_0365
 
-		IL_0370: ldloc.s 6
-		IL_0372: ldstr "done"
-		IL_0377: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:82"
-		IL_037c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_034f: ldloc.s 6
+		IL_0351: ldstr "value"
+		IL_0356: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:75"
+		IL_035b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0386: stloc.s 9
-		IL_0388: ldstr "r4.done="
-		IL_038d: ldloc.s 9
-		IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0394: stloc.s 10
-		IL_0396: ldloc.s 8
-		IL_0398: ldloc.s 10
-		IL_039a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_039f: pop
-		IL_03a0: ret
+		IL_0365: stloc.s 9
+		IL_0367: ldstr "r4.value="
+		IL_036c: ldloc.s 9
+		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0373: stloc.s 10
+		IL_0375: ldloc.s 8
+		IL_0377: ldloc.s 10
+		IL_0379: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_037e: pop
+		IL_037f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0384: stloc.s 8
+		IL_0386: volatile.
+		IL_0388: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_038d: brfalse IL_03a3
+
+		IL_0392: ldloc.s 6
+		IL_0394: ldstr "done"
+		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_039e: br IL_03b9
+
+		IL_03a3: ldloc.s 6
+		IL_03a5: ldstr "done"
+		IL_03aa: ldstr "Generator_TryFinally_Nested_ReturnWhileSuspended:Modules.Generator_TryFinally_Nested_ReturnWhileSuspended:__js_module_init__:82"
+		IL_03af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_03b9: stloc.s 9
+		IL_03bb: ldstr "r4.done="
+		IL_03c0: ldloc.s 9
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03c7: stloc.s 10
+		IL_03c9: ldloc.s 8
+		IL_03cb: ldloc.s 10
+		IL_03cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03d2: pop
+		IL_03d3: ret
 	} // end of method Generator_TryFinally_Nested_ReturnWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended
@@ -1048,6 +1061,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ReturnWhileSuspended.verified.txt
@@ -531,7 +531,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 706 (0x2c2)
+		// Code size: 757 (0x2f5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_ReturnWhileSuspended/Scope,
@@ -642,132 +642,145 @@
 		IL_0119: pop
 		IL_011a: ldloc.2
 		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0120: ldstr "return"
-		IL_0125: ldc.r8 123
-		IL_012e: box [System.Runtime]System.Double
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0138: stloc.s 4
-		IL_013a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013f: stloc.s 7
-		IL_0141: volatile.
-		IL_0143: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0148: brfalse IL_015e
+		IL_0120: volatile.
+		IL_0122: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0127: brfalse IL_0149
 
-		IL_014d: ldloc.s 4
-		IL_014f: ldstr "value"
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0159: br IL_0174
+		IL_012c: ldstr "return"
+		IL_0131: ldc.r8 123
+		IL_013a: box [System.Runtime]System.Double
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0144: br IL_016b
 
-		IL_015e: ldloc.s 4
-		IL_0160: ldstr "value"
-		IL_0165: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:39"
-		IL_016a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0149: ldstr "return"
+		IL_014e: ldc.r8 123
+		IL_0157: box [System.Runtime]System.Double
+		IL_015c: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:33"
+		IL_0161: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0174: stloc.s 8
-		IL_0176: ldstr "r2.value="
-		IL_017b: ldloc.s 8
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0182: stloc.s 9
-		IL_0184: ldloc.s 7
-		IL_0186: ldloc.s 9
-		IL_0188: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018d: pop
-		IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0193: stloc.s 7
-		IL_0195: volatile.
-		IL_0197: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_019c: brfalse IL_01b2
+		IL_016b: stloc.s 4
+		IL_016d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0172: stloc.s 7
+		IL_0174: volatile.
+		IL_0176: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_017b: brfalse IL_0191
 
-		IL_01a1: ldloc.s 4
-		IL_01a3: ldstr "done"
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ad: br IL_01c8
+		IL_0180: ldloc.s 4
+		IL_0182: ldstr "value"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018c: br IL_01a7
 
-		IL_01b2: ldloc.s 4
-		IL_01b4: ldstr "done"
-		IL_01b9: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:46"
-		IL_01be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0191: ldloc.s 4
+		IL_0193: ldstr "value"
+		IL_0198: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:39"
+		IL_019d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01c8: stloc.s 8
-		IL_01ca: ldstr "r2.done="
-		IL_01cf: ldloc.s 8
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01d6: stloc.s 9
-		IL_01d8: ldloc.s 7
-		IL_01da: ldloc.s 9
-		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e1: pop
-		IL_01e2: ldloc.2
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e8: volatile.
-		IL_01ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_01ef: brfalse IL_0203
+		IL_01a7: stloc.s 8
+		IL_01a9: ldstr "r2.value="
+		IL_01ae: ldloc.s 8
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01b5: stloc.s 9
+		IL_01b7: ldloc.s 7
+		IL_01b9: ldloc.s 9
+		IL_01bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c0: pop
+		IL_01c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c6: stloc.s 7
+		IL_01c8: volatile.
+		IL_01ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01cf: brfalse IL_01e5
 
-		IL_01f4: ldstr "next"
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01fe: br IL_0217
+		IL_01d4: ldloc.s 4
+		IL_01d6: ldstr "done"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e0: br IL_01fb
 
-		IL_0203: ldstr "next"
-		IL_0208: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:51"
-		IL_020d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01e5: ldloc.s 4
+		IL_01e7: ldstr "done"
+		IL_01ec: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:46"
+		IL_01f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0217: stloc.s 5
-		IL_0219: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021e: stloc.s 7
-		IL_0220: volatile.
-		IL_0222: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0227: brfalse IL_023d
+		IL_01fb: stloc.s 8
+		IL_01fd: ldstr "r2.done="
+		IL_0202: ldloc.s 8
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0209: stloc.s 9
+		IL_020b: ldloc.s 7
+		IL_020d: ldloc.s 9
+		IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0214: pop
+		IL_0215: ldloc.2
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021b: volatile.
+		IL_021d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0222: brfalse IL_0236
 
-		IL_022c: ldloc.s 5
-		IL_022e: ldstr "value"
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0238: br IL_0253
+		IL_0227: ldstr "next"
+		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0231: br IL_024a
 
-		IL_023d: ldloc.s 5
-		IL_023f: ldstr "value"
-		IL_0244: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:57"
-		IL_0249: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0236: ldstr "next"
+		IL_023b: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:51"
+		IL_0240: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0253: stloc.s 8
-		IL_0255: ldstr "r3.value="
-		IL_025a: ldloc.s 8
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0261: stloc.s 9
-		IL_0263: ldloc.s 7
-		IL_0265: ldloc.s 9
-		IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026c: pop
-		IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0272: stloc.s 7
-		IL_0274: volatile.
-		IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_027b: brfalse IL_0291
+		IL_024a: stloc.s 5
+		IL_024c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0251: stloc.s 7
+		IL_0253: volatile.
+		IL_0255: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_025a: brfalse IL_0270
 
-		IL_0280: ldloc.s 5
-		IL_0282: ldstr "done"
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028c: br IL_02a7
+		IL_025f: ldloc.s 5
+		IL_0261: ldstr "value"
+		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026b: br IL_0286
 
-		IL_0291: ldloc.s 5
-		IL_0293: ldstr "done"
-		IL_0298: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:64"
-		IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0270: ldloc.s 5
+		IL_0272: ldstr "value"
+		IL_0277: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:57"
+		IL_027c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02a7: stloc.s 8
-		IL_02a9: ldstr "r3.done="
-		IL_02ae: ldloc.s 8
-		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02b5: stloc.s 9
-		IL_02b7: ldloc.s 7
-		IL_02b9: ldloc.s 9
-		IL_02bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c0: pop
-		IL_02c1: ret
+		IL_0286: stloc.s 8
+		IL_0288: ldstr "r3.value="
+		IL_028d: ldloc.s 8
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0294: stloc.s 9
+		IL_0296: ldloc.s 7
+		IL_0298: ldloc.s 9
+		IL_029a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029f: pop
+		IL_02a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a5: stloc.s 7
+		IL_02a7: volatile.
+		IL_02a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02ae: brfalse IL_02c4
+
+		IL_02b3: ldloc.s 5
+		IL_02b5: ldstr "done"
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02bf: br IL_02da
+
+		IL_02c4: ldloc.s 5
+		IL_02c6: ldstr "done"
+		IL_02cb: ldstr "Generator_TryFinally_ReturnWhileSuspended:Modules.Generator_TryFinally_ReturnWhileSuspended:__js_module_init__:64"
+		IL_02d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02da: stloc.s 8
+		IL_02dc: ldstr "r3.done="
+		IL_02e1: ldloc.s 8
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02e8: stloc.s 9
+		IL_02ea: ldloc.s 7
+		IL_02ec: ldloc.s 9
+		IL_02ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02f3: pop
+		IL_02f4: ret
 	} // end of method Generator_TryFinally_ReturnWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_ReturnWhileSuspended
@@ -805,6 +818,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
@@ -565,7 +565,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 643 (0x283)
+		// Code size: 685 (0x2ad)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_ThrowWhileSuspended/Scope,
@@ -682,127 +682,139 @@
 			IL_011a: nop
 			IL_011b: ldloc.2
 			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0121: ldstr "throw"
-			IL_0126: ldstr "boom"
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0130: pop
-			IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0136: stloc.s 10
-			IL_0138: ldloc.s 10
-			IL_013a: ldstr "throw-returned"
-			IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0144: pop
-			IL_0145: leave IL_01a0
+			IL_0121: volatile.
+			IL_0123: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0128: brfalse IL_0141
+
+			IL_012d: ldstr "throw"
+			IL_0132: ldstr "boom"
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_013c: br IL_015a
+
+			IL_0141: ldstr "throw"
+			IL_0146: ldstr "boom"
+			IL_014b: ldstr "Generator_TryFinally_ThrowWhileSuspended:Modules.Generator_TryFinally_ThrowWhileSuspended:__js_module_init__:35"
+			IL_0150: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_015a: pop
+			IL_015b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0160: stloc.s 10
+			IL_0162: ldloc.s 10
+			IL_0164: ldstr "throw-returned"
+			IL_0169: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_016e: pop
+			IL_016f: leave IL_01ca
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_014a: stloc.s 4
-			IL_014c: ldloc.s 4
-			IL_014e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0153: dup
-			IL_0154: brtrue IL_016a
+			IL_0174: stloc.s 4
+			IL_0176: ldloc.s 4
+			IL_0178: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_017d: dup
+			IL_017e: brtrue IL_0194
 
-			IL_0159: pop
-			IL_015a: ldloc.s 4
-			IL_015c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0161: dup
-			IL_0162: brtrue IL_0176
+			IL_0183: pop
+			IL_0184: ldloc.s 4
+			IL_0186: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_018b: dup
+			IL_018c: brtrue IL_01a0
 
-			IL_0167: pop
-			IL_0168: rethrow
+			IL_0191: pop
+			IL_0192: rethrow
 
-			IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_016f: stloc.s 5
-			IL_0171: br IL_0178
+			IL_0194: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0199: stloc.s 5
+			IL_019b: br IL_01a2
 
-			IL_0176: stloc.s 5
+			IL_01a0: stloc.s 5
 
-			IL_0178: ldloc.s 5
-			IL_017a: stloc.s 6
-			IL_017c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0181: stloc.s 10
-			IL_0183: ldstr "caught="
-			IL_0188: ldloc.s 6
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_018f: stloc.s 12
-			IL_0191: ldloc.s 10
-			IL_0193: ldloc.s 12
-			IL_0195: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_019a: pop
-			IL_019b: leave IL_01a0
+			IL_01a2: ldloc.s 5
+			IL_01a4: stloc.s 6
+			IL_01a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01ab: stloc.s 10
+			IL_01ad: ldstr "caught="
+			IL_01b2: ldloc.s 6
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01b9: stloc.s 12
+			IL_01bb: ldloc.s 10
+			IL_01bd: ldloc.s 12
+			IL_01bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01c4: pop
+			IL_01c5: leave IL_01ca
 		} // end handler
 
-		IL_01a0: ldloc.2
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a6: volatile.
-		IL_01a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01ad: brfalse IL_01c1
+		IL_01ca: ldloc.2
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d0: volatile.
+		IL_01d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01d7: brfalse IL_01eb
 
-		IL_01b2: ldstr "next"
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01bc: br IL_01d5
+		IL_01dc: ldstr "next"
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01e6: br IL_01ff
 
-		IL_01c1: ldstr "next"
-		IL_01c6: ldstr "Generator_TryFinally_ThrowWhileSuspended:Modules.Generator_TryFinally_ThrowWhileSuspended:__js_module_init__:58"
-		IL_01cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01eb: ldstr "next"
+		IL_01f0: ldstr "Generator_TryFinally_ThrowWhileSuspended:Modules.Generator_TryFinally_ThrowWhileSuspended:__js_module_init__:58"
+		IL_01f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_01d5: stloc.s 7
-		IL_01d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01dc: stloc.s 10
-		IL_01de: volatile.
-		IL_01e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01e5: brfalse IL_01fb
+		IL_01ff: stloc.s 7
+		IL_0201: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0206: stloc.s 10
+		IL_0208: volatile.
+		IL_020a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_020f: brfalse IL_0225
 
-		IL_01ea: ldloc.s 7
-		IL_01ec: ldstr "value"
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f6: br IL_0211
+		IL_0214: ldloc.s 7
+		IL_0216: ldstr "value"
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0220: br IL_023b
 
-		IL_01fb: ldloc.s 7
-		IL_01fd: ldstr "value"
-		IL_0202: ldstr "Generator_TryFinally_ThrowWhileSuspended:Modules.Generator_TryFinally_ThrowWhileSuspended:__js_module_init__:64"
-		IL_0207: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0225: ldloc.s 7
+		IL_0227: ldstr "value"
+		IL_022c: ldstr "Generator_TryFinally_ThrowWhileSuspended:Modules.Generator_TryFinally_ThrowWhileSuspended:__js_module_init__:64"
+		IL_0231: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0211: stloc.s 11
-		IL_0213: ldstr "r2.value="
-		IL_0218: ldloc.s 11
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_021f: stloc.s 12
-		IL_0221: ldloc.s 10
-		IL_0223: ldloc.s 12
-		IL_0225: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_022a: pop
-		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0230: stloc.s 10
-		IL_0232: volatile.
-		IL_0234: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0239: brfalse IL_024f
+		IL_023b: stloc.s 11
+		IL_023d: ldstr "r2.value="
+		IL_0242: ldloc.s 11
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0249: stloc.s 12
+		IL_024b: ldloc.s 10
+		IL_024d: ldloc.s 12
+		IL_024f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0254: pop
+		IL_0255: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025a: stloc.s 10
+		IL_025c: volatile.
+		IL_025e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0263: brfalse IL_0279
 
-		IL_023e: ldloc.s 7
-		IL_0240: ldstr "done"
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_024a: br IL_0265
+		IL_0268: ldloc.s 7
+		IL_026a: ldstr "done"
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0274: br IL_028f
 
-		IL_024f: ldloc.s 7
-		IL_0251: ldstr "done"
-		IL_0256: ldstr "Generator_TryFinally_ThrowWhileSuspended:Modules.Generator_TryFinally_ThrowWhileSuspended:__js_module_init__:71"
-		IL_025b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0279: ldloc.s 7
+		IL_027b: ldstr "done"
+		IL_0280: ldstr "Generator_TryFinally_ThrowWhileSuspended:Modules.Generator_TryFinally_ThrowWhileSuspended:__js_module_init__:71"
+		IL_0285: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0265: stloc.s 11
-		IL_0267: ldstr "r2.done="
-		IL_026c: ldloc.s 11
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0273: stloc.s 12
-		IL_0275: ldloc.s 10
-		IL_0277: ldloc.s 12
-		IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_027e: pop
-		IL_027f: ldnull
-		IL_0280: stloc.s 8
-		IL_0282: ret
+		IL_028f: stloc.s 11
+		IL_0291: ldstr "r2.done="
+		IL_0296: ldloc.s 11
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_029d: stloc.s 12
+		IL_029f: ldloc.s 10
+		IL_02a1: ldloc.s 12
+		IL_02a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a8: pop
+		IL_02a9: ldnull
+		IL_02aa: stloc.s 8
+		IL_02ac: ret
 	} // end of method Generator_TryFinally_ThrowWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_ThrowWhileSuspended
@@ -838,6 +850,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
@@ -1095,7 +1095,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 685 (0x2ad)
+		// Code size: 736 (0x2e0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_PassNextValue/Scope,
@@ -1224,116 +1224,129 @@
 		IL_013c: pop
 		IL_013d: ldloc.2
 		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0143: ldstr "next"
-		IL_0148: ldc.r8 42
-		IL_0151: box [System.Runtime]System.Double
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015b: stloc.s 4
-		IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0162: stloc.s 8
-		IL_0164: volatile.
-		IL_0166: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_016b: brfalse IL_0181
+		IL_0143: volatile.
+		IL_0145: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_014a: brfalse IL_016c
 
-		IL_0170: ldloc.s 4
-		IL_0172: ldstr "value"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017c: br IL_0197
+		IL_014f: ldstr "next"
+		IL_0154: ldc.r8 42
+		IL_015d: box [System.Runtime]System.Double
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0167: br IL_018e
 
-		IL_0181: ldloc.s 4
-		IL_0183: ldstr "value"
-		IL_0188: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:38"
-		IL_018d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_016c: ldstr "next"
+		IL_0171: ldc.r8 42
+		IL_017a: box [System.Runtime]System.Double
+		IL_017f: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:33"
+		IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0197: stloc.s 9
-		IL_0199: ldloc.s 8
-		IL_019b: ldloc.s 9
-		IL_019d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a2: pop
-		IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a8: stloc.s 8
-		IL_01aa: volatile.
-		IL_01ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_01b1: brfalse IL_01c7
+		IL_018e: stloc.s 4
+		IL_0190: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0195: stloc.s 8
+		IL_0197: volatile.
+		IL_0199: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_019e: brfalse IL_01b4
 
-		IL_01b6: ldloc.s 4
-		IL_01b8: ldstr "done"
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c2: br IL_01dd
+		IL_01a3: ldloc.s 4
+		IL_01a5: ldstr "value"
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01af: br IL_01ca
 
-		IL_01c7: ldloc.s 4
-		IL_01c9: ldstr "done"
-		IL_01ce: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:43"
-		IL_01d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01b4: ldloc.s 4
+		IL_01b6: ldstr "value"
+		IL_01bb: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:38"
+		IL_01c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01dd: stloc.s 9
-		IL_01df: ldloc.s 8
-		IL_01e1: ldloc.s 9
-		IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e8: pop
-		IL_01e9: ldloc.2
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ef: volatile.
-		IL_01f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_01f6: brfalse IL_020a
+		IL_01ca: stloc.s 9
+		IL_01cc: ldloc.s 8
+		IL_01ce: ldloc.s 9
+		IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d5: pop
+		IL_01d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01db: stloc.s 8
+		IL_01dd: volatile.
+		IL_01df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_01e4: brfalse IL_01fa
 
-		IL_01fb: ldstr "next"
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0205: br IL_021e
+		IL_01e9: ldloc.s 4
+		IL_01eb: ldstr "done"
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f5: br IL_0210
 
-		IL_020a: ldstr "next"
-		IL_020f: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:47"
-		IL_0214: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01fa: ldloc.s 4
+		IL_01fc: ldstr "done"
+		IL_0201: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:43"
+		IL_0206: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_021e: stloc.s 5
-		IL_0220: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0225: stloc.s 8
-		IL_0227: volatile.
-		IL_0229: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_022e: brfalse IL_0244
+		IL_0210: stloc.s 9
+		IL_0212: ldloc.s 8
+		IL_0214: ldloc.s 9
+		IL_0216: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_021b: pop
+		IL_021c: ldloc.2
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0222: volatile.
+		IL_0224: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0229: brfalse IL_023d
 
-		IL_0233: ldloc.s 5
-		IL_0235: ldstr "value"
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_023f: br IL_025a
+		IL_022e: ldstr "next"
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0238: br IL_0251
 
-		IL_0244: ldloc.s 5
-		IL_0246: ldstr "value"
-		IL_024b: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:52"
-		IL_0250: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_023d: ldstr "next"
+		IL_0242: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:47"
+		IL_0247: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_025a: stloc.s 9
-		IL_025c: ldloc.s 8
-		IL_025e: ldloc.s 9
-		IL_0260: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0265: pop
-		IL_0266: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_026b: stloc.s 8
-		IL_026d: volatile.
-		IL_026f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0274: brfalse IL_028a
+		IL_0251: stloc.s 5
+		IL_0253: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0258: stloc.s 8
+		IL_025a: volatile.
+		IL_025c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0261: brfalse IL_0277
 
-		IL_0279: ldloc.s 5
-		IL_027b: ldstr "done"
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0285: br IL_02a0
+		IL_0266: ldloc.s 5
+		IL_0268: ldstr "value"
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0272: br IL_028d
 
-		IL_028a: ldloc.s 5
-		IL_028c: ldstr "done"
-		IL_0291: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:57"
-		IL_0296: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0277: ldloc.s 5
+		IL_0279: ldstr "value"
+		IL_027e: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:52"
+		IL_0283: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02a0: stloc.s 9
-		IL_02a2: ldloc.s 8
-		IL_02a4: ldloc.s 9
-		IL_02a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ab: pop
-		IL_02ac: ret
+		IL_028d: stloc.s 9
+		IL_028f: ldloc.s 8
+		IL_0291: ldloc.s 9
+		IL_0293: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0298: pop
+		IL_0299: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_029e: stloc.s 8
+		IL_02a0: volatile.
+		IL_02a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_02a7: brfalse IL_02bd
+
+		IL_02ac: ldloc.s 5
+		IL_02ae: ldstr "done"
+		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b8: br IL_02d3
+
+		IL_02bd: ldloc.s 5
+		IL_02bf: ldstr "done"
+		IL_02c4: ldstr "Generator_YieldStar_PassNextValue:Modules.Generator_YieldStar_PassNextValue:__js_module_init__:57"
+		IL_02c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02d3: stloc.s 9
+		IL_02d5: ldloc.s 8
+		IL_02d7: ldloc.s 9
+		IL_02d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02de: pop
+		IL_02df: ret
 	} // end of method Generator_YieldStar_PassNextValue::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_PassNextValue
@@ -1371,6 +1384,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
@@ -1166,7 +1166,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 490 (0x1ea)
+		// Code size: 541 (0x21d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_ReturnForwards/Scope,
@@ -1294,56 +1294,69 @@
 		IL_013c: pop
 		IL_013d: ldloc.2
 		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0143: ldstr "return"
-		IL_0148: ldc.r8 123
-		IL_0151: box [System.Runtime]System.Double
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015b: stloc.s 4
-		IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0162: stloc.s 7
-		IL_0164: volatile.
-		IL_0166: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_016b: brfalse IL_0181
+		IL_0143: volatile.
+		IL_0145: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_014a: brfalse IL_016c
 
-		IL_0170: ldloc.s 4
-		IL_0172: ldstr "value"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017c: br IL_0197
+		IL_014f: ldstr "return"
+		IL_0154: ldc.r8 123
+		IL_015d: box [System.Runtime]System.Double
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0167: br IL_018e
 
-		IL_0181: ldloc.s 4
-		IL_0183: ldstr "value"
-		IL_0188: ldstr "Generator_YieldStar_ReturnForwards:Modules.Generator_YieldStar_ReturnForwards:__js_module_init__:38"
-		IL_018d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_016c: ldstr "return"
+		IL_0171: ldc.r8 123
+		IL_017a: box [System.Runtime]System.Double
+		IL_017f: ldstr "Generator_YieldStar_ReturnForwards:Modules.Generator_YieldStar_ReturnForwards:__js_module_init__:33"
+		IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0197: stloc.s 8
-		IL_0199: ldloc.s 7
-		IL_019b: ldloc.s 8
-		IL_019d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a2: pop
-		IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a8: stloc.s 7
-		IL_01aa: volatile.
-		IL_01ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_01b1: brfalse IL_01c7
+		IL_018e: stloc.s 4
+		IL_0190: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0195: stloc.s 7
+		IL_0197: volatile.
+		IL_0199: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_019e: brfalse IL_01b4
 
-		IL_01b6: ldloc.s 4
-		IL_01b8: ldstr "done"
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c2: br IL_01dd
+		IL_01a3: ldloc.s 4
+		IL_01a5: ldstr "value"
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01af: br IL_01ca
 
-		IL_01c7: ldloc.s 4
-		IL_01c9: ldstr "done"
-		IL_01ce: ldstr "Generator_YieldStar_ReturnForwards:Modules.Generator_YieldStar_ReturnForwards:__js_module_init__:43"
-		IL_01d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01b4: ldloc.s 4
+		IL_01b6: ldstr "value"
+		IL_01bb: ldstr "Generator_YieldStar_ReturnForwards:Modules.Generator_YieldStar_ReturnForwards:__js_module_init__:38"
+		IL_01c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01dd: stloc.s 8
-		IL_01df: ldloc.s 7
-		IL_01e1: ldloc.s 8
-		IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e8: pop
-		IL_01e9: ret
+		IL_01ca: stloc.s 8
+		IL_01cc: ldloc.s 7
+		IL_01ce: ldloc.s 8
+		IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d5: pop
+		IL_01d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01db: stloc.s 7
+		IL_01dd: volatile.
+		IL_01df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_01e4: brfalse IL_01fa
+
+		IL_01e9: ldloc.s 4
+		IL_01eb: ldstr "done"
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f5: br IL_0210
+
+		IL_01fa: ldloc.s 4
+		IL_01fc: ldstr "done"
+		IL_0201: ldstr "Generator_YieldStar_ReturnForwards:Modules.Generator_YieldStar_ReturnForwards:__js_module_init__:43"
+		IL_0206: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0210: stloc.s 8
+		IL_0212: ldloc.s 7
+		IL_0214: ldloc.s 8
+		IL_0216: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_021b: pop
+		IL_021c: ret
 	} // end of method Generator_YieldStar_ReturnForwards::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_ReturnForwards
@@ -1378,6 +1391,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_BasicImport.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_BasicImport.verified.txt
@@ -366,7 +366,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 202 (0xca)
+		// Code size: 243 (0xf3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_BasicImport/Scope,
@@ -451,12 +451,25 @@
 		IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_BasicImport/ArrowFunction_L11C10/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_BasicImport/ArrowFunction_L11C10/FunctionObject>(!!0)
 		IL_00b8: stloc.s 6
-		IL_00ba: ldloc.s 5
-		IL_00bc: ldstr "catch"
-		IL_00c1: ldloc.s 6
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c8: pop
-		IL_00c9: ret
+		IL_00ba: volatile.
+		IL_00bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00c1: brfalse IL_00d9
+
+		IL_00c6: ldloc.s 5
+		IL_00c8: ldstr "catch"
+		IL_00cd: ldloc.s 6
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d4: br IL_00f1
+
+		IL_00d9: ldloc.s 5
+		IL_00db: ldstr "catch"
+		IL_00e0: ldloc.s 6
+		IL_00e2: ldstr "Import_BasicImport:Modules.Import_BasicImport:__js_module_init__:18"
+		IL_00e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f1: pop
+		IL_00f2: ret
 	} // end of method Import_BasicImport::__js_module_init__
 
 } // end of class Modules.Import_BasicImport
@@ -481,4 +494,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
@@ -220,7 +220,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 678 (0x2a6)
+				// Code size: 720 (0x2d0)
 				.maxstack 9
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -264,7 +264,7 @@
 				IL_004b: ldloc.1
 				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0051: volatile.
-				IL_0053: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+				IL_0053: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 				IL_0058: brfalse IL_006c
 
 				IL_005d: ldstr "sort"
@@ -273,186 +273,198 @@
 
 				IL_006c: ldstr "sort"
 				IL_0071: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:14"
-				IL_0076: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+				IL_0076: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0080: stloc.1
 				IL_0081: ldloc.1
 				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0087: ldstr "join"
-				IL_008c: ldstr ","
-				IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0096: stloc.1
-				IL_0097: ldloc.0
-				IL_0098: ldstr "keys:"
-				IL_009d: ldloc.1
-				IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_00a3: pop
-				IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_00a9: stloc.0
-				IL_00aa: ldarg.0
-				IL_00ab: ldc.i4.1
-				IL_00ac: ldelem.ref
-				IL_00ad: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_00b2: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_00b7: volatile.
-				IL_00b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-				IL_00be: brfalse IL_00d2
+				IL_0087: volatile.
+				IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+				IL_008e: brfalse IL_00a7
 
-				IL_00c3: ldstr "default"
-				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00cd: br IL_00e6
+				IL_0093: ldstr "join"
+				IL_0098: ldstr ","
+				IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00a2: br IL_00c0
 
-				IL_00d2: ldstr "default"
-				IL_00d7: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:24"
-				IL_00dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-				IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_00a7: ldstr "join"
+				IL_00ac: ldstr ","
+				IL_00b1: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:17"
+				IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_00e6: stloc.1
-				IL_00e7: ldarg.0
-				IL_00e8: ldc.i4.1
-				IL_00e9: ldelem.ref
-				IL_00ea: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_00ef: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_00f4: volatile.
-				IL_00f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-				IL_00fb: brfalse IL_010f
+				IL_00c0: stloc.1
+				IL_00c1: ldloc.0
+				IL_00c2: ldstr "keys:"
+				IL_00c7: ldloc.1
+				IL_00c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_00cd: pop
+				IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_00d3: stloc.0
+				IL_00d4: ldarg.0
+				IL_00d5: ldc.i4.1
+				IL_00d6: ldelem.ref
+				IL_00d7: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_00dc: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_00e1: volatile.
+				IL_00e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+				IL_00e8: brfalse IL_00fc
 
-				IL_0100: ldstr "module.exports"
-				IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_010a: br IL_0123
+				IL_00ed: ldstr "default"
+				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00f7: br IL_0110
 
-				IL_010f: ldstr "module.exports"
-				IL_0114: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:27"
-				IL_0119: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-				IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_00fc: ldstr "default"
+				IL_0101: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:24"
+				IL_0106: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0123: stloc.s 4
-				IL_0125: ldloc.1
-				IL_0126: ldloc.s 4
-				IL_0128: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_012d: stloc.2
-				IL_012e: ldloc.2
-				IL_012f: box [System.Runtime]System.Boolean
-				IL_0134: stloc.3
-				IL_0135: ldloc.0
-				IL_0136: ldstr "defaultSame:"
-				IL_013b: ldloc.3
-				IL_013c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0141: pop
-				IL_0142: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0147: stloc.0
-				IL_0148: ldarg.0
-				IL_0149: ldc.i4.1
-				IL_014a: ldelem.ref
-				IL_014b: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_0150: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_0155: volatile.
-				IL_0157: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-				IL_015c: brfalse IL_0170
+				IL_0110: stloc.1
+				IL_0111: ldarg.0
+				IL_0112: ldc.i4.1
+				IL_0113: ldelem.ref
+				IL_0114: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_0119: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_011e: volatile.
+				IL_0120: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+				IL_0125: brfalse IL_0139
 
-				IL_0161: ldstr "value"
-				IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_016b: br IL_0184
+				IL_012a: ldstr "module.exports"
+				IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0134: br IL_014d
 
-				IL_0170: ldstr "value"
-				IL_0175: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:36"
-				IL_017a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-				IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0139: ldstr "module.exports"
+				IL_013e: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:27"
+				IL_0143: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+				IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0184: stloc.s 4
-				IL_0186: ldloc.0
-				IL_0187: ldstr "value0:"
-				IL_018c: ldloc.s 4
-				IL_018e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0193: pop
-				IL_0194: ldarg.0
-				IL_0195: ldc.i4.1
-				IL_0196: ldelem.ref
-				IL_0197: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_019c: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01a6: volatile.
-				IL_01a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-				IL_01ad: brfalse IL_01c1
+				IL_014d: stloc.s 4
+				IL_014f: ldloc.1
+				IL_0150: ldloc.s 4
+				IL_0152: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0157: stloc.2
+				IL_0158: ldloc.2
+				IL_0159: box [System.Runtime]System.Boolean
+				IL_015e: stloc.3
+				IL_015f: ldloc.0
+				IL_0160: ldstr "defaultSame:"
+				IL_0165: ldloc.3
+				IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_016b: pop
+				IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0171: stloc.0
+				IL_0172: ldarg.0
+				IL_0173: ldc.i4.1
+				IL_0174: ldelem.ref
+				IL_0175: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_017a: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_017f: volatile.
+				IL_0181: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+				IL_0186: brfalse IL_019a
 
-				IL_01b2: ldstr "inc"
-				IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_01bc: br IL_01d5
+				IL_018b: ldstr "value"
+				IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0195: br IL_01ae
 
-				IL_01c1: ldstr "inc"
-				IL_01c6: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:41"
-				IL_01cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-				IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+				IL_019a: ldstr "value"
+				IL_019f: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:36"
+				IL_01a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_01d5: pop
-				IL_01d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_01db: stloc.0
-				IL_01dc: volatile.
-				IL_01de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-				IL_01e3: brfalse IL_01f8
+				IL_01ae: stloc.s 4
+				IL_01b0: ldloc.0
+				IL_01b1: ldstr "value0:"
+				IL_01b6: ldloc.s 4
+				IL_01b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_01bd: pop
+				IL_01be: ldarg.0
+				IL_01bf: ldc.i4.1
+				IL_01c0: ldelem.ref
+				IL_01c1: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_01c6: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01d0: volatile.
+				IL_01d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_01d7: brfalse IL_01eb
 
-				IL_01e8: ldarg.2
-				IL_01e9: ldstr "value"
-				IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01f3: br IL_020d
+				IL_01dc: ldstr "inc"
+				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01e6: br IL_01ff
 
-				IL_01f8: ldarg.2
-				IL_01f9: ldstr "value"
-				IL_01fe: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:47"
-				IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-				IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_01eb: ldstr "inc"
+				IL_01f0: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:41"
+				IL_01f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-				IL_020d: stloc.s 4
-				IL_020f: ldloc.0
-				IL_0210: ldstr "value1:"
-				IL_0215: ldloc.s 4
-				IL_0217: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_021c: pop
-				IL_021d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0222: stloc.0
-				IL_0223: ldarg.0
-				IL_0224: ldc.i4.1
-				IL_0225: ldelem.ref
-				IL_0226: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
-				IL_022b: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_0230: volatile.
-				IL_0232: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_0237: brfalse IL_024b
+				IL_01ff: pop
+				IL_0200: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0205: stloc.0
+				IL_0206: volatile.
+				IL_0208: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_020d: brfalse IL_0222
 
-				IL_023c: ldstr "default"
-				IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0246: br IL_025f
+				IL_0212: ldarg.2
+				IL_0213: ldstr "value"
+				IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_021d: br IL_0237
 
-				IL_024b: ldstr "default"
-				IL_0250: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:54"
-				IL_0255: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0222: ldarg.2
+				IL_0223: ldstr "value"
+				IL_0228: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:47"
+				IL_022d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_025f: stloc.s 4
-				IL_0261: volatile.
-				IL_0263: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-				IL_0268: brfalse IL_027e
+				IL_0237: stloc.s 4
+				IL_0239: ldloc.0
+				IL_023a: ldstr "value1:"
+				IL_023f: ldloc.s 4
+				IL_0241: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0246: pop
+				IL_0247: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_024c: stloc.0
+				IL_024d: ldarg.0
+				IL_024e: ldc.i4.1
+				IL_024f: ldelem.ref
+				IL_0250: castclass Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope
+				IL_0255: ldfld object Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_025a: volatile.
+				IL_025c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_0261: brfalse IL_0275
 
-				IL_026d: ldloc.s 4
-				IL_026f: ldstr "value"
-				IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0279: br IL_0294
+				IL_0266: ldstr "default"
+				IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0270: br IL_0289
 
-				IL_027e: ldloc.s 4
-				IL_0280: ldstr "value"
-				IL_0285: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:56"
-				IL_028a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-				IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0275: ldstr "default"
+				IL_027a: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:54"
+				IL_027f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0294: stloc.s 4
-				IL_0296: ldloc.0
-				IL_0297: ldstr "default1:"
-				IL_029c: ldloc.s 4
-				IL_029e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_02a3: pop
-				IL_02a4: ldnull
-				IL_02a5: ret
+				IL_0289: stloc.s 4
+				IL_028b: volatile.
+				IL_028d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_0292: brfalse IL_02a8
+
+				IL_0297: ldloc.s 4
+				IL_0299: ldstr "value"
+				IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02a3: br IL_02be
+
+				IL_02a8: ldloc.s 4
+				IL_02aa: ldstr "value"
+				IL_02af: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M8>:__js_call__:56"
+				IL_02b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_02be: stloc.s 4
+				IL_02c0: ldloc.0
+				IL_02c1: ldstr "default1:"
+				IL_02c6: ldloc.s 4
+				IL_02c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_02cd: pop
+				IL_02ce: ldnull
+				IL_02cf: ret
 			} // end of method ArrowFunction_L4C72::__js_call__
 
 		} // end of class ArrowFunction_L4C72
@@ -764,7 +776,7 @@
 			IL_0018: brfalse IL_0057
 
 			IL_001d: volatile.
-			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_0024: brfalse IL_0039
 
 			IL_0029: ldarg.1
@@ -775,7 +787,7 @@
 			IL_0039: ldarg.1
 			IL_003a: ldstr "message"
 			IL_003f: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M7>:__js_call__:10"
-			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004e: stloc.3
@@ -793,7 +805,7 @@
 			IL_0063: brfalse IL_00a1
 
 			IL_0068: volatile.
-			IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_006f: brfalse IL_0084
 
 			IL_0074: ldarg.1
@@ -804,7 +816,7 @@
 			IL_0084: ldarg.1
 			IL_0085: ldstr "message"
 			IL_008a: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M7>:__js_call__:20"
-			IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0099: stloc.3
@@ -861,7 +873,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 189 (0xbd)
+		// Code size: 230 (0xe6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_DynamicImport_Cjs_Namespace/Scope,
@@ -943,12 +955,25 @@
 		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L13C10/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace/ArrowFunction_L13C10/FunctionObject>(!!0)
 		IL_00ab: stloc.s 5
-		IL_00ad: ldloc.s 4
-		IL_00af: ldstr "catch"
-		IL_00b4: ldloc.s 5
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ret
+		IL_00ad: volatile.
+		IL_00af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_00b4: brfalse IL_00cc
+
+		IL_00b9: ldloc.s 4
+		IL_00bb: ldstr "catch"
+		IL_00c0: ldloc.s 5
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c7: br IL_00e4
+
+		IL_00cc: ldloc.s 4
+		IL_00ce: ldstr "catch"
+		IL_00d3: ldloc.s 5
+		IL_00d5: ldstr "Import_DynamicImport_Cjs_Namespace:Modules.Import_DynamicImport_Cjs_Namespace:__js_module_init__:14"
+		IL_00da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00e4: pop
+		IL_00e5: ret
 	} // end of method Import_DynamicImport_Cjs_Namespace::__js_module_init__
 
 } // end of class Modules.Import_DynamicImport_Cjs_Namespace
@@ -1354,6 +1379,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
 	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -220,7 +220,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 466 (0x1d2)
+				// Code size: 508 (0x1fc)
 				.maxstack 9
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -263,7 +263,7 @@
 				IL_004b: ldloc.1
 				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0051: volatile.
-				IL_0053: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+				IL_0053: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 				IL_0058: brfalse IL_006c
 
 				IL_005d: ldstr "sort"
@@ -272,119 +272,131 @@
 
 				IL_006c: ldstr "sort"
 				IL_0071: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:14"
-				IL_0076: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+				IL_0076: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0080: stloc.1
 				IL_0081: ldloc.1
 				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0087: ldstr "join"
-				IL_008c: ldstr ","
-				IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0096: stloc.1
-				IL_0097: ldloc.0
-				IL_0098: ldstr "keys:"
-				IL_009d: ldloc.1
-				IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_00a3: pop
-				IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_00a9: stloc.0
-				IL_00aa: ldarg.0
-				IL_00ab: ldc.i4.1
-				IL_00ac: ldelem.ref
-				IL_00ad: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
-				IL_00b2: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_00b7: volatile.
-				IL_00b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-				IL_00be: brfalse IL_00d2
+				IL_0087: volatile.
+				IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+				IL_008e: brfalse IL_00a7
 
-				IL_00c3: ldstr "value"
-				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00cd: br IL_00e6
+				IL_0093: ldstr "join"
+				IL_0098: ldstr ","
+				IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00a2: br IL_00c0
 
-				IL_00d2: ldstr "value"
-				IL_00d7: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:24"
-				IL_00dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-				IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_00a7: ldstr "join"
+				IL_00ac: ldstr ","
+				IL_00b1: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:17"
+				IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_00e6: stloc.1
-				IL_00e7: ldloc.0
-				IL_00e8: ldstr "value0:"
-				IL_00ed: ldloc.1
-				IL_00ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_00f3: pop
-				IL_00f4: ldarg.0
-				IL_00f5: ldc.i4.1
-				IL_00f6: ldelem.ref
-				IL_00f7: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
-				IL_00fc: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0106: volatile.
-				IL_0108: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-				IL_010d: brfalse IL_0121
+				IL_00c0: stloc.1
+				IL_00c1: ldloc.0
+				IL_00c2: ldstr "keys:"
+				IL_00c7: ldloc.1
+				IL_00c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_00cd: pop
+				IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_00d3: stloc.0
+				IL_00d4: ldarg.0
+				IL_00d5: ldc.i4.1
+				IL_00d6: ldelem.ref
+				IL_00d7: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
+				IL_00dc: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_00e1: volatile.
+				IL_00e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+				IL_00e8: brfalse IL_00fc
 
-				IL_0112: ldstr "inc"
-				IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_011c: br IL_0135
+				IL_00ed: ldstr "value"
+				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00f7: br IL_0110
 
-				IL_0121: ldstr "inc"
-				IL_0126: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:29"
-				IL_012b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-				IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+				IL_00fc: ldstr "value"
+				IL_0101: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:24"
+				IL_0106: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0135: pop
-				IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_013b: stloc.0
-				IL_013c: volatile.
-				IL_013e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-				IL_0143: brfalse IL_0158
+				IL_0110: stloc.1
+				IL_0111: ldloc.0
+				IL_0112: ldstr "value0:"
+				IL_0117: ldloc.1
+				IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_011d: pop
+				IL_011e: ldarg.0
+				IL_011f: ldc.i4.1
+				IL_0120: ldelem.ref
+				IL_0121: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
+				IL_0126: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0130: volatile.
+				IL_0132: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_0137: brfalse IL_014b
 
-				IL_0148: ldarg.2
-				IL_0149: ldstr "value"
-				IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0153: br IL_016d
+				IL_013c: ldstr "inc"
+				IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0146: br IL_015f
 
-				IL_0158: ldarg.2
-				IL_0159: ldstr "value"
-				IL_015e: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:35"
-				IL_0163: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-				IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_014b: ldstr "inc"
+				IL_0150: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:29"
+				IL_0155: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-				IL_016d: stloc.1
-				IL_016e: ldloc.0
-				IL_016f: ldstr "value1:"
-				IL_0174: ldloc.1
-				IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_017a: pop
-				IL_017b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0180: stloc.0
-				IL_0181: ldarg.0
-				IL_0182: ldc.i4.1
-				IL_0183: ldelem.ref
-				IL_0184: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
-				IL_0189: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
-				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0193: volatile.
-				IL_0195: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_019a: brfalse IL_01ae
+				IL_015f: pop
+				IL_0160: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0165: stloc.0
+				IL_0166: volatile.
+				IL_0168: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_016d: brfalse IL_0182
 
-				IL_019f: ldstr "default"
-				IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_01a9: br IL_01c2
+				IL_0172: ldarg.2
+				IL_0173: ldstr "value"
+				IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_017d: br IL_0197
 
-				IL_01ae: ldstr "default"
-				IL_01b3: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:42"
-				IL_01b8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+				IL_0182: ldarg.2
+				IL_0183: ldstr "value"
+				IL_0188: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:35"
+				IL_018d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_01c2: stloc.1
-				IL_01c3: ldloc.0
-				IL_01c4: ldstr "default1:"
-				IL_01c9: ldloc.1
-				IL_01ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_01cf: pop
-				IL_01d0: ldnull
-				IL_01d1: ret
+				IL_0197: stloc.1
+				IL_0198: ldloc.0
+				IL_0199: ldstr "value1:"
+				IL_019e: ldloc.1
+				IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_01a4: pop
+				IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_01aa: stloc.0
+				IL_01ab: ldarg.0
+				IL_01ac: ldc.i4.1
+				IL_01ad: ldelem.ref
+				IL_01ae: castclass Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope
+				IL_01b3: ldfld object Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L3C61/Scope::nsA
+				IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01bd: volatile.
+				IL_01bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_01c4: brfalse IL_01d8
+
+				IL_01c9: ldstr "default"
+				IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01d3: br IL_01ec
+
+				IL_01d8: ldstr "default"
+				IL_01dd: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M8>:__js_call__:42"
+				IL_01e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+				IL_01ec: stloc.1
+				IL_01ed: ldloc.0
+				IL_01ee: ldstr "default1:"
+				IL_01f3: ldloc.1
+				IL_01f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_01f9: pop
+				IL_01fa: ldnull
+				IL_01fb: ret
 			} // end of method ArrowFunction_L4C72::__js_call__
 
 		} // end of class ArrowFunction_L4C72
@@ -696,7 +708,7 @@
 			IL_0018: brfalse IL_0057
 
 			IL_001d: volatile.
-			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_0024: brfalse IL_0039
 
 			IL_0029: ldarg.1
@@ -707,7 +719,7 @@
 			IL_0039: ldarg.1
 			IL_003a: ldstr "message"
 			IL_003f: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M7>:__js_call__:10"
-			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004e: stloc.3
@@ -725,7 +737,7 @@
 			IL_0063: brfalse IL_00a1
 
 			IL_0068: volatile.
-			IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_006f: brfalse IL_0084
 
 			IL_0074: ldarg.1
@@ -736,7 +748,7 @@
 			IL_0084: ldarg.1
 			IL_0085: ldstr "message"
 			IL_008a: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M7>:__js_call__:20"
-			IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0099: stloc.3
@@ -793,7 +805,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 189 (0xbd)
+		// Code size: 230 (0xe6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_DynamicImport_Esm_Namespace/Scope,
@@ -875,12 +887,25 @@
 		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L12C10/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Esm_Namespace/ArrowFunction_L12C10/FunctionObject>(!!0)
 		IL_00ab: stloc.s 5
-		IL_00ad: ldloc.s 4
-		IL_00af: ldstr "catch"
-		IL_00b4: ldloc.s 5
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ret
+		IL_00ad: volatile.
+		IL_00af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_00b4: brfalse IL_00cc
+
+		IL_00b9: ldloc.s 4
+		IL_00bb: ldstr "catch"
+		IL_00c0: ldloc.s 5
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c7: br IL_00e4
+
+		IL_00cc: ldloc.s 4
+		IL_00ce: ldstr "catch"
+		IL_00d3: ldloc.s 5
+		IL_00d5: ldstr "Import_DynamicImport_Esm_Namespace:Modules.Import_DynamicImport_Esm_Namespace:__js_module_init__:14"
+		IL_00da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00e4: pop
+		IL_00e5: ret
 	} // end of method Import_DynamicImport_Esm_Namespace::__js_module_init__
 
 } // end of class Modules.Import_DynamicImport_Esm_Namespace
@@ -1367,6 +1392,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -137,7 +137,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1243 (0x4db)
+		// Code size: 1663 (0x67f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url/Scope,
@@ -196,363 +196,483 @@
 		IL_0079: stloc.s 6
 		IL_007b: ldloc.s 6
 		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0082: ldstr "split"
-		IL_0087: ldstr "\\"
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0091: stloc.s 6
-		IL_0093: ldloc.s 6
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009a: ldstr "join"
-		IL_009f: ldstr "/"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a9: stloc.2
-		IL_00aa: ldloc.1
-		IL_00ab: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
-		IL_00b0: stloc.s 6
-		IL_00b2: ldarg.3
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_00b8: stloc.s 7
-		IL_00ba: volatile.
-		IL_00bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00c1: brfalse IL_00d7
+		IL_0082: volatile.
+		IL_0084: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0089: brfalse IL_00a2
 
-		IL_00c6: ldloc.s 7
-		IL_00c8: ldstr "url"
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d2: br IL_00ed
+		IL_008e: ldstr "split"
+		IL_0093: ldstr "\\"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009d: br IL_00bb
 
-		IL_00d7: ldloc.s 7
-		IL_00d9: ldstr "url"
-		IL_00de: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:34"
-		IL_00e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00a2: ldstr "split"
+		IL_00a7: ldstr "\\"
+		IL_00ac: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:23"
+		IL_00b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00ed: stloc.s 7
-		IL_00ef: ldloc.s 6
-		IL_00f1: dup
-		IL_00f2: ldstr "./fixtures/main.txt"
-		IL_00f7: ldloc.s 7
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_00fe: stloc.s 7
-		IL_0100: ldloc.1
-		IL_0101: ldloc.s 7
-		IL_0103: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_0108: stloc.s 7
-		IL_010a: ldloc.s 7
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0111: ldstr "split"
-		IL_0116: ldstr "\\"
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0120: stloc.s 7
-		IL_0122: ldloc.s 7
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0129: ldstr "join"
-		IL_012e: ldstr "/"
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0138: stloc.3
-		IL_0139: ldloc.0
-		IL_013a: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_013f: stloc.s 7
-		IL_0141: ldloc.s 7
-		IL_0143: ldstr "importedUrl"
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_014d: stloc.s 7
-		IL_014f: ldloc.1
-		IL_0150: ldloc.s 7
-		IL_0152: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_0157: stloc.s 7
-		IL_0159: ldloc.s 7
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0160: ldstr "split"
-		IL_0165: ldstr "\\"
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016f: stloc.s 7
-		IL_0171: ldloc.s 7
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0178: ldstr "join"
-		IL_017d: ldstr "/"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0187: stloc.s 4
-		IL_0189: ldloc.1
-		IL_018a: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
-		IL_018f: stloc.s 7
-		IL_0191: ldloc.0
-		IL_0192: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_0197: stloc.s 6
-		IL_0199: ldloc.s 6
-		IL_019b: ldstr "importedUrl"
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_01a5: stloc.s 6
-		IL_01a7: ldloc.s 7
-		IL_01a9: dup
-		IL_01aa: ldstr "./fixtures/lib.txt"
-		IL_01af: ldloc.s 6
-		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_01b6: stloc.s 6
-		IL_01b8: ldloc.1
-		IL_01b9: ldloc.s 6
-		IL_01bb: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_01c0: stloc.s 6
-		IL_01c2: ldloc.s 6
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c9: ldstr "split"
-		IL_01ce: ldstr "\\"
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d8: stloc.s 6
-		IL_01da: ldloc.s 6
-		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e1: ldstr "join"
-		IL_01e6: ldstr "/"
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f0: stloc.s 5
-		IL_01f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f7: stloc.s 8
-		IL_01f9: ldarg.3
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_01ff: stloc.s 6
-		IL_0201: volatile.
-		IL_0203: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0208: brfalse IL_021e
+		IL_00bb: stloc.s 6
+		IL_00bd: ldloc.s 6
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c4: volatile.
+		IL_00c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cb: brfalse IL_00e4
 
-		IL_020d: ldloc.s 6
-		IL_020f: ldstr "url"
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0219: br IL_0234
+		IL_00d0: ldstr "join"
+		IL_00d5: ldstr "/"
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00df: br IL_00fd
 
-		IL_021e: ldloc.s 6
-		IL_0220: ldstr "url"
-		IL_0225: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:77"
-		IL_022a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00e4: ldstr "join"
+		IL_00e9: ldstr "/"
+		IL_00ee: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:26"
+		IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0234: stloc.s 6
-		IL_0236: ldloc.s 6
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023d: stloc.s 6
-		IL_023f: ldc.i4.0
-		IL_0240: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0245: brfalse IL_0281
+		IL_00fd: stloc.2
+		IL_00fe: ldloc.1
+		IL_00ff: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
+		IL_0104: stloc.s 6
+		IL_0106: ldarg.3
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_010c: stloc.s 7
+		IL_010e: volatile.
+		IL_0110: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0115: brfalse IL_012b
 
-		IL_024a: ldloc.s 6
-		IL_024c: isinst [System.Runtime]System.String
-		IL_0251: dup
-		IL_0252: brtrue IL_026a
+		IL_011a: ldloc.s 7
+		IL_011c: ldstr "url"
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0126: br IL_0141
 
-		IL_0257: pop
-		IL_0258: ldloc.s 6
-		IL_025a: ldstr "startsWith"
-		IL_025f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_0264: dup
-		IL_0265: brfalse IL_0280
+		IL_012b: ldloc.s 7
+		IL_012d: ldstr "url"
+		IL_0132: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:34"
+		IL_0137: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_026a: ldstr "file://"
-		IL_026f: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-		IL_0274: box [System.Runtime]System.Boolean
-		IL_0279: stloc.s 6
-		IL_027b: br IL_0294
+		IL_0141: stloc.s 7
+		IL_0143: ldloc.s 6
+		IL_0145: dup
+		IL_0146: ldstr "./fixtures/main.txt"
+		IL_014b: ldloc.s 7
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+		IL_0152: stloc.s 7
+		IL_0154: ldloc.1
+		IL_0155: ldloc.s 7
+		IL_0157: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_015c: stloc.s 7
+		IL_015e: ldloc.s 7
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0165: volatile.
+		IL_0167: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_016c: brfalse IL_0185
 
-		IL_0280: pop
+		IL_0171: ldstr "split"
+		IL_0176: ldstr "\\"
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0180: br IL_019e
 
-		IL_0281: ldloc.s 6
-		IL_0283: ldstr "startsWith"
-		IL_0288: ldstr "file://"
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0292: stloc.s 6
+		IL_0185: ldstr "split"
+		IL_018a: ldstr "\\"
+		IL_018f: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:39"
+		IL_0194: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0294: ldloc.s 8
-		IL_0296: ldstr "main has file url:"
-		IL_029b: ldloc.s 6
-		IL_029d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02a2: pop
-		IL_02a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02a8: stloc.s 8
-		IL_02aa: ldarg.3
-		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b0: ldstr "split"
-		IL_02b5: ldstr "\\"
-		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02bf: stloc.s 6
-		IL_02c1: ldloc.s 6
-		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c8: ldstr "join"
-		IL_02cd: ldstr "/"
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d7: stloc.s 6
-		IL_02d9: ldloc.2
-		IL_02da: ldloc.s 6
-		IL_02dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02e1: stloc.s 9
-		IL_02e3: ldloc.s 9
-		IL_02e5: box [System.Runtime]System.Boolean
-		IL_02ea: stloc.s 10
-		IL_02ec: ldloc.s 8
-		IL_02ee: ldstr "main path matches filename:"
-		IL_02f3: ldloc.s 10
-		IL_02f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02fa: pop
-		IL_02fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0300: stloc.s 8
-		IL_0302: ldloc.3
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0308: stloc.s 6
-		IL_030a: ldc.i4.0
-		IL_030b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0310: brfalse IL_034c
+		IL_019e: stloc.s 7
+		IL_01a0: ldloc.s 7
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a7: volatile.
+		IL_01a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01ae: brfalse IL_01c7
 
-		IL_0315: ldloc.s 6
-		IL_0317: isinst [System.Runtime]System.String
-		IL_031c: dup
-		IL_031d: brtrue IL_0335
+		IL_01b3: ldstr "join"
+		IL_01b8: ldstr "/"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c2: br IL_01e0
 
-		IL_0322: pop
-		IL_0323: ldloc.s 6
-		IL_0325: ldstr "endsWith"
-		IL_032a: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_032f: dup
-		IL_0330: brfalse IL_034b
+		IL_01c7: ldstr "join"
+		IL_01cc: ldstr "/"
+		IL_01d1: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:42"
+		IL_01d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0335: ldstr "/fixtures/main.txt"
-		IL_033a: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
-		IL_033f: box [System.Runtime]System.Boolean
-		IL_0344: stloc.s 6
-		IL_0346: br IL_035f
+		IL_01e0: stloc.3
+		IL_01e1: ldloc.0
+		IL_01e2: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_01e7: stloc.s 7
+		IL_01e9: ldloc.s 7
+		IL_01eb: ldstr "importedUrl"
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_01f5: stloc.s 7
+		IL_01f7: ldloc.1
+		IL_01f8: ldloc.s 7
+		IL_01fa: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_01ff: stloc.s 7
+		IL_0201: ldloc.s 7
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0208: volatile.
+		IL_020a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_020f: brfalse IL_0228
 
-		IL_034b: pop
+		IL_0214: ldstr "split"
+		IL_0219: ldstr "\\"
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0223: br IL_0241
 
-		IL_034c: ldloc.s 6
-		IL_034e: ldstr "endsWith"
-		IL_0353: ldstr "/fixtures/main.txt"
-		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_035d: stloc.s 6
+		IL_0228: ldstr "split"
+		IL_022d: ldstr "\\"
+		IL_0232: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:51"
+		IL_0237: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_035f: ldloc.s 8
-		IL_0361: ldstr "main asset path:"
-		IL_0366: ldloc.s 6
-		IL_0368: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_036d: pop
-		IL_036e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0373: stloc.s 8
-		IL_0375: ldloc.0
-		IL_0376: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_037b: stloc.s 6
-		IL_037d: ldloc.s 6
-		IL_037f: ldstr "importedUrlHasFileScheme"
-		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_0389: stloc.s 6
-		IL_038b: ldloc.s 8
-		IL_038d: ldstr "lib has file url:"
-		IL_0392: ldloc.s 6
-		IL_0394: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0399: pop
-		IL_039a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_039f: stloc.s 8
-		IL_03a1: ldloc.s 4
-		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03a8: stloc.s 6
-		IL_03aa: ldc.i4.0
-		IL_03ab: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_03b0: brfalse IL_03ec
+		IL_0241: stloc.s 7
+		IL_0243: ldloc.s 7
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024a: volatile.
+		IL_024c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0251: brfalse IL_026a
 
-		IL_03b5: ldloc.s 6
-		IL_03b7: isinst [System.Runtime]System.String
-		IL_03bc: dup
-		IL_03bd: brtrue IL_03d5
+		IL_0256: ldstr "join"
+		IL_025b: ldstr "/"
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0265: br IL_0283
 
-		IL_03c2: pop
-		IL_03c3: ldloc.s 6
-		IL_03c5: ldstr "endsWith"
-		IL_03ca: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_03cf: dup
-		IL_03d0: brfalse IL_03eb
+		IL_026a: ldstr "join"
+		IL_026f: ldstr "/"
+		IL_0274: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:54"
+		IL_0279: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03d5: ldstr "/Import_ImportMeta_Url_Lib"
-		IL_03da: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
-		IL_03df: box [System.Runtime]System.Boolean
-		IL_03e4: stloc.s 6
-		IL_03e6: br IL_03ff
+		IL_0283: stloc.s 4
+		IL_0285: ldloc.1
+		IL_0286: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
+		IL_028b: stloc.s 7
+		IL_028d: ldloc.0
+		IL_028e: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_0293: stloc.s 6
+		IL_0295: ldloc.s 6
+		IL_0297: ldstr "importedUrl"
+		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_02a1: stloc.s 6
+		IL_02a3: ldloc.s 7
+		IL_02a5: dup
+		IL_02a6: ldstr "./fixtures/lib.txt"
+		IL_02ab: ldloc.s 6
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+		IL_02b2: stloc.s 6
+		IL_02b4: ldloc.1
+		IL_02b5: ldloc.s 6
+		IL_02b7: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_02bc: stloc.s 6
+		IL_02be: ldloc.s 6
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c5: volatile.
+		IL_02c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02cc: brfalse IL_02e5
 
-		IL_03eb: pop
+		IL_02d1: ldstr "split"
+		IL_02d6: ldstr "\\"
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e0: br IL_02fe
 
-		IL_03ec: ldloc.s 6
-		IL_03ee: ldstr "endsWith"
-		IL_03f3: ldstr "/Import_ImportMeta_Url_Lib"
-		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03fd: stloc.s 6
+		IL_02e5: ldstr "split"
+		IL_02ea: ldstr "\\"
+		IL_02ef: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:66"
+		IL_02f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03ff: ldloc.s 8
-		IL_0401: ldstr "lib path:"
-		IL_0406: ldloc.s 6
-		IL_0408: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_040d: pop
-		IL_040e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0413: stloc.s 8
-		IL_0415: ldloc.s 5
-		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_041c: stloc.s 6
-		IL_041e: ldc.i4.0
-		IL_041f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0424: brfalse IL_0460
+		IL_02fe: stloc.s 6
+		IL_0300: ldloc.s 6
+		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0307: volatile.
+		IL_0309: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_030e: brfalse IL_0327
 
-		IL_0429: ldloc.s 6
-		IL_042b: isinst [System.Runtime]System.String
-		IL_0430: dup
-		IL_0431: brtrue IL_0449
+		IL_0313: ldstr "join"
+		IL_0318: ldstr "/"
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0322: br IL_0340
 
-		IL_0436: pop
-		IL_0437: ldloc.s 6
-		IL_0439: ldstr "endsWith"
-		IL_043e: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_0443: dup
-		IL_0444: brfalse IL_045f
+		IL_0327: ldstr "join"
+		IL_032c: ldstr "/"
+		IL_0331: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:69"
+		IL_0336: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0449: ldstr "/fixtures/lib.txt"
-		IL_044e: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
-		IL_0453: box [System.Runtime]System.Boolean
-		IL_0458: stloc.s 6
-		IL_045a: br IL_0473
+		IL_0340: stloc.s 5
+		IL_0342: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0347: stloc.s 8
+		IL_0349: ldarg.3
+		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_034f: stloc.s 6
+		IL_0351: volatile.
+		IL_0353: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0358: brfalse IL_036e
 
-		IL_045f: pop
+		IL_035d: ldloc.s 6
+		IL_035f: ldstr "url"
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0369: br IL_0384
 
-		IL_0460: ldloc.s 6
-		IL_0462: ldstr "endsWith"
-		IL_0467: ldstr "/fixtures/lib.txt"
-		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0471: stloc.s 6
+		IL_036e: ldloc.s 6
+		IL_0370: ldstr "url"
+		IL_0375: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:77"
+		IL_037a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0473: ldloc.s 8
-		IL_0475: ldstr "lib asset path:"
-		IL_047a: ldloc.s 6
-		IL_047c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0481: pop
-		IL_0482: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0487: stloc.s 8
-		IL_0489: ldloc.0
-		IL_048a: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_048f: stloc.s 6
-		IL_0491: ldloc.s 6
-		IL_0493: ldstr "importedModuleFilenameMatches"
-		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_049d: stloc.s 6
-		IL_049f: ldloc.s 8
-		IL_04a1: ldstr "lib module.filename:"
-		IL_04a6: ldloc.s 6
-		IL_04a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_04ad: pop
-		IL_04ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04b3: stloc.s 8
-		IL_04b5: ldloc.0
-		IL_04b6: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_04bb: stloc.s 6
-		IL_04bd: ldloc.s 6
-		IL_04bf: ldstr "importedModulePathMatches"
-		IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_04c9: stloc.s 6
-		IL_04cb: ldloc.s 8
-		IL_04cd: ldstr "lib module.path:"
-		IL_04d2: ldloc.s 6
-		IL_04d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_04d9: pop
-		IL_04da: ret
+		IL_0384: stloc.s 6
+		IL_0386: ldloc.s 6
+		IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_038d: stloc.s 6
+		IL_038f: ldc.i4.0
+		IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0395: brfalse IL_03d1
+
+		IL_039a: ldloc.s 6
+		IL_039c: isinst [System.Runtime]System.String
+		IL_03a1: dup
+		IL_03a2: brtrue IL_03ba
+
+		IL_03a7: pop
+		IL_03a8: ldloc.s 6
+		IL_03aa: ldstr "startsWith"
+		IL_03af: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_03b4: dup
+		IL_03b5: brfalse IL_03d0
+
+		IL_03ba: ldstr "file://"
+		IL_03bf: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_03c4: box [System.Runtime]System.Boolean
+		IL_03c9: stloc.s 6
+		IL_03cb: br IL_03e4
+
+		IL_03d0: pop
+
+		IL_03d1: ldloc.s 6
+		IL_03d3: ldstr "startsWith"
+		IL_03d8: ldstr "file://"
+		IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03e2: stloc.s 6
+
+		IL_03e4: ldloc.s 8
+		IL_03e6: ldstr "main has file url:"
+		IL_03eb: ldloc.s 6
+		IL_03ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03f2: pop
+		IL_03f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03f8: stloc.s 8
+		IL_03fa: ldarg.3
+		IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0400: volatile.
+		IL_0402: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0407: brfalse IL_0420
+
+		IL_040c: ldstr "split"
+		IL_0411: ldstr "\\"
+		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_041b: br IL_0439
+
+		IL_0420: ldstr "split"
+		IL_0425: ldstr "\\"
+		IL_042a: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:88"
+		IL_042f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0439: stloc.s 6
+		IL_043b: ldloc.s 6
+		IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0442: volatile.
+		IL_0444: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0449: brfalse IL_0462
+
+		IL_044e: ldstr "join"
+		IL_0453: ldstr "/"
+		IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_045d: br IL_047b
+
+		IL_0462: ldstr "join"
+		IL_0467: ldstr "/"
+		IL_046c: ldstr "Import_ImportMeta_Url:Modules.Import_ImportMeta_Url:__js_module_init__:91"
+		IL_0471: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_047b: stloc.s 6
+		IL_047d: ldloc.2
+		IL_047e: ldloc.s 6
+		IL_0480: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0485: stloc.s 9
+		IL_0487: ldloc.s 9
+		IL_0489: box [System.Runtime]System.Boolean
+		IL_048e: stloc.s 10
+		IL_0490: ldloc.s 8
+		IL_0492: ldstr "main path matches filename:"
+		IL_0497: ldloc.s 10
+		IL_0499: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_049e: pop
+		IL_049f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04a4: stloc.s 8
+		IL_04a6: ldloc.3
+		IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04ac: stloc.s 6
+		IL_04ae: ldc.i4.0
+		IL_04af: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_04b4: brfalse IL_04f0
+
+		IL_04b9: ldloc.s 6
+		IL_04bb: isinst [System.Runtime]System.String
+		IL_04c0: dup
+		IL_04c1: brtrue IL_04d9
+
+		IL_04c6: pop
+		IL_04c7: ldloc.s 6
+		IL_04c9: ldstr "endsWith"
+		IL_04ce: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_04d3: dup
+		IL_04d4: brfalse IL_04ef
+
+		IL_04d9: ldstr "/fixtures/main.txt"
+		IL_04de: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_04e3: box [System.Runtime]System.Boolean
+		IL_04e8: stloc.s 6
+		IL_04ea: br IL_0503
+
+		IL_04ef: pop
+
+		IL_04f0: ldloc.s 6
+		IL_04f2: ldstr "endsWith"
+		IL_04f7: ldstr "/fixtures/main.txt"
+		IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0501: stloc.s 6
+
+		IL_0503: ldloc.s 8
+		IL_0505: ldstr "main asset path:"
+		IL_050a: ldloc.s 6
+		IL_050c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0511: pop
+		IL_0512: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0517: stloc.s 8
+		IL_0519: ldloc.0
+		IL_051a: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_051f: stloc.s 6
+		IL_0521: ldloc.s 6
+		IL_0523: ldstr "importedUrlHasFileScheme"
+		IL_0528: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_052d: stloc.s 6
+		IL_052f: ldloc.s 8
+		IL_0531: ldstr "lib has file url:"
+		IL_0536: ldloc.s 6
+		IL_0538: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_053d: pop
+		IL_053e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0543: stloc.s 8
+		IL_0545: ldloc.s 4
+		IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_054c: stloc.s 6
+		IL_054e: ldc.i4.0
+		IL_054f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0554: brfalse IL_0590
+
+		IL_0559: ldloc.s 6
+		IL_055b: isinst [System.Runtime]System.String
+		IL_0560: dup
+		IL_0561: brtrue IL_0579
+
+		IL_0566: pop
+		IL_0567: ldloc.s 6
+		IL_0569: ldstr "endsWith"
+		IL_056e: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0573: dup
+		IL_0574: brfalse IL_058f
+
+		IL_0579: ldstr "/Import_ImportMeta_Url_Lib"
+		IL_057e: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_0583: box [System.Runtime]System.Boolean
+		IL_0588: stloc.s 6
+		IL_058a: br IL_05a3
+
+		IL_058f: pop
+
+		IL_0590: ldloc.s 6
+		IL_0592: ldstr "endsWith"
+		IL_0597: ldstr "/Import_ImportMeta_Url_Lib"
+		IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05a1: stloc.s 6
+
+		IL_05a3: ldloc.s 8
+		IL_05a5: ldstr "lib path:"
+		IL_05aa: ldloc.s 6
+		IL_05ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_05b1: pop
+		IL_05b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05b7: stloc.s 8
+		IL_05b9: ldloc.s 5
+		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05c0: stloc.s 6
+		IL_05c2: ldc.i4.0
+		IL_05c3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_05c8: brfalse IL_0604
+
+		IL_05cd: ldloc.s 6
+		IL_05cf: isinst [System.Runtime]System.String
+		IL_05d4: dup
+		IL_05d5: brtrue IL_05ed
+
+		IL_05da: pop
+		IL_05db: ldloc.s 6
+		IL_05dd: ldstr "endsWith"
+		IL_05e2: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_05e7: dup
+		IL_05e8: brfalse IL_0603
+
+		IL_05ed: ldstr "/fixtures/lib.txt"
+		IL_05f2: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_05f7: box [System.Runtime]System.Boolean
+		IL_05fc: stloc.s 6
+		IL_05fe: br IL_0617
+
+		IL_0603: pop
+
+		IL_0604: ldloc.s 6
+		IL_0606: ldstr "endsWith"
+		IL_060b: ldstr "/fixtures/lib.txt"
+		IL_0610: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0615: stloc.s 6
+
+		IL_0617: ldloc.s 8
+		IL_0619: ldstr "lib asset path:"
+		IL_061e: ldloc.s 6
+		IL_0620: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0625: pop
+		IL_0626: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_062b: stloc.s 8
+		IL_062d: ldloc.0
+		IL_062e: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_0633: stloc.s 6
+		IL_0635: ldloc.s 6
+		IL_0637: ldstr "importedModuleFilenameMatches"
+		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_0641: stloc.s 6
+		IL_0643: ldloc.s 8
+		IL_0645: ldstr "lib module.filename:"
+		IL_064a: ldloc.s 6
+		IL_064c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0651: pop
+		IL_0652: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0657: stloc.s 8
+		IL_0659: ldloc.0
+		IL_065a: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_065f: stloc.s 6
+		IL_0661: ldloc.s 6
+		IL_0663: ldstr "importedModulePathMatches"
+		IL_0668: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_066d: stloc.s 6
+		IL_066f: ldloc.s 8
+		IL_0671: ldstr "lib module.path:"
+		IL_0676: ldloc.s 6
+		IL_0678: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_067d: pop
+		IL_067e: ret
 	} // end of method Import_ImportMeta_Url::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url
@@ -592,7 +712,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 534 (0x216)
+		// Code size: 702 (0x2be)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url_Lib/Scope,
@@ -630,7 +750,7 @@
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
 		IL_0053: stloc.s 5
 		IL_0055: volatile.
-		IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 		IL_005c: brfalse IL_0072
 
 		IL_0061: ldloc.s 5
@@ -641,7 +761,7 @@
 		IL_0072: ldloc.s 5
 		IL_0074: ldstr "url"
 		IL_0079: ldstr "Import_ImportMeta_Url_Lib:Modules.Import_ImportMeta_Url_Lib:__js_module_init__:21"
-		IL_007e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_007e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0088: stloc.1
@@ -689,7 +809,7 @@
 		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
 		IL_0105: pop
 		IL_0106: volatile.
-		IL_0108: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0108: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 		IL_010d: brfalse IL_0122
 
 		IL_0112: ldarg.2
@@ -700,7 +820,7 @@
 		IL_0122: ldarg.2
 		IL_0123: ldstr "filename"
 		IL_0128: ldstr "Import_ImportMeta_Url_Lib:Modules.Import_ImportMeta_Url_Lib:__js_module_init__:37"
-		IL_012d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_012d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0137: stloc.s 5
@@ -717,7 +837,7 @@
 		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
 		IL_015b: pop
 		IL_015c: volatile.
-		IL_015e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_015e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 		IL_0163: brfalse IL_0178
 
 		IL_0168: ldarg.2
@@ -728,47 +848,95 @@
 		IL_0178: ldarg.2
 		IL_0179: ldstr "path"
 		IL_017e: ldstr "Import_ImportMeta_Url_Lib:Modules.Import_ImportMeta_Url_Lib:__js_module_init__:48"
-		IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_018d: stloc.s 5
 		IL_018f: ldloc.s 5
 		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0196: ldstr "split"
-		IL_019b: ldstr "\\"
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a5: stloc.s 5
-		IL_01a7: ldloc.s 5
-		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ae: ldstr "join"
-		IL_01b3: ldstr "/"
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bd: stloc.s 5
-		IL_01bf: ldarg.s __dirname
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c6: ldstr "split"
-		IL_01cb: ldstr "\\"
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d5: stloc.s 7
-		IL_01d7: ldloc.s 7
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01de: ldstr "join"
-		IL_01e3: ldstr "/"
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ed: stloc.s 7
-		IL_01ef: ldloc.s 5
-		IL_01f1: ldloc.s 7
-		IL_01f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01f8: stloc.s 4
-		IL_01fa: ldloc.s 4
-		IL_01fc: box [System.Runtime]System.Boolean
-		IL_0201: stloc.s 6
-		IL_0203: ldstr "Import_ImportMeta_Url_Lib"
-		IL_0208: ldstr "importedModulePathMatches"
-		IL_020d: ldloc.s 6
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
-		IL_0214: pop
-		IL_0215: ret
+		IL_0196: volatile.
+		IL_0198: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_019d: brfalse IL_01b6
+
+		IL_01a2: ldstr "split"
+		IL_01a7: ldstr "\\"
+		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b1: br IL_01cf
+
+		IL_01b6: ldstr "split"
+		IL_01bb: ldstr "\\"
+		IL_01c0: ldstr "Import_ImportMeta_Url_Lib:Modules.Import_ImportMeta_Url_Lib:__js_module_init__:51"
+		IL_01c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01cf: stloc.s 5
+		IL_01d1: ldloc.s 5
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d8: volatile.
+		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_01df: brfalse IL_01f8
+
+		IL_01e4: ldstr "join"
+		IL_01e9: ldstr "/"
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f3: br IL_0211
+
+		IL_01f8: ldstr "join"
+		IL_01fd: ldstr "/"
+		IL_0202: ldstr "Import_ImportMeta_Url_Lib:Modules.Import_ImportMeta_Url_Lib:__js_module_init__:54"
+		IL_0207: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0211: stloc.s 5
+		IL_0213: ldarg.s __dirname
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021a: volatile.
+		IL_021c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0221: brfalse IL_023a
+
+		IL_0226: ldstr "split"
+		IL_022b: ldstr "\\"
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0235: br IL_0253
+
+		IL_023a: ldstr "split"
+		IL_023f: ldstr "\\"
+		IL_0244: ldstr "Import_ImportMeta_Url_Lib:Modules.Import_ImportMeta_Url_Lib:__js_module_init__:58"
+		IL_0249: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0253: stloc.s 7
+		IL_0255: ldloc.s 7
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025c: volatile.
+		IL_025e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0263: brfalse IL_027c
+
+		IL_0268: ldstr "join"
+		IL_026d: ldstr "/"
+		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0277: br IL_0295
+
+		IL_027c: ldstr "join"
+		IL_0281: ldstr "/"
+		IL_0286: ldstr "Import_ImportMeta_Url_Lib:Modules.Import_ImportMeta_Url_Lib:__js_module_init__:61"
+		IL_028b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0295: stloc.s 7
+		IL_0297: ldloc.s 5
+		IL_0299: ldloc.s 7
+		IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02a0: stloc.s 4
+		IL_02a2: ldloc.s 4
+		IL_02a4: box [System.Runtime]System.Boolean
+		IL_02a9: stloc.s 6
+		IL_02ab: ldstr "Import_ImportMeta_Url_Lib"
+		IL_02b0: ldstr "importedModulePathMatches"
+		IL_02b5: ldloc.s 6
+		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
+		IL_02bc: pop
+		IL_02bd: ret
 	} // end of method Import_ImportMeta_Url_Lib::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url_Lib
@@ -804,6 +972,20 @@
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
@@ -137,7 +137,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 943 (0x3af)
+		// Code size: 985 (0x3d9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_Esm_Basic/Scope,
@@ -189,262 +189,274 @@
 		IL_0076: stloc.2
 		IL_0077: ldloc.2
 		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007d: ldstr "join"
-		IL_0082: ldstr ","
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: stloc.2
-		IL_008d: ldloc.3
-		IL_008e: ldstr "keys:"
-		IL_0093: ldloc.2
-		IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0099: pop
-		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009f: stloc.3
-		IL_00a0: ldstr "Object"
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00aa: volatile.
-		IL_00ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_00b1: brfalse IL_00c5
+		IL_007d: volatile.
+		IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0084: brfalse IL_009d
 
-		IL_00b6: ldstr "prototype"
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c0: br IL_00d9
+		IL_0089: ldstr "join"
+		IL_008e: ldstr ","
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0098: br IL_00b6
 
-		IL_00c5: ldstr "prototype"
-		IL_00ca: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:30"
-		IL_00cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_009d: ldstr "join"
+		IL_00a2: ldstr ","
+		IL_00a7: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:22"
+		IL_00ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00d9: stloc.2
-		IL_00da: volatile.
-		IL_00dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_00e1: brfalse IL_00f6
+		IL_00b6: stloc.2
+		IL_00b7: ldloc.3
+		IL_00b8: ldstr "keys:"
+		IL_00bd: ldloc.2
+		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00c3: pop
+		IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c9: stloc.3
+		IL_00ca: ldstr "Object"
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d4: volatile.
+		IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_00db: brfalse IL_00ef
 
-		IL_00e6: ldloc.2
-		IL_00e7: ldstr "propertyIsEnumerable"
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f1: br IL_010b
+		IL_00e0: ldstr "prototype"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ea: br IL_0103
 
-		IL_00f6: ldloc.2
-		IL_00f7: ldstr "propertyIsEnumerable"
-		IL_00fc: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:32"
-		IL_0101: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00ef: ldstr "prototype"
+		IL_00f4: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:30"
+		IL_00f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_010b: stloc.2
-		IL_010c: ldloc.2
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0112: ldstr "call"
-		IL_0117: ldloc.1
-		IL_0118: ldstr "default"
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0122: stloc.2
-		IL_0123: ldloc.3
-		IL_0124: ldstr "enum.default:"
-		IL_0129: ldloc.2
-		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_012f: pop
-		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0135: stloc.3
-		IL_0136: ldstr "Object"
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0140: volatile.
-		IL_0142: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0147: brfalse IL_015b
+		IL_0103: stloc.2
+		IL_0104: volatile.
+		IL_0106: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_010b: brfalse IL_0120
 
-		IL_014c: ldstr "prototype"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0156: br IL_016f
+		IL_0110: ldloc.2
+		IL_0111: ldstr "propertyIsEnumerable"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011b: br IL_0135
 
-		IL_015b: ldstr "prototype"
-		IL_0160: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:43"
-		IL_0165: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0120: ldloc.2
+		IL_0121: ldstr "propertyIsEnumerable"
+		IL_0126: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:32"
+		IL_012b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_016f: stloc.2
-		IL_0170: volatile.
-		IL_0172: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0177: brfalse IL_018c
+		IL_0135: stloc.2
+		IL_0136: ldloc.2
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013c: ldstr "call"
+		IL_0141: ldloc.1
+		IL_0142: ldstr "default"
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_014c: stloc.2
+		IL_014d: ldloc.3
+		IL_014e: ldstr "enum.default:"
+		IL_0153: ldloc.2
+		IL_0154: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0159: pop
+		IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_015f: stloc.3
+		IL_0160: ldstr "Object"
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_016a: volatile.
+		IL_016c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0171: brfalse IL_0185
 
-		IL_017c: ldloc.2
-		IL_017d: ldstr "propertyIsEnumerable"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0187: br IL_01a1
+		IL_0176: ldstr "prototype"
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0180: br IL_0199
 
-		IL_018c: ldloc.2
-		IL_018d: ldstr "propertyIsEnumerable"
-		IL_0192: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:45"
-		IL_0197: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0185: ldstr "prototype"
+		IL_018a: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:43"
+		IL_018f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01a1: stloc.2
-		IL_01a2: ldloc.2
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a8: ldstr "call"
-		IL_01ad: ldloc.1
-		IL_01ae: ldstr "inc"
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01b8: stloc.2
-		IL_01b9: ldloc.3
-		IL_01ba: ldstr "enum.inc:"
-		IL_01bf: ldloc.2
-		IL_01c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01c5: pop
-		IL_01c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01cb: stloc.3
-		IL_01cc: ldstr "Object"
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d6: volatile.
-		IL_01d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_01dd: brfalse IL_01f1
+		IL_0199: stloc.2
+		IL_019a: volatile.
+		IL_019c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_01a1: brfalse IL_01b6
 
-		IL_01e2: ldstr "prototype"
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ec: br IL_0205
+		IL_01a6: ldloc.2
+		IL_01a7: ldstr "propertyIsEnumerable"
+		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b1: br IL_01cb
 
-		IL_01f1: ldstr "prototype"
-		IL_01f6: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:56"
-		IL_01fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01b6: ldloc.2
+		IL_01b7: ldstr "propertyIsEnumerable"
+		IL_01bc: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:45"
+		IL_01c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0205: stloc.2
-		IL_0206: volatile.
-		IL_0208: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_020d: brfalse IL_0222
+		IL_01cb: stloc.2
+		IL_01cc: ldloc.2
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d2: ldstr "call"
+		IL_01d7: ldloc.1
+		IL_01d8: ldstr "inc"
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01e2: stloc.2
+		IL_01e3: ldloc.3
+		IL_01e4: ldstr "enum.inc:"
+		IL_01e9: ldloc.2
+		IL_01ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01ef: pop
+		IL_01f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f5: stloc.3
+		IL_01f6: ldstr "Object"
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0200: volatile.
+		IL_0202: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0207: brfalse IL_021b
 
-		IL_0212: ldloc.2
-		IL_0213: ldstr "propertyIsEnumerable"
-		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_021d: br IL_0237
+		IL_020c: ldstr "prototype"
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0216: br IL_022f
 
-		IL_0222: ldloc.2
-		IL_0223: ldstr "propertyIsEnumerable"
-		IL_0228: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:58"
-		IL_022d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_021b: ldstr "prototype"
+		IL_0220: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:56"
+		IL_0225: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0237: stloc.2
-		IL_0238: ldloc.2
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023e: ldstr "call"
-		IL_0243: ldloc.1
-		IL_0244: ldstr "x"
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_024e: stloc.2
-		IL_024f: ldloc.3
-		IL_0250: ldstr "enum.x:"
-		IL_0255: ldloc.2
-		IL_0256: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_025b: pop
-		IL_025c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0261: stloc.3
-		IL_0262: volatile.
-		IL_0264: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0269: brfalse IL_027e
+		IL_022f: stloc.2
+		IL_0230: volatile.
+		IL_0232: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0237: brfalse IL_024c
 
-		IL_026e: ldloc.1
-		IL_026f: ldstr "x"
-		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0279: br IL_0293
+		IL_023c: ldloc.2
+		IL_023d: ldstr "propertyIsEnumerable"
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0247: br IL_0261
 
-		IL_027e: ldloc.1
-		IL_027f: ldstr "x"
-		IL_0284: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:67"
-		IL_0289: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_024c: ldloc.2
+		IL_024d: ldstr "propertyIsEnumerable"
+		IL_0252: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:58"
+		IL_0257: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0293: stloc.2
-		IL_0294: ldloc.3
-		IL_0295: ldstr "x0:"
-		IL_029a: ldloc.2
-		IL_029b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02a0: pop
-		IL_02a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02a6: stloc.3
-		IL_02a7: ldloc.1
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ad: volatile.
-		IL_02af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_02b4: brfalse IL_02c8
+		IL_0261: stloc.2
+		IL_0262: ldloc.2
+		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0268: ldstr "call"
+		IL_026d: ldloc.1
+		IL_026e: ldstr "x"
+		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0278: stloc.2
+		IL_0279: ldloc.3
+		IL_027a: ldstr "enum.x:"
+		IL_027f: ldloc.2
+		IL_0280: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0285: pop
+		IL_0286: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_028b: stloc.3
+		IL_028c: volatile.
+		IL_028e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0293: brfalse IL_02a8
 
-		IL_02b9: ldstr "default"
-		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02c3: br IL_02dc
+		IL_0298: ldloc.1
+		IL_0299: ldstr "x"
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a3: br IL_02bd
 
-		IL_02c8: ldstr "default"
-		IL_02cd: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:73"
-		IL_02d2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_02a8: ldloc.1
+		IL_02a9: ldstr "x"
+		IL_02ae: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:67"
+		IL_02b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02dc: stloc.2
-		IL_02dd: ldloc.3
-		IL_02de: ldstr "def0:"
-		IL_02e3: ldloc.2
-		IL_02e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02e9: pop
-		IL_02ea: ldloc.1
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f0: volatile.
-		IL_02f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_02f7: brfalse IL_030b
+		IL_02bd: stloc.2
+		IL_02be: ldloc.3
+		IL_02bf: ldstr "x0:"
+		IL_02c4: ldloc.2
+		IL_02c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02ca: pop
+		IL_02cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d0: stloc.3
+		IL_02d1: ldloc.1
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d7: volatile.
+		IL_02d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_02de: brfalse IL_02f2
 
-		IL_02fc: ldstr "inc"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0306: br IL_031f
+		IL_02e3: ldstr "default"
+		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02ed: br IL_0306
 
-		IL_030b: ldstr "inc"
-		IL_0310: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:77"
-		IL_0315: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_02f2: ldstr "default"
+		IL_02f7: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:73"
+		IL_02fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_031f: pop
-		IL_0320: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0325: stloc.3
-		IL_0326: volatile.
-		IL_0328: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_032d: brfalse IL_0342
+		IL_0306: stloc.2
+		IL_0307: ldloc.3
+		IL_0308: ldstr "def0:"
+		IL_030d: ldloc.2
+		IL_030e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0313: pop
+		IL_0314: ldloc.1
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_031a: volatile.
+		IL_031c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0321: brfalse IL_0335
 
-		IL_0332: ldloc.1
-		IL_0333: ldstr "x"
-		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_033d: br IL_0357
+		IL_0326: ldstr "inc"
+		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0330: br IL_0349
 
-		IL_0342: ldloc.1
-		IL_0343: ldstr "x"
-		IL_0348: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:82"
-		IL_034d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0335: ldstr "inc"
+		IL_033a: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:77"
+		IL_033f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0357: stloc.2
-		IL_0358: ldloc.3
-		IL_0359: ldstr "x1:"
-		IL_035e: ldloc.2
-		IL_035f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0364: pop
-		IL_0365: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_036a: stloc.3
-		IL_036b: ldloc.1
-		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0371: volatile.
-		IL_0373: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0378: brfalse IL_038c
+		IL_0349: pop
+		IL_034a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_034f: stloc.3
+		IL_0350: volatile.
+		IL_0352: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0357: brfalse IL_036c
 
-		IL_037d: ldstr "default"
-		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0387: br IL_03a0
+		IL_035c: ldloc.1
+		IL_035d: ldstr "x"
+		IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0367: br IL_0381
 
-		IL_038c: ldstr "default"
-		IL_0391: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:88"
-		IL_0396: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_036c: ldloc.1
+		IL_036d: ldstr "x"
+		IL_0372: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:82"
+		IL_0377: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03a0: stloc.2
-		IL_03a1: ldloc.3
-		IL_03a2: ldstr "def1:"
-		IL_03a7: ldloc.2
-		IL_03a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03ad: pop
-		IL_03ae: ret
+		IL_0381: stloc.2
+		IL_0382: ldloc.3
+		IL_0383: ldstr "x1:"
+		IL_0388: ldloc.2
+		IL_0389: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_038e: pop
+		IL_038f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0394: stloc.3
+		IL_0395: ldloc.1
+		IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_039b: volatile.
+		IL_039d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_03a2: brfalse IL_03b6
+
+		IL_03a7: ldstr "default"
+		IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_03b1: br IL_03ca
+
+		IL_03b6: ldstr "default"
+		IL_03bb: ldstr "Import_Namespace_Esm_Basic:Modules.Import_Namespace_Esm_Basic:__js_module_init__:88"
+		IL_03c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_03ca: stloc.2
+		IL_03cb: ldloc.3
+		IL_03cc: ldstr "def1:"
+		IL_03d1: ldloc.2
+		IL_03d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03d7: pop
+		IL_03d8: ret
 	} // end of method Import_Namespace_Esm_Basic::__js_module_init__
 
 } // end of class Modules.Import_Namespace_Esm_Basic
@@ -935,6 +947,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
@@ -194,7 +194,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 674 (0x2a2)
+		// Code size: 716 (0x2cc)
 		.maxstack 11
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable/Scope,
@@ -286,147 +286,159 @@
 		IL_00e0: stloc.3
 		IL_00e1: ldloc.3
 		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e7: ldstr "join"
-		IL_00ec: ldstr ","
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f6: stloc.3
-		IL_00f7: ldloc.2
-		IL_00f8: ldstr "keys:"
-		IL_00fd: ldloc.3
-		IL_00fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0103: pop
-		IL_0104: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0109: stloc.2
-		IL_010a: ldloc.0
-		IL_010b: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_A.mjs'
-		IL_0110: stloc.3
-		IL_0111: ldloc.3
-		IL_0112: ldstr "ns"
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_011c: volatile.
-		IL_011e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0123: brfalse IL_0137
+		IL_00e7: volatile.
+		IL_00e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00ee: brfalse IL_0107
 
-		IL_0128: ldstr "default"
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0132: br IL_014b
+		IL_00f3: ldstr "join"
+		IL_00f8: ldstr ","
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0102: br IL_0120
 
-		IL_0137: ldstr "default"
-		IL_013c: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:46"
-		IL_0141: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0107: ldstr "join"
+		IL_010c: ldstr ","
+		IL_0111: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:37"
+		IL_0116: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_014b: stloc.3
-		IL_014c: ldloc.0
-		IL_014d: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_A.mjs'
-		IL_0152: stloc.1
-		IL_0153: ldloc.1
-		IL_0154: ldstr "ns"
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_015e: volatile.
-		IL_0160: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0165: brfalse IL_0179
+		IL_0120: stloc.3
+		IL_0121: ldloc.2
+		IL_0122: ldstr "keys:"
+		IL_0127: ldloc.3
+		IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_012d: pop
+		IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0133: stloc.2
+		IL_0134: ldloc.0
+		IL_0135: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_A.mjs'
+		IL_013a: stloc.3
+		IL_013b: ldloc.3
+		IL_013c: ldstr "ns"
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_0146: volatile.
+		IL_0148: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_014d: brfalse IL_0161
 
-		IL_016a: ldstr "module.exports"
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0174: br IL_018d
+		IL_0152: ldstr "default"
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015c: br IL_0175
 
-		IL_0179: ldstr "module.exports"
-		IL_017e: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:51"
-		IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0161: ldstr "default"
+		IL_0166: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:46"
+		IL_016b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_018d: stloc.1
-		IL_018e: ldloc.3
-		IL_018f: ldloc.1
-		IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0195: stloc.s 4
-		IL_0197: ldloc.s 4
-		IL_0199: box [System.Runtime]System.Boolean
-		IL_019e: stloc.s 5
-		IL_01a0: ldloc.2
-		IL_01a1: ldstr "defaultIsModuleExports:"
-		IL_01a6: ldloc.s 5
-		IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01ad: pop
-		IL_01ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b3: stloc.2
-		IL_01b4: ldloc.0
-		IL_01b5: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_A.mjs'
-		IL_01ba: stloc.1
-		IL_01bb: ldloc.1
-		IL_01bc: ldstr "ns"
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_01c6: volatile.
-		IL_01c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_01cd: brfalse IL_01e1
+		IL_0175: stloc.3
+		IL_0176: ldloc.0
+		IL_0177: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_A.mjs'
+		IL_017c: stloc.1
+		IL_017d: ldloc.1
+		IL_017e: ldstr "ns"
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_0188: volatile.
+		IL_018a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_018f: brfalse IL_01a3
 
-		IL_01d2: ldstr "x"
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01dc: br IL_01f5
+		IL_0194: ldstr "module.exports"
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019e: br IL_01b7
 
-		IL_01e1: ldstr "x"
-		IL_01e6: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:62"
-		IL_01eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01a3: ldstr "module.exports"
+		IL_01a8: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:51"
+		IL_01ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01f5: stloc.1
-		IL_01f6: ldloc.2
-		IL_01f7: ldstr "x0:"
-		IL_01fc: ldloc.1
-		IL_01fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0202: pop
-		IL_0203: ldloc.0
-		IL_0204: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_A.mjs'
-		IL_0209: stloc.1
-		IL_020a: ldloc.1
-		IL_020b: ldstr "ns"
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_0215: stloc.1
-		IL_0216: ldloc.1
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021c: volatile.
-		IL_021e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0223: brfalse IL_0237
+		IL_01b7: stloc.1
+		IL_01b8: ldloc.3
+		IL_01b9: ldloc.1
+		IL_01ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01bf: stloc.s 4
+		IL_01c1: ldloc.s 4
+		IL_01c3: box [System.Runtime]System.Boolean
+		IL_01c8: stloc.s 5
+		IL_01ca: ldloc.2
+		IL_01cb: ldstr "defaultIsModuleExports:"
+		IL_01d0: ldloc.s 5
+		IL_01d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01d7: pop
+		IL_01d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01dd: stloc.2
+		IL_01de: ldloc.0
+		IL_01df: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_A.mjs'
+		IL_01e4: stloc.1
+		IL_01e5: ldloc.1
+		IL_01e6: ldstr "ns"
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_01f0: volatile.
+		IL_01f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_01f7: brfalse IL_020b
 
-		IL_0228: ldstr "inc"
-		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0232: br IL_024b
+		IL_01fc: ldstr "x"
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0206: br IL_021f
 
-		IL_0237: ldstr "inc"
-		IL_023c: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:69"
-		IL_0241: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_020b: ldstr "x"
+		IL_0210: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:62"
+		IL_0215: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_024b: pop
-		IL_024c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0251: stloc.2
-		IL_0252: ldloc.0
-		IL_0253: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_B.mjs'
-		IL_0258: stloc.1
-		IL_0259: ldloc.1
-		IL_025a: ldstr "ns"
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_0264: volatile.
-		IL_0266: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_026b: brfalse IL_027f
+		IL_021f: stloc.1
+		IL_0220: ldloc.2
+		IL_0221: ldstr "x0:"
+		IL_0226: ldloc.1
+		IL_0227: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_022c: pop
+		IL_022d: ldloc.0
+		IL_022e: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_A.mjs'
+		IL_0233: stloc.1
+		IL_0234: ldloc.1
+		IL_0235: ldstr "ns"
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_023f: stloc.1
+		IL_0240: ldloc.1
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0246: volatile.
+		IL_0248: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_024d: brfalse IL_0261
 
-		IL_0270: ldstr "x"
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_027a: br IL_0293
+		IL_0252: ldstr "inc"
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_025c: br IL_0275
 
-		IL_027f: ldstr "x"
-		IL_0284: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:77"
-		IL_0289: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0261: ldstr "inc"
+		IL_0266: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:69"
+		IL_026b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0293: stloc.1
-		IL_0294: ldloc.2
-		IL_0295: ldstr "x1:"
-		IL_029a: ldloc.1
-		IL_029b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02a0: pop
-		IL_02a1: ret
+		IL_0275: pop
+		IL_0276: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_027b: stloc.2
+		IL_027c: ldloc.0
+		IL_027d: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::'*esm-src:./Import_Namespace_FromCjs_Stable_B.mjs'
+		IL_0282: stloc.1
+		IL_0283: ldloc.1
+		IL_0284: ldstr "ns"
+		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_028e: volatile.
+		IL_0290: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0295: brfalse IL_02a9
+
+		IL_029a: ldstr "x"
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a4: br IL_02bd
+
+		IL_02a9: ldstr "x"
+		IL_02ae: ldstr "Import_Namespace_FromCjs_Stable:Modules.Import_Namespace_FromCjs_Stable:__js_module_init__:77"
+		IL_02b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02bd: stloc.1
+		IL_02be: ldloc.2
+		IL_02bf: ldstr "x1:"
+		IL_02c4: ldloc.1
+		IL_02c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02ca: pop
+		IL_02cb: ret
 	} // end of method Import_Namespace_FromCjs_Stable::__js_module_init__
 
 } // end of class Modules.Import_Namespace_FromCjs_Stable
@@ -672,7 +684,7 @@
 			IL_0007: ldarg.0
 			IL_0008: ldfld object Modules.Import_Namespace_FromCjs_Stable_Lib/Scope::exports
 			IL_000d: volatile.
-			IL_000f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_000f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_0014: brfalse IL_0028
 
 			IL_0019: ldstr "x"
@@ -681,7 +693,7 @@
 
 			IL_0028: ldstr "x"
 			IL_002d: ldstr "Import_Namespace_FromCjs_Stable_Lib:<TwoPhaseDummy_M10>:__js_call__:4"
-			IL_0032: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0032: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_003c: stloc.1
@@ -913,6 +925,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -1629,7 +1629,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 144 (0x90)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1646,7 +1646,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 30
 				IL_0016: clt
-				IL_0018: brfalse IL_0067
+				IL_0018: brfalse IL_008e
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -1661,23 +1661,36 @@
 				IL_003b: ldarg.0
 				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 				IL_0041: stloc.3
-				IL_0042: ldloc.2
-				IL_0043: ldstr "split"
-				IL_0048: ldloc.3
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004e: stloc.3
-				IL_004f: ldarg.0
-				IL_0050: ldloc.3
-				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0056: ldloc.0
-				IL_0057: ldc.r8 1
-				IL_0060: add
-				IL_0061: stloc.0
-				IL_0062: br IL_000a
+				IL_0042: volatile.
+				IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+				IL_0049: brfalse IL_005f
+
+				IL_004e: ldloc.2
+				IL_004f: ldstr "split"
+				IL_0054: ldloc.3
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_005a: br IL_0075
+
+				IL_005f: ldloc.2
+				IL_0060: ldstr "split"
+				IL_0065: ldloc.3
+				IL_0066: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M11>:__js_call__:13"
+				IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0075: stloc.3
+				IL_0076: ldarg.0
+				IL_0077: ldloc.3
+				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007d: ldloc.0
+				IL_007e: ldc.r8 1
+				IL_0087: add
+				IL_0088: stloc.0
+				IL_0089: br IL_000a
 			// end loop
 
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_008e: ldnull
+			IL_008f: ret
 		} // end of method FunctionExpression_L56C36::__js_call__
 
 	} // end of class FunctionExpression_L56C36
@@ -1997,7 +2010,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 144 (0x90)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -2014,7 +2027,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 30
 				IL_0016: clt
-				IL_0018: brfalse IL_0067
+				IL_0018: brfalse IL_008e
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -2029,23 +2042,36 @@
 				IL_003b: ldarg.0
 				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 				IL_0041: stloc.3
-				IL_0042: ldloc.2
-				IL_0043: ldstr "split"
-				IL_0048: ldloc.3
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004e: stloc.3
-				IL_004f: ldarg.0
-				IL_0050: ldloc.3
-				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0056: ldloc.0
-				IL_0057: ldc.r8 1
-				IL_0060: add
-				IL_0061: stloc.0
-				IL_0062: br IL_000a
+				IL_0042: volatile.
+				IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+				IL_0049: brfalse IL_005f
+
+				IL_004e: ldloc.2
+				IL_004f: ldstr "split"
+				IL_0054: ldloc.3
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_005a: br IL_0075
+
+				IL_005f: ldloc.2
+				IL_0060: ldstr "split"
+				IL_0065: ldloc.3
+				IL_0066: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M13>:__js_call__:13"
+				IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0075: stloc.3
+				IL_0076: ldarg.0
+				IL_0077: ldloc.3
+				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007d: ldloc.0
+				IL_007e: ldc.r8 1
+				IL_0087: add
+				IL_0088: stloc.0
+				IL_0089: br IL_000a
 			// end loop
 
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_008e: ldnull
+			IL_008f: ret
 		} // end of method FunctionExpression_L66C35::__js_call__
 
 	} // end of class FunctionExpression_L66C35
@@ -2365,7 +2391,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 144 (0x90)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -2382,7 +2408,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0067
+				IL_0018: brfalse IL_008e
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -2397,23 +2423,36 @@
 				IL_003b: ldarg.0
 				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 				IL_0041: stloc.3
-				IL_0042: ldloc.2
-				IL_0043: ldstr "split"
-				IL_0048: ldloc.3
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004e: stloc.3
-				IL_004f: ldarg.0
-				IL_0050: ldloc.3
-				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0056: ldloc.0
-				IL_0057: ldc.r8 1
-				IL_0060: add
-				IL_0061: stloc.0
-				IL_0062: br IL_000a
+				IL_0042: volatile.
+				IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+				IL_0049: brfalse IL_005f
+
+				IL_004e: ldloc.2
+				IL_004f: ldstr "split"
+				IL_0054: ldloc.3
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_005a: br IL_0075
+
+				IL_005f: ldloc.2
+				IL_0060: ldstr "split"
+				IL_0065: ldloc.3
+				IL_0066: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M15>:__js_call__:13"
+				IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0075: stloc.3
+				IL_0076: ldarg.0
+				IL_0077: ldloc.3
+				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007d: ldloc.0
+				IL_007e: ldc.r8 1
+				IL_0087: add
+				IL_0088: stloc.0
+				IL_0089: br IL_000a
 			// end loop
 
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_008e: ldnull
+			IL_008f: ret
 		} // end of method FunctionExpression_L76C39::__js_call__
 
 	} // end of class FunctionExpression_L76C39
@@ -2733,7 +2772,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 144 (0x90)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -2750,7 +2789,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0067
+				IL_0018: brfalse IL_008e
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -2765,23 +2804,36 @@
 				IL_003b: ldarg.0
 				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 				IL_0041: stloc.3
-				IL_0042: ldloc.2
-				IL_0043: ldstr "match"
-				IL_0048: ldloc.3
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004e: stloc.3
-				IL_004f: ldarg.0
-				IL_0050: ldloc.3
-				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0056: ldloc.0
-				IL_0057: ldc.r8 1
-				IL_0060: add
-				IL_0061: stloc.0
-				IL_0062: br IL_000a
+				IL_0042: volatile.
+				IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+				IL_0049: brfalse IL_005f
+
+				IL_004e: ldloc.2
+				IL_004f: ldstr "match"
+				IL_0054: ldloc.3
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_005a: br IL_0075
+
+				IL_005f: ldloc.2
+				IL_0060: ldstr "match"
+				IL_0065: ldloc.3
+				IL_0066: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M17>:__js_call__:13"
+				IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0075: stloc.3
+				IL_0076: ldarg.0
+				IL_0077: ldloc.3
+				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007d: ldloc.0
+				IL_007e: ldc.r8 1
+				IL_0087: add
+				IL_0088: stloc.0
+				IL_0089: br IL_000a
 			// end loop
 
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_008e: ldnull
+			IL_008f: ret
 		} // end of method FunctionExpression_L88C23::__js_call__
 
 	} // end of class FunctionExpression_L88C23
@@ -4181,7 +4233,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 144 (0x90)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -4198,7 +4250,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0067
+				IL_0018: brfalse IL_008e
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -4213,23 +4265,36 @@
 				IL_003b: ldarg.0
 				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 				IL_0041: stloc.3
-				IL_0042: ldloc.2
-				IL_0043: ldstr "match"
-				IL_0048: ldloc.3
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004e: stloc.3
-				IL_004f: ldarg.0
-				IL_0050: ldloc.3
-				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0056: ldloc.0
-				IL_0057: ldc.r8 1
-				IL_0060: add
-				IL_0061: stloc.0
-				IL_0062: br IL_000a
+				IL_0042: volatile.
+				IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+				IL_0049: brfalse IL_005f
+
+				IL_004e: ldloc.2
+				IL_004f: ldstr "match"
+				IL_0054: ldloc.3
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_005a: br IL_0075
+
+				IL_005f: ldloc.2
+				IL_0060: ldstr "match"
+				IL_0065: ldloc.3
+				IL_0066: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M25>:__js_call__:13"
+				IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0075: stloc.3
+				IL_0076: ldarg.0
+				IL_0077: ldloc.3
+				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007d: ldloc.0
+				IL_007e: ldc.r8 1
+				IL_0087: add
+				IL_0088: stloc.0
+				IL_0089: br IL_000a
 			// end loop
 
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_008e: ldnull
+			IL_008f: ret
 		} // end of method FunctionExpression_L125C30::__js_call__
 
 	} // end of class FunctionExpression_L125C30
@@ -6149,7 +6214,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 144 (0x90)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -6166,7 +6231,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0067
+				IL_0018: brfalse IL_008e
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -6181,23 +6246,36 @@
 				IL_003b: ldarg.0
 				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 				IL_0041: stloc.3
-				IL_0042: ldloc.2
-				IL_0043: ldstr "match"
-				IL_0048: ldloc.3
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004e: stloc.3
-				IL_004f: ldarg.0
-				IL_0050: ldloc.3
-				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0056: ldloc.0
-				IL_0057: ldc.r8 1
-				IL_0060: add
-				IL_0061: stloc.0
-				IL_0062: br IL_000a
+				IL_0042: volatile.
+				IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+				IL_0049: brfalse IL_005f
+
+				IL_004e: ldloc.2
+				IL_004f: ldstr "match"
+				IL_0054: ldloc.3
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_005a: br IL_0075
+
+				IL_005f: ldloc.2
+				IL_0060: ldstr "match"
+				IL_0065: ldloc.3
+				IL_0066: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M35>:__js_call__:13"
+				IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0075: stloc.3
+				IL_0076: ldarg.0
+				IL_0077: ldloc.3
+				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007d: ldloc.0
+				IL_007e: ldc.r8 1
+				IL_0087: add
+				IL_0088: stloc.0
+				IL_0089: br IL_000a
 			// end loop
 
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_008e: ldnull
+			IL_008f: ret
 		} // end of method FunctionExpression_L175C32::__js_call__
 
 	} // end of class FunctionExpression_L175C32
@@ -7597,7 +7675,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 144 (0x90)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -7614,7 +7692,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0067
+				IL_0018: brfalse IL_008e
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -7629,23 +7707,36 @@
 				IL_003b: ldarg.0
 				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 				IL_0041: stloc.3
-				IL_0042: ldloc.2
-				IL_0043: ldstr "match"
-				IL_0048: ldloc.3
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004e: stloc.3
-				IL_004f: ldarg.0
-				IL_0050: ldloc.3
-				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0056: ldloc.0
-				IL_0057: ldc.r8 1
-				IL_0060: add
-				IL_0061: stloc.0
-				IL_0062: br IL_000a
+				IL_0042: volatile.
+				IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+				IL_0049: brfalse IL_005f
+
+				IL_004e: ldloc.2
+				IL_004f: ldstr "match"
+				IL_0054: ldloc.3
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_005a: br IL_0075
+
+				IL_005f: ldloc.2
+				IL_0060: ldstr "match"
+				IL_0065: ldloc.3
+				IL_0066: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M43>:__js_call__:13"
+				IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0075: stloc.3
+				IL_0076: ldarg.0
+				IL_0077: ldloc.3
+				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007d: ldloc.0
+				IL_007e: ldc.r8 1
+				IL_0087: add
+				IL_0088: stloc.0
+				IL_0089: br IL_000a
 			// end loop
 
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_008e: ldnull
+			IL_008f: ret
 		} // end of method FunctionExpression_L212C39::__js_call__
 
 	} // end of class FunctionExpression_L212C39
@@ -9565,7 +9656,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 144 (0x90)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -9582,7 +9673,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0067
+				IL_0018: brfalse IL_008e
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -9597,23 +9688,36 @@
 				IL_003b: ldarg.0
 				IL_003c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 				IL_0041: stloc.3
-				IL_0042: ldloc.2
-				IL_0043: ldstr "match"
-				IL_0048: ldloc.3
-				IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004e: stloc.3
-				IL_004f: ldarg.0
-				IL_0050: ldloc.3
-				IL_0051: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0056: ldloc.0
-				IL_0057: ldc.r8 1
-				IL_0060: add
-				IL_0061: stloc.0
-				IL_0062: br IL_000a
+				IL_0042: volatile.
+				IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+				IL_0049: brfalse IL_005f
+
+				IL_004e: ldloc.2
+				IL_004f: ldstr "match"
+				IL_0054: ldloc.3
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_005a: br IL_0075
+
+				IL_005f: ldloc.2
+				IL_0060: ldstr "match"
+				IL_0065: ldloc.3
+				IL_0066: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M53>:__js_call__:13"
+				IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0075: stloc.3
+				IL_0076: ldarg.0
+				IL_0077: ldloc.3
+				IL_0078: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_007d: ldloc.0
+				IL_007e: ldc.r8 1
+				IL_0087: add
+				IL_0088: stloc.0
+				IL_0089: br IL_000a
 			// end loop
 
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_008e: ldnull
+			IL_008f: ret
 		} // end of method FunctionExpression_L262C31::__js_call__
 
 	} // end of class FunctionExpression_L262C31
@@ -11745,7 +11849,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 155 (0x9b)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -11763,7 +11867,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0072
+				IL_0018: brfalse IL_0099
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -11779,23 +11883,36 @@
 				IL_0040: ldstr "g"
 				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_004a: stloc.3
-				IL_004b: ldloc.2
-				IL_004c: ldstr "match"
-				IL_0051: ldloc.3
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0057: stloc.s 4
-				IL_0059: ldarg.0
-				IL_005a: ldloc.s 4
-				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0061: ldloc.0
-				IL_0062: ldc.r8 1
-				IL_006b: add
-				IL_006c: stloc.0
-				IL_006d: br IL_000a
+				IL_004b: volatile.
+				IL_004d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+				IL_0052: brfalse IL_0068
+
+				IL_0057: ldloc.2
+				IL_0058: ldstr "match"
+				IL_005d: ldloc.3
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0063: br IL_007e
+
+				IL_0068: ldloc.2
+				IL_0069: ldstr "match"
+				IL_006e: ldloc.3
+				IL_006f: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M63>:__js_call__:15"
+				IL_0074: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+				IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_007e: stloc.s 4
+				IL_0080: ldarg.0
+				IL_0081: ldloc.s 4
+				IL_0083: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0088: ldloc.0
+				IL_0089: ldc.r8 1
+				IL_0092: add
+				IL_0093: stloc.0
+				IL_0094: br IL_000a
 			// end loop
 
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_0099: ldnull
+			IL_009a: ret
 		} // end of method FunctionExpression_L313C25::__js_call__
 
 	} // end of class FunctionExpression_L313C25
@@ -13191,7 +13308,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 155 (0x9b)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -13209,7 +13326,7 @@
 				IL_000c: ldloc.1
 				IL_000d: ldc.r8 100
 				IL_0016: clt
-				IL_0018: brfalse IL_0072
+				IL_0018: brfalse IL_0099
 
 				IL_001d: ldarg.0
 				IL_001e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
@@ -13225,23 +13342,36 @@
 				IL_0040: ldstr "g"
 				IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 				IL_004a: stloc.3
-				IL_004b: ldloc.2
-				IL_004c: ldstr "match"
-				IL_0051: ldloc.3
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0057: stloc.s 4
-				IL_0059: ldarg.0
-				IL_005a: ldloc.s 4
-				IL_005c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-				IL_0061: ldloc.0
-				IL_0062: ldc.r8 1
-				IL_006b: add
-				IL_006c: stloc.0
-				IL_006d: br IL_000a
+				IL_004b: volatile.
+				IL_004d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+				IL_0052: brfalse IL_0068
+
+				IL_0057: ldloc.2
+				IL_0058: ldstr "match"
+				IL_005d: ldloc.3
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0063: br IL_007e
+
+				IL_0068: ldloc.2
+				IL_0069: ldstr "match"
+				IL_006e: ldloc.3
+				IL_006f: ldstr "Compile_Performance_Dromaeo_Object_Regexp:<TwoPhaseDummy_M71>:__js_call__:15"
+				IL_0074: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+				IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_007e: stloc.s 4
+				IL_0080: ldarg.0
+				IL_0081: ldloc.s 4
+				IL_0083: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+				IL_0088: ldloc.0
+				IL_0089: ldc.r8 1
+				IL_0092: add
+				IL_0093: stloc.0
+				IL_0094: br IL_000a
 			// end loop
 
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_0099: ldnull
+			IL_009a: ret
 		} // end of method FunctionExpression_L349C32::__js_call__
 
 	} // end of class FunctionExpression_L349C32
@@ -14384,7 +14514,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 4915 (0x1333)
+		// Code size: 4957 (0x135d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope,
@@ -14678,1847 +14808,1859 @@
 		IL_01ff: ldloc.0
 		IL_0200: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
 		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020a: ldstr "join"
-		IL_020f: ldstr ""
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0219: stloc.s 12
-		IL_021b: ldloc.0
-		IL_021c: ldloc.s 12
-		IL_021e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0223: ldloc.0
-		IL_0224: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0229: stloc.s 12
-		IL_022b: ldloc.0
-		IL_022c: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0231: stloc.s 11
-		IL_0233: ldloc.s 12
-		IL_0235: ldloc.s 11
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_023c: stloc.s 13
-		IL_023e: ldloc.0
-		IL_023f: ldloc.s 13
-		IL_0241: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0246: ldloc.0
-		IL_0247: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_024c: stloc.s 11
-		IL_024e: ldloc.0
-		IL_024f: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0254: stloc.s 12
-		IL_0256: ldloc.s 11
-		IL_0258: ldloc.s 12
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_025f: stloc.s 13
-		IL_0261: ldloc.0
-		IL_0262: ldloc.s 13
-		IL_0264: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0269: nop
-		IL_026a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_026f: stloc.s 6
-		IL_0271: ldc.i4.1
-		IL_0272: newarr [System.Runtime]System.Object
-		IL_0277: dup
-		IL_0278: ldc.i4.0
-		IL_0279: ldloc.0
-		IL_027a: stelem.ref
-		IL_027b: stloc.s 14
-		IL_027d: ldloc.s 14
-		IL_027f: ldc.i4.0
-		IL_0280: ldelem.ref
-		IL_0281: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0286: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_028b: ldc.i4.0
-		IL_028c: conv.r8
-		IL_028d: ldstr ""
-		IL_0292: ldc.i4.0
-		IL_0293: ldc.i4.1
-		IL_0294: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0299: stloc.s 15
-		IL_029b: ldloc.3
-		IL_029c: ldloc.s 6
-		IL_029e: ldloc.s 15
-		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02a5: pop
-		IL_02a6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02ab: stloc.s 6
-		IL_02ad: ldc.i4.1
-		IL_02ae: newarr [System.Runtime]System.Object
-		IL_02b3: dup
-		IL_02b4: ldc.i4.0
-		IL_02b5: ldloc.0
-		IL_02b6: stelem.ref
-		IL_02b7: stloc.s 14
-		IL_02b9: ldloc.s 14
-		IL_02bb: ldc.i4.0
-		IL_02bc: ldelem.ref
-		IL_02bd: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02c2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_02c7: ldc.i4.0
-		IL_02c8: conv.r8
-		IL_02c9: ldstr ""
-		IL_02ce: ldc.i4.0
-		IL_02cf: ldc.i4.1
-		IL_02d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02d5: stloc.s 16
-		IL_02d7: ldloc.s 4
-		IL_02d9: ldloc.s 6
-		IL_02db: ldstr "Compiled Object Empty Split"
-		IL_02e0: ldloc.s 16
-		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02e7: pop
-		IL_02e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02ed: stloc.s 6
-		IL_02ef: ldc.i4.1
-		IL_02f0: newarr [System.Runtime]System.Object
-		IL_02f5: dup
-		IL_02f6: ldc.i4.0
-		IL_02f7: ldloc.0
-		IL_02f8: stelem.ref
-		IL_02f9: stloc.s 14
-		IL_02fb: ldloc.s 14
-		IL_02fd: ldc.i4.0
-		IL_02fe: ldelem.ref
-		IL_02ff: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0304: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0309: ldc.i4.0
-		IL_030a: conv.r8
-		IL_030b: ldstr ""
-		IL_0310: ldc.i4.0
-		IL_0311: ldc.i4.1
-		IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0317: stloc.s 17
-		IL_0319: ldloc.3
-		IL_031a: ldloc.s 6
-		IL_031c: ldloc.s 17
-		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0323: pop
-		IL_0324: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0329: stloc.s 6
-		IL_032b: ldc.i4.1
-		IL_032c: newarr [System.Runtime]System.Object
-		IL_0331: dup
-		IL_0332: ldc.i4.0
-		IL_0333: ldloc.0
-		IL_0334: stelem.ref
-		IL_0335: stloc.s 14
-		IL_0337: ldloc.s 14
-		IL_0339: ldc.i4.0
-		IL_033a: ldelem.ref
-		IL_033b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0340: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0345: ldc.i4.0
-		IL_0346: conv.r8
-		IL_0347: ldstr ""
-		IL_034c: ldc.i4.0
-		IL_034d: ldc.i4.1
-		IL_034e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0353: stloc.s 18
-		IL_0355: ldloc.s 4
-		IL_0357: ldloc.s 6
-		IL_0359: ldstr "Compiled Object Char Split"
-		IL_035e: ldloc.s 18
-		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0365: pop
-		IL_0366: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_036b: stloc.s 6
-		IL_036d: ldc.i4.1
-		IL_036e: newarr [System.Runtime]System.Object
-		IL_0373: dup
-		IL_0374: ldc.i4.0
-		IL_0375: ldloc.0
-		IL_0376: stelem.ref
-		IL_0377: stloc.s 14
-		IL_0379: ldloc.s 14
-		IL_037b: ldc.i4.0
-		IL_037c: ldelem.ref
-		IL_037d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0382: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0387: ldc.i4.0
-		IL_0388: conv.r8
-		IL_0389: ldstr ""
-		IL_038e: ldc.i4.0
-		IL_038f: ldc.i4.1
-		IL_0390: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0395: stloc.s 19
-		IL_0397: ldloc.3
-		IL_0398: ldloc.s 6
-		IL_039a: ldloc.s 19
-		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03a1: pop
-		IL_03a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03a7: stloc.s 6
-		IL_03a9: ldc.i4.1
-		IL_03aa: newarr [System.Runtime]System.Object
-		IL_03af: dup
-		IL_03b0: ldc.i4.0
-		IL_03b1: ldloc.0
-		IL_03b2: stelem.ref
-		IL_03b3: stloc.s 14
-		IL_03b5: ldloc.s 14
-		IL_03b7: ldc.i4.0
-		IL_03b8: ldelem.ref
-		IL_03b9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03be: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_03c3: ldc.i4.0
-		IL_03c4: conv.r8
-		IL_03c5: ldstr ""
-		IL_03ca: ldc.i4.0
-		IL_03cb: ldc.i4.1
-		IL_03cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03d1: stloc.s 20
-		IL_03d3: ldloc.s 4
-		IL_03d5: ldloc.s 6
-		IL_03d7: ldstr "Compiled Object Variable Split"
-		IL_03dc: ldloc.s 20
-		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_03e3: pop
-		IL_03e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03e9: stloc.s 6
-		IL_03eb: ldc.i4.1
-		IL_03ec: newarr [System.Runtime]System.Object
-		IL_03f1: dup
-		IL_03f2: ldc.i4.0
-		IL_03f3: ldloc.0
-		IL_03f4: stelem.ref
-		IL_03f5: stloc.s 14
-		IL_03f7: ldloc.s 14
-		IL_03f9: ldc.i4.0
-		IL_03fa: ldelem.ref
-		IL_03fb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0400: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0405: ldc.i4.0
-		IL_0406: conv.r8
-		IL_0407: ldstr ""
-		IL_040c: ldc.i4.0
-		IL_040d: ldc.i4.1
-		IL_040e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0413: stloc.s 21
-		IL_0415: ldloc.3
-		IL_0416: ldloc.s 6
-		IL_0418: ldloc.s 21
-		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_041f: pop
-		IL_0420: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0425: stloc.s 6
-		IL_0427: ldc.i4.1
-		IL_0428: newarr [System.Runtime]System.Object
-		IL_042d: dup
-		IL_042e: ldc.i4.0
-		IL_042f: ldloc.0
-		IL_0430: stelem.ref
-		IL_0431: stloc.s 14
-		IL_0433: ldloc.s 14
-		IL_0435: ldc.i4.0
-		IL_0436: ldelem.ref
-		IL_0437: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_043c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0441: ldc.i4.0
-		IL_0442: conv.r8
-		IL_0443: ldstr ""
-		IL_0448: ldc.i4.0
-		IL_0449: ldc.i4.1
-		IL_044a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_044f: stloc.s 22
-		IL_0451: ldloc.s 4
-		IL_0453: ldloc.s 6
-		IL_0455: ldstr "Compiled Match"
-		IL_045a: ldloc.s 22
-		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0461: pop
-		IL_0462: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0467: stloc.s 6
-		IL_0469: ldc.i4.1
-		IL_046a: newarr [System.Runtime]System.Object
-		IL_046f: dup
-		IL_0470: ldc.i4.0
-		IL_0471: ldloc.0
-		IL_0472: stelem.ref
-		IL_0473: stloc.s 14
-		IL_0475: ldloc.s 14
-		IL_0477: ldc.i4.0
-		IL_0478: ldelem.ref
-		IL_0479: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_047e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0483: ldc.i4.0
-		IL_0484: conv.r8
-		IL_0485: ldstr ""
-		IL_048a: ldc.i4.0
-		IL_048b: ldc.i4.1
-		IL_048c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0491: stloc.s 23
-		IL_0493: ldloc.3
-		IL_0494: ldloc.s 6
-		IL_0496: ldloc.s 23
-		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_049d: pop
-		IL_049e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04a3: stloc.s 6
-		IL_04a5: ldc.i4.1
-		IL_04a6: newarr [System.Runtime]System.Object
-		IL_04ab: dup
-		IL_04ac: ldc.i4.0
-		IL_04ad: ldloc.0
-		IL_04ae: stelem.ref
-		IL_04af: stloc.s 14
-		IL_04b1: ldloc.s 14
-		IL_04b3: ldc.i4.0
-		IL_04b4: ldelem.ref
-		IL_04b5: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04ba: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_04bf: ldc.i4.0
-		IL_04c0: conv.r8
-		IL_04c1: ldstr ""
-		IL_04c6: ldc.i4.0
-		IL_04c7: ldc.i4.1
-		IL_04c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04cd: stloc.s 24
-		IL_04cf: ldloc.s 4
-		IL_04d1: ldloc.s 6
-		IL_04d3: ldstr "Compiled Test"
-		IL_04d8: ldloc.s 24
-		IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_04df: pop
-		IL_04e0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04e5: stloc.s 6
-		IL_04e7: ldc.i4.1
-		IL_04e8: newarr [System.Runtime]System.Object
-		IL_04ed: dup
-		IL_04ee: ldc.i4.0
-		IL_04ef: ldloc.0
-		IL_04f0: stelem.ref
-		IL_04f1: stloc.s 14
-		IL_04f3: ldloc.s 14
-		IL_04f5: ldc.i4.0
-		IL_04f6: ldelem.ref
-		IL_04f7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04fc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0501: ldc.i4.0
-		IL_0502: conv.r8
-		IL_0503: ldstr ""
-		IL_0508: ldc.i4.0
-		IL_0509: ldc.i4.1
-		IL_050a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_050f: stloc.s 25
-		IL_0511: ldloc.3
-		IL_0512: ldloc.s 6
-		IL_0514: ldloc.s 25
-		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_051b: pop
-		IL_051c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0521: stloc.s 6
-		IL_0523: ldc.i4.1
-		IL_0524: newarr [System.Runtime]System.Object
-		IL_0529: dup
-		IL_052a: ldc.i4.0
-		IL_052b: ldloc.0
-		IL_052c: stelem.ref
-		IL_052d: stloc.s 14
-		IL_052f: ldloc.s 14
-		IL_0531: ldc.i4.0
-		IL_0532: ldelem.ref
-		IL_0533: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0538: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_053d: ldc.i4.0
-		IL_053e: conv.r8
-		IL_053f: ldstr ""
-		IL_0544: ldc.i4.0
-		IL_0545: ldc.i4.1
-		IL_0546: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_054b: stloc.s 26
-		IL_054d: ldloc.s 4
-		IL_054f: ldloc.s 6
-		IL_0551: ldstr "Compiled Empty Replace"
-		IL_0556: ldloc.s 26
-		IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_055d: pop
-		IL_055e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0563: stloc.s 6
-		IL_0565: ldc.i4.1
-		IL_0566: newarr [System.Runtime]System.Object
-		IL_056b: dup
-		IL_056c: ldc.i4.0
-		IL_056d: ldloc.0
-		IL_056e: stelem.ref
-		IL_056f: stloc.s 14
-		IL_0571: ldloc.s 14
-		IL_0573: ldc.i4.0
-		IL_0574: ldelem.ref
-		IL_0575: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_057a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_057f: ldc.i4.0
-		IL_0580: conv.r8
-		IL_0581: ldstr ""
-		IL_0586: ldc.i4.0
-		IL_0587: ldc.i4.1
-		IL_0588: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_058d: stloc.s 27
-		IL_058f: ldloc.3
-		IL_0590: ldloc.s 6
-		IL_0592: ldloc.s 27
-		IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0599: pop
-		IL_059a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_059f: stloc.s 6
-		IL_05a1: ldc.i4.1
-		IL_05a2: newarr [System.Runtime]System.Object
-		IL_05a7: dup
-		IL_05a8: ldc.i4.0
-		IL_05a9: ldloc.0
-		IL_05aa: stelem.ref
-		IL_05ab: stloc.s 14
-		IL_05ad: ldloc.s 14
-		IL_05af: ldc.i4.0
-		IL_05b0: ldelem.ref
-		IL_05b1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05b6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_05bb: ldc.i4.0
-		IL_05bc: conv.r8
-		IL_05bd: ldstr ""
-		IL_05c2: ldc.i4.0
-		IL_05c3: ldc.i4.1
-		IL_05c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05c9: stloc.s 28
-		IL_05cb: ldloc.s 4
-		IL_05cd: ldloc.s 6
-		IL_05cf: ldstr "Compiled 12 Char Replace"
-		IL_05d4: ldloc.s 28
-		IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_05db: pop
-		IL_05dc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05e1: stloc.s 6
-		IL_05e3: ldc.i4.1
-		IL_05e4: newarr [System.Runtime]System.Object
-		IL_05e9: dup
-		IL_05ea: ldc.i4.0
-		IL_05eb: ldloc.0
-		IL_05ec: stelem.ref
-		IL_05ed: stloc.s 14
-		IL_05ef: ldloc.s 14
-		IL_05f1: ldc.i4.0
-		IL_05f2: ldelem.ref
-		IL_05f3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05f8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_05fd: ldc.i4.0
-		IL_05fe: conv.r8
-		IL_05ff: ldstr ""
-		IL_0604: ldc.i4.0
-		IL_0605: ldc.i4.1
-		IL_0606: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_060b: stloc.s 29
-		IL_060d: ldloc.3
-		IL_060e: ldloc.s 6
-		IL_0610: ldloc.s 29
-		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0617: pop
-		IL_0618: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_061d: stloc.s 6
-		IL_061f: ldc.i4.1
-		IL_0620: newarr [System.Runtime]System.Object
-		IL_0625: dup
-		IL_0626: ldc.i4.0
-		IL_0627: ldloc.0
-		IL_0628: stelem.ref
-		IL_0629: stloc.s 14
-		IL_062b: ldloc.s 14
-		IL_062d: ldc.i4.0
-		IL_062e: ldelem.ref
-		IL_062f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0634: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0639: ldc.i4.0
-		IL_063a: conv.r8
-		IL_063b: ldstr ""
-		IL_0640: ldc.i4.0
-		IL_0641: ldc.i4.1
-		IL_0642: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0647: stloc.s 30
-		IL_0649: ldloc.s 4
-		IL_064b: ldloc.s 6
-		IL_064d: ldstr "Compiled Object Match"
-		IL_0652: ldloc.s 30
-		IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0659: pop
-		IL_065a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_065f: stloc.s 6
-		IL_0661: ldc.i4.1
-		IL_0662: newarr [System.Runtime]System.Object
-		IL_0667: dup
-		IL_0668: ldc.i4.0
-		IL_0669: ldloc.0
-		IL_066a: stelem.ref
-		IL_066b: stloc.s 14
-		IL_066d: ldloc.s 14
-		IL_066f: ldc.i4.0
-		IL_0670: ldelem.ref
-		IL_0671: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0676: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_067b: ldc.i4.0
-		IL_067c: conv.r8
-		IL_067d: ldstr ""
-		IL_0682: ldc.i4.0
-		IL_0683: ldc.i4.1
-		IL_0684: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0689: stloc.s 31
-		IL_068b: ldloc.3
-		IL_068c: ldloc.s 6
-		IL_068e: ldloc.s 31
-		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0695: pop
-		IL_0696: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_069b: stloc.s 6
-		IL_069d: ldc.i4.1
-		IL_069e: newarr [System.Runtime]System.Object
-		IL_06a3: dup
-		IL_06a4: ldc.i4.0
-		IL_06a5: ldloc.0
-		IL_06a6: stelem.ref
-		IL_06a7: stloc.s 14
-		IL_06a9: ldloc.s 14
-		IL_06ab: ldc.i4.0
-		IL_06ac: ldelem.ref
-		IL_06ad: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06b2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_06b7: ldc.i4.0
-		IL_06b8: conv.r8
-		IL_06b9: ldstr ""
-		IL_06be: ldc.i4.0
-		IL_06bf: ldc.i4.1
-		IL_06c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06c5: stloc.s 32
-		IL_06c7: ldloc.s 4
-		IL_06c9: ldloc.s 6
-		IL_06cb: ldstr "Compiled Object Test"
-		IL_06d0: ldloc.s 32
-		IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_06d7: pop
-		IL_06d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06dd: stloc.s 6
-		IL_06df: ldc.i4.1
-		IL_06e0: newarr [System.Runtime]System.Object
-		IL_06e5: dup
-		IL_06e6: ldc.i4.0
-		IL_06e7: ldloc.0
-		IL_06e8: stelem.ref
-		IL_06e9: stloc.s 14
-		IL_06eb: ldloc.s 14
-		IL_06ed: ldc.i4.0
-		IL_06ee: ldelem.ref
-		IL_06ef: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06f4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_06f9: ldc.i4.0
-		IL_06fa: conv.r8
-		IL_06fb: ldstr ""
-		IL_0700: ldc.i4.0
-		IL_0701: ldc.i4.1
-		IL_0702: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0707: stloc.s 33
-		IL_0709: ldloc.3
-		IL_070a: ldloc.s 6
-		IL_070c: ldloc.s 33
-		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0713: pop
-		IL_0714: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0719: stloc.s 6
-		IL_071b: ldc.i4.1
-		IL_071c: newarr [System.Runtime]System.Object
-		IL_0721: dup
-		IL_0722: ldc.i4.0
-		IL_0723: ldloc.0
-		IL_0724: stelem.ref
-		IL_0725: stloc.s 14
-		IL_0727: ldloc.s 14
-		IL_0729: ldc.i4.0
-		IL_072a: ldelem.ref
-		IL_072b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0730: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0735: ldc.i4.0
-		IL_0736: conv.r8
-		IL_0737: ldstr ""
-		IL_073c: ldc.i4.0
-		IL_073d: ldc.i4.1
-		IL_073e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0743: stloc.s 34
-		IL_0745: ldloc.s 4
-		IL_0747: ldloc.s 6
-		IL_0749: ldstr "Compiled Object Empty Replace"
-		IL_074e: ldloc.s 34
-		IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0755: pop
-		IL_0756: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_075b: stloc.s 6
-		IL_075d: ldc.i4.1
-		IL_075e: newarr [System.Runtime]System.Object
-		IL_0763: dup
-		IL_0764: ldc.i4.0
-		IL_0765: ldloc.0
-		IL_0766: stelem.ref
-		IL_0767: stloc.s 14
-		IL_0769: ldloc.s 14
-		IL_076b: ldc.i4.0
-		IL_076c: ldelem.ref
-		IL_076d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0772: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0777: ldc.i4.0
-		IL_0778: conv.r8
-		IL_0779: ldstr ""
-		IL_077e: ldc.i4.0
-		IL_077f: ldc.i4.1
-		IL_0780: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0785: stloc.s 35
-		IL_0787: ldloc.3
-		IL_0788: ldloc.s 6
-		IL_078a: ldloc.s 35
-		IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0791: pop
-		IL_0792: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0797: stloc.s 6
-		IL_0799: ldc.i4.1
-		IL_079a: newarr [System.Runtime]System.Object
-		IL_079f: dup
-		IL_07a0: ldc.i4.0
-		IL_07a1: ldloc.0
-		IL_07a2: stelem.ref
-		IL_07a3: stloc.s 14
-		IL_07a5: ldloc.s 14
-		IL_07a7: ldc.i4.0
-		IL_07a8: ldelem.ref
-		IL_07a9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_07ae: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_07b3: ldc.i4.0
-		IL_07b4: conv.r8
-		IL_07b5: ldstr ""
-		IL_07ba: ldc.i4.0
-		IL_07bb: ldc.i4.1
-		IL_07bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07c1: stloc.s 36
-		IL_07c3: ldloc.s 4
-		IL_07c5: ldloc.s 6
-		IL_07c7: ldstr "Compiled Object 12 Char Replace"
-		IL_07cc: ldloc.s 36
-		IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_07d3: pop
-		IL_07d4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_07d9: stloc.s 6
-		IL_07db: ldc.i4.1
-		IL_07dc: newarr [System.Runtime]System.Object
-		IL_07e1: dup
-		IL_07e2: ldc.i4.0
-		IL_07e3: ldloc.0
-		IL_07e4: stelem.ref
-		IL_07e5: stloc.s 14
-		IL_07e7: ldloc.s 14
-		IL_07e9: ldc.i4.0
-		IL_07ea: ldelem.ref
-		IL_07eb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_07f0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_07f5: ldc.i4.0
-		IL_07f6: conv.r8
-		IL_07f7: ldstr ""
-		IL_07fc: ldc.i4.0
-		IL_07fd: ldc.i4.1
-		IL_07fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0803: stloc.s 37
-		IL_0805: ldloc.3
-		IL_0806: ldloc.s 6
-		IL_0808: ldloc.s 37
-		IL_080a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_080f: pop
-		IL_0810: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0815: stloc.s 6
-		IL_0817: ldc.i4.1
-		IL_0818: newarr [System.Runtime]System.Object
-		IL_081d: dup
-		IL_081e: ldc.i4.0
-		IL_081f: ldloc.0
-		IL_0820: stelem.ref
-		IL_0821: stloc.s 14
-		IL_0823: ldloc.s 14
-		IL_0825: ldc.i4.0
-		IL_0826: ldelem.ref
-		IL_0827: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_082c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0831: ldc.i4.0
-		IL_0832: conv.r8
-		IL_0833: ldstr ""
-		IL_0838: ldc.i4.0
-		IL_0839: ldc.i4.1
-		IL_083a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_083f: stloc.s 38
-		IL_0841: ldloc.s 4
-		IL_0843: ldloc.s 6
-		IL_0845: ldstr "Compiled Object 12 Char Replace Function"
-		IL_084a: ldloc.s 38
-		IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0851: pop
-		IL_0852: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0857: stloc.s 6
-		IL_0859: ldc.i4.1
-		IL_085a: newarr [System.Runtime]System.Object
-		IL_085f: dup
-		IL_0860: ldc.i4.0
-		IL_0861: ldloc.0
-		IL_0862: stelem.ref
-		IL_0863: stloc.s 14
-		IL_0865: ldloc.s 14
-		IL_0867: ldc.i4.0
-		IL_0868: ldelem.ref
-		IL_0869: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_086e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0873: ldc.i4.0
-		IL_0874: conv.r8
-		IL_0875: ldstr ""
-		IL_087a: ldc.i4.0
-		IL_087b: ldc.i4.1
-		IL_087c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0881: stloc.s 39
-		IL_0883: ldloc.3
-		IL_0884: ldloc.s 6
-		IL_0886: ldloc.s 39
-		IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_088d: pop
-		IL_088e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0893: stloc.s 6
-		IL_0895: ldc.i4.1
-		IL_0896: newarr [System.Runtime]System.Object
-		IL_089b: dup
-		IL_089c: ldc.i4.0
-		IL_089d: ldloc.0
-		IL_089e: stelem.ref
-		IL_089f: stloc.s 14
-		IL_08a1: ldloc.s 14
-		IL_08a3: ldc.i4.0
-		IL_08a4: ldelem.ref
-		IL_08a5: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_08aa: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_08af: ldc.i4.0
-		IL_08b0: conv.r8
-		IL_08b1: ldstr ""
-		IL_08b6: ldc.i4.0
-		IL_08b7: ldc.i4.1
-		IL_08b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08bd: stloc.s 40
-		IL_08bf: ldloc.s 4
-		IL_08c1: ldloc.s 6
-		IL_08c3: ldstr "Compiled Variable Match"
-		IL_08c8: ldloc.s 40
-		IL_08ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_08cf: pop
-		IL_08d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08d5: stloc.s 6
-		IL_08d7: ldc.i4.1
-		IL_08d8: newarr [System.Runtime]System.Object
-		IL_08dd: dup
-		IL_08de: ldc.i4.0
-		IL_08df: ldloc.0
-		IL_08e0: stelem.ref
-		IL_08e1: stloc.s 14
-		IL_08e3: ldloc.s 14
-		IL_08e5: ldc.i4.0
-		IL_08e6: ldelem.ref
-		IL_08e7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_08ec: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_08f1: ldc.i4.0
-		IL_08f2: conv.r8
-		IL_08f3: ldstr ""
-		IL_08f8: ldc.i4.0
-		IL_08f9: ldc.i4.1
-		IL_08fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08ff: stloc.s 41
-		IL_0901: ldloc.3
-		IL_0902: ldloc.s 6
-		IL_0904: ldloc.s 41
-		IL_0906: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_090b: pop
-		IL_090c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0911: stloc.s 6
-		IL_0913: ldc.i4.1
-		IL_0914: newarr [System.Runtime]System.Object
-		IL_0919: dup
-		IL_091a: ldc.i4.0
-		IL_091b: ldloc.0
-		IL_091c: stelem.ref
-		IL_091d: stloc.s 14
-		IL_091f: ldloc.s 14
-		IL_0921: ldc.i4.0
-		IL_0922: ldelem.ref
-		IL_0923: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0928: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_092d: ldc.i4.0
-		IL_092e: conv.r8
-		IL_092f: ldstr ""
-		IL_0934: ldc.i4.0
-		IL_0935: ldc.i4.1
-		IL_0936: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_093b: stloc.s 42
-		IL_093d: ldloc.s 4
-		IL_093f: ldloc.s 6
-		IL_0941: ldstr "Compiled Variable Test"
-		IL_0946: ldloc.s 42
-		IL_0948: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_094d: pop
-		IL_094e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0953: stloc.s 6
-		IL_0955: ldc.i4.1
-		IL_0956: newarr [System.Runtime]System.Object
-		IL_095b: dup
-		IL_095c: ldc.i4.0
-		IL_095d: ldloc.0
-		IL_095e: stelem.ref
-		IL_095f: stloc.s 14
-		IL_0961: ldloc.s 14
-		IL_0963: ldc.i4.0
-		IL_0964: ldelem.ref
-		IL_0965: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_096a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_096f: ldc.i4.0
-		IL_0970: conv.r8
-		IL_0971: ldstr ""
-		IL_0976: ldc.i4.0
-		IL_0977: ldc.i4.1
-		IL_0978: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_097d: stloc.s 43
-		IL_097f: ldloc.3
-		IL_0980: ldloc.s 6
-		IL_0982: ldloc.s 43
-		IL_0984: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0989: pop
-		IL_098a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_098f: stloc.s 6
-		IL_0991: ldc.i4.1
-		IL_0992: newarr [System.Runtime]System.Object
-		IL_0997: dup
-		IL_0998: ldc.i4.0
-		IL_0999: ldloc.0
-		IL_099a: stelem.ref
-		IL_099b: stloc.s 14
-		IL_099d: ldloc.s 14
-		IL_099f: ldc.i4.0
-		IL_09a0: ldelem.ref
-		IL_09a1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_09a6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_09ab: ldc.i4.0
-		IL_09ac: conv.r8
-		IL_09ad: ldstr ""
-		IL_09b2: ldc.i4.0
-		IL_09b3: ldc.i4.1
-		IL_09b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_09b9: stloc.s 44
-		IL_09bb: ldloc.s 4
-		IL_09bd: ldloc.s 6
-		IL_09bf: ldstr "Compiled Variable Empty Replace"
-		IL_09c4: ldloc.s 44
-		IL_09c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_09cb: pop
-		IL_09cc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_09d1: stloc.s 6
-		IL_09d3: ldc.i4.1
-		IL_09d4: newarr [System.Runtime]System.Object
-		IL_09d9: dup
-		IL_09da: ldc.i4.0
-		IL_09db: ldloc.0
-		IL_09dc: stelem.ref
-		IL_09dd: stloc.s 14
-		IL_09df: ldloc.s 14
-		IL_09e1: ldc.i4.0
-		IL_09e2: ldelem.ref
-		IL_09e3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_09e8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_09ed: ldc.i4.0
-		IL_09ee: conv.r8
-		IL_09ef: ldstr ""
-		IL_09f4: ldc.i4.0
-		IL_09f5: ldc.i4.1
-		IL_09f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_09fb: stloc.s 45
-		IL_09fd: ldloc.3
-		IL_09fe: ldloc.s 6
-		IL_0a00: ldloc.s 45
-		IL_0a02: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0a07: pop
-		IL_0a08: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0a0d: stloc.s 6
-		IL_0a0f: ldc.i4.1
-		IL_0a10: newarr [System.Runtime]System.Object
-		IL_0a15: dup
-		IL_0a16: ldc.i4.0
-		IL_0a17: ldloc.0
-		IL_0a18: stelem.ref
-		IL_0a19: stloc.s 14
-		IL_0a1b: ldloc.s 14
-		IL_0a1d: ldc.i4.0
-		IL_0a1e: ldelem.ref
-		IL_0a1f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a24: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0a29: ldc.i4.0
-		IL_0a2a: conv.r8
-		IL_0a2b: ldstr ""
-		IL_0a30: ldc.i4.0
-		IL_0a31: ldc.i4.1
-		IL_0a32: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0a37: stloc.s 46
-		IL_0a39: ldloc.s 4
-		IL_0a3b: ldloc.s 6
-		IL_0a3d: ldstr "Compiled Variable 12 Char Replace"
-		IL_0a42: ldloc.s 46
-		IL_0a44: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0a49: pop
-		IL_0a4a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0a4f: stloc.s 6
-		IL_0a51: ldc.i4.1
-		IL_0a52: newarr [System.Runtime]System.Object
-		IL_0a57: dup
-		IL_0a58: ldc.i4.0
-		IL_0a59: ldloc.0
-		IL_0a5a: stelem.ref
-		IL_0a5b: stloc.s 14
-		IL_0a5d: ldloc.s 14
-		IL_0a5f: ldc.i4.0
-		IL_0a60: ldelem.ref
-		IL_0a61: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a66: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0a6b: ldc.i4.0
-		IL_0a6c: conv.r8
-		IL_0a6d: ldstr ""
-		IL_0a72: ldc.i4.0
-		IL_0a73: ldc.i4.1
-		IL_0a74: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0a79: stloc.s 47
-		IL_0a7b: ldloc.3
-		IL_0a7c: ldloc.s 6
-		IL_0a7e: ldloc.s 47
-		IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0a85: pop
-		IL_0a86: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0a8b: stloc.s 6
-		IL_0a8d: ldc.i4.1
-		IL_0a8e: newarr [System.Runtime]System.Object
-		IL_0a93: dup
-		IL_0a94: ldc.i4.0
-		IL_0a95: ldloc.0
-		IL_0a96: stelem.ref
-		IL_0a97: stloc.s 14
-		IL_0a99: ldloc.s 14
-		IL_0a9b: ldc.i4.0
-		IL_0a9c: ldelem.ref
-		IL_0a9d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0aa2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0aa7: ldc.i4.0
-		IL_0aa8: conv.r8
-		IL_0aa9: ldstr ""
-		IL_0aae: ldc.i4.0
-		IL_0aaf: ldc.i4.1
-		IL_0ab0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0ab5: stloc.s 48
-		IL_0ab7: ldloc.s 4
-		IL_0ab9: ldloc.s 6
-		IL_0abb: ldstr "Compiled Variable Object Match"
-		IL_0ac0: ldloc.s 48
-		IL_0ac2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0ac7: pop
-		IL_0ac8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0acd: stloc.s 6
-		IL_0acf: ldc.i4.1
-		IL_0ad0: newarr [System.Runtime]System.Object
-		IL_0ad5: dup
-		IL_0ad6: ldc.i4.0
-		IL_0ad7: ldloc.0
-		IL_0ad8: stelem.ref
-		IL_0ad9: stloc.s 14
-		IL_0adb: ldloc.s 14
-		IL_0add: ldc.i4.0
-		IL_0ade: ldelem.ref
-		IL_0adf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ae4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0ae9: ldc.i4.0
-		IL_0aea: conv.r8
-		IL_0aeb: ldstr ""
-		IL_0af0: ldc.i4.0
-		IL_0af1: ldc.i4.1
-		IL_0af2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0af7: stloc.s 49
-		IL_0af9: ldloc.3
-		IL_0afa: ldloc.s 6
-		IL_0afc: ldloc.s 49
-		IL_0afe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0b03: pop
-		IL_0b04: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0b09: stloc.s 6
-		IL_0b0b: ldc.i4.1
-		IL_0b0c: newarr [System.Runtime]System.Object
-		IL_0b11: dup
-		IL_0b12: ldc.i4.0
-		IL_0b13: ldloc.0
-		IL_0b14: stelem.ref
-		IL_0b15: stloc.s 14
-		IL_0b17: ldloc.s 14
-		IL_0b19: ldc.i4.0
-		IL_0b1a: ldelem.ref
-		IL_0b1b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b20: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0b25: ldc.i4.0
-		IL_0b26: conv.r8
-		IL_0b27: ldstr ""
-		IL_0b2c: ldc.i4.0
-		IL_0b2d: ldc.i4.1
-		IL_0b2e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b33: stloc.s 50
-		IL_0b35: ldloc.s 4
-		IL_0b37: ldloc.s 6
-		IL_0b39: ldstr "Compiled Variable Object Test"
-		IL_0b3e: ldloc.s 50
-		IL_0b40: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0b45: pop
-		IL_0b46: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0b4b: stloc.s 6
-		IL_0b4d: ldc.i4.1
-		IL_0b4e: newarr [System.Runtime]System.Object
-		IL_0b53: dup
-		IL_0b54: ldc.i4.0
-		IL_0b55: ldloc.0
-		IL_0b56: stelem.ref
-		IL_0b57: stloc.s 14
-		IL_0b59: ldloc.s 14
-		IL_0b5b: ldc.i4.0
-		IL_0b5c: ldelem.ref
-		IL_0b5d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b62: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0b67: ldc.i4.0
-		IL_0b68: conv.r8
-		IL_0b69: ldstr ""
-		IL_0b6e: ldc.i4.0
-		IL_0b6f: ldc.i4.1
-		IL_0b70: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b75: stloc.s 51
-		IL_0b77: ldloc.3
-		IL_0b78: ldloc.s 6
-		IL_0b7a: ldloc.s 51
-		IL_0b7c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0b81: pop
-		IL_0b82: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0b87: stloc.s 6
-		IL_0b89: ldc.i4.1
-		IL_0b8a: newarr [System.Runtime]System.Object
-		IL_0b8f: dup
-		IL_0b90: ldc.i4.0
-		IL_0b91: ldloc.0
-		IL_0b92: stelem.ref
-		IL_0b93: stloc.s 14
-		IL_0b95: ldloc.s 14
-		IL_0b97: ldc.i4.0
-		IL_0b98: ldelem.ref
-		IL_0b99: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b9e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0ba3: ldc.i4.0
-		IL_0ba4: conv.r8
-		IL_0ba5: ldstr ""
-		IL_0baa: ldc.i4.0
-		IL_0bab: ldc.i4.1
-		IL_0bac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0bb1: stloc.s 52
-		IL_0bb3: ldloc.s 4
-		IL_0bb5: ldloc.s 6
-		IL_0bb7: ldstr "Compiled Variable Object Empty Replace"
-		IL_0bbc: ldloc.s 52
-		IL_0bbe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0bc3: pop
-		IL_0bc4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0bc9: stloc.s 6
-		IL_0bcb: ldc.i4.1
-		IL_0bcc: newarr [System.Runtime]System.Object
-		IL_0bd1: dup
-		IL_0bd2: ldc.i4.0
-		IL_0bd3: ldloc.0
-		IL_0bd4: stelem.ref
-		IL_0bd5: stloc.s 14
-		IL_0bd7: ldloc.s 14
-		IL_0bd9: ldc.i4.0
-		IL_0bda: ldelem.ref
-		IL_0bdb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0be0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0be5: ldc.i4.0
-		IL_0be6: conv.r8
-		IL_0be7: ldstr ""
-		IL_0bec: ldc.i4.0
-		IL_0bed: ldc.i4.1
-		IL_0bee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0bf3: stloc.s 53
-		IL_0bf5: ldloc.3
-		IL_0bf6: ldloc.s 6
-		IL_0bf8: ldloc.s 53
-		IL_0bfa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0bff: pop
-		IL_0c00: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0c05: stloc.s 6
-		IL_0c07: ldc.i4.1
-		IL_0c08: newarr [System.Runtime]System.Object
-		IL_0c0d: dup
-		IL_0c0e: ldc.i4.0
-		IL_0c0f: ldloc.0
-		IL_0c10: stelem.ref
-		IL_0c11: stloc.s 14
-		IL_0c13: ldloc.s 14
-		IL_0c15: ldc.i4.0
-		IL_0c16: ldelem.ref
-		IL_0c17: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c1c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0c21: ldc.i4.0
-		IL_0c22: conv.r8
-		IL_0c23: ldstr ""
-		IL_0c28: ldc.i4.0
-		IL_0c29: ldc.i4.1
-		IL_0c2a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0c2f: stloc.s 54
-		IL_0c31: ldloc.s 4
-		IL_0c33: ldloc.s 6
-		IL_0c35: ldstr "Compiled Variable Object 12 Char Replace"
-		IL_0c3a: ldloc.s 54
-		IL_0c3c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0c41: pop
-		IL_0c42: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0c47: stloc.s 6
-		IL_0c49: ldc.i4.1
-		IL_0c4a: newarr [System.Runtime]System.Object
-		IL_0c4f: dup
-		IL_0c50: ldc.i4.0
-		IL_0c51: ldloc.0
-		IL_0c52: stelem.ref
-		IL_0c53: stloc.s 14
-		IL_0c55: ldloc.s 14
-		IL_0c57: ldc.i4.0
-		IL_0c58: ldelem.ref
-		IL_0c59: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c5e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0c63: ldc.i4.0
-		IL_0c64: conv.r8
-		IL_0c65: ldstr ""
-		IL_0c6a: ldc.i4.0
-		IL_0c6b: ldc.i4.1
-		IL_0c6c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0c71: stloc.s 55
-		IL_0c73: ldloc.3
-		IL_0c74: ldloc.s 6
-		IL_0c76: ldloc.s 55
-		IL_0c78: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0c7d: pop
-		IL_0c7e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0c83: stloc.s 6
-		IL_0c85: ldc.i4.1
-		IL_0c86: newarr [System.Runtime]System.Object
-		IL_0c8b: dup
-		IL_0c8c: ldc.i4.0
-		IL_0c8d: ldloc.0
-		IL_0c8e: stelem.ref
-		IL_0c8f: stloc.s 14
-		IL_0c91: ldloc.s 14
-		IL_0c93: ldc.i4.0
-		IL_0c94: ldelem.ref
-		IL_0c95: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c9a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0c9f: ldc.i4.0
-		IL_0ca0: conv.r8
-		IL_0ca1: ldstr ""
-		IL_0ca6: ldc.i4.0
-		IL_0ca7: ldc.i4.1
-		IL_0ca8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0cad: stloc.s 56
-		IL_0caf: ldloc.s 4
-		IL_0cb1: ldloc.s 6
-		IL_0cb3: ldstr "Compiled Variable Object 12 Char Replace Function"
-		IL_0cb8: ldloc.s 56
-		IL_0cba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0cbf: pop
-		IL_0cc0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0cc5: stloc.s 6
-		IL_0cc7: ldc.i4.1
-		IL_0cc8: newarr [System.Runtime]System.Object
-		IL_0ccd: dup
-		IL_0cce: ldc.i4.0
-		IL_0ccf: ldloc.0
-		IL_0cd0: stelem.ref
-		IL_0cd1: stloc.s 14
-		IL_0cd3: ldloc.s 14
-		IL_0cd5: ldc.i4.0
-		IL_0cd6: ldelem.ref
-		IL_0cd7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0cdc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0ce1: ldc.i4.0
-		IL_0ce2: conv.r8
-		IL_0ce3: ldstr ""
-		IL_0ce8: ldc.i4.0
-		IL_0ce9: ldc.i4.1
-		IL_0cea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0cef: stloc.s 57
-		IL_0cf1: ldloc.3
-		IL_0cf2: ldloc.s 6
-		IL_0cf4: ldloc.s 57
-		IL_0cf6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0cfb: pop
-		IL_0cfc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0d01: stloc.s 6
-		IL_0d03: ldc.i4.1
-		IL_0d04: newarr [System.Runtime]System.Object
-		IL_0d09: dup
-		IL_0d0a: ldc.i4.0
-		IL_0d0b: ldloc.0
-		IL_0d0c: stelem.ref
-		IL_0d0d: stloc.s 14
-		IL_0d0f: ldloc.s 14
-		IL_0d11: ldc.i4.0
-		IL_0d12: ldelem.ref
-		IL_0d13: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d18: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0d1d: ldc.i4.0
-		IL_0d1e: conv.r8
-		IL_0d1f: ldstr ""
-		IL_0d24: ldc.i4.0
-		IL_0d25: ldc.i4.1
-		IL_0d26: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0d2b: stloc.s 58
-		IL_0d2d: ldloc.s 4
-		IL_0d2f: ldloc.s 6
-		IL_0d31: ldstr "Compiled Capture Match"
-		IL_0d36: ldloc.s 58
-		IL_0d38: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0d3d: pop
-		IL_0d3e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0d43: stloc.s 6
-		IL_0d45: ldc.i4.1
-		IL_0d46: newarr [System.Runtime]System.Object
-		IL_0d4b: dup
-		IL_0d4c: ldc.i4.0
-		IL_0d4d: ldloc.0
-		IL_0d4e: stelem.ref
-		IL_0d4f: stloc.s 14
-		IL_0d51: ldloc.s 14
-		IL_0d53: ldc.i4.0
-		IL_0d54: ldelem.ref
-		IL_0d55: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d5a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0d5f: ldc.i4.0
-		IL_0d60: conv.r8
-		IL_0d61: ldstr ""
-		IL_0d66: ldc.i4.0
-		IL_0d67: ldc.i4.1
-		IL_0d68: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0d6d: stloc.s 59
-		IL_0d6f: ldloc.3
-		IL_0d70: ldloc.s 6
-		IL_0d72: ldloc.s 59
-		IL_0d74: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0d79: pop
-		IL_0d7a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0d7f: stloc.s 6
-		IL_0d81: ldc.i4.1
-		IL_0d82: newarr [System.Runtime]System.Object
-		IL_0d87: dup
-		IL_0d88: ldc.i4.0
-		IL_0d89: ldloc.0
-		IL_0d8a: stelem.ref
-		IL_0d8b: stloc.s 14
-		IL_0d8d: ldloc.s 14
-		IL_0d8f: ldc.i4.0
-		IL_0d90: ldelem.ref
-		IL_0d91: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d96: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0d9b: ldc.i4.0
-		IL_0d9c: conv.r8
-		IL_0d9d: ldstr ""
-		IL_0da2: ldc.i4.0
-		IL_0da3: ldc.i4.1
-		IL_0da4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0da9: stloc.s 60
-		IL_0dab: ldloc.s 4
-		IL_0dad: ldloc.s 6
-		IL_0daf: ldstr "Compiled Capture Replace"
-		IL_0db4: ldloc.s 60
-		IL_0db6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0dbb: pop
-		IL_0dbc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0dc1: stloc.s 6
-		IL_0dc3: ldc.i4.1
-		IL_0dc4: newarr [System.Runtime]System.Object
-		IL_0dc9: dup
-		IL_0dca: ldc.i4.0
-		IL_0dcb: ldloc.0
-		IL_0dcc: stelem.ref
-		IL_0dcd: stloc.s 14
-		IL_0dcf: ldloc.s 14
-		IL_0dd1: ldc.i4.0
-		IL_0dd2: ldelem.ref
-		IL_0dd3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0dd8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0ddd: ldc.i4.0
-		IL_0dde: conv.r8
-		IL_0ddf: ldstr ""
-		IL_0de4: ldc.i4.0
-		IL_0de5: ldc.i4.1
-		IL_0de6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0deb: stloc.s 61
-		IL_0ded: ldloc.3
-		IL_0dee: ldloc.s 6
-		IL_0df0: ldloc.s 61
-		IL_0df2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0df7: pop
-		IL_0df8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0dfd: stloc.s 6
-		IL_0dff: ldc.i4.1
-		IL_0e00: newarr [System.Runtime]System.Object
-		IL_0e05: dup
-		IL_0e06: ldc.i4.0
-		IL_0e07: ldloc.0
-		IL_0e08: stelem.ref
-		IL_0e09: stloc.s 14
-		IL_0e0b: ldloc.s 14
-		IL_0e0d: ldc.i4.0
-		IL_0e0e: ldelem.ref
-		IL_0e0f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e14: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0e19: ldc.i4.0
-		IL_0e1a: conv.r8
-		IL_0e1b: ldstr ""
-		IL_0e20: ldc.i4.0
-		IL_0e21: ldc.i4.1
-		IL_0e22: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0e27: stloc.s 62
-		IL_0e29: ldloc.s 4
-		IL_0e2b: ldloc.s 6
-		IL_0e2d: ldstr "Compiled Capture Replace with Capture"
-		IL_0e32: ldloc.s 62
-		IL_0e34: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0e39: pop
-		IL_0e3a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0e3f: stloc.s 6
-		IL_0e41: ldc.i4.1
-		IL_0e42: newarr [System.Runtime]System.Object
-		IL_0e47: dup
-		IL_0e48: ldc.i4.0
-		IL_0e49: ldloc.0
-		IL_0e4a: stelem.ref
-		IL_0e4b: stloc.s 14
-		IL_0e4d: ldloc.s 14
-		IL_0e4f: ldc.i4.0
-		IL_0e50: ldelem.ref
-		IL_0e51: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e56: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0e5b: ldc.i4.0
-		IL_0e5c: conv.r8
-		IL_0e5d: ldstr ""
-		IL_0e62: ldc.i4.0
-		IL_0e63: ldc.i4.1
-		IL_0e64: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0e69: stloc.s 63
-		IL_0e6b: ldloc.3
-		IL_0e6c: ldloc.s 6
-		IL_0e6e: ldloc.s 63
-		IL_0e70: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0e75: pop
-		IL_0e76: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0e7b: stloc.s 6
-		IL_0e7d: ldc.i4.1
-		IL_0e7e: newarr [System.Runtime]System.Object
-		IL_0e83: dup
-		IL_0e84: ldc.i4.0
-		IL_0e85: ldloc.0
-		IL_0e86: stelem.ref
-		IL_0e87: stloc.s 14
-		IL_0e89: ldloc.s 14
-		IL_0e8b: ldc.i4.0
-		IL_0e8c: ldelem.ref
-		IL_0e8d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e92: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0e97: ldc.i4.0
-		IL_0e98: conv.r8
-		IL_0e99: ldstr ""
-		IL_0e9e: ldc.i4.0
-		IL_0e9f: ldc.i4.1
-		IL_0ea0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0ea5: stloc.s 64
-		IL_0ea7: ldloc.s 4
-		IL_0ea9: ldloc.s 6
-		IL_0eab: ldstr "Compiled Capture Replace with Capture Function"
-		IL_0eb0: ldloc.s 64
-		IL_0eb2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0eb7: pop
-		IL_0eb8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0ebd: stloc.s 6
-		IL_0ebf: ldc.i4.1
-		IL_0ec0: newarr [System.Runtime]System.Object
-		IL_0ec5: dup
-		IL_0ec6: ldc.i4.0
-		IL_0ec7: ldloc.0
-		IL_0ec8: stelem.ref
-		IL_0ec9: stloc.s 14
-		IL_0ecb: ldloc.s 14
-		IL_0ecd: ldc.i4.0
-		IL_0ece: ldelem.ref
-		IL_0ecf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ed4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0ed9: ldc.i4.0
-		IL_0eda: conv.r8
-		IL_0edb: ldstr ""
-		IL_0ee0: ldc.i4.0
-		IL_0ee1: ldc.i4.1
-		IL_0ee2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0ee7: stloc.s 65
-		IL_0ee9: ldloc.3
-		IL_0eea: ldloc.s 6
-		IL_0eec: ldloc.s 65
-		IL_0eee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0ef3: pop
-		IL_0ef4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0ef9: stloc.s 6
-		IL_0efb: ldc.i4.1
-		IL_0efc: newarr [System.Runtime]System.Object
-		IL_0f01: dup
-		IL_0f02: ldc.i4.0
-		IL_0f03: ldloc.0
-		IL_0f04: stelem.ref
-		IL_0f05: stloc.s 14
-		IL_0f07: ldloc.s 14
-		IL_0f09: ldc.i4.0
-		IL_0f0a: ldelem.ref
-		IL_0f0b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f10: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0f15: ldc.i4.0
-		IL_0f16: conv.r8
-		IL_0f17: ldstr ""
-		IL_0f1c: ldc.i4.0
-		IL_0f1d: ldc.i4.1
-		IL_0f1e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0f23: stloc.s 66
-		IL_0f25: ldloc.s 4
-		IL_0f27: ldloc.s 6
-		IL_0f29: ldstr "Compiled Capture Replace with Upperase Capture Function"
-		IL_0f2e: ldloc.s 66
-		IL_0f30: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0f35: pop
-		IL_0f36: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0f3b: stloc.s 6
-		IL_0f3d: ldc.i4.1
-		IL_0f3e: newarr [System.Runtime]System.Object
-		IL_0f43: dup
-		IL_0f44: ldc.i4.0
-		IL_0f45: ldloc.0
-		IL_0f46: stelem.ref
-		IL_0f47: stloc.s 14
-		IL_0f49: ldloc.s 14
-		IL_0f4b: ldc.i4.0
-		IL_0f4c: ldelem.ref
-		IL_0f4d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f52: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0f57: ldc.i4.0
-		IL_0f58: conv.r8
-		IL_0f59: ldstr ""
-		IL_0f5e: ldc.i4.0
-		IL_0f5f: ldc.i4.1
-		IL_0f60: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0f65: stloc.s 67
-		IL_0f67: ldloc.3
-		IL_0f68: ldloc.s 6
-		IL_0f6a: ldloc.s 67
-		IL_0f6c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0f71: pop
-		IL_0f72: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0f77: stloc.s 6
-		IL_0f79: ldc.i4.1
-		IL_0f7a: newarr [System.Runtime]System.Object
-		IL_0f7f: dup
-		IL_0f80: ldc.i4.0
-		IL_0f81: ldloc.0
-		IL_0f82: stelem.ref
-		IL_0f83: stloc.s 14
-		IL_0f85: ldloc.s 14
-		IL_0f87: ldc.i4.0
-		IL_0f88: ldelem.ref
-		IL_0f89: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f8e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0f93: ldc.i4.0
-		IL_0f94: conv.r8
-		IL_0f95: ldstr ""
-		IL_0f9a: ldc.i4.0
-		IL_0f9b: ldc.i4.1
-		IL_0f9c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0fa1: stloc.s 68
-		IL_0fa3: ldloc.s 4
-		IL_0fa5: ldloc.s 6
-		IL_0fa7: ldstr "Uncompiled Match"
-		IL_0fac: ldloc.s 68
-		IL_0fae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0fb3: pop
-		IL_0fb4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0fb9: stloc.s 6
-		IL_0fbb: ldc.i4.1
-		IL_0fbc: newarr [System.Runtime]System.Object
-		IL_0fc1: dup
-		IL_0fc2: ldc.i4.0
-		IL_0fc3: ldloc.0
-		IL_0fc4: stelem.ref
-		IL_0fc5: stloc.s 14
-		IL_0fc7: ldloc.s 14
-		IL_0fc9: ldc.i4.0
-		IL_0fca: ldelem.ref
-		IL_0fcb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0fd0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0fd5: ldc.i4.0
-		IL_0fd6: conv.r8
-		IL_0fd7: ldstr ""
-		IL_0fdc: ldc.i4.0
-		IL_0fdd: ldc.i4.1
-		IL_0fde: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0fe3: stloc.s 69
-		IL_0fe5: ldloc.3
-		IL_0fe6: ldloc.s 6
-		IL_0fe8: ldloc.s 69
-		IL_0fea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0fef: pop
-		IL_0ff0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0ff5: stloc.s 6
-		IL_0ff7: ldc.i4.1
-		IL_0ff8: newarr [System.Runtime]System.Object
-		IL_0ffd: dup
-		IL_0ffe: ldc.i4.0
-		IL_0fff: ldloc.0
-		IL_1000: stelem.ref
-		IL_1001: stloc.s 14
-		IL_1003: ldloc.s 14
-		IL_1005: ldc.i4.0
-		IL_1006: ldelem.ref
-		IL_1007: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_100c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1011: ldc.i4.0
-		IL_1012: conv.r8
-		IL_1013: ldstr ""
-		IL_1018: ldc.i4.0
-		IL_1019: ldc.i4.1
-		IL_101a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_101f: stloc.s 70
-		IL_1021: ldloc.s 4
-		IL_1023: ldloc.s 6
-		IL_1025: ldstr "Uncompiled Test"
-		IL_102a: ldloc.s 70
-		IL_102c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_1031: pop
-		IL_1032: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1037: stloc.s 6
-		IL_1039: ldc.i4.1
-		IL_103a: newarr [System.Runtime]System.Object
-		IL_103f: dup
-		IL_1040: ldc.i4.0
-		IL_1041: ldloc.0
-		IL_1042: stelem.ref
-		IL_1043: stloc.s 14
-		IL_1045: ldloc.s 14
-		IL_1047: ldc.i4.0
-		IL_1048: ldelem.ref
-		IL_1049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_104e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1053: ldc.i4.0
-		IL_1054: conv.r8
-		IL_1055: ldstr ""
-		IL_105a: ldc.i4.0
-		IL_105b: ldc.i4.1
-		IL_105c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1061: stloc.s 71
-		IL_1063: ldloc.3
-		IL_1064: ldloc.s 6
-		IL_1066: ldloc.s 71
-		IL_1068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_106d: pop
-		IL_106e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1073: stloc.s 6
-		IL_1075: ldc.i4.1
-		IL_1076: newarr [System.Runtime]System.Object
-		IL_107b: dup
-		IL_107c: ldc.i4.0
-		IL_107d: ldloc.0
-		IL_107e: stelem.ref
-		IL_107f: stloc.s 14
-		IL_1081: ldloc.s 14
-		IL_1083: ldc.i4.0
-		IL_1084: ldelem.ref
-		IL_1085: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_108a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_108f: ldc.i4.0
-		IL_1090: conv.r8
-		IL_1091: ldstr ""
-		IL_1096: ldc.i4.0
-		IL_1097: ldc.i4.1
-		IL_1098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_109d: stloc.s 72
-		IL_109f: ldloc.s 4
-		IL_10a1: ldloc.s 6
-		IL_10a3: ldstr "Uncompiled Empty Replace"
-		IL_10a8: ldloc.s 72
-		IL_10aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_10af: pop
-		IL_10b0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_10b5: stloc.s 6
-		IL_10b7: ldc.i4.1
-		IL_10b8: newarr [System.Runtime]System.Object
-		IL_10bd: dup
-		IL_10be: ldc.i4.0
-		IL_10bf: ldloc.0
-		IL_10c0: stelem.ref
-		IL_10c1: stloc.s 14
-		IL_10c3: ldloc.s 14
-		IL_10c5: ldc.i4.0
-		IL_10c6: ldelem.ref
-		IL_10c7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_10cc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_10d1: ldc.i4.0
-		IL_10d2: conv.r8
-		IL_10d3: ldstr ""
-		IL_10d8: ldc.i4.0
-		IL_10d9: ldc.i4.1
-		IL_10da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_10df: stloc.s 73
-		IL_10e1: ldloc.3
-		IL_10e2: ldloc.s 6
-		IL_10e4: ldloc.s 73
-		IL_10e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_10eb: pop
-		IL_10ec: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_10f1: stloc.s 6
-		IL_10f3: ldc.i4.1
-		IL_10f4: newarr [System.Runtime]System.Object
-		IL_10f9: dup
-		IL_10fa: ldc.i4.0
-		IL_10fb: ldloc.0
-		IL_10fc: stelem.ref
-		IL_10fd: stloc.s 14
-		IL_10ff: ldloc.s 14
-		IL_1101: ldc.i4.0
-		IL_1102: ldelem.ref
-		IL_1103: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1108: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_110d: ldc.i4.0
-		IL_110e: conv.r8
-		IL_110f: ldstr ""
-		IL_1114: ldc.i4.0
-		IL_1115: ldc.i4.1
-		IL_1116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_111b: stloc.s 74
-		IL_111d: ldloc.s 4
-		IL_111f: ldloc.s 6
-		IL_1121: ldstr "Uncompiled 12 Char Replace"
-		IL_1126: ldloc.s 74
-		IL_1128: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_112d: pop
-		IL_112e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1133: stloc.s 6
-		IL_1135: ldc.i4.1
-		IL_1136: newarr [System.Runtime]System.Object
-		IL_113b: dup
-		IL_113c: ldc.i4.0
-		IL_113d: ldloc.0
-		IL_113e: stelem.ref
-		IL_113f: stloc.s 14
-		IL_1141: ldloc.s 14
-		IL_1143: ldc.i4.0
-		IL_1144: ldelem.ref
-		IL_1145: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_114a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_114f: ldc.i4.0
-		IL_1150: conv.r8
-		IL_1151: ldstr ""
-		IL_1156: ldc.i4.0
-		IL_1157: ldc.i4.1
-		IL_1158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_115d: stloc.s 75
-		IL_115f: ldloc.3
-		IL_1160: ldloc.s 6
-		IL_1162: ldloc.s 75
-		IL_1164: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1169: pop
-		IL_116a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_116f: stloc.s 6
-		IL_1171: ldc.i4.1
-		IL_1172: newarr [System.Runtime]System.Object
-		IL_1177: dup
-		IL_1178: ldc.i4.0
-		IL_1179: ldloc.0
-		IL_117a: stelem.ref
-		IL_117b: stloc.s 14
-		IL_117d: ldloc.s 14
-		IL_117f: ldc.i4.0
-		IL_1180: ldelem.ref
-		IL_1181: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1186: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_118b: ldc.i4.0
-		IL_118c: conv.r8
-		IL_118d: ldstr ""
-		IL_1192: ldc.i4.0
-		IL_1193: ldc.i4.1
-		IL_1194: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1199: stloc.s 76
-		IL_119b: ldloc.s 4
-		IL_119d: ldloc.s 6
-		IL_119f: ldstr "Uncompiled Object Match"
-		IL_11a4: ldloc.s 76
-		IL_11a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_11ab: pop
-		IL_11ac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_11b1: stloc.s 6
-		IL_11b3: ldc.i4.1
-		IL_11b4: newarr [System.Runtime]System.Object
-		IL_11b9: dup
-		IL_11ba: ldc.i4.0
-		IL_11bb: ldloc.0
-		IL_11bc: stelem.ref
-		IL_11bd: stloc.s 14
-		IL_11bf: ldloc.s 14
-		IL_11c1: ldc.i4.0
-		IL_11c2: ldelem.ref
-		IL_11c3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_11c8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_11cd: ldc.i4.0
-		IL_11ce: conv.r8
-		IL_11cf: ldstr ""
-		IL_11d4: ldc.i4.0
-		IL_11d5: ldc.i4.1
-		IL_11d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_11db: stloc.s 77
-		IL_11dd: ldloc.3
-		IL_11de: ldloc.s 6
-		IL_11e0: ldloc.s 77
-		IL_11e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_11e7: pop
-		IL_11e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_11ed: stloc.s 6
-		IL_11ef: ldc.i4.1
-		IL_11f0: newarr [System.Runtime]System.Object
-		IL_11f5: dup
-		IL_11f6: ldc.i4.0
-		IL_11f7: ldloc.0
-		IL_11f8: stelem.ref
-		IL_11f9: stloc.s 14
-		IL_11fb: ldloc.s 14
-		IL_11fd: ldc.i4.0
-		IL_11fe: ldelem.ref
-		IL_11ff: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1204: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1209: ldc.i4.0
-		IL_120a: conv.r8
-		IL_120b: ldstr ""
-		IL_1210: ldc.i4.0
-		IL_1211: ldc.i4.1
-		IL_1212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1217: stloc.s 78
-		IL_1219: ldloc.s 4
-		IL_121b: ldloc.s 6
-		IL_121d: ldstr "Uncompiled Object Test"
-		IL_1222: ldloc.s 78
-		IL_1224: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_1229: pop
-		IL_122a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_122f: stloc.s 6
-		IL_1231: ldc.i4.1
-		IL_1232: newarr [System.Runtime]System.Object
-		IL_1237: dup
-		IL_1238: ldc.i4.0
-		IL_1239: ldloc.0
-		IL_123a: stelem.ref
-		IL_123b: stloc.s 14
-		IL_123d: ldloc.s 14
-		IL_123f: ldc.i4.0
-		IL_1240: ldelem.ref
-		IL_1241: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1246: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_124b: ldc.i4.0
-		IL_124c: conv.r8
-		IL_124d: ldstr ""
-		IL_1252: ldc.i4.0
-		IL_1253: ldc.i4.1
-		IL_1254: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1259: stloc.s 79
-		IL_125b: ldloc.3
-		IL_125c: ldloc.s 6
-		IL_125e: ldloc.s 79
-		IL_1260: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1265: pop
-		IL_1266: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_126b: stloc.s 6
-		IL_126d: ldc.i4.1
-		IL_126e: newarr [System.Runtime]System.Object
-		IL_1273: dup
-		IL_1274: ldc.i4.0
-		IL_1275: ldloc.0
-		IL_1276: stelem.ref
-		IL_1277: stloc.s 14
-		IL_1279: ldloc.s 14
-		IL_127b: ldc.i4.0
-		IL_127c: ldelem.ref
-		IL_127d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1282: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1287: ldc.i4.0
-		IL_1288: conv.r8
-		IL_1289: ldstr ""
-		IL_128e: ldc.i4.0
-		IL_128f: ldc.i4.1
-		IL_1290: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1295: stloc.s 80
-		IL_1297: ldloc.s 4
-		IL_1299: ldloc.s 6
-		IL_129b: ldstr "Uncompiled Object Empty Replace"
-		IL_12a0: ldloc.s 80
-		IL_12a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_12a7: pop
-		IL_12a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_12ad: stloc.s 6
-		IL_12af: ldc.i4.1
-		IL_12b0: newarr [System.Runtime]System.Object
-		IL_12b5: dup
-		IL_12b6: ldc.i4.0
-		IL_12b7: ldloc.0
-		IL_12b8: stelem.ref
-		IL_12b9: stloc.s 14
-		IL_12bb: ldloc.s 14
-		IL_12bd: ldc.i4.0
-		IL_12be: ldelem.ref
-		IL_12bf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_12c4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_12c9: ldc.i4.0
-		IL_12ca: conv.r8
-		IL_12cb: ldstr ""
-		IL_12d0: ldc.i4.0
-		IL_12d1: ldc.i4.1
-		IL_12d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_12d7: stloc.s 81
-		IL_12d9: ldloc.3
-		IL_12da: ldloc.s 6
-		IL_12dc: ldloc.s 81
-		IL_12de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_12e3: pop
-		IL_12e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_12e9: stloc.s 6
-		IL_12eb: ldc.i4.1
-		IL_12ec: newarr [System.Runtime]System.Object
-		IL_12f1: dup
-		IL_12f2: ldc.i4.0
-		IL_12f3: ldloc.0
-		IL_12f4: stelem.ref
-		IL_12f5: stloc.s 14
-		IL_12f7: ldloc.s 14
-		IL_12f9: ldc.i4.0
-		IL_12fa: ldelem.ref
-		IL_12fb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1300: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1305: ldc.i4.0
-		IL_1306: conv.r8
-		IL_1307: ldstr ""
-		IL_130c: ldc.i4.0
-		IL_130d: ldc.i4.1
-		IL_130e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1313: stloc.s 82
-		IL_1315: ldloc.s 4
-		IL_1317: ldloc.s 6
-		IL_1319: ldstr "Uncompiled Object 12 Char Replace"
-		IL_131e: ldloc.s 82
-		IL_1320: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_1325: pop
-		IL_1326: ldloc.2
-		IL_1327: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_132c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_1331: pop
-		IL_1332: ret
+		IL_020a: volatile.
+		IL_020c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_0211: brfalse IL_022a
+
+		IL_0216: ldstr "join"
+		IL_021b: ldstr ""
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0225: br IL_0243
+
+		IL_022a: ldstr "join"
+		IL_022f: ldstr ""
+		IL_0234: ldstr "Compile_Performance_Dromaeo_Object_Regexp:Modules.Compile_Performance_Dromaeo_Object_Regexp:__js_module_init__:70"
+		IL_0239: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0243: stloc.s 12
+		IL_0245: ldloc.0
+		IL_0246: ldloc.s 12
+		IL_0248: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_024d: ldloc.0
+		IL_024e: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0253: stloc.s 12
+		IL_0255: ldloc.0
+		IL_0256: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_025b: stloc.s 11
+		IL_025d: ldloc.s 12
+		IL_025f: ldloc.s 11
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0266: stloc.s 13
+		IL_0268: ldloc.0
+		IL_0269: ldloc.s 13
+		IL_026b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0270: ldloc.0
+		IL_0271: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0276: stloc.s 11
+		IL_0278: ldloc.0
+		IL_0279: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_027e: stloc.s 12
+		IL_0280: ldloc.s 11
+		IL_0282: ldloc.s 12
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0289: stloc.s 13
+		IL_028b: ldloc.0
+		IL_028c: ldloc.s 13
+		IL_028e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0293: nop
+		IL_0294: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0299: stloc.s 6
+		IL_029b: ldc.i4.1
+		IL_029c: newarr [System.Runtime]System.Object
+		IL_02a1: dup
+		IL_02a2: ldc.i4.0
+		IL_02a3: ldloc.0
+		IL_02a4: stelem.ref
+		IL_02a5: stloc.s 14
+		IL_02a7: ldloc.s 14
+		IL_02a9: ldc.i4.0
+		IL_02aa: ldelem.ref
+		IL_02ab: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_02b0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_02b5: ldc.i4.0
+		IL_02b6: conv.r8
+		IL_02b7: ldstr ""
+		IL_02bc: ldc.i4.0
+		IL_02bd: ldc.i4.1
+		IL_02be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02c3: stloc.s 15
+		IL_02c5: ldloc.3
+		IL_02c6: ldloc.s 6
+		IL_02c8: ldloc.s 15
+		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_02cf: pop
+		IL_02d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02d5: stloc.s 6
+		IL_02d7: ldc.i4.1
+		IL_02d8: newarr [System.Runtime]System.Object
+		IL_02dd: dup
+		IL_02de: ldc.i4.0
+		IL_02df: ldloc.0
+		IL_02e0: stelem.ref
+		IL_02e1: stloc.s 14
+		IL_02e3: ldloc.s 14
+		IL_02e5: ldc.i4.0
+		IL_02e6: ldelem.ref
+		IL_02e7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_02ec: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_02f1: ldc.i4.0
+		IL_02f2: conv.r8
+		IL_02f3: ldstr ""
+		IL_02f8: ldc.i4.0
+		IL_02f9: ldc.i4.1
+		IL_02fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02ff: stloc.s 16
+		IL_0301: ldloc.s 4
+		IL_0303: ldloc.s 6
+		IL_0305: ldstr "Compiled Object Empty Split"
+		IL_030a: ldloc.s 16
+		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0311: pop
+		IL_0312: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0317: stloc.s 6
+		IL_0319: ldc.i4.1
+		IL_031a: newarr [System.Runtime]System.Object
+		IL_031f: dup
+		IL_0320: ldc.i4.0
+		IL_0321: ldloc.0
+		IL_0322: stelem.ref
+		IL_0323: stloc.s 14
+		IL_0325: ldloc.s 14
+		IL_0327: ldc.i4.0
+		IL_0328: ldelem.ref
+		IL_0329: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_032e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0333: ldc.i4.0
+		IL_0334: conv.r8
+		IL_0335: ldstr ""
+		IL_033a: ldc.i4.0
+		IL_033b: ldc.i4.1
+		IL_033c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0341: stloc.s 17
+		IL_0343: ldloc.3
+		IL_0344: ldloc.s 6
+		IL_0346: ldloc.s 17
+		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_034d: pop
+		IL_034e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0353: stloc.s 6
+		IL_0355: ldc.i4.1
+		IL_0356: newarr [System.Runtime]System.Object
+		IL_035b: dup
+		IL_035c: ldc.i4.0
+		IL_035d: ldloc.0
+		IL_035e: stelem.ref
+		IL_035f: stloc.s 14
+		IL_0361: ldloc.s 14
+		IL_0363: ldc.i4.0
+		IL_0364: ldelem.ref
+		IL_0365: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_036a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_036f: ldc.i4.0
+		IL_0370: conv.r8
+		IL_0371: ldstr ""
+		IL_0376: ldc.i4.0
+		IL_0377: ldc.i4.1
+		IL_0378: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_037d: stloc.s 18
+		IL_037f: ldloc.s 4
+		IL_0381: ldloc.s 6
+		IL_0383: ldstr "Compiled Object Char Split"
+		IL_0388: ldloc.s 18
+		IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_038f: pop
+		IL_0390: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0395: stloc.s 6
+		IL_0397: ldc.i4.1
+		IL_0398: newarr [System.Runtime]System.Object
+		IL_039d: dup
+		IL_039e: ldc.i4.0
+		IL_039f: ldloc.0
+		IL_03a0: stelem.ref
+		IL_03a1: stloc.s 14
+		IL_03a3: ldloc.s 14
+		IL_03a5: ldc.i4.0
+		IL_03a6: ldelem.ref
+		IL_03a7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_03ac: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_03b1: ldc.i4.0
+		IL_03b2: conv.r8
+		IL_03b3: ldstr ""
+		IL_03b8: ldc.i4.0
+		IL_03b9: ldc.i4.1
+		IL_03ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03bf: stloc.s 19
+		IL_03c1: ldloc.3
+		IL_03c2: ldloc.s 6
+		IL_03c4: ldloc.s 19
+		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_03cb: pop
+		IL_03cc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03d1: stloc.s 6
+		IL_03d3: ldc.i4.1
+		IL_03d4: newarr [System.Runtime]System.Object
+		IL_03d9: dup
+		IL_03da: ldc.i4.0
+		IL_03db: ldloc.0
+		IL_03dc: stelem.ref
+		IL_03dd: stloc.s 14
+		IL_03df: ldloc.s 14
+		IL_03e1: ldc.i4.0
+		IL_03e2: ldelem.ref
+		IL_03e3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_03e8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_03ed: ldc.i4.0
+		IL_03ee: conv.r8
+		IL_03ef: ldstr ""
+		IL_03f4: ldc.i4.0
+		IL_03f5: ldc.i4.1
+		IL_03f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03fb: stloc.s 20
+		IL_03fd: ldloc.s 4
+		IL_03ff: ldloc.s 6
+		IL_0401: ldstr "Compiled Object Variable Split"
+		IL_0406: ldloc.s 20
+		IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_040d: pop
+		IL_040e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0413: stloc.s 6
+		IL_0415: ldc.i4.1
+		IL_0416: newarr [System.Runtime]System.Object
+		IL_041b: dup
+		IL_041c: ldc.i4.0
+		IL_041d: ldloc.0
+		IL_041e: stelem.ref
+		IL_041f: stloc.s 14
+		IL_0421: ldloc.s 14
+		IL_0423: ldc.i4.0
+		IL_0424: ldelem.ref
+		IL_0425: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_042a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_042f: ldc.i4.0
+		IL_0430: conv.r8
+		IL_0431: ldstr ""
+		IL_0436: ldc.i4.0
+		IL_0437: ldc.i4.1
+		IL_0438: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_043d: stloc.s 21
+		IL_043f: ldloc.3
+		IL_0440: ldloc.s 6
+		IL_0442: ldloc.s 21
+		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0449: pop
+		IL_044a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_044f: stloc.s 6
+		IL_0451: ldc.i4.1
+		IL_0452: newarr [System.Runtime]System.Object
+		IL_0457: dup
+		IL_0458: ldc.i4.0
+		IL_0459: ldloc.0
+		IL_045a: stelem.ref
+		IL_045b: stloc.s 14
+		IL_045d: ldloc.s 14
+		IL_045f: ldc.i4.0
+		IL_0460: ldelem.ref
+		IL_0461: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0466: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_046b: ldc.i4.0
+		IL_046c: conv.r8
+		IL_046d: ldstr ""
+		IL_0472: ldc.i4.0
+		IL_0473: ldc.i4.1
+		IL_0474: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0479: stloc.s 22
+		IL_047b: ldloc.s 4
+		IL_047d: ldloc.s 6
+		IL_047f: ldstr "Compiled Match"
+		IL_0484: ldloc.s 22
+		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_048b: pop
+		IL_048c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0491: stloc.s 6
+		IL_0493: ldc.i4.1
+		IL_0494: newarr [System.Runtime]System.Object
+		IL_0499: dup
+		IL_049a: ldc.i4.0
+		IL_049b: ldloc.0
+		IL_049c: stelem.ref
+		IL_049d: stloc.s 14
+		IL_049f: ldloc.s 14
+		IL_04a1: ldc.i4.0
+		IL_04a2: ldelem.ref
+		IL_04a3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_04a8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_04ad: ldc.i4.0
+		IL_04ae: conv.r8
+		IL_04af: ldstr ""
+		IL_04b4: ldc.i4.0
+		IL_04b5: ldc.i4.1
+		IL_04b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04bb: stloc.s 23
+		IL_04bd: ldloc.3
+		IL_04be: ldloc.s 6
+		IL_04c0: ldloc.s 23
+		IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_04c7: pop
+		IL_04c8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04cd: stloc.s 6
+		IL_04cf: ldc.i4.1
+		IL_04d0: newarr [System.Runtime]System.Object
+		IL_04d5: dup
+		IL_04d6: ldc.i4.0
+		IL_04d7: ldloc.0
+		IL_04d8: stelem.ref
+		IL_04d9: stloc.s 14
+		IL_04db: ldloc.s 14
+		IL_04dd: ldc.i4.0
+		IL_04de: ldelem.ref
+		IL_04df: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_04e4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_04e9: ldc.i4.0
+		IL_04ea: conv.r8
+		IL_04eb: ldstr ""
+		IL_04f0: ldc.i4.0
+		IL_04f1: ldc.i4.1
+		IL_04f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04f7: stloc.s 24
+		IL_04f9: ldloc.s 4
+		IL_04fb: ldloc.s 6
+		IL_04fd: ldstr "Compiled Test"
+		IL_0502: ldloc.s 24
+		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0509: pop
+		IL_050a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_050f: stloc.s 6
+		IL_0511: ldc.i4.1
+		IL_0512: newarr [System.Runtime]System.Object
+		IL_0517: dup
+		IL_0518: ldc.i4.0
+		IL_0519: ldloc.0
+		IL_051a: stelem.ref
+		IL_051b: stloc.s 14
+		IL_051d: ldloc.s 14
+		IL_051f: ldc.i4.0
+		IL_0520: ldelem.ref
+		IL_0521: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0526: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_052b: ldc.i4.0
+		IL_052c: conv.r8
+		IL_052d: ldstr ""
+		IL_0532: ldc.i4.0
+		IL_0533: ldc.i4.1
+		IL_0534: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0539: stloc.s 25
+		IL_053b: ldloc.3
+		IL_053c: ldloc.s 6
+		IL_053e: ldloc.s 25
+		IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0545: pop
+		IL_0546: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_054b: stloc.s 6
+		IL_054d: ldc.i4.1
+		IL_054e: newarr [System.Runtime]System.Object
+		IL_0553: dup
+		IL_0554: ldc.i4.0
+		IL_0555: ldloc.0
+		IL_0556: stelem.ref
+		IL_0557: stloc.s 14
+		IL_0559: ldloc.s 14
+		IL_055b: ldc.i4.0
+		IL_055c: ldelem.ref
+		IL_055d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0562: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0567: ldc.i4.0
+		IL_0568: conv.r8
+		IL_0569: ldstr ""
+		IL_056e: ldc.i4.0
+		IL_056f: ldc.i4.1
+		IL_0570: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0575: stloc.s 26
+		IL_0577: ldloc.s 4
+		IL_0579: ldloc.s 6
+		IL_057b: ldstr "Compiled Empty Replace"
+		IL_0580: ldloc.s 26
+		IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0587: pop
+		IL_0588: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_058d: stloc.s 6
+		IL_058f: ldc.i4.1
+		IL_0590: newarr [System.Runtime]System.Object
+		IL_0595: dup
+		IL_0596: ldc.i4.0
+		IL_0597: ldloc.0
+		IL_0598: stelem.ref
+		IL_0599: stloc.s 14
+		IL_059b: ldloc.s 14
+		IL_059d: ldc.i4.0
+		IL_059e: ldelem.ref
+		IL_059f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_05a4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05a9: ldc.i4.0
+		IL_05aa: conv.r8
+		IL_05ab: ldstr ""
+		IL_05b0: ldc.i4.0
+		IL_05b1: ldc.i4.1
+		IL_05b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05b7: stloc.s 27
+		IL_05b9: ldloc.3
+		IL_05ba: ldloc.s 6
+		IL_05bc: ldloc.s 27
+		IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_05c3: pop
+		IL_05c4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05c9: stloc.s 6
+		IL_05cb: ldc.i4.1
+		IL_05cc: newarr [System.Runtime]System.Object
+		IL_05d1: dup
+		IL_05d2: ldc.i4.0
+		IL_05d3: ldloc.0
+		IL_05d4: stelem.ref
+		IL_05d5: stloc.s 14
+		IL_05d7: ldloc.s 14
+		IL_05d9: ldc.i4.0
+		IL_05da: ldelem.ref
+		IL_05db: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_05e0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05e5: ldc.i4.0
+		IL_05e6: conv.r8
+		IL_05e7: ldstr ""
+		IL_05ec: ldc.i4.0
+		IL_05ed: ldc.i4.1
+		IL_05ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05f3: stloc.s 28
+		IL_05f5: ldloc.s 4
+		IL_05f7: ldloc.s 6
+		IL_05f9: ldstr "Compiled 12 Char Replace"
+		IL_05fe: ldloc.s 28
+		IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0605: pop
+		IL_0606: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_060b: stloc.s 6
+		IL_060d: ldc.i4.1
+		IL_060e: newarr [System.Runtime]System.Object
+		IL_0613: dup
+		IL_0614: ldc.i4.0
+		IL_0615: ldloc.0
+		IL_0616: stelem.ref
+		IL_0617: stloc.s 14
+		IL_0619: ldloc.s 14
+		IL_061b: ldc.i4.0
+		IL_061c: ldelem.ref
+		IL_061d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0622: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0627: ldc.i4.0
+		IL_0628: conv.r8
+		IL_0629: ldstr ""
+		IL_062e: ldc.i4.0
+		IL_062f: ldc.i4.1
+		IL_0630: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0635: stloc.s 29
+		IL_0637: ldloc.3
+		IL_0638: ldloc.s 6
+		IL_063a: ldloc.s 29
+		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0641: pop
+		IL_0642: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0647: stloc.s 6
+		IL_0649: ldc.i4.1
+		IL_064a: newarr [System.Runtime]System.Object
+		IL_064f: dup
+		IL_0650: ldc.i4.0
+		IL_0651: ldloc.0
+		IL_0652: stelem.ref
+		IL_0653: stloc.s 14
+		IL_0655: ldloc.s 14
+		IL_0657: ldc.i4.0
+		IL_0658: ldelem.ref
+		IL_0659: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_065e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0663: ldc.i4.0
+		IL_0664: conv.r8
+		IL_0665: ldstr ""
+		IL_066a: ldc.i4.0
+		IL_066b: ldc.i4.1
+		IL_066c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0671: stloc.s 30
+		IL_0673: ldloc.s 4
+		IL_0675: ldloc.s 6
+		IL_0677: ldstr "Compiled Object Match"
+		IL_067c: ldloc.s 30
+		IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0683: pop
+		IL_0684: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0689: stloc.s 6
+		IL_068b: ldc.i4.1
+		IL_068c: newarr [System.Runtime]System.Object
+		IL_0691: dup
+		IL_0692: ldc.i4.0
+		IL_0693: ldloc.0
+		IL_0694: stelem.ref
+		IL_0695: stloc.s 14
+		IL_0697: ldloc.s 14
+		IL_0699: ldc.i4.0
+		IL_069a: ldelem.ref
+		IL_069b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_06a0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06a5: ldc.i4.0
+		IL_06a6: conv.r8
+		IL_06a7: ldstr ""
+		IL_06ac: ldc.i4.0
+		IL_06ad: ldc.i4.1
+		IL_06ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06b3: stloc.s 31
+		IL_06b5: ldloc.3
+		IL_06b6: ldloc.s 6
+		IL_06b8: ldloc.s 31
+		IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_06bf: pop
+		IL_06c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06c5: stloc.s 6
+		IL_06c7: ldc.i4.1
+		IL_06c8: newarr [System.Runtime]System.Object
+		IL_06cd: dup
+		IL_06ce: ldc.i4.0
+		IL_06cf: ldloc.0
+		IL_06d0: stelem.ref
+		IL_06d1: stloc.s 14
+		IL_06d3: ldloc.s 14
+		IL_06d5: ldc.i4.0
+		IL_06d6: ldelem.ref
+		IL_06d7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_06dc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06e1: ldc.i4.0
+		IL_06e2: conv.r8
+		IL_06e3: ldstr ""
+		IL_06e8: ldc.i4.0
+		IL_06e9: ldc.i4.1
+		IL_06ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06ef: stloc.s 32
+		IL_06f1: ldloc.s 4
+		IL_06f3: ldloc.s 6
+		IL_06f5: ldstr "Compiled Object Test"
+		IL_06fa: ldloc.s 32
+		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0701: pop
+		IL_0702: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0707: stloc.s 6
+		IL_0709: ldc.i4.1
+		IL_070a: newarr [System.Runtime]System.Object
+		IL_070f: dup
+		IL_0710: ldc.i4.0
+		IL_0711: ldloc.0
+		IL_0712: stelem.ref
+		IL_0713: stloc.s 14
+		IL_0715: ldloc.s 14
+		IL_0717: ldc.i4.0
+		IL_0718: ldelem.ref
+		IL_0719: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_071e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0723: ldc.i4.0
+		IL_0724: conv.r8
+		IL_0725: ldstr ""
+		IL_072a: ldc.i4.0
+		IL_072b: ldc.i4.1
+		IL_072c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0731: stloc.s 33
+		IL_0733: ldloc.3
+		IL_0734: ldloc.s 6
+		IL_0736: ldloc.s 33
+		IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_073d: pop
+		IL_073e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0743: stloc.s 6
+		IL_0745: ldc.i4.1
+		IL_0746: newarr [System.Runtime]System.Object
+		IL_074b: dup
+		IL_074c: ldc.i4.0
+		IL_074d: ldloc.0
+		IL_074e: stelem.ref
+		IL_074f: stloc.s 14
+		IL_0751: ldloc.s 14
+		IL_0753: ldc.i4.0
+		IL_0754: ldelem.ref
+		IL_0755: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_075a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_075f: ldc.i4.0
+		IL_0760: conv.r8
+		IL_0761: ldstr ""
+		IL_0766: ldc.i4.0
+		IL_0767: ldc.i4.1
+		IL_0768: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_076d: stloc.s 34
+		IL_076f: ldloc.s 4
+		IL_0771: ldloc.s 6
+		IL_0773: ldstr "Compiled Object Empty Replace"
+		IL_0778: ldloc.s 34
+		IL_077a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_077f: pop
+		IL_0780: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0785: stloc.s 6
+		IL_0787: ldc.i4.1
+		IL_0788: newarr [System.Runtime]System.Object
+		IL_078d: dup
+		IL_078e: ldc.i4.0
+		IL_078f: ldloc.0
+		IL_0790: stelem.ref
+		IL_0791: stloc.s 14
+		IL_0793: ldloc.s 14
+		IL_0795: ldc.i4.0
+		IL_0796: ldelem.ref
+		IL_0797: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_079c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_07a1: ldc.i4.0
+		IL_07a2: conv.r8
+		IL_07a3: ldstr ""
+		IL_07a8: ldc.i4.0
+		IL_07a9: ldc.i4.1
+		IL_07aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07af: stloc.s 35
+		IL_07b1: ldloc.3
+		IL_07b2: ldloc.s 6
+		IL_07b4: ldloc.s 35
+		IL_07b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_07bb: pop
+		IL_07bc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_07c1: stloc.s 6
+		IL_07c3: ldc.i4.1
+		IL_07c4: newarr [System.Runtime]System.Object
+		IL_07c9: dup
+		IL_07ca: ldc.i4.0
+		IL_07cb: ldloc.0
+		IL_07cc: stelem.ref
+		IL_07cd: stloc.s 14
+		IL_07cf: ldloc.s 14
+		IL_07d1: ldc.i4.0
+		IL_07d2: ldelem.ref
+		IL_07d3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_07d8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_07dd: ldc.i4.0
+		IL_07de: conv.r8
+		IL_07df: ldstr ""
+		IL_07e4: ldc.i4.0
+		IL_07e5: ldc.i4.1
+		IL_07e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07eb: stloc.s 36
+		IL_07ed: ldloc.s 4
+		IL_07ef: ldloc.s 6
+		IL_07f1: ldstr "Compiled Object 12 Char Replace"
+		IL_07f6: ldloc.s 36
+		IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_07fd: pop
+		IL_07fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0803: stloc.s 6
+		IL_0805: ldc.i4.1
+		IL_0806: newarr [System.Runtime]System.Object
+		IL_080b: dup
+		IL_080c: ldc.i4.0
+		IL_080d: ldloc.0
+		IL_080e: stelem.ref
+		IL_080f: stloc.s 14
+		IL_0811: ldloc.s 14
+		IL_0813: ldc.i4.0
+		IL_0814: ldelem.ref
+		IL_0815: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_081a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_081f: ldc.i4.0
+		IL_0820: conv.r8
+		IL_0821: ldstr ""
+		IL_0826: ldc.i4.0
+		IL_0827: ldc.i4.1
+		IL_0828: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_082d: stloc.s 37
+		IL_082f: ldloc.3
+		IL_0830: ldloc.s 6
+		IL_0832: ldloc.s 37
+		IL_0834: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0839: pop
+		IL_083a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_083f: stloc.s 6
+		IL_0841: ldc.i4.1
+		IL_0842: newarr [System.Runtime]System.Object
+		IL_0847: dup
+		IL_0848: ldc.i4.0
+		IL_0849: ldloc.0
+		IL_084a: stelem.ref
+		IL_084b: stloc.s 14
+		IL_084d: ldloc.s 14
+		IL_084f: ldc.i4.0
+		IL_0850: ldelem.ref
+		IL_0851: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0856: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_085b: ldc.i4.0
+		IL_085c: conv.r8
+		IL_085d: ldstr ""
+		IL_0862: ldc.i4.0
+		IL_0863: ldc.i4.1
+		IL_0864: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0869: stloc.s 38
+		IL_086b: ldloc.s 4
+		IL_086d: ldloc.s 6
+		IL_086f: ldstr "Compiled Object 12 Char Replace Function"
+		IL_0874: ldloc.s 38
+		IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_087b: pop
+		IL_087c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0881: stloc.s 6
+		IL_0883: ldc.i4.1
+		IL_0884: newarr [System.Runtime]System.Object
+		IL_0889: dup
+		IL_088a: ldc.i4.0
+		IL_088b: ldloc.0
+		IL_088c: stelem.ref
+		IL_088d: stloc.s 14
+		IL_088f: ldloc.s 14
+		IL_0891: ldc.i4.0
+		IL_0892: ldelem.ref
+		IL_0893: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0898: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_089d: ldc.i4.0
+		IL_089e: conv.r8
+		IL_089f: ldstr ""
+		IL_08a4: ldc.i4.0
+		IL_08a5: ldc.i4.1
+		IL_08a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08ab: stloc.s 39
+		IL_08ad: ldloc.3
+		IL_08ae: ldloc.s 6
+		IL_08b0: ldloc.s 39
+		IL_08b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_08b7: pop
+		IL_08b8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_08bd: stloc.s 6
+		IL_08bf: ldc.i4.1
+		IL_08c0: newarr [System.Runtime]System.Object
+		IL_08c5: dup
+		IL_08c6: ldc.i4.0
+		IL_08c7: ldloc.0
+		IL_08c8: stelem.ref
+		IL_08c9: stloc.s 14
+		IL_08cb: ldloc.s 14
+		IL_08cd: ldc.i4.0
+		IL_08ce: ldelem.ref
+		IL_08cf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_08d4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_08d9: ldc.i4.0
+		IL_08da: conv.r8
+		IL_08db: ldstr ""
+		IL_08e0: ldc.i4.0
+		IL_08e1: ldc.i4.1
+		IL_08e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08e7: stloc.s 40
+		IL_08e9: ldloc.s 4
+		IL_08eb: ldloc.s 6
+		IL_08ed: ldstr "Compiled Variable Match"
+		IL_08f2: ldloc.s 40
+		IL_08f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_08f9: pop
+		IL_08fa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_08ff: stloc.s 6
+		IL_0901: ldc.i4.1
+		IL_0902: newarr [System.Runtime]System.Object
+		IL_0907: dup
+		IL_0908: ldc.i4.0
+		IL_0909: ldloc.0
+		IL_090a: stelem.ref
+		IL_090b: stloc.s 14
+		IL_090d: ldloc.s 14
+		IL_090f: ldc.i4.0
+		IL_0910: ldelem.ref
+		IL_0911: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0916: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_091b: ldc.i4.0
+		IL_091c: conv.r8
+		IL_091d: ldstr ""
+		IL_0922: ldc.i4.0
+		IL_0923: ldc.i4.1
+		IL_0924: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0929: stloc.s 41
+		IL_092b: ldloc.3
+		IL_092c: ldloc.s 6
+		IL_092e: ldloc.s 41
+		IL_0930: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0935: pop
+		IL_0936: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_093b: stloc.s 6
+		IL_093d: ldc.i4.1
+		IL_093e: newarr [System.Runtime]System.Object
+		IL_0943: dup
+		IL_0944: ldc.i4.0
+		IL_0945: ldloc.0
+		IL_0946: stelem.ref
+		IL_0947: stloc.s 14
+		IL_0949: ldloc.s 14
+		IL_094b: ldc.i4.0
+		IL_094c: ldelem.ref
+		IL_094d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0952: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0957: ldc.i4.0
+		IL_0958: conv.r8
+		IL_0959: ldstr ""
+		IL_095e: ldc.i4.0
+		IL_095f: ldc.i4.1
+		IL_0960: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0965: stloc.s 42
+		IL_0967: ldloc.s 4
+		IL_0969: ldloc.s 6
+		IL_096b: ldstr "Compiled Variable Test"
+		IL_0970: ldloc.s 42
+		IL_0972: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0977: pop
+		IL_0978: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_097d: stloc.s 6
+		IL_097f: ldc.i4.1
+		IL_0980: newarr [System.Runtime]System.Object
+		IL_0985: dup
+		IL_0986: ldc.i4.0
+		IL_0987: ldloc.0
+		IL_0988: stelem.ref
+		IL_0989: stloc.s 14
+		IL_098b: ldloc.s 14
+		IL_098d: ldc.i4.0
+		IL_098e: ldelem.ref
+		IL_098f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0994: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0999: ldc.i4.0
+		IL_099a: conv.r8
+		IL_099b: ldstr ""
+		IL_09a0: ldc.i4.0
+		IL_09a1: ldc.i4.1
+		IL_09a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_09a7: stloc.s 43
+		IL_09a9: ldloc.3
+		IL_09aa: ldloc.s 6
+		IL_09ac: ldloc.s 43
+		IL_09ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_09b3: pop
+		IL_09b4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_09b9: stloc.s 6
+		IL_09bb: ldc.i4.1
+		IL_09bc: newarr [System.Runtime]System.Object
+		IL_09c1: dup
+		IL_09c2: ldc.i4.0
+		IL_09c3: ldloc.0
+		IL_09c4: stelem.ref
+		IL_09c5: stloc.s 14
+		IL_09c7: ldloc.s 14
+		IL_09c9: ldc.i4.0
+		IL_09ca: ldelem.ref
+		IL_09cb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_09d0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_09d5: ldc.i4.0
+		IL_09d6: conv.r8
+		IL_09d7: ldstr ""
+		IL_09dc: ldc.i4.0
+		IL_09dd: ldc.i4.1
+		IL_09de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_09e3: stloc.s 44
+		IL_09e5: ldloc.s 4
+		IL_09e7: ldloc.s 6
+		IL_09e9: ldstr "Compiled Variable Empty Replace"
+		IL_09ee: ldloc.s 44
+		IL_09f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_09f5: pop
+		IL_09f6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_09fb: stloc.s 6
+		IL_09fd: ldc.i4.1
+		IL_09fe: newarr [System.Runtime]System.Object
+		IL_0a03: dup
+		IL_0a04: ldc.i4.0
+		IL_0a05: ldloc.0
+		IL_0a06: stelem.ref
+		IL_0a07: stloc.s 14
+		IL_0a09: ldloc.s 14
+		IL_0a0b: ldc.i4.0
+		IL_0a0c: ldelem.ref
+		IL_0a0d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a12: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a17: ldc.i4.0
+		IL_0a18: conv.r8
+		IL_0a19: ldstr ""
+		IL_0a1e: ldc.i4.0
+		IL_0a1f: ldc.i4.1
+		IL_0a20: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a25: stloc.s 45
+		IL_0a27: ldloc.3
+		IL_0a28: ldloc.s 6
+		IL_0a2a: ldloc.s 45
+		IL_0a2c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0a31: pop
+		IL_0a32: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0a37: stloc.s 6
+		IL_0a39: ldc.i4.1
+		IL_0a3a: newarr [System.Runtime]System.Object
+		IL_0a3f: dup
+		IL_0a40: ldc.i4.0
+		IL_0a41: ldloc.0
+		IL_0a42: stelem.ref
+		IL_0a43: stloc.s 14
+		IL_0a45: ldloc.s 14
+		IL_0a47: ldc.i4.0
+		IL_0a48: ldelem.ref
+		IL_0a49: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a4e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a53: ldc.i4.0
+		IL_0a54: conv.r8
+		IL_0a55: ldstr ""
+		IL_0a5a: ldc.i4.0
+		IL_0a5b: ldc.i4.1
+		IL_0a5c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a61: stloc.s 46
+		IL_0a63: ldloc.s 4
+		IL_0a65: ldloc.s 6
+		IL_0a67: ldstr "Compiled Variable 12 Char Replace"
+		IL_0a6c: ldloc.s 46
+		IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0a73: pop
+		IL_0a74: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0a79: stloc.s 6
+		IL_0a7b: ldc.i4.1
+		IL_0a7c: newarr [System.Runtime]System.Object
+		IL_0a81: dup
+		IL_0a82: ldc.i4.0
+		IL_0a83: ldloc.0
+		IL_0a84: stelem.ref
+		IL_0a85: stloc.s 14
+		IL_0a87: ldloc.s 14
+		IL_0a89: ldc.i4.0
+		IL_0a8a: ldelem.ref
+		IL_0a8b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a90: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a95: ldc.i4.0
+		IL_0a96: conv.r8
+		IL_0a97: ldstr ""
+		IL_0a9c: ldc.i4.0
+		IL_0a9d: ldc.i4.1
+		IL_0a9e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0aa3: stloc.s 47
+		IL_0aa5: ldloc.3
+		IL_0aa6: ldloc.s 6
+		IL_0aa8: ldloc.s 47
+		IL_0aaa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0aaf: pop
+		IL_0ab0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ab5: stloc.s 6
+		IL_0ab7: ldc.i4.1
+		IL_0ab8: newarr [System.Runtime]System.Object
+		IL_0abd: dup
+		IL_0abe: ldc.i4.0
+		IL_0abf: ldloc.0
+		IL_0ac0: stelem.ref
+		IL_0ac1: stloc.s 14
+		IL_0ac3: ldloc.s 14
+		IL_0ac5: ldc.i4.0
+		IL_0ac6: ldelem.ref
+		IL_0ac7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0acc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ad1: ldc.i4.0
+		IL_0ad2: conv.r8
+		IL_0ad3: ldstr ""
+		IL_0ad8: ldc.i4.0
+		IL_0ad9: ldc.i4.1
+		IL_0ada: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0adf: stloc.s 48
+		IL_0ae1: ldloc.s 4
+		IL_0ae3: ldloc.s 6
+		IL_0ae5: ldstr "Compiled Variable Object Match"
+		IL_0aea: ldloc.s 48
+		IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0af1: pop
+		IL_0af2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0af7: stloc.s 6
+		IL_0af9: ldc.i4.1
+		IL_0afa: newarr [System.Runtime]System.Object
+		IL_0aff: dup
+		IL_0b00: ldc.i4.0
+		IL_0b01: ldloc.0
+		IL_0b02: stelem.ref
+		IL_0b03: stloc.s 14
+		IL_0b05: ldloc.s 14
+		IL_0b07: ldc.i4.0
+		IL_0b08: ldelem.ref
+		IL_0b09: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b0e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b13: ldc.i4.0
+		IL_0b14: conv.r8
+		IL_0b15: ldstr ""
+		IL_0b1a: ldc.i4.0
+		IL_0b1b: ldc.i4.1
+		IL_0b1c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b21: stloc.s 49
+		IL_0b23: ldloc.3
+		IL_0b24: ldloc.s 6
+		IL_0b26: ldloc.s 49
+		IL_0b28: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0b2d: pop
+		IL_0b2e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0b33: stloc.s 6
+		IL_0b35: ldc.i4.1
+		IL_0b36: newarr [System.Runtime]System.Object
+		IL_0b3b: dup
+		IL_0b3c: ldc.i4.0
+		IL_0b3d: ldloc.0
+		IL_0b3e: stelem.ref
+		IL_0b3f: stloc.s 14
+		IL_0b41: ldloc.s 14
+		IL_0b43: ldc.i4.0
+		IL_0b44: ldelem.ref
+		IL_0b45: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b4a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b4f: ldc.i4.0
+		IL_0b50: conv.r8
+		IL_0b51: ldstr ""
+		IL_0b56: ldc.i4.0
+		IL_0b57: ldc.i4.1
+		IL_0b58: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b5d: stloc.s 50
+		IL_0b5f: ldloc.s 4
+		IL_0b61: ldloc.s 6
+		IL_0b63: ldstr "Compiled Variable Object Test"
+		IL_0b68: ldloc.s 50
+		IL_0b6a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0b6f: pop
+		IL_0b70: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0b75: stloc.s 6
+		IL_0b77: ldc.i4.1
+		IL_0b78: newarr [System.Runtime]System.Object
+		IL_0b7d: dup
+		IL_0b7e: ldc.i4.0
+		IL_0b7f: ldloc.0
+		IL_0b80: stelem.ref
+		IL_0b81: stloc.s 14
+		IL_0b83: ldloc.s 14
+		IL_0b85: ldc.i4.0
+		IL_0b86: ldelem.ref
+		IL_0b87: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b8c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b91: ldc.i4.0
+		IL_0b92: conv.r8
+		IL_0b93: ldstr ""
+		IL_0b98: ldc.i4.0
+		IL_0b99: ldc.i4.1
+		IL_0b9a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b9f: stloc.s 51
+		IL_0ba1: ldloc.3
+		IL_0ba2: ldloc.s 6
+		IL_0ba4: ldloc.s 51
+		IL_0ba6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0bab: pop
+		IL_0bac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0bb1: stloc.s 6
+		IL_0bb3: ldc.i4.1
+		IL_0bb4: newarr [System.Runtime]System.Object
+		IL_0bb9: dup
+		IL_0bba: ldc.i4.0
+		IL_0bbb: ldloc.0
+		IL_0bbc: stelem.ref
+		IL_0bbd: stloc.s 14
+		IL_0bbf: ldloc.s 14
+		IL_0bc1: ldc.i4.0
+		IL_0bc2: ldelem.ref
+		IL_0bc3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0bc8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0bcd: ldc.i4.0
+		IL_0bce: conv.r8
+		IL_0bcf: ldstr ""
+		IL_0bd4: ldc.i4.0
+		IL_0bd5: ldc.i4.1
+		IL_0bd6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0bdb: stloc.s 52
+		IL_0bdd: ldloc.s 4
+		IL_0bdf: ldloc.s 6
+		IL_0be1: ldstr "Compiled Variable Object Empty Replace"
+		IL_0be6: ldloc.s 52
+		IL_0be8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0bed: pop
+		IL_0bee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0bf3: stloc.s 6
+		IL_0bf5: ldc.i4.1
+		IL_0bf6: newarr [System.Runtime]System.Object
+		IL_0bfb: dup
+		IL_0bfc: ldc.i4.0
+		IL_0bfd: ldloc.0
+		IL_0bfe: stelem.ref
+		IL_0bff: stloc.s 14
+		IL_0c01: ldloc.s 14
+		IL_0c03: ldc.i4.0
+		IL_0c04: ldelem.ref
+		IL_0c05: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c0a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c0f: ldc.i4.0
+		IL_0c10: conv.r8
+		IL_0c11: ldstr ""
+		IL_0c16: ldc.i4.0
+		IL_0c17: ldc.i4.1
+		IL_0c18: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c1d: stloc.s 53
+		IL_0c1f: ldloc.3
+		IL_0c20: ldloc.s 6
+		IL_0c22: ldloc.s 53
+		IL_0c24: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0c29: pop
+		IL_0c2a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0c2f: stloc.s 6
+		IL_0c31: ldc.i4.1
+		IL_0c32: newarr [System.Runtime]System.Object
+		IL_0c37: dup
+		IL_0c38: ldc.i4.0
+		IL_0c39: ldloc.0
+		IL_0c3a: stelem.ref
+		IL_0c3b: stloc.s 14
+		IL_0c3d: ldloc.s 14
+		IL_0c3f: ldc.i4.0
+		IL_0c40: ldelem.ref
+		IL_0c41: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c46: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c4b: ldc.i4.0
+		IL_0c4c: conv.r8
+		IL_0c4d: ldstr ""
+		IL_0c52: ldc.i4.0
+		IL_0c53: ldc.i4.1
+		IL_0c54: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c59: stloc.s 54
+		IL_0c5b: ldloc.s 4
+		IL_0c5d: ldloc.s 6
+		IL_0c5f: ldstr "Compiled Variable Object 12 Char Replace"
+		IL_0c64: ldloc.s 54
+		IL_0c66: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0c6b: pop
+		IL_0c6c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0c71: stloc.s 6
+		IL_0c73: ldc.i4.1
+		IL_0c74: newarr [System.Runtime]System.Object
+		IL_0c79: dup
+		IL_0c7a: ldc.i4.0
+		IL_0c7b: ldloc.0
+		IL_0c7c: stelem.ref
+		IL_0c7d: stloc.s 14
+		IL_0c7f: ldloc.s 14
+		IL_0c81: ldc.i4.0
+		IL_0c82: ldelem.ref
+		IL_0c83: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c88: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c8d: ldc.i4.0
+		IL_0c8e: conv.r8
+		IL_0c8f: ldstr ""
+		IL_0c94: ldc.i4.0
+		IL_0c95: ldc.i4.1
+		IL_0c96: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c9b: stloc.s 55
+		IL_0c9d: ldloc.3
+		IL_0c9e: ldloc.s 6
+		IL_0ca0: ldloc.s 55
+		IL_0ca2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0ca7: pop
+		IL_0ca8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0cad: stloc.s 6
+		IL_0caf: ldc.i4.1
+		IL_0cb0: newarr [System.Runtime]System.Object
+		IL_0cb5: dup
+		IL_0cb6: ldc.i4.0
+		IL_0cb7: ldloc.0
+		IL_0cb8: stelem.ref
+		IL_0cb9: stloc.s 14
+		IL_0cbb: ldloc.s 14
+		IL_0cbd: ldc.i4.0
+		IL_0cbe: ldelem.ref
+		IL_0cbf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0cc4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0cc9: ldc.i4.0
+		IL_0cca: conv.r8
+		IL_0ccb: ldstr ""
+		IL_0cd0: ldc.i4.0
+		IL_0cd1: ldc.i4.1
+		IL_0cd2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0cd7: stloc.s 56
+		IL_0cd9: ldloc.s 4
+		IL_0cdb: ldloc.s 6
+		IL_0cdd: ldstr "Compiled Variable Object 12 Char Replace Function"
+		IL_0ce2: ldloc.s 56
+		IL_0ce4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0ce9: pop
+		IL_0cea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0cef: stloc.s 6
+		IL_0cf1: ldc.i4.1
+		IL_0cf2: newarr [System.Runtime]System.Object
+		IL_0cf7: dup
+		IL_0cf8: ldc.i4.0
+		IL_0cf9: ldloc.0
+		IL_0cfa: stelem.ref
+		IL_0cfb: stloc.s 14
+		IL_0cfd: ldloc.s 14
+		IL_0cff: ldc.i4.0
+		IL_0d00: ldelem.ref
+		IL_0d01: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d06: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d0b: ldc.i4.0
+		IL_0d0c: conv.r8
+		IL_0d0d: ldstr ""
+		IL_0d12: ldc.i4.0
+		IL_0d13: ldc.i4.1
+		IL_0d14: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d19: stloc.s 57
+		IL_0d1b: ldloc.3
+		IL_0d1c: ldloc.s 6
+		IL_0d1e: ldloc.s 57
+		IL_0d20: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0d25: pop
+		IL_0d26: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0d2b: stloc.s 6
+		IL_0d2d: ldc.i4.1
+		IL_0d2e: newarr [System.Runtime]System.Object
+		IL_0d33: dup
+		IL_0d34: ldc.i4.0
+		IL_0d35: ldloc.0
+		IL_0d36: stelem.ref
+		IL_0d37: stloc.s 14
+		IL_0d39: ldloc.s 14
+		IL_0d3b: ldc.i4.0
+		IL_0d3c: ldelem.ref
+		IL_0d3d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d42: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d47: ldc.i4.0
+		IL_0d48: conv.r8
+		IL_0d49: ldstr ""
+		IL_0d4e: ldc.i4.0
+		IL_0d4f: ldc.i4.1
+		IL_0d50: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d55: stloc.s 58
+		IL_0d57: ldloc.s 4
+		IL_0d59: ldloc.s 6
+		IL_0d5b: ldstr "Compiled Capture Match"
+		IL_0d60: ldloc.s 58
+		IL_0d62: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0d67: pop
+		IL_0d68: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0d6d: stloc.s 6
+		IL_0d6f: ldc.i4.1
+		IL_0d70: newarr [System.Runtime]System.Object
+		IL_0d75: dup
+		IL_0d76: ldc.i4.0
+		IL_0d77: ldloc.0
+		IL_0d78: stelem.ref
+		IL_0d79: stloc.s 14
+		IL_0d7b: ldloc.s 14
+		IL_0d7d: ldc.i4.0
+		IL_0d7e: ldelem.ref
+		IL_0d7f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d84: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d89: ldc.i4.0
+		IL_0d8a: conv.r8
+		IL_0d8b: ldstr ""
+		IL_0d90: ldc.i4.0
+		IL_0d91: ldc.i4.1
+		IL_0d92: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d97: stloc.s 59
+		IL_0d99: ldloc.3
+		IL_0d9a: ldloc.s 6
+		IL_0d9c: ldloc.s 59
+		IL_0d9e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0da3: pop
+		IL_0da4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0da9: stloc.s 6
+		IL_0dab: ldc.i4.1
+		IL_0dac: newarr [System.Runtime]System.Object
+		IL_0db1: dup
+		IL_0db2: ldc.i4.0
+		IL_0db3: ldloc.0
+		IL_0db4: stelem.ref
+		IL_0db5: stloc.s 14
+		IL_0db7: ldloc.s 14
+		IL_0db9: ldc.i4.0
+		IL_0dba: ldelem.ref
+		IL_0dbb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0dc0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0dc5: ldc.i4.0
+		IL_0dc6: conv.r8
+		IL_0dc7: ldstr ""
+		IL_0dcc: ldc.i4.0
+		IL_0dcd: ldc.i4.1
+		IL_0dce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0dd3: stloc.s 60
+		IL_0dd5: ldloc.s 4
+		IL_0dd7: ldloc.s 6
+		IL_0dd9: ldstr "Compiled Capture Replace"
+		IL_0dde: ldloc.s 60
+		IL_0de0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0de5: pop
+		IL_0de6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0deb: stloc.s 6
+		IL_0ded: ldc.i4.1
+		IL_0dee: newarr [System.Runtime]System.Object
+		IL_0df3: dup
+		IL_0df4: ldc.i4.0
+		IL_0df5: ldloc.0
+		IL_0df6: stelem.ref
+		IL_0df7: stloc.s 14
+		IL_0df9: ldloc.s 14
+		IL_0dfb: ldc.i4.0
+		IL_0dfc: ldelem.ref
+		IL_0dfd: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e02: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e07: ldc.i4.0
+		IL_0e08: conv.r8
+		IL_0e09: ldstr ""
+		IL_0e0e: ldc.i4.0
+		IL_0e0f: ldc.i4.1
+		IL_0e10: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e15: stloc.s 61
+		IL_0e17: ldloc.3
+		IL_0e18: ldloc.s 6
+		IL_0e1a: ldloc.s 61
+		IL_0e1c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0e21: pop
+		IL_0e22: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0e27: stloc.s 6
+		IL_0e29: ldc.i4.1
+		IL_0e2a: newarr [System.Runtime]System.Object
+		IL_0e2f: dup
+		IL_0e30: ldc.i4.0
+		IL_0e31: ldloc.0
+		IL_0e32: stelem.ref
+		IL_0e33: stloc.s 14
+		IL_0e35: ldloc.s 14
+		IL_0e37: ldc.i4.0
+		IL_0e38: ldelem.ref
+		IL_0e39: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e3e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e43: ldc.i4.0
+		IL_0e44: conv.r8
+		IL_0e45: ldstr ""
+		IL_0e4a: ldc.i4.0
+		IL_0e4b: ldc.i4.1
+		IL_0e4c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e51: stloc.s 62
+		IL_0e53: ldloc.s 4
+		IL_0e55: ldloc.s 6
+		IL_0e57: ldstr "Compiled Capture Replace with Capture"
+		IL_0e5c: ldloc.s 62
+		IL_0e5e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0e63: pop
+		IL_0e64: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0e69: stloc.s 6
+		IL_0e6b: ldc.i4.1
+		IL_0e6c: newarr [System.Runtime]System.Object
+		IL_0e71: dup
+		IL_0e72: ldc.i4.0
+		IL_0e73: ldloc.0
+		IL_0e74: stelem.ref
+		IL_0e75: stloc.s 14
+		IL_0e77: ldloc.s 14
+		IL_0e79: ldc.i4.0
+		IL_0e7a: ldelem.ref
+		IL_0e7b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e80: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e85: ldc.i4.0
+		IL_0e86: conv.r8
+		IL_0e87: ldstr ""
+		IL_0e8c: ldc.i4.0
+		IL_0e8d: ldc.i4.1
+		IL_0e8e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e93: stloc.s 63
+		IL_0e95: ldloc.3
+		IL_0e96: ldloc.s 6
+		IL_0e98: ldloc.s 63
+		IL_0e9a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0e9f: pop
+		IL_0ea0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ea5: stloc.s 6
+		IL_0ea7: ldc.i4.1
+		IL_0ea8: newarr [System.Runtime]System.Object
+		IL_0ead: dup
+		IL_0eae: ldc.i4.0
+		IL_0eaf: ldloc.0
+		IL_0eb0: stelem.ref
+		IL_0eb1: stloc.s 14
+		IL_0eb3: ldloc.s 14
+		IL_0eb5: ldc.i4.0
+		IL_0eb6: ldelem.ref
+		IL_0eb7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0ebc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ec1: ldc.i4.0
+		IL_0ec2: conv.r8
+		IL_0ec3: ldstr ""
+		IL_0ec8: ldc.i4.0
+		IL_0ec9: ldc.i4.1
+		IL_0eca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0ecf: stloc.s 64
+		IL_0ed1: ldloc.s 4
+		IL_0ed3: ldloc.s 6
+		IL_0ed5: ldstr "Compiled Capture Replace with Capture Function"
+		IL_0eda: ldloc.s 64
+		IL_0edc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0ee1: pop
+		IL_0ee2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ee7: stloc.s 6
+		IL_0ee9: ldc.i4.1
+		IL_0eea: newarr [System.Runtime]System.Object
+		IL_0eef: dup
+		IL_0ef0: ldc.i4.0
+		IL_0ef1: ldloc.0
+		IL_0ef2: stelem.ref
+		IL_0ef3: stloc.s 14
+		IL_0ef5: ldloc.s 14
+		IL_0ef7: ldc.i4.0
+		IL_0ef8: ldelem.ref
+		IL_0ef9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0efe: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f03: ldc.i4.0
+		IL_0f04: conv.r8
+		IL_0f05: ldstr ""
+		IL_0f0a: ldc.i4.0
+		IL_0f0b: ldc.i4.1
+		IL_0f0c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0f11: stloc.s 65
+		IL_0f13: ldloc.3
+		IL_0f14: ldloc.s 6
+		IL_0f16: ldloc.s 65
+		IL_0f18: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0f1d: pop
+		IL_0f1e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0f23: stloc.s 6
+		IL_0f25: ldc.i4.1
+		IL_0f26: newarr [System.Runtime]System.Object
+		IL_0f2b: dup
+		IL_0f2c: ldc.i4.0
+		IL_0f2d: ldloc.0
+		IL_0f2e: stelem.ref
+		IL_0f2f: stloc.s 14
+		IL_0f31: ldloc.s 14
+		IL_0f33: ldc.i4.0
+		IL_0f34: ldelem.ref
+		IL_0f35: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f3a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f3f: ldc.i4.0
+		IL_0f40: conv.r8
+		IL_0f41: ldstr ""
+		IL_0f46: ldc.i4.0
+		IL_0f47: ldc.i4.1
+		IL_0f48: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0f4d: stloc.s 66
+		IL_0f4f: ldloc.s 4
+		IL_0f51: ldloc.s 6
+		IL_0f53: ldstr "Compiled Capture Replace with Upperase Capture Function"
+		IL_0f58: ldloc.s 66
+		IL_0f5a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0f5f: pop
+		IL_0f60: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0f65: stloc.s 6
+		IL_0f67: ldc.i4.1
+		IL_0f68: newarr [System.Runtime]System.Object
+		IL_0f6d: dup
+		IL_0f6e: ldc.i4.0
+		IL_0f6f: ldloc.0
+		IL_0f70: stelem.ref
+		IL_0f71: stloc.s 14
+		IL_0f73: ldloc.s 14
+		IL_0f75: ldc.i4.0
+		IL_0f76: ldelem.ref
+		IL_0f77: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f7c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f81: ldc.i4.0
+		IL_0f82: conv.r8
+		IL_0f83: ldstr ""
+		IL_0f88: ldc.i4.0
+		IL_0f89: ldc.i4.1
+		IL_0f8a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0f8f: stloc.s 67
+		IL_0f91: ldloc.3
+		IL_0f92: ldloc.s 6
+		IL_0f94: ldloc.s 67
+		IL_0f96: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0f9b: pop
+		IL_0f9c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0fa1: stloc.s 6
+		IL_0fa3: ldc.i4.1
+		IL_0fa4: newarr [System.Runtime]System.Object
+		IL_0fa9: dup
+		IL_0faa: ldc.i4.0
+		IL_0fab: ldloc.0
+		IL_0fac: stelem.ref
+		IL_0fad: stloc.s 14
+		IL_0faf: ldloc.s 14
+		IL_0fb1: ldc.i4.0
+		IL_0fb2: ldelem.ref
+		IL_0fb3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0fb8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0fbd: ldc.i4.0
+		IL_0fbe: conv.r8
+		IL_0fbf: ldstr ""
+		IL_0fc4: ldc.i4.0
+		IL_0fc5: ldc.i4.1
+		IL_0fc6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0fcb: stloc.s 68
+		IL_0fcd: ldloc.s 4
+		IL_0fcf: ldloc.s 6
+		IL_0fd1: ldstr "Uncompiled Match"
+		IL_0fd6: ldloc.s 68
+		IL_0fd8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0fdd: pop
+		IL_0fde: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0fe3: stloc.s 6
+		IL_0fe5: ldc.i4.1
+		IL_0fe6: newarr [System.Runtime]System.Object
+		IL_0feb: dup
+		IL_0fec: ldc.i4.0
+		IL_0fed: ldloc.0
+		IL_0fee: stelem.ref
+		IL_0fef: stloc.s 14
+		IL_0ff1: ldloc.s 14
+		IL_0ff3: ldc.i4.0
+		IL_0ff4: ldelem.ref
+		IL_0ff5: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0ffa: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0fff: ldc.i4.0
+		IL_1000: conv.r8
+		IL_1001: ldstr ""
+		IL_1006: ldc.i4.0
+		IL_1007: ldc.i4.1
+		IL_1008: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_100d: stloc.s 69
+		IL_100f: ldloc.3
+		IL_1010: ldloc.s 6
+		IL_1012: ldloc.s 69
+		IL_1014: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1019: pop
+		IL_101a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_101f: stloc.s 6
+		IL_1021: ldc.i4.1
+		IL_1022: newarr [System.Runtime]System.Object
+		IL_1027: dup
+		IL_1028: ldc.i4.0
+		IL_1029: ldloc.0
+		IL_102a: stelem.ref
+		IL_102b: stloc.s 14
+		IL_102d: ldloc.s 14
+		IL_102f: ldc.i4.0
+		IL_1030: ldelem.ref
+		IL_1031: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1036: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_103b: ldc.i4.0
+		IL_103c: conv.r8
+		IL_103d: ldstr ""
+		IL_1042: ldc.i4.0
+		IL_1043: ldc.i4.1
+		IL_1044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1049: stloc.s 70
+		IL_104b: ldloc.s 4
+		IL_104d: ldloc.s 6
+		IL_104f: ldstr "Uncompiled Test"
+		IL_1054: ldloc.s 70
+		IL_1056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_105b: pop
+		IL_105c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1061: stloc.s 6
+		IL_1063: ldc.i4.1
+		IL_1064: newarr [System.Runtime]System.Object
+		IL_1069: dup
+		IL_106a: ldc.i4.0
+		IL_106b: ldloc.0
+		IL_106c: stelem.ref
+		IL_106d: stloc.s 14
+		IL_106f: ldloc.s 14
+		IL_1071: ldc.i4.0
+		IL_1072: ldelem.ref
+		IL_1073: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1078: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_107d: ldc.i4.0
+		IL_107e: conv.r8
+		IL_107f: ldstr ""
+		IL_1084: ldc.i4.0
+		IL_1085: ldc.i4.1
+		IL_1086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_108b: stloc.s 71
+		IL_108d: ldloc.3
+		IL_108e: ldloc.s 6
+		IL_1090: ldloc.s 71
+		IL_1092: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1097: pop
+		IL_1098: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_109d: stloc.s 6
+		IL_109f: ldc.i4.1
+		IL_10a0: newarr [System.Runtime]System.Object
+		IL_10a5: dup
+		IL_10a6: ldc.i4.0
+		IL_10a7: ldloc.0
+		IL_10a8: stelem.ref
+		IL_10a9: stloc.s 14
+		IL_10ab: ldloc.s 14
+		IL_10ad: ldc.i4.0
+		IL_10ae: ldelem.ref
+		IL_10af: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_10b4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_10b9: ldc.i4.0
+		IL_10ba: conv.r8
+		IL_10bb: ldstr ""
+		IL_10c0: ldc.i4.0
+		IL_10c1: ldc.i4.1
+		IL_10c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_10c7: stloc.s 72
+		IL_10c9: ldloc.s 4
+		IL_10cb: ldloc.s 6
+		IL_10cd: ldstr "Uncompiled Empty Replace"
+		IL_10d2: ldloc.s 72
+		IL_10d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_10d9: pop
+		IL_10da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_10df: stloc.s 6
+		IL_10e1: ldc.i4.1
+		IL_10e2: newarr [System.Runtime]System.Object
+		IL_10e7: dup
+		IL_10e8: ldc.i4.0
+		IL_10e9: ldloc.0
+		IL_10ea: stelem.ref
+		IL_10eb: stloc.s 14
+		IL_10ed: ldloc.s 14
+		IL_10ef: ldc.i4.0
+		IL_10f0: ldelem.ref
+		IL_10f1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_10f6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_10fb: ldc.i4.0
+		IL_10fc: conv.r8
+		IL_10fd: ldstr ""
+		IL_1102: ldc.i4.0
+		IL_1103: ldc.i4.1
+		IL_1104: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1109: stloc.s 73
+		IL_110b: ldloc.3
+		IL_110c: ldloc.s 6
+		IL_110e: ldloc.s 73
+		IL_1110: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1115: pop
+		IL_1116: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_111b: stloc.s 6
+		IL_111d: ldc.i4.1
+		IL_111e: newarr [System.Runtime]System.Object
+		IL_1123: dup
+		IL_1124: ldc.i4.0
+		IL_1125: ldloc.0
+		IL_1126: stelem.ref
+		IL_1127: stloc.s 14
+		IL_1129: ldloc.s 14
+		IL_112b: ldc.i4.0
+		IL_112c: ldelem.ref
+		IL_112d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1132: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1137: ldc.i4.0
+		IL_1138: conv.r8
+		IL_1139: ldstr ""
+		IL_113e: ldc.i4.0
+		IL_113f: ldc.i4.1
+		IL_1140: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1145: stloc.s 74
+		IL_1147: ldloc.s 4
+		IL_1149: ldloc.s 6
+		IL_114b: ldstr "Uncompiled 12 Char Replace"
+		IL_1150: ldloc.s 74
+		IL_1152: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_1157: pop
+		IL_1158: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_115d: stloc.s 6
+		IL_115f: ldc.i4.1
+		IL_1160: newarr [System.Runtime]System.Object
+		IL_1165: dup
+		IL_1166: ldc.i4.0
+		IL_1167: ldloc.0
+		IL_1168: stelem.ref
+		IL_1169: stloc.s 14
+		IL_116b: ldloc.s 14
+		IL_116d: ldc.i4.0
+		IL_116e: ldelem.ref
+		IL_116f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1174: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1179: ldc.i4.0
+		IL_117a: conv.r8
+		IL_117b: ldstr ""
+		IL_1180: ldc.i4.0
+		IL_1181: ldc.i4.1
+		IL_1182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1187: stloc.s 75
+		IL_1189: ldloc.3
+		IL_118a: ldloc.s 6
+		IL_118c: ldloc.s 75
+		IL_118e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1193: pop
+		IL_1194: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1199: stloc.s 6
+		IL_119b: ldc.i4.1
+		IL_119c: newarr [System.Runtime]System.Object
+		IL_11a1: dup
+		IL_11a2: ldc.i4.0
+		IL_11a3: ldloc.0
+		IL_11a4: stelem.ref
+		IL_11a5: stloc.s 14
+		IL_11a7: ldloc.s 14
+		IL_11a9: ldc.i4.0
+		IL_11aa: ldelem.ref
+		IL_11ab: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_11b0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_11b5: ldc.i4.0
+		IL_11b6: conv.r8
+		IL_11b7: ldstr ""
+		IL_11bc: ldc.i4.0
+		IL_11bd: ldc.i4.1
+		IL_11be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_11c3: stloc.s 76
+		IL_11c5: ldloc.s 4
+		IL_11c7: ldloc.s 6
+		IL_11c9: ldstr "Uncompiled Object Match"
+		IL_11ce: ldloc.s 76
+		IL_11d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_11d5: pop
+		IL_11d6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_11db: stloc.s 6
+		IL_11dd: ldc.i4.1
+		IL_11de: newarr [System.Runtime]System.Object
+		IL_11e3: dup
+		IL_11e4: ldc.i4.0
+		IL_11e5: ldloc.0
+		IL_11e6: stelem.ref
+		IL_11e7: stloc.s 14
+		IL_11e9: ldloc.s 14
+		IL_11eb: ldc.i4.0
+		IL_11ec: ldelem.ref
+		IL_11ed: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_11f2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_11f7: ldc.i4.0
+		IL_11f8: conv.r8
+		IL_11f9: ldstr ""
+		IL_11fe: ldc.i4.0
+		IL_11ff: ldc.i4.1
+		IL_1200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1205: stloc.s 77
+		IL_1207: ldloc.3
+		IL_1208: ldloc.s 6
+		IL_120a: ldloc.s 77
+		IL_120c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1211: pop
+		IL_1212: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1217: stloc.s 6
+		IL_1219: ldc.i4.1
+		IL_121a: newarr [System.Runtime]System.Object
+		IL_121f: dup
+		IL_1220: ldc.i4.0
+		IL_1221: ldloc.0
+		IL_1222: stelem.ref
+		IL_1223: stloc.s 14
+		IL_1225: ldloc.s 14
+		IL_1227: ldc.i4.0
+		IL_1228: ldelem.ref
+		IL_1229: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_122e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1233: ldc.i4.0
+		IL_1234: conv.r8
+		IL_1235: ldstr ""
+		IL_123a: ldc.i4.0
+		IL_123b: ldc.i4.1
+		IL_123c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1241: stloc.s 78
+		IL_1243: ldloc.s 4
+		IL_1245: ldloc.s 6
+		IL_1247: ldstr "Uncompiled Object Test"
+		IL_124c: ldloc.s 78
+		IL_124e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_1253: pop
+		IL_1254: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1259: stloc.s 6
+		IL_125b: ldc.i4.1
+		IL_125c: newarr [System.Runtime]System.Object
+		IL_1261: dup
+		IL_1262: ldc.i4.0
+		IL_1263: ldloc.0
+		IL_1264: stelem.ref
+		IL_1265: stloc.s 14
+		IL_1267: ldloc.s 14
+		IL_1269: ldc.i4.0
+		IL_126a: ldelem.ref
+		IL_126b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1270: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1275: ldc.i4.0
+		IL_1276: conv.r8
+		IL_1277: ldstr ""
+		IL_127c: ldc.i4.0
+		IL_127d: ldc.i4.1
+		IL_127e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1283: stloc.s 79
+		IL_1285: ldloc.3
+		IL_1286: ldloc.s 6
+		IL_1288: ldloc.s 79
+		IL_128a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_128f: pop
+		IL_1290: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1295: stloc.s 6
+		IL_1297: ldc.i4.1
+		IL_1298: newarr [System.Runtime]System.Object
+		IL_129d: dup
+		IL_129e: ldc.i4.0
+		IL_129f: ldloc.0
+		IL_12a0: stelem.ref
+		IL_12a1: stloc.s 14
+		IL_12a3: ldloc.s 14
+		IL_12a5: ldc.i4.0
+		IL_12a6: ldelem.ref
+		IL_12a7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_12ac: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_12b1: ldc.i4.0
+		IL_12b2: conv.r8
+		IL_12b3: ldstr ""
+		IL_12b8: ldc.i4.0
+		IL_12b9: ldc.i4.1
+		IL_12ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_12bf: stloc.s 80
+		IL_12c1: ldloc.s 4
+		IL_12c3: ldloc.s 6
+		IL_12c5: ldstr "Uncompiled Object Empty Replace"
+		IL_12ca: ldloc.s 80
+		IL_12cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_12d1: pop
+		IL_12d2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_12d7: stloc.s 6
+		IL_12d9: ldc.i4.1
+		IL_12da: newarr [System.Runtime]System.Object
+		IL_12df: dup
+		IL_12e0: ldc.i4.0
+		IL_12e1: ldloc.0
+		IL_12e2: stelem.ref
+		IL_12e3: stloc.s 14
+		IL_12e5: ldloc.s 14
+		IL_12e7: ldc.i4.0
+		IL_12e8: ldelem.ref
+		IL_12e9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_12ee: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_12f3: ldc.i4.0
+		IL_12f4: conv.r8
+		IL_12f5: ldstr ""
+		IL_12fa: ldc.i4.0
+		IL_12fb: ldc.i4.1
+		IL_12fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1301: stloc.s 81
+		IL_1303: ldloc.3
+		IL_1304: ldloc.s 6
+		IL_1306: ldloc.s 81
+		IL_1308: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_130d: pop
+		IL_130e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1313: stloc.s 6
+		IL_1315: ldc.i4.1
+		IL_1316: newarr [System.Runtime]System.Object
+		IL_131b: dup
+		IL_131c: ldc.i4.0
+		IL_131d: ldloc.0
+		IL_131e: stelem.ref
+		IL_131f: stloc.s 14
+		IL_1321: ldloc.s 14
+		IL_1323: ldc.i4.0
+		IL_1324: ldelem.ref
+		IL_1325: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_132a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_132f: ldc.i4.0
+		IL_1330: conv.r8
+		IL_1331: ldstr ""
+		IL_1336: ldc.i4.0
+		IL_1337: ldc.i4.1
+		IL_1338: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_133d: stloc.s 82
+		IL_133f: ldloc.s 4
+		IL_1341: ldloc.s 6
+		IL_1343: ldstr "Uncompiled Object 12 Char Replace"
+		IL_1348: ldloc.s 82
+		IL_134a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_134f: pop
+		IL_1350: ldloc.2
+		IL_1351: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1356: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_135b: pop
+		IL_135c: ret
 	} // end of method Compile_Performance_Dromaeo_Object_Regexp::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Regexp
@@ -16543,4 +16685,22 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_81
+	.field assembly static int32 __jroc_dynamicLookup_82
+	.field assembly static int32 __jroc_dynamicLookup_83
+	.field assembly static int32 __jroc_dynamicLookup_84
+	.field assembly static int32 __jroc_dynamicLookup_85
+	.field assembly static int32 __jroc_dynamicLookup_86
+	.field assembly static int32 __jroc_dynamicLookup_87
+	.field assembly static int32 __jroc_dynamicLookup_88
+	.field assembly static int32 __jroc_dynamicLookup_89
+	.field assembly static int32 __jroc_dynamicLookup_90
+	.field assembly static int32 __jroc_dynamicLookup_91
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_String.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_String.verified.txt
@@ -1792,7 +1792,7 @@
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 78 (0x4e)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -1801,15 +1801,27 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000b: ldstr "split"
-			IL_0010: ldstr ""
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001a: stloc.0
-			IL_001b: ldarg.0
-			IL_001c: ldloc.0
-			IL_001d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_000b: volatile.
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0012: brfalse IL_002b
+
+			IL_0017: ldstr "split"
+			IL_001c: ldstr ""
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0026: br IL_0044
+
+			IL_002b: ldstr "split"
+			IL_0030: ldstr ""
+			IL_0035: ldstr "Compile_Performance_Dromaeo_Object_String:<TwoPhaseDummy_M13>:__js_call__:4"
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0044: stloc.0
+			IL_0045: ldarg.0
+			IL_0046: ldloc.0
+			IL_0047: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+			IL_004c: ldnull
+			IL_004d: ret
 		} // end of method FunctionExpression_L60C21::__js_call__
 
 	} // end of class FunctionExpression_L60C21
@@ -2162,7 +2174,7 @@
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 36 (0x24)
+			// Code size: 78 (0x4e)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2171,15 +2183,27 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000b: ldstr "split"
-			IL_0010: ldstr "a"
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001a: stloc.0
-			IL_001b: ldarg.0
-			IL_001c: ldloc.0
-			IL_001d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-			IL_0022: ldnull
-			IL_0023: ret
+			IL_000b: volatile.
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0012: brfalse IL_002b
+
+			IL_0017: ldstr "split"
+			IL_001c: ldstr "a"
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0026: br IL_0044
+
+			IL_002b: ldstr "split"
+			IL_0030: ldstr "a"
+			IL_0035: ldstr "Compile_Performance_Dromaeo_Object_String:<TwoPhaseDummy_M15>:__js_call__:4"
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0044: stloc.0
+			IL_0045: ldarg.0
+			IL_0046: ldloc.0
+			IL_0047: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+			IL_004c: ldnull
+			IL_004d: ret
 		} // end of method FunctionExpression_L72C29::__js_call__
 
 	} // end of class FunctionExpression_L72C29
@@ -2579,7 +2603,7 @@
 				IL_009d: ldarg.0
 				IL_009e: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
 				IL_00a3: volatile.
-				IL_00a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_00a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 				IL_00aa: brfalse IL_00be
 
 				IL_00af: ldstr "length"
@@ -2588,7 +2612,7 @@
 
 				IL_00be: ldstr "length"
 				IL_00c3: ldstr "Compile_Performance_Dromaeo_Object_String:<TwoPhaseDummy_M17>:__js_call__:21"
-				IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00d2: stloc.s 4
@@ -2926,7 +2950,7 @@
 				IL_0046: ldarg.0
 				IL_0047: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
 				IL_004c: volatile.
-				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 				IL_0053: brfalse IL_0067
 
 				IL_0058: ldstr "length"
@@ -2935,7 +2959,7 @@
 
 				IL_0067: ldstr "length"
 				IL_006c: ldstr "Compile_Performance_Dromaeo_Object_String:<TwoPhaseDummy_M18>:__js_call__:18"
-				IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_007b: stloc.s 4
@@ -3225,7 +3249,7 @@
 				IL_00a2: ldarg.0
 				IL_00a3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
 				IL_00a8: volatile.
-				IL_00aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_00aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_00af: brfalse IL_00c3
 
 				IL_00b4: ldstr "length"
@@ -3234,7 +3258,7 @@
 
 				IL_00c3: ldstr "length"
 				IL_00c8: ldstr "Compile_Performance_Dromaeo_Object_String:<TwoPhaseDummy_M19>:__js_call__:21"
-				IL_00cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_00cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00d7: stloc.s 4
@@ -6469,7 +6493,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1862 (0x746)
+		// Code size: 1943 (0x797)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_String/Scope,
@@ -6726,7 +6750,7 @@
 			IL_0211: ldloc.s 13
 			IL_0213: ldc.r8 16384
 			IL_021c: clt
-			IL_021e: brfalse IL_0273
+			IL_021e: brfalse IL_029a
 
 			IL_0223: ldloc.0
 			IL_0224: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
@@ -6739,518 +6763,542 @@
 			IL_0247: box [System.Runtime]System.Double
 			IL_024c: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
 			IL_0251: stloc.s 14
-			IL_0253: ldstr "push"
-			IL_0258: ldloc.s 14
-			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_025f: pop
-			IL_0260: ldloc.s 5
-			IL_0262: ldc.r8 1
-			IL_026b: add
-			IL_026c: stloc.s 5
-			IL_026e: br IL_020d
+			IL_0253: volatile.
+			IL_0255: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_025a: brfalse IL_0270
+
+			IL_025f: ldstr "push"
+			IL_0264: ldloc.s 14
+			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_026b: br IL_0286
+
+			IL_0270: ldstr "push"
+			IL_0275: ldloc.s 14
+			IL_0277: ldstr "Compile_Performance_Dromaeo_Object_String:Modules.Compile_Performance_Dromaeo_Object_String:__js_module_init__:85"
+			IL_027c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0286: pop
+			IL_0287: ldloc.s 5
+			IL_0289: ldc.r8 1
+			IL_0292: add
+			IL_0293: stloc.s 5
+			IL_0295: br IL_020d
 		// end loop
 
-		IL_0273: ldloc.0
-		IL_0274: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027e: ldstr "join"
-		IL_0283: ldstr ""
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_028d: stloc.s 15
-		IL_028f: ldloc.0
-		IL_0290: ldloc.s 15
-		IL_0292: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_0297: ldloc.0
-		IL_0298: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_029d: stloc.s 15
-		IL_029f: ldloc.0
-		IL_02a0: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_02a5: stloc.s 16
-		IL_02a7: ldloc.s 15
-		IL_02a9: ldloc.s 16
-		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02b0: stloc.s 17
-		IL_02b2: ldloc.0
-		IL_02b3: ldloc.s 17
-		IL_02b5: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_02ba: ldloc.0
-		IL_02bb: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_02c0: stloc.s 16
-		IL_02c2: ldloc.0
-		IL_02c3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_02c8: stloc.s 15
-		IL_02ca: ldloc.s 16
-		IL_02cc: ldloc.s 15
-		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02d3: stloc.s 17
-		IL_02d5: ldloc.0
-		IL_02d6: ldloc.s 17
-		IL_02d8: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_02dd: ldloc.0
-		IL_02de: ldnull
-		IL_02df: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-		IL_02e4: ldc.r8 52288
-		IL_02ed: stloc.s 5
-		IL_02ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02f4: stloc.s 6
-		IL_02f6: ldc.i4.1
-		IL_02f7: newarr [System.Runtime]System.Object
-		IL_02fc: dup
-		IL_02fd: ldc.i4.0
-		IL_02fe: ldloc.0
-		IL_02ff: stelem.ref
-		IL_0300: stloc.s 7
-		IL_0302: ldloc.s 7
-		IL_0304: ldc.i4.0
-		IL_0305: ldelem.ref
-		IL_0306: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_030b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0310: ldc.i4.0
-		IL_0311: conv.r8
-		IL_0312: ldstr ""
-		IL_0317: ldc.i4.0
-		IL_0318: ldc.i4.1
-		IL_0319: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_031e: stloc.s 18
-		IL_0320: ldloc.3
-		IL_0321: ldloc.s 6
-		IL_0323: ldloc.s 18
-		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_032a: pop
-		IL_032b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0330: stloc.s 6
-		IL_0332: ldc.i4.1
-		IL_0333: newarr [System.Runtime]System.Object
-		IL_0338: dup
-		IL_0339: ldc.i4.0
-		IL_033a: ldloc.0
-		IL_033b: stelem.ref
-		IL_033c: stloc.s 7
-		IL_033e: ldloc.s 7
-		IL_0340: ldc.i4.0
-		IL_0341: ldelem.ref
-		IL_0342: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0347: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_034c: ldc.i4.0
-		IL_034d: conv.r8
-		IL_034e: ldstr ""
-		IL_0353: ldc.i4.0
-		IL_0354: ldc.i4.1
-		IL_0355: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_035a: stloc.s 19
-		IL_035c: ldloc.s 4
-		IL_035e: ldloc.s 6
-		IL_0360: ldstr "String Split"
-		IL_0365: ldloc.s 19
-		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_036c: pop
-		IL_036d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0372: stloc.s 6
-		IL_0374: ldc.i4.1
-		IL_0375: newarr [System.Runtime]System.Object
-		IL_037a: dup
-		IL_037b: ldc.i4.0
-		IL_037c: ldloc.0
-		IL_037d: stelem.ref
-		IL_037e: stloc.s 7
-		IL_0380: ldloc.s 7
-		IL_0382: ldc.i4.0
-		IL_0383: ldelem.ref
-		IL_0384: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0389: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_038e: ldc.i4.0
-		IL_038f: conv.r8
-		IL_0390: ldstr ""
-		IL_0395: ldc.i4.0
-		IL_0396: ldc.i4.1
-		IL_0397: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_039c: stloc.s 20
-		IL_039e: ldloc.3
-		IL_039f: ldloc.s 6
-		IL_03a1: ldloc.s 20
-		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03a8: pop
-		IL_03a9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03ae: stloc.s 6
-		IL_03b0: ldc.i4.1
-		IL_03b1: newarr [System.Runtime]System.Object
-		IL_03b6: dup
-		IL_03b7: ldc.i4.0
-		IL_03b8: ldloc.0
-		IL_03b9: stelem.ref
-		IL_03ba: stloc.s 7
-		IL_03bc: ldloc.s 7
-		IL_03be: ldc.i4.0
-		IL_03bf: ldelem.ref
-		IL_03c0: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_03c5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_03ca: ldc.i4.0
-		IL_03cb: conv.r8
-		IL_03cc: ldstr ""
-		IL_03d1: ldc.i4.0
-		IL_03d2: ldc.i4.1
-		IL_03d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03d8: stloc.s 21
-		IL_03da: ldloc.s 4
-		IL_03dc: ldloc.s 6
-		IL_03de: ldstr "String Split on Char"
-		IL_03e3: ldloc.s 21
-		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_03ea: pop
-		IL_03eb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03f0: stloc.s 6
-		IL_03f2: ldc.i4.1
-		IL_03f3: newarr [System.Runtime]System.Object
-		IL_03f8: dup
-		IL_03f9: ldc.i4.0
-		IL_03fa: ldloc.0
-		IL_03fb: stelem.ref
-		IL_03fc: stloc.s 7
-		IL_03fe: ldloc.s 7
-		IL_0400: ldc.i4.0
-		IL_0401: ldelem.ref
-		IL_0402: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0407: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_040c: ldc.i4.0
-		IL_040d: conv.r8
-		IL_040e: ldstr ""
-		IL_0413: ldc.i4.0
-		IL_0414: ldc.i4.1
-		IL_0415: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_041a: stloc.s 22
-		IL_041c: ldloc.3
-		IL_041d: ldloc.s 6
-		IL_041f: ldloc.s 22
-		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0426: pop
-		IL_0427: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_042c: stloc.s 6
-		IL_042e: ldc.i4.1
-		IL_042f: newarr [System.Runtime]System.Object
-		IL_0434: dup
-		IL_0435: ldc.i4.0
-		IL_0436: ldloc.0
-		IL_0437: stelem.ref
-		IL_0438: stloc.s 7
-		IL_043a: ldloc.s 7
-		IL_043c: ldc.i4.0
-		IL_043d: ldelem.ref
-		IL_043e: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0443: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0448: ldc.i4.0
-		IL_0449: conv.r8
-		IL_044a: ldstr ""
-		IL_044f: ldc.i4.0
-		IL_0450: ldc.i4.1
-		IL_0451: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0456: stloc.s 23
-		IL_0458: ldloc.s 4
-		IL_045a: ldloc.s 6
-		IL_045c: ldstr "charAt"
-		IL_0461: ldloc.s 23
-		IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0468: pop
-		IL_0469: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_046e: stloc.s 6
-		IL_0470: ldc.i4.1
-		IL_0471: newarr [System.Runtime]System.Object
-		IL_0476: dup
-		IL_0477: ldc.i4.0
-		IL_0478: ldloc.0
-		IL_0479: stelem.ref
-		IL_047a: stloc.s 7
-		IL_047c: ldloc.s 7
-		IL_047e: ldc.i4.0
-		IL_047f: ldelem.ref
-		IL_0480: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0485: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_048a: ldc.i4.0
-		IL_048b: conv.r8
-		IL_048c: ldstr ""
-		IL_0491: ldc.i4.0
-		IL_0492: ldc.i4.1
-		IL_0493: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0498: stloc.s 24
-		IL_049a: ldloc.s 4
-		IL_049c: ldloc.s 6
-		IL_049e: ldstr "[Number]"
-		IL_04a3: ldloc.s 24
-		IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_04aa: pop
-		IL_04ab: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04b0: stloc.s 6
-		IL_04b2: ldc.i4.1
-		IL_04b3: newarr [System.Runtime]System.Object
-		IL_04b8: dup
-		IL_04b9: ldc.i4.0
-		IL_04ba: ldloc.0
-		IL_04bb: stelem.ref
-		IL_04bc: stloc.s 7
-		IL_04be: ldloc.s 7
-		IL_04c0: ldc.i4.0
-		IL_04c1: ldelem.ref
-		IL_04c2: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_04c7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_04cc: ldc.i4.0
-		IL_04cd: conv.r8
-		IL_04ce: ldstr ""
-		IL_04d3: ldc.i4.0
-		IL_04d4: ldc.i4.1
-		IL_04d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04da: stloc.s 25
-		IL_04dc: ldloc.s 4
-		IL_04de: ldloc.s 6
-		IL_04e0: ldstr "charCodeAt"
-		IL_04e5: ldloc.s 25
-		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_04ec: pop
-		IL_04ed: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04f2: stloc.s 6
-		IL_04f4: ldc.i4.1
-		IL_04f5: newarr [System.Runtime]System.Object
-		IL_04fa: dup
-		IL_04fb: ldc.i4.0
-		IL_04fc: ldloc.0
-		IL_04fd: stelem.ref
-		IL_04fe: stloc.s 7
-		IL_0500: ldloc.s 7
-		IL_0502: ldc.i4.0
-		IL_0503: ldelem.ref
-		IL_0504: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0509: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_050e: ldc.i4.0
-		IL_050f: conv.r8
-		IL_0510: ldstr ""
-		IL_0515: ldc.i4.0
-		IL_0516: ldc.i4.1
-		IL_0517: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_051c: stloc.s 26
-		IL_051e: ldloc.s 4
-		IL_0520: ldloc.s 6
-		IL_0522: ldstr "indexOf"
-		IL_0527: ldloc.s 26
-		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_052e: pop
-		IL_052f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0534: stloc.s 6
-		IL_0536: ldc.i4.1
-		IL_0537: newarr [System.Runtime]System.Object
-		IL_053c: dup
-		IL_053d: ldc.i4.0
-		IL_053e: ldloc.0
-		IL_053f: stelem.ref
-		IL_0540: stloc.s 7
-		IL_0542: ldloc.s 7
-		IL_0544: ldc.i4.0
-		IL_0545: ldelem.ref
-		IL_0546: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_054b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0550: ldc.i4.0
-		IL_0551: conv.r8
-		IL_0552: ldstr ""
-		IL_0557: ldc.i4.0
-		IL_0558: ldc.i4.1
-		IL_0559: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_055e: stloc.s 27
-		IL_0560: ldloc.s 4
-		IL_0562: ldloc.s 6
-		IL_0564: ldstr "lastIndexOf"
-		IL_0569: ldloc.s 27
-		IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0570: pop
-		IL_0571: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0576: stloc.s 6
-		IL_0578: ldc.i4.1
-		IL_0579: newarr [System.Runtime]System.Object
-		IL_057e: dup
-		IL_057f: ldc.i4.0
-		IL_0580: ldloc.0
-		IL_0581: stelem.ref
-		IL_0582: stloc.s 7
-		IL_0584: ldloc.s 7
-		IL_0586: ldc.i4.0
-		IL_0587: ldelem.ref
-		IL_0588: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_058d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0592: ldc.i4.0
-		IL_0593: conv.r8
-		IL_0594: ldstr ""
-		IL_0599: ldc.i4.0
-		IL_059a: ldc.i4.1
-		IL_059b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05a0: stloc.s 28
-		IL_05a2: ldloc.s 4
-		IL_05a4: ldloc.s 6
-		IL_05a6: ldstr "slice"
-		IL_05ab: ldloc.s 28
-		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_05b2: pop
-		IL_05b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05b8: stloc.s 6
-		IL_05ba: ldc.i4.1
-		IL_05bb: newarr [System.Runtime]System.Object
-		IL_05c0: dup
-		IL_05c1: ldc.i4.0
-		IL_05c2: ldloc.0
-		IL_05c3: stelem.ref
-		IL_05c4: stloc.s 7
-		IL_05c6: ldloc.s 7
-		IL_05c8: ldc.i4.0
-		IL_05c9: ldelem.ref
-		IL_05ca: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_05cf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_05d4: ldc.i4.0
-		IL_05d5: conv.r8
-		IL_05d6: ldstr ""
-		IL_05db: ldc.i4.0
-		IL_05dc: ldc.i4.1
-		IL_05dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05e2: stloc.s 29
-		IL_05e4: ldloc.s 4
-		IL_05e6: ldloc.s 6
-		IL_05e8: ldstr "substr"
-		IL_05ed: ldloc.s 29
-		IL_05ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_05f4: pop
-		IL_05f5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05fa: stloc.s 6
-		IL_05fc: ldc.i4.1
-		IL_05fd: newarr [System.Runtime]System.Object
-		IL_0602: dup
-		IL_0603: ldc.i4.0
-		IL_0604: ldloc.0
-		IL_0605: stelem.ref
-		IL_0606: stloc.s 7
-		IL_0608: ldloc.s 7
-		IL_060a: ldc.i4.0
-		IL_060b: ldelem.ref
-		IL_060c: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0611: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0616: ldc.i4.0
-		IL_0617: conv.r8
-		IL_0618: ldstr ""
-		IL_061d: ldc.i4.0
-		IL_061e: ldc.i4.1
-		IL_061f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0624: stloc.s 30
-		IL_0626: ldloc.s 4
-		IL_0628: ldloc.s 6
-		IL_062a: ldstr "substring"
-		IL_062f: ldloc.s 30
-		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0636: pop
-		IL_0637: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_063c: stloc.s 6
-		IL_063e: ldc.i4.1
-		IL_063f: newarr [System.Runtime]System.Object
-		IL_0644: dup
-		IL_0645: ldc.i4.0
-		IL_0646: ldloc.0
-		IL_0647: stelem.ref
-		IL_0648: stloc.s 7
-		IL_064a: ldloc.s 7
-		IL_064c: ldc.i4.0
-		IL_064d: ldelem.ref
-		IL_064e: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0653: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0658: ldc.i4.0
-		IL_0659: conv.r8
-		IL_065a: ldstr ""
-		IL_065f: ldc.i4.0
-		IL_0660: ldc.i4.1
-		IL_0661: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0666: stloc.s 31
-		IL_0668: ldloc.s 4
-		IL_066a: ldloc.s 6
-		IL_066c: ldstr "toLowerCase"
-		IL_0671: ldloc.s 31
-		IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0678: pop
-		IL_0679: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_067e: stloc.s 6
-		IL_0680: ldc.i4.1
-		IL_0681: newarr [System.Runtime]System.Object
-		IL_0686: dup
-		IL_0687: ldc.i4.0
-		IL_0688: ldloc.0
-		IL_0689: stelem.ref
-		IL_068a: stloc.s 7
-		IL_068c: ldloc.s 7
-		IL_068e: ldc.i4.0
-		IL_068f: ldelem.ref
-		IL_0690: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0695: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_069a: ldc.i4.0
-		IL_069b: conv.r8
-		IL_069c: ldstr ""
-		IL_06a1: ldc.i4.0
-		IL_06a2: ldc.i4.1
-		IL_06a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06a8: stloc.s 32
-		IL_06aa: ldloc.s 4
-		IL_06ac: ldloc.s 6
-		IL_06ae: ldstr "toUpperCase"
-		IL_06b3: ldloc.s 32
-		IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_06ba: pop
-		IL_06bb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06c0: stloc.s 6
-		IL_06c2: ldc.i4.1
-		IL_06c3: newarr [System.Runtime]System.Object
-		IL_06c8: dup
-		IL_06c9: ldc.i4.0
-		IL_06ca: ldloc.0
-		IL_06cb: stelem.ref
-		IL_06cc: stloc.s 7
-		IL_06ce: ldloc.s 7
-		IL_06d0: ldc.i4.0
-		IL_06d1: ldelem.ref
-		IL_06d2: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_06d7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_06dc: ldc.i4.0
-		IL_06dd: conv.r8
-		IL_06de: ldstr ""
-		IL_06e3: ldc.i4.0
-		IL_06e4: ldc.i4.1
-		IL_06e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06ea: stloc.s 33
-		IL_06ec: ldloc.3
-		IL_06ed: ldloc.s 6
-		IL_06ef: ldloc.s 33
-		IL_06f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_06f6: pop
-		IL_06f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06fc: stloc.s 6
-		IL_06fe: ldc.i4.1
-		IL_06ff: newarr [System.Runtime]System.Object
-		IL_0704: dup
-		IL_0705: ldc.i4.0
-		IL_0706: ldloc.0
-		IL_0707: stelem.ref
-		IL_0708: stloc.s 7
-		IL_070a: ldloc.s 7
-		IL_070c: ldc.i4.0
-		IL_070d: ldelem.ref
-		IL_070e: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0713: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0718: ldc.i4.0
-		IL_0719: conv.r8
-		IL_071a: ldstr ""
-		IL_071f: ldc.i4.0
-		IL_0720: ldc.i4.1
-		IL_0721: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0726: stloc.s 34
-		IL_0728: ldloc.s 4
-		IL_072a: ldloc.s 6
-		IL_072c: ldstr "comparing"
-		IL_0731: ldloc.s 34
-		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0738: pop
-		IL_0739: ldloc.2
-		IL_073a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0744: pop
-		IL_0745: ret
+		IL_029a: ldloc.0
+		IL_029b: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a5: volatile.
+		IL_02a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_02ac: brfalse IL_02c5
+
+		IL_02b1: ldstr "join"
+		IL_02b6: ldstr ""
+		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c0: br IL_02de
+
+		IL_02c5: ldstr "join"
+		IL_02ca: ldstr ""
+		IL_02cf: ldstr "Compile_Performance_Dromaeo_Object_String:Modules.Compile_Performance_Dromaeo_Object_String:__js_module_init__:96"
+		IL_02d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02de: stloc.s 15
+		IL_02e0: ldloc.0
+		IL_02e1: ldloc.s 15
+		IL_02e3: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02e8: ldloc.0
+		IL_02e9: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02ee: stloc.s 15
+		IL_02f0: ldloc.0
+		IL_02f1: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02f6: stloc.s 16
+		IL_02f8: ldloc.s 15
+		IL_02fa: ldloc.s 16
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0301: stloc.s 17
+		IL_0303: ldloc.0
+		IL_0304: ldloc.s 17
+		IL_0306: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_030b: ldloc.0
+		IL_030c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_0311: stloc.s 16
+		IL_0313: ldloc.0
+		IL_0314: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_0319: stloc.s 15
+		IL_031b: ldloc.s 16
+		IL_031d: ldloc.s 15
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0324: stloc.s 17
+		IL_0326: ldloc.0
+		IL_0327: ldloc.s 17
+		IL_0329: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_032e: ldloc.0
+		IL_032f: ldnull
+		IL_0330: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+		IL_0335: ldc.r8 52288
+		IL_033e: stloc.s 5
+		IL_0340: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0345: stloc.s 6
+		IL_0347: ldc.i4.1
+		IL_0348: newarr [System.Runtime]System.Object
+		IL_034d: dup
+		IL_034e: ldc.i4.0
+		IL_034f: ldloc.0
+		IL_0350: stelem.ref
+		IL_0351: stloc.s 7
+		IL_0353: ldloc.s 7
+		IL_0355: ldc.i4.0
+		IL_0356: ldelem.ref
+		IL_0357: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_035c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0361: ldc.i4.0
+		IL_0362: conv.r8
+		IL_0363: ldstr ""
+		IL_0368: ldc.i4.0
+		IL_0369: ldc.i4.1
+		IL_036a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_036f: stloc.s 18
+		IL_0371: ldloc.3
+		IL_0372: ldloc.s 6
+		IL_0374: ldloc.s 18
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_037b: pop
+		IL_037c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0381: stloc.s 6
+		IL_0383: ldc.i4.1
+		IL_0384: newarr [System.Runtime]System.Object
+		IL_0389: dup
+		IL_038a: ldc.i4.0
+		IL_038b: ldloc.0
+		IL_038c: stelem.ref
+		IL_038d: stloc.s 7
+		IL_038f: ldloc.s 7
+		IL_0391: ldc.i4.0
+		IL_0392: ldelem.ref
+		IL_0393: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0398: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_039d: ldc.i4.0
+		IL_039e: conv.r8
+		IL_039f: ldstr ""
+		IL_03a4: ldc.i4.0
+		IL_03a5: ldc.i4.1
+		IL_03a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03ab: stloc.s 19
+		IL_03ad: ldloc.s 4
+		IL_03af: ldloc.s 6
+		IL_03b1: ldstr "String Split"
+		IL_03b6: ldloc.s 19
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_03bd: pop
+		IL_03be: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03c3: stloc.s 6
+		IL_03c5: ldc.i4.1
+		IL_03c6: newarr [System.Runtime]System.Object
+		IL_03cb: dup
+		IL_03cc: ldc.i4.0
+		IL_03cd: ldloc.0
+		IL_03ce: stelem.ref
+		IL_03cf: stloc.s 7
+		IL_03d1: ldloc.s 7
+		IL_03d3: ldc.i4.0
+		IL_03d4: ldelem.ref
+		IL_03d5: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_03da: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_03df: ldc.i4.0
+		IL_03e0: conv.r8
+		IL_03e1: ldstr ""
+		IL_03e6: ldc.i4.0
+		IL_03e7: ldc.i4.1
+		IL_03e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03ed: stloc.s 20
+		IL_03ef: ldloc.3
+		IL_03f0: ldloc.s 6
+		IL_03f2: ldloc.s 20
+		IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_03f9: pop
+		IL_03fa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03ff: stloc.s 6
+		IL_0401: ldc.i4.1
+		IL_0402: newarr [System.Runtime]System.Object
+		IL_0407: dup
+		IL_0408: ldc.i4.0
+		IL_0409: ldloc.0
+		IL_040a: stelem.ref
+		IL_040b: stloc.s 7
+		IL_040d: ldloc.s 7
+		IL_040f: ldc.i4.0
+		IL_0410: ldelem.ref
+		IL_0411: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0416: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_041b: ldc.i4.0
+		IL_041c: conv.r8
+		IL_041d: ldstr ""
+		IL_0422: ldc.i4.0
+		IL_0423: ldc.i4.1
+		IL_0424: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0429: stloc.s 21
+		IL_042b: ldloc.s 4
+		IL_042d: ldloc.s 6
+		IL_042f: ldstr "String Split on Char"
+		IL_0434: ldloc.s 21
+		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_043b: pop
+		IL_043c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0441: stloc.s 6
+		IL_0443: ldc.i4.1
+		IL_0444: newarr [System.Runtime]System.Object
+		IL_0449: dup
+		IL_044a: ldc.i4.0
+		IL_044b: ldloc.0
+		IL_044c: stelem.ref
+		IL_044d: stloc.s 7
+		IL_044f: ldloc.s 7
+		IL_0451: ldc.i4.0
+		IL_0452: ldelem.ref
+		IL_0453: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0458: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_045d: ldc.i4.0
+		IL_045e: conv.r8
+		IL_045f: ldstr ""
+		IL_0464: ldc.i4.0
+		IL_0465: ldc.i4.1
+		IL_0466: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_046b: stloc.s 22
+		IL_046d: ldloc.3
+		IL_046e: ldloc.s 6
+		IL_0470: ldloc.s 22
+		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0477: pop
+		IL_0478: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_047d: stloc.s 6
+		IL_047f: ldc.i4.1
+		IL_0480: newarr [System.Runtime]System.Object
+		IL_0485: dup
+		IL_0486: ldc.i4.0
+		IL_0487: ldloc.0
+		IL_0488: stelem.ref
+		IL_0489: stloc.s 7
+		IL_048b: ldloc.s 7
+		IL_048d: ldc.i4.0
+		IL_048e: ldelem.ref
+		IL_048f: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0494: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0499: ldc.i4.0
+		IL_049a: conv.r8
+		IL_049b: ldstr ""
+		IL_04a0: ldc.i4.0
+		IL_04a1: ldc.i4.1
+		IL_04a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04a7: stloc.s 23
+		IL_04a9: ldloc.s 4
+		IL_04ab: ldloc.s 6
+		IL_04ad: ldstr "charAt"
+		IL_04b2: ldloc.s 23
+		IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_04b9: pop
+		IL_04ba: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04bf: stloc.s 6
+		IL_04c1: ldc.i4.1
+		IL_04c2: newarr [System.Runtime]System.Object
+		IL_04c7: dup
+		IL_04c8: ldc.i4.0
+		IL_04c9: ldloc.0
+		IL_04ca: stelem.ref
+		IL_04cb: stloc.s 7
+		IL_04cd: ldloc.s 7
+		IL_04cf: ldc.i4.0
+		IL_04d0: ldelem.ref
+		IL_04d1: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_04d6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_04db: ldc.i4.0
+		IL_04dc: conv.r8
+		IL_04dd: ldstr ""
+		IL_04e2: ldc.i4.0
+		IL_04e3: ldc.i4.1
+		IL_04e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04e9: stloc.s 24
+		IL_04eb: ldloc.s 4
+		IL_04ed: ldloc.s 6
+		IL_04ef: ldstr "[Number]"
+		IL_04f4: ldloc.s 24
+		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_04fb: pop
+		IL_04fc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0501: stloc.s 6
+		IL_0503: ldc.i4.1
+		IL_0504: newarr [System.Runtime]System.Object
+		IL_0509: dup
+		IL_050a: ldc.i4.0
+		IL_050b: ldloc.0
+		IL_050c: stelem.ref
+		IL_050d: stloc.s 7
+		IL_050f: ldloc.s 7
+		IL_0511: ldc.i4.0
+		IL_0512: ldelem.ref
+		IL_0513: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0518: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_051d: ldc.i4.0
+		IL_051e: conv.r8
+		IL_051f: ldstr ""
+		IL_0524: ldc.i4.0
+		IL_0525: ldc.i4.1
+		IL_0526: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_052b: stloc.s 25
+		IL_052d: ldloc.s 4
+		IL_052f: ldloc.s 6
+		IL_0531: ldstr "charCodeAt"
+		IL_0536: ldloc.s 25
+		IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_053d: pop
+		IL_053e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0543: stloc.s 6
+		IL_0545: ldc.i4.1
+		IL_0546: newarr [System.Runtime]System.Object
+		IL_054b: dup
+		IL_054c: ldc.i4.0
+		IL_054d: ldloc.0
+		IL_054e: stelem.ref
+		IL_054f: stloc.s 7
+		IL_0551: ldloc.s 7
+		IL_0553: ldc.i4.0
+		IL_0554: ldelem.ref
+		IL_0555: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_055a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_055f: ldc.i4.0
+		IL_0560: conv.r8
+		IL_0561: ldstr ""
+		IL_0566: ldc.i4.0
+		IL_0567: ldc.i4.1
+		IL_0568: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_056d: stloc.s 26
+		IL_056f: ldloc.s 4
+		IL_0571: ldloc.s 6
+		IL_0573: ldstr "indexOf"
+		IL_0578: ldloc.s 26
+		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_057f: pop
+		IL_0580: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0585: stloc.s 6
+		IL_0587: ldc.i4.1
+		IL_0588: newarr [System.Runtime]System.Object
+		IL_058d: dup
+		IL_058e: ldc.i4.0
+		IL_058f: ldloc.0
+		IL_0590: stelem.ref
+		IL_0591: stloc.s 7
+		IL_0593: ldloc.s 7
+		IL_0595: ldc.i4.0
+		IL_0596: ldelem.ref
+		IL_0597: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_059c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_05a1: ldc.i4.0
+		IL_05a2: conv.r8
+		IL_05a3: ldstr ""
+		IL_05a8: ldc.i4.0
+		IL_05a9: ldc.i4.1
+		IL_05aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05af: stloc.s 27
+		IL_05b1: ldloc.s 4
+		IL_05b3: ldloc.s 6
+		IL_05b5: ldstr "lastIndexOf"
+		IL_05ba: ldloc.s 27
+		IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_05c1: pop
+		IL_05c2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05c7: stloc.s 6
+		IL_05c9: ldc.i4.1
+		IL_05ca: newarr [System.Runtime]System.Object
+		IL_05cf: dup
+		IL_05d0: ldc.i4.0
+		IL_05d1: ldloc.0
+		IL_05d2: stelem.ref
+		IL_05d3: stloc.s 7
+		IL_05d5: ldloc.s 7
+		IL_05d7: ldc.i4.0
+		IL_05d8: ldelem.ref
+		IL_05d9: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_05de: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_05e3: ldc.i4.0
+		IL_05e4: conv.r8
+		IL_05e5: ldstr ""
+		IL_05ea: ldc.i4.0
+		IL_05eb: ldc.i4.1
+		IL_05ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05f1: stloc.s 28
+		IL_05f3: ldloc.s 4
+		IL_05f5: ldloc.s 6
+		IL_05f7: ldstr "slice"
+		IL_05fc: ldloc.s 28
+		IL_05fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0603: pop
+		IL_0604: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0609: stloc.s 6
+		IL_060b: ldc.i4.1
+		IL_060c: newarr [System.Runtime]System.Object
+		IL_0611: dup
+		IL_0612: ldc.i4.0
+		IL_0613: ldloc.0
+		IL_0614: stelem.ref
+		IL_0615: stloc.s 7
+		IL_0617: ldloc.s 7
+		IL_0619: ldc.i4.0
+		IL_061a: ldelem.ref
+		IL_061b: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0620: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0625: ldc.i4.0
+		IL_0626: conv.r8
+		IL_0627: ldstr ""
+		IL_062c: ldc.i4.0
+		IL_062d: ldc.i4.1
+		IL_062e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0633: stloc.s 29
+		IL_0635: ldloc.s 4
+		IL_0637: ldloc.s 6
+		IL_0639: ldstr "substr"
+		IL_063e: ldloc.s 29
+		IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0645: pop
+		IL_0646: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_064b: stloc.s 6
+		IL_064d: ldc.i4.1
+		IL_064e: newarr [System.Runtime]System.Object
+		IL_0653: dup
+		IL_0654: ldc.i4.0
+		IL_0655: ldloc.0
+		IL_0656: stelem.ref
+		IL_0657: stloc.s 7
+		IL_0659: ldloc.s 7
+		IL_065b: ldc.i4.0
+		IL_065c: ldelem.ref
+		IL_065d: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0662: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0667: ldc.i4.0
+		IL_0668: conv.r8
+		IL_0669: ldstr ""
+		IL_066e: ldc.i4.0
+		IL_066f: ldc.i4.1
+		IL_0670: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0675: stloc.s 30
+		IL_0677: ldloc.s 4
+		IL_0679: ldloc.s 6
+		IL_067b: ldstr "substring"
+		IL_0680: ldloc.s 30
+		IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0687: pop
+		IL_0688: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_068d: stloc.s 6
+		IL_068f: ldc.i4.1
+		IL_0690: newarr [System.Runtime]System.Object
+		IL_0695: dup
+		IL_0696: ldc.i4.0
+		IL_0697: ldloc.0
+		IL_0698: stelem.ref
+		IL_0699: stloc.s 7
+		IL_069b: ldloc.s 7
+		IL_069d: ldc.i4.0
+		IL_069e: ldelem.ref
+		IL_069f: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_06a4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_06a9: ldc.i4.0
+		IL_06aa: conv.r8
+		IL_06ab: ldstr ""
+		IL_06b0: ldc.i4.0
+		IL_06b1: ldc.i4.1
+		IL_06b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06b7: stloc.s 31
+		IL_06b9: ldloc.s 4
+		IL_06bb: ldloc.s 6
+		IL_06bd: ldstr "toLowerCase"
+		IL_06c2: ldloc.s 31
+		IL_06c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_06c9: pop
+		IL_06ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06cf: stloc.s 6
+		IL_06d1: ldc.i4.1
+		IL_06d2: newarr [System.Runtime]System.Object
+		IL_06d7: dup
+		IL_06d8: ldc.i4.0
+		IL_06d9: ldloc.0
+		IL_06da: stelem.ref
+		IL_06db: stloc.s 7
+		IL_06dd: ldloc.s 7
+		IL_06df: ldc.i4.0
+		IL_06e0: ldelem.ref
+		IL_06e1: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_06e6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_06eb: ldc.i4.0
+		IL_06ec: conv.r8
+		IL_06ed: ldstr ""
+		IL_06f2: ldc.i4.0
+		IL_06f3: ldc.i4.1
+		IL_06f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06f9: stloc.s 32
+		IL_06fb: ldloc.s 4
+		IL_06fd: ldloc.s 6
+		IL_06ff: ldstr "toUpperCase"
+		IL_0704: ldloc.s 32
+		IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_070b: pop
+		IL_070c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0711: stloc.s 6
+		IL_0713: ldc.i4.1
+		IL_0714: newarr [System.Runtime]System.Object
+		IL_0719: dup
+		IL_071a: ldc.i4.0
+		IL_071b: ldloc.0
+		IL_071c: stelem.ref
+		IL_071d: stloc.s 7
+		IL_071f: ldloc.s 7
+		IL_0721: ldc.i4.0
+		IL_0722: ldelem.ref
+		IL_0723: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0728: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_072d: ldc.i4.0
+		IL_072e: conv.r8
+		IL_072f: ldstr ""
+		IL_0734: ldc.i4.0
+		IL_0735: ldc.i4.1
+		IL_0736: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_073b: stloc.s 33
+		IL_073d: ldloc.3
+		IL_073e: ldloc.s 6
+		IL_0740: ldloc.s 33
+		IL_0742: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0747: pop
+		IL_0748: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_074d: stloc.s 6
+		IL_074f: ldc.i4.1
+		IL_0750: newarr [System.Runtime]System.Object
+		IL_0755: dup
+		IL_0756: ldc.i4.0
+		IL_0757: ldloc.0
+		IL_0758: stelem.ref
+		IL_0759: stloc.s 7
+		IL_075b: ldloc.s 7
+		IL_075d: ldc.i4.0
+		IL_075e: ldelem.ref
+		IL_075f: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0764: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0769: ldc.i4.0
+		IL_076a: conv.r8
+		IL_076b: ldstr ""
+		IL_0770: ldc.i4.0
+		IL_0771: ldc.i4.1
+		IL_0772: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0777: stloc.s 34
+		IL_0779: ldloc.s 4
+		IL_077b: ldloc.s 6
+		IL_077d: ldstr "comparing"
+		IL_0782: ldloc.s 34
+		IL_0784: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0789: pop
+		IL_078a: ldloc.2
+		IL_078b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0795: pop
+		IL_0796: ret
 	} // end of method Compile_Performance_Dromaeo_Object_String::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_String
@@ -7283,6 +7331,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_33
 	.field assembly static int32 __jroc_dynamicLookup_34
 	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
+	.field assembly static int32 __jroc_dynamicLookup_37
+	.field assembly static int32 __jroc_dynamicLookup_38
+	.field assembly static int32 __jroc_dynamicLookup_39
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -502,7 +502,7 @@
 			IL_0033: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 			IL_0038: stloc.1
 			IL_0039: volatile.
-			IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0040: brfalse IL_0055
 
 			IL_0045: ldarg.2
@@ -513,12 +513,12 @@
 			IL_0055: ldarg.2
 			IL_0056: ldstr "verbose"
 			IL_005b: ldstr "Compile_Performance_PrimeJavaScript:<TwoPhaseDummy_M5>:__js_call__:14"
-			IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_006a: stloc.2
 			IL_006b: volatile.
-			IL_006d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_006d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_0072: brfalse IL_0087
 
 			IL_0077: ldarg.2
@@ -529,7 +529,7 @@
 			IL_0087: ldarg.2
 			IL_0088: ldstr "runtime"
 			IL_008d: ldstr "Compile_Performance_PrimeJavaScript:<TwoPhaseDummy_M5>:__js_call__:16"
-			IL_0092: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0092: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_009c: stloc.3
@@ -3233,7 +3233,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 894 (0x37e)
+		// Code size: 935 (0x3a7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -3317,232 +3317,245 @@
 		IL_00da: ldstr ""
 		IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_00e4: stloc.s 6
-		IL_00e6: ldloc.s 5
-		IL_00e8: ldstr "split"
-		IL_00ed: ldloc.s 6
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f4: stloc.2
-		IL_00f5: volatile.
-		IL_00f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_00fc: brfalse IL_0111
+		IL_00e6: volatile.
+		IL_00e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_00ed: brfalse IL_0105
 
-		IL_0101: ldloc.2
-		IL_0102: ldstr "length"
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010c: br IL_0126
+		IL_00f2: ldloc.s 5
+		IL_00f4: ldstr "split"
+		IL_00f9: ldloc.s 6
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0100: br IL_011d
 
-		IL_0111: ldloc.2
-		IL_0112: ldstr "length"
-		IL_0117: ldstr "Compile_Performance_PrimeJavaScript:Modules.Compile_Performance_PrimeJavaScript:__js_module_init__:42"
-		IL_011c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0105: ldloc.s 5
+		IL_0107: ldstr "split"
+		IL_010c: ldloc.s 6
+		IL_010e: ldstr "Compile_Performance_PrimeJavaScript:Modules.Compile_Performance_PrimeJavaScript:__js_module_init__:38"
+		IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0126: stloc.s 5
-		IL_0128: ldloc.s 5
-		IL_012a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_012f: ldc.r8 1
-		IL_0138: sub
-		IL_0139: stloc.s 7
-		IL_013b: ldloc.2
-		IL_013c: ldloc.s 7
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0143: stloc.s 5
-		IL_0145: ldloc.1
-		IL_0146: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_014b: ldloc.s 5
-		IL_014d: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
-		IL_0152: ldstr "process"
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015c: volatile.
-		IL_015e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0163: brfalse IL_0177
+		IL_011d: stloc.2
+		IL_011e: volatile.
+		IL_0120: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0125: brfalse IL_013a
 
-		IL_0168: ldstr "argv"
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0172: br IL_018b
+		IL_012a: ldloc.2
+		IL_012b: ldstr "length"
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0135: br IL_014f
 
-		IL_0177: ldstr "argv"
-		IL_017c: ldstr "Compile_Performance_PrimeJavaScript:Modules.Compile_Performance_PrimeJavaScript:__js_module_init__:52"
-		IL_0181: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_013a: ldloc.2
+		IL_013b: ldstr "length"
+		IL_0140: ldstr "Compile_Performance_PrimeJavaScript:Modules.Compile_Performance_PrimeJavaScript:__js_module_init__:42"
+		IL_0145: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_018b: stloc.s 5
-		IL_018d: ldloc.s 5
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0194: stloc.s 5
-		IL_0196: ldc.i4.0
-		IL_0197: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_019c: brfalse IL_01d8
+		IL_014f: stloc.s 5
+		IL_0151: ldloc.s 5
+		IL_0153: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0158: ldc.r8 1
+		IL_0161: sub
+		IL_0162: stloc.s 7
+		IL_0164: ldloc.2
+		IL_0165: ldloc.s 7
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_016c: stloc.s 5
+		IL_016e: ldloc.1
+		IL_016f: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_0174: ldloc.s 5
+		IL_0176: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_runtime(object)
+		IL_017b: ldstr "process"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0185: volatile.
+		IL_0187: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_018c: brfalse IL_01a0
 
-		IL_01a1: ldloc.s 5
-		IL_01a3: isinst [System.Runtime]System.String
-		IL_01a8: dup
-		IL_01a9: brtrue IL_01c1
+		IL_0191: ldstr "argv"
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019b: br IL_01b4
 
-		IL_01ae: pop
-		IL_01af: ldloc.s 5
-		IL_01b1: ldstr "includes"
-		IL_01b6: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_01bb: dup
-		IL_01bc: brfalse IL_01d7
+		IL_01a0: ldstr "argv"
+		IL_01a5: ldstr "Compile_Performance_PrimeJavaScript:Modules.Compile_Performance_PrimeJavaScript:__js_module_init__:52"
+		IL_01aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01c1: ldstr "verbose"
-		IL_01c6: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_01cb: box [System.Runtime]System.Boolean
-		IL_01d0: stloc.s 5
-		IL_01d2: br IL_01eb
+		IL_01b4: stloc.s 5
+		IL_01b6: ldloc.s 5
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bd: stloc.s 5
+		IL_01bf: ldc.i4.0
+		IL_01c0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01c5: brfalse IL_0201
+
+		IL_01ca: ldloc.s 5
+		IL_01cc: isinst [System.Runtime]System.String
+		IL_01d1: dup
+		IL_01d2: brtrue IL_01ea
 
 		IL_01d7: pop
-
 		IL_01d8: ldloc.s 5
 		IL_01da: ldstr "includes"
-		IL_01df: ldstr "verbose"
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e9: stloc.s 5
+		IL_01df: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_01e4: dup
+		IL_01e5: brfalse IL_0200
 
-		IL_01eb: ldloc.1
-		IL_01ec: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_01f1: ldloc.s 5
-		IL_01f3: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
-		IL_01f8: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_01fd: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0202: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0207: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_020c: stloc.s 8
-		IL_020e: volatile.
-		IL_0210: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0215: brfalse IL_022b
+		IL_01ea: ldstr "verbose"
+		IL_01ef: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_01f4: box [System.Runtime]System.Boolean
+		IL_01f9: stloc.s 5
+		IL_01fb: br IL_0214
 
-		IL_021a: ldloc.s 8
-		IL_021c: ldstr "prototype"
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0226: br IL_0241
+		IL_0200: pop
 
-		IL_022b: ldloc.s 8
-		IL_022d: ldstr "prototype"
-		IL_0232: ldstr "Compile_Performance_PrimeJavaScript:Modules.Compile_Performance_PrimeJavaScript:__js_module_init__:60"
-		IL_0237: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0201: ldloc.s 5
+		IL_0203: ldstr "includes"
+		IL_0208: ldstr "verbose"
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0212: stloc.s 5
 
-		IL_0241: stloc.s 5
-		IL_0243: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0248: stloc.s 9
-		IL_024a: ldloc.s 5
-		IL_024c: ldstr "setBitTrue"
-		IL_0251: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
-		IL_0256: ldc.i4.1
-		IL_0257: conv.r8
-		IL_0258: ldstr "setBitTrue"
-		IL_025d: ldc.i4.1
-		IL_025e: ldc.i4.1
-		IL_025f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0264: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_026e: pop
-		IL_026f: ldc.i4.1
-		IL_0270: newarr [System.Runtime]System.Object
-		IL_0275: dup
-		IL_0276: ldc.i4.0
-		IL_0277: ldloc.0
-		IL_0278: stelem.ref
-		IL_0279: stloc.s 9
-		IL_027b: ldloc.s 5
-		IL_027d: ldstr "setBitsTrue"
-		IL_0282: ldloc.s 9
-		IL_0284: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
-		IL_0289: ldc.i4.3
-		IL_028a: conv.r8
-		IL_028b: ldstr "setBitsTrue"
-		IL_0290: ldc.i4.1
-		IL_0291: ldc.i4.1
-		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02a1: pop
-		IL_02a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02a7: stloc.s 9
-		IL_02a9: ldloc.s 5
-		IL_02ab: ldstr "testBitTrue"
-		IL_02b0: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
-		IL_02b5: ldc.i4.1
-		IL_02b6: conv.r8
-		IL_02b7: ldstr "testBitTrue"
-		IL_02bc: ldc.i4.1
-		IL_02bd: ldc.i4.1
-		IL_02be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02cd: pop
-		IL_02ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02d3: stloc.s 9
-		IL_02d5: ldloc.s 5
-		IL_02d7: ldstr "searchBitFalse"
-		IL_02dc: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
-		IL_02e1: ldc.i4.1
-		IL_02e2: conv.r8
-		IL_02e3: ldstr "searchBitFalse"
-		IL_02e8: ldc.i4.1
-		IL_02e9: ldc.i4.1
-		IL_02ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
-		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02f9: pop
-		IL_02fa: ldc.i4.1
-		IL_02fb: newarr [System.Runtime]System.Object
-		IL_0300: dup
-		IL_0301: ldc.i4.0
-		IL_0302: ldloc.0
-		IL_0303: stelem.ref
-		IL_0304: stloc.s 9
-		IL_0306: ldloc.s 9
-		IL_0308: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
-		IL_030d: ldloc.s 8
-		IL_030f: ldloc.s 9
+		IL_0214: ldloc.1
+		IL_0215: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_021a: ldloc.s 5
+		IL_021c: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
+		IL_0221: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_0226: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_022b: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_0230: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0235: stloc.s 8
+		IL_0237: volatile.
+		IL_0239: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_023e: brfalse IL_0254
+
+		IL_0243: ldloc.s 8
+		IL_0245: ldstr "prototype"
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024f: br IL_026a
+
+		IL_0254: ldloc.s 8
+		IL_0256: ldstr "prototype"
+		IL_025b: ldstr "Compile_Performance_PrimeJavaScript:Modules.Compile_Performance_PrimeJavaScript:__js_module_init__:60"
+		IL_0260: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_026a: stloc.s 5
+		IL_026c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0271: stloc.s 9
+		IL_0273: ldloc.s 5
+		IL_0275: ldstr "setBitTrue"
+		IL_027a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
+		IL_027f: ldc.i4.1
+		IL_0280: conv.r8
+		IL_0281: ldstr "setBitTrue"
+		IL_0286: ldc.i4.1
+		IL_0287: ldc.i4.1
+		IL_0288: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_028d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0297: pop
+		IL_0298: ldc.i4.1
+		IL_0299: newarr [System.Runtime]System.Object
+		IL_029e: dup
+		IL_029f: ldc.i4.0
+		IL_02a0: ldloc.0
+		IL_02a1: stelem.ref
+		IL_02a2: stloc.s 9
+		IL_02a4: ldloc.s 5
+		IL_02a6: ldstr "setBitsTrue"
+		IL_02ab: ldloc.s 9
+		IL_02ad: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
+		IL_02b2: ldc.i4.3
+		IL_02b3: conv.r8
+		IL_02b4: ldstr "setBitsTrue"
+		IL_02b9: ldc.i4.1
+		IL_02ba: ldc.i4.1
+		IL_02bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02ca: pop
+		IL_02cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02d0: stloc.s 9
+		IL_02d2: ldloc.s 5
+		IL_02d4: ldstr "testBitTrue"
+		IL_02d9: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
+		IL_02de: ldc.i4.1
+		IL_02df: conv.r8
+		IL_02e0: ldstr "testBitTrue"
+		IL_02e5: ldc.i4.1
+		IL_02e6: ldc.i4.1
+		IL_02e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02f6: pop
+		IL_02f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02fc: stloc.s 9
+		IL_02fe: ldloc.s 5
+		IL_0300: ldstr "searchBitFalse"
+		IL_0305: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
+		IL_030a: ldc.i4.1
+		IL_030b: conv.r8
+		IL_030c: ldstr "searchBitFalse"
 		IL_0311: ldc.i4.1
-		IL_0312: conv.r8
-		IL_0313: ldc.i4.0
-		IL_0314: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0319: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject
-		IL_031e: stloc.s 10
-		IL_0320: ldloc.0
-		IL_0321: ldloc.s 10
-		IL_0323: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_0328: nop
-		IL_0329: ldc.i4.1
-		IL_032a: newarr [System.Runtime]System.Object
-		IL_032f: dup
-		IL_0330: ldc.i4.0
-		IL_0331: ldloc.0
-		IL_0332: stelem.ref
-		IL_0333: stloc.s 9
-		IL_0335: ldloc.s 9
-		IL_0337: ldc.i4.0
-		IL_0338: ldelem.ref
-		IL_0339: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_033e: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
-		IL_0343: ldc.i4.1
-		IL_0344: conv.r8
-		IL_0345: ldstr ""
-		IL_034a: ldc.i4.0
-		IL_034b: ldc.i4.0
-		IL_034c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0351: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
-		IL_0356: stloc.s 11
-		IL_0358: ldloc.s 11
-		IL_035a: ldstr "runSieveBatch"
-		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0364: stloc.s 5
-		IL_0366: ldloc.0
-		IL_0367: ldloc.s 5
-		IL_0369: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_036e: nop
-		IL_036f: ldloc.0
-		IL_0370: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0375: ldnull
-		IL_0376: ldloc.1
-		IL_0377: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_037c: pop
-		IL_037d: ret
+		IL_0312: ldc.i4.1
+		IL_0313: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0318: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0322: pop
+		IL_0323: ldc.i4.1
+		IL_0324: newarr [System.Runtime]System.Object
+		IL_0329: dup
+		IL_032a: ldc.i4.0
+		IL_032b: ldloc.0
+		IL_032c: stelem.ref
+		IL_032d: stloc.s 9
+		IL_032f: ldloc.s 9
+		IL_0331: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
+		IL_0336: ldloc.s 8
+		IL_0338: ldloc.s 9
+		IL_033a: ldc.i4.1
+		IL_033b: conv.r8
+		IL_033c: ldc.i4.0
+		IL_033d: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0342: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject
+		IL_0347: stloc.s 10
+		IL_0349: ldloc.0
+		IL_034a: ldloc.s 10
+		IL_034c: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_0351: nop
+		IL_0352: ldc.i4.1
+		IL_0353: newarr [System.Runtime]System.Object
+		IL_0358: dup
+		IL_0359: ldc.i4.0
+		IL_035a: ldloc.0
+		IL_035b: stelem.ref
+		IL_035c: stloc.s 9
+		IL_035e: ldloc.s 9
+		IL_0360: ldc.i4.0
+		IL_0361: ldelem.ref
+		IL_0362: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0367: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
+		IL_036c: ldc.i4.1
+		IL_036d: conv.r8
+		IL_036e: ldstr ""
+		IL_0373: ldc.i4.0
+		IL_0374: ldc.i4.0
+		IL_0375: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_037a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
+		IL_037f: stloc.s 11
+		IL_0381: ldloc.s 11
+		IL_0383: ldstr "runSieveBatch"
+		IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_038d: stloc.s 5
+		IL_038f: ldloc.0
+		IL_0390: ldloc.s 5
+		IL_0392: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_0397: nop
+		IL_0398: ldloc.0
+		IL_0399: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_039e: ldnull
+		IL_039f: ldloc.1
+		IL_03a0: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_03a5: pop
+		IL_03a6: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
@@ -3578,6 +3591,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_34
 	.field assembly static int32 __jroc_dynamicLookup_35
 	.field assembly static int32 __jroc_dynamicLookup_36
+	.field assembly static int32 __jroc_dynamicLookup_37
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -540,7 +540,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 176 (0xb0)
+			// Code size: 215 (0xd7)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -557,70 +557,83 @@
 			IL_000c: ldstr ""
 			IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0016: stloc.3
-			IL_0017: ldloc.2
-			IL_0018: ldstr "match"
-			IL_001d: ldloc.3
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0023: stloc.0
-			IL_0024: ldloc.0
-			IL_0025: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_002a: ldc.i4.0
-			IL_002b: ceq
-			IL_002d: stloc.s 4
-			IL_002f: ldloc.s 4
-			IL_0031: brfalse IL_0056
+			IL_0017: volatile.
+			IL_0019: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_001e: brfalse IL_0034
 
-			IL_0036: ldstr "Could not find <Version> in Jroc.csproj"
-			IL_003b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0040: stloc.1
-			IL_0041: ldloc.1
-			IL_0042: isinst [System.Runtime]System.Exception
-			IL_0047: dup
-			IL_0048: brtrue IL_0055
+			IL_0023: ldloc.2
+			IL_0024: ldstr "match"
+			IL_0029: ldloc.3
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002f: br IL_004a
 
-			IL_004d: pop
-			IL_004e: ldloc.1
-			IL_004f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0054: throw
+			IL_0034: ldloc.2
+			IL_0035: ldstr "match"
+			IL_003a: ldloc.3
+			IL_003b: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M6>:__js_call__:6"
+			IL_0040: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0055: throw
+			IL_004a: stloc.0
+			IL_004b: ldloc.0
+			IL_004c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0051: ldc.i4.0
+			IL_0052: ceq
+			IL_0054: stloc.s 4
+			IL_0056: ldloc.s 4
+			IL_0058: brfalse IL_007d
 
-			IL_0056: ldloc.0
-			IL_0057: ldc.r8 1
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0065: stloc.2
-			IL_0066: ldloc.2
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006c: stloc.2
-			IL_006d: ldc.i4.0
-			IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0073: brfalse IL_00a2
+			IL_005d: ldstr "Could not find <Version> in Jroc.csproj"
+			IL_0062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0067: stloc.1
+			IL_0068: ldloc.1
+			IL_0069: isinst [System.Runtime]System.Exception
+			IL_006e: dup
+			IL_006f: brtrue IL_007c
 
-			IL_0078: ldloc.2
-			IL_0079: isinst [System.Runtime]System.String
-			IL_007e: dup
-			IL_007f: brtrue IL_0096
+			IL_0074: pop
+			IL_0075: ldloc.1
+			IL_0076: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_007b: throw
 
-			IL_0084: pop
-			IL_0085: ldloc.2
-			IL_0086: ldstr "trim"
-			IL_008b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0090: dup
-			IL_0091: brfalse IL_00a1
+			IL_007c: throw
 
-			IL_0096: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_009b: stloc.2
-			IL_009c: br IL_00ae
+			IL_007d: ldloc.0
+			IL_007e: ldc.r8 1
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_008c: stloc.2
+			IL_008d: ldloc.2
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0093: stloc.2
+			IL_0094: ldc.i4.0
+			IL_0095: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_009a: brfalse IL_00c9
 
-			IL_00a1: pop
+			IL_009f: ldloc.2
+			IL_00a0: isinst [System.Runtime]System.String
+			IL_00a5: dup
+			IL_00a6: brtrue IL_00bd
 
-			IL_00a2: ldloc.2
-			IL_00a3: ldstr "trim"
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00ad: stloc.2
+			IL_00ab: pop
+			IL_00ac: ldloc.2
+			IL_00ad: ldstr "trim"
+			IL_00b2: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00b7: dup
+			IL_00b8: brfalse IL_00c8
 
-			IL_00ae: ldloc.2
-			IL_00af: ret
+			IL_00bd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_00c2: stloc.2
+			IL_00c3: br IL_00d5
+
+			IL_00c8: pop
+
+			IL_00c9: ldloc.2
+			IL_00ca: ldstr "trim"
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00d4: stloc.2
+
+			IL_00d5: ldloc.2
+			IL_00d6: ret
 		} // end of method parseCurrentVersion::__js_call__
 
 	} // end of class parseCurrentVersion
@@ -1010,7 +1023,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 869 (0x365)
+			// Code size: 994 (0x3e2)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/incVersion/Scope,
@@ -1042,333 +1055,370 @@
 			IL_0005: stloc.0
 			IL_0006: ldarg.1
 			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000c: ldstr "split"
-			IL_0011: ldstr "-"
-			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001b: stloc.s 13
-			IL_001d: ldloc.s 13
-			IL_001f: ldc.r8 0.0
-			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_002d: stloc.1
-			IL_002e: ldloc.1
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0034: ldstr "split"
-			IL_0039: ldstr "."
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0043: stloc.s 13
-			IL_0045: ldloc.s 13
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004c: stloc.s 13
-			IL_004e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0053: stloc.s 14
-			IL_0055: newobj instance void Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L51C46/FunctionObject::.ctor()
-			IL_005a: ldc.i4.1
-			IL_005b: conv.r8
-			IL_005c: ldstr ""
-			IL_0061: ldc.i4.0
-			IL_0062: ldc.i4.0
-			IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L51C46/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L51C46/FunctionObject>(!!0)
-			IL_006d: stloc.s 15
-			IL_006f: ldloc.s 13
-			IL_0071: ldstr "map"
-			IL_0076: ldloc.s 15
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007d: stloc.s 13
-			IL_007f: ldloc.s 13
-			IL_0081: brfalse IL_0092
+			IL_000c: volatile.
+			IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0013: brfalse IL_002c
 
-			IL_0086: ldloc.s 13
-			IL_0088: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_008d: brfalse IL_00a3
+			IL_0018: ldstr "split"
+			IL_001d: ldstr "-"
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0027: br IL_0045
 
-			IL_0092: ldloc.s 13
-			IL_0094: ldstr ""
-			IL_0099: ldstr "0"
-			IL_009e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_002c: ldstr "split"
+			IL_0031: ldstr "-"
+			IL_0036: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M7>:__js_call__:5"
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_00a3: ldloc.s 13
-			IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_00aa: stloc.2
-			IL_00ab: ldc.i4.0
-			IL_00ac: stloc.3
-			IL_00ad: ldc.i4.0
-			IL_00ae: stloc.s 4
+			IL_0045: stloc.s 13
+			IL_0047: ldloc.s 13
+			IL_0049: ldc.r8 0.0
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0057: stloc.1
+			IL_0058: ldloc.1
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005e: volatile.
+			IL_0060: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0065: brfalse IL_007e
+
+			IL_006a: ldstr "split"
+			IL_006f: ldstr "."
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0079: br IL_0097
+
+			IL_007e: ldstr "split"
+			IL_0083: ldstr "."
+			IL_0088: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M7>:__js_call__:12"
+			IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0097: stloc.s 13
+			IL_0099: ldloc.s 13
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a0: stloc.s 13
+			IL_00a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_00a7: stloc.s 14
+			IL_00a9: newobj instance void Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L51C46/FunctionObject::.ctor()
+			IL_00ae: ldc.i4.1
+			IL_00af: conv.r8
+			IL_00b0: ldstr ""
+			IL_00b5: ldc.i4.0
+			IL_00b6: ldc.i4.0
+			IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L51C46/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L51C46/FunctionObject>(!!0)
+			IL_00c1: stloc.s 15
+			IL_00c3: volatile.
+			IL_00c5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_00ca: brfalse IL_00e2
+
+			IL_00cf: ldloc.s 13
+			IL_00d1: ldstr "map"
+			IL_00d6: ldloc.s 15
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00dd: br IL_00fa
+
+			IL_00e2: ldloc.s 13
+			IL_00e4: ldstr "map"
+			IL_00e9: ldloc.s 15
+			IL_00eb: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M7>:__js_call__:16"
+			IL_00f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00fa: stloc.s 13
+			IL_00fc: ldloc.s 13
+			IL_00fe: brfalse IL_010f
+
+			IL_0103: ldloc.s 13
+			IL_0105: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_010a: brfalse IL_0120
+
+			IL_010f: ldloc.s 13
+			IL_0111: ldstr ""
+			IL_0116: ldstr "0"
+			IL_011b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+
+			IL_0120: ldloc.s 13
+			IL_0122: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0127: stloc.2
+			IL_0128: ldc.i4.0
+			IL_0129: stloc.3
+			IL_012a: ldc.i4.0
+			IL_012b: stloc.s 4
 			.try
 			{
-				IL_00b0: ldloc.s 4
-				IL_00b2: brtrue IL_00e1
+				IL_012d: ldloc.s 4
+				IL_012f: brtrue IL_015e
 
-				IL_00b7: ldc.i4.1
-				IL_00b8: stloc.s 4
-				IL_00ba: ldloc.2
-				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
-				IL_00c0: stloc.s 13
-				IL_00c2: ldloc.s 13
-				IL_00c4: brfalse IL_00de
+				IL_0134: ldc.i4.1
+				IL_0135: stloc.s 4
+				IL_0137: ldloc.2
+				IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+				IL_013d: stloc.s 13
+				IL_013f: ldloc.s 13
+				IL_0141: brfalse IL_015b
 
-				IL_00c9: ldc.i4.0
-				IL_00ca: stloc.s 4
-				IL_00cc: ldloc.s 13
-				IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
-				IL_00d3: stloc.s 13
-				IL_00d5: ldloc.s 13
-				IL_00d7: stloc.s 5
-				IL_00d9: br IL_00e4
-
-				IL_00de: ldc.i4.1
-				IL_00df: stloc.s 4
-
-				IL_00e1: ldnull
-				IL_00e2: stloc.s 5
-
-				IL_00e4: ldloc.s 4
-				IL_00e6: brtrue IL_0115
-
-				IL_00eb: ldc.i4.1
-				IL_00ec: stloc.s 4
-				IL_00ee: ldloc.2
-				IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
-				IL_00f4: stloc.s 13
-				IL_00f6: ldloc.s 13
-				IL_00f8: brfalse IL_0112
-
-				IL_00fd: ldc.i4.0
-				IL_00fe: stloc.s 4
-				IL_0100: ldloc.s 13
-				IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
-				IL_0107: stloc.s 13
-				IL_0109: ldloc.s 13
-				IL_010b: stloc.s 6
-				IL_010d: br IL_0118
-
-				IL_0112: ldc.i4.1
-				IL_0113: stloc.s 4
-
-				IL_0115: ldnull
-				IL_0116: stloc.s 6
-
-				IL_0118: ldloc.s 4
-				IL_011a: brtrue IL_0149
-
-				IL_011f: ldc.i4.1
-				IL_0120: stloc.s 4
-				IL_0122: ldloc.2
-				IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
-				IL_0128: stloc.s 13
-				IL_012a: ldloc.s 13
-				IL_012c: brfalse IL_0146
-
-				IL_0131: ldc.i4.0
-				IL_0132: stloc.s 4
-				IL_0134: ldloc.s 13
-				IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
-				IL_013b: stloc.s 13
-				IL_013d: ldloc.s 13
-				IL_013f: stloc.s 7
-				IL_0141: br IL_014c
-
-				IL_0146: ldc.i4.1
+				IL_0146: ldc.i4.0
 				IL_0147: stloc.s 4
-
-				IL_0149: ldnull
-				IL_014a: stloc.s 7
-
-				IL_014c: ldloc.s 4
-				IL_014e: brtrue IL_015b
-
-				IL_0153: ldc.i4.1
-				IL_0154: stloc.3
-				IL_0155: ldloc.2
-				IL_0156: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0149: ldloc.s 13
+				IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+				IL_0150: stloc.s 13
+				IL_0152: ldloc.s 13
+				IL_0154: stloc.s 5
+				IL_0156: br IL_0161
 
 				IL_015b: ldc.i4.1
-				IL_015c: stloc.3
-				IL_015d: leave IL_0176
+				IL_015c: stloc.s 4
+
+				IL_015e: ldnull
+				IL_015f: stloc.s 5
+
+				IL_0161: ldloc.s 4
+				IL_0163: brtrue IL_0192
+
+				IL_0168: ldc.i4.1
+				IL_0169: stloc.s 4
+				IL_016b: ldloc.2
+				IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+				IL_0171: stloc.s 13
+				IL_0173: ldloc.s 13
+				IL_0175: brfalse IL_018f
+
+				IL_017a: ldc.i4.0
+				IL_017b: stloc.s 4
+				IL_017d: ldloc.s 13
+				IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+				IL_0184: stloc.s 13
+				IL_0186: ldloc.s 13
+				IL_0188: stloc.s 6
+				IL_018a: br IL_0195
+
+				IL_018f: ldc.i4.1
+				IL_0190: stloc.s 4
+
+				IL_0192: ldnull
+				IL_0193: stloc.s 6
+
+				IL_0195: ldloc.s 4
+				IL_0197: brtrue IL_01c6
+
+				IL_019c: ldc.i4.1
+				IL_019d: stloc.s 4
+				IL_019f: ldloc.2
+				IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+				IL_01a5: stloc.s 13
+				IL_01a7: ldloc.s 13
+				IL_01a9: brfalse IL_01c3
+
+				IL_01ae: ldc.i4.0
+				IL_01af: stloc.s 4
+				IL_01b1: ldloc.s 13
+				IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+				IL_01b8: stloc.s 13
+				IL_01ba: ldloc.s 13
+				IL_01bc: stloc.s 7
+				IL_01be: br IL_01c9
+
+				IL_01c3: ldc.i4.1
+				IL_01c4: stloc.s 4
+
+				IL_01c6: ldnull
+				IL_01c7: stloc.s 7
+
+				IL_01c9: ldloc.s 4
+				IL_01cb: brtrue IL_01d8
+
+				IL_01d0: ldc.i4.1
+				IL_01d1: stloc.3
+				IL_01d2: ldloc.2
+				IL_01d3: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+
+				IL_01d8: ldc.i4.1
+				IL_01d9: stloc.3
+				IL_01da: leave IL_01f3
 			} // end .try
 			finally
 			{
-				IL_0162: ldloc.3
-				IL_0163: brtrue IL_0175
+				IL_01df: ldloc.3
+				IL_01e0: brtrue IL_01f2
 
-				IL_0168: ldloc.s 4
-				IL_016a: brtrue IL_0175
+				IL_01e5: ldloc.s 4
+				IL_01e7: brtrue IL_01f2
 
-				IL_016f: ldloc.2
-				IL_0170: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_01ec: ldloc.2
+				IL_01ed: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0175: endfinally
+				IL_01f2: endfinally
 			} // end handler
 
-			IL_0176: ldc.i4.3
-			IL_0177: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_017c: dup
-			IL_017d: ldloc.s 5
-			IL_017f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0184: dup
-			IL_0185: ldloc.s 6
-			IL_0187: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_018c: dup
-			IL_018d: ldloc.s 7
-			IL_018f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0194: stloc.s 16
-			IL_0196: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_019b: stloc.s 14
-			IL_019d: newobj instance void Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L52C27/FunctionObject::.ctor()
-			IL_01a2: ldc.i4.1
-			IL_01a3: conv.r8
-			IL_01a4: ldstr ""
-			IL_01a9: ldc.i4.0
-			IL_01aa: ldc.i4.0
-			IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L52C27/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L52C27/FunctionObject>(!!0)
-			IL_01b5: stloc.s 17
-			IL_01b7: ldloc.s 16
-			IL_01b9: ldloc.s 17
-			IL_01bb: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Array::some(object)
-			IL_01c0: stloc.s 18
-			IL_01c2: ldloc.s 18
-			IL_01c4: brfalse IL_01f6
+			IL_01f3: ldc.i4.3
+			IL_01f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01f9: dup
+			IL_01fa: ldloc.s 5
+			IL_01fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0201: dup
+			IL_0202: ldloc.s 6
+			IL_0204: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0209: dup
+			IL_020a: ldloc.s 7
+			IL_020c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0211: stloc.s 16
+			IL_0213: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0218: stloc.s 14
+			IL_021a: newobj instance void Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L52C27/FunctionObject::.ctor()
+			IL_021f: ldc.i4.1
+			IL_0220: conv.r8
+			IL_0221: ldstr ""
+			IL_0226: ldc.i4.0
+			IL_0227: ldc.i4.0
+			IL_0228: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L52C27/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_022d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/incVersion/ArrowFunction_L52C27/FunctionObject>(!!0)
+			IL_0232: stloc.s 17
+			IL_0234: ldloc.s 16
+			IL_0236: ldloc.s 17
+			IL_0238: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Array::some(object)
+			IL_023d: stloc.s 18
+			IL_023f: ldloc.s 18
+			IL_0241: brfalse IL_0273
 
-			IL_01c9: ldstr "Invalid current version: "
-			IL_01ce: ldarg.1
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01d4: stloc.s 19
-			IL_01d6: ldloc.s 19
-			IL_01d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(object)
-			IL_01dd: stloc.s 8
-			IL_01df: ldloc.s 8
-			IL_01e1: isinst [System.Runtime]System.Exception
-			IL_01e6: dup
-			IL_01e7: brtrue IL_01f5
+			IL_0246: ldstr "Invalid current version: "
+			IL_024b: ldarg.1
+			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0251: stloc.s 19
+			IL_0253: ldloc.s 19
+			IL_0255: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(object)
+			IL_025a: stloc.s 8
+			IL_025c: ldloc.s 8
+			IL_025e: isinst [System.Runtime]System.Exception
+			IL_0263: dup
+			IL_0264: brtrue IL_0272
 
-			IL_01ec: pop
-			IL_01ed: ldloc.s 8
-			IL_01ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_01f4: throw
+			IL_0269: pop
+			IL_026a: ldloc.s 8
+			IL_026c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0271: throw
 
-			IL_01f5: throw
+			IL_0272: throw
 
-			IL_01f6: ldloc.s 5
-			IL_01f8: stloc.s 9
-			IL_01fa: ldloc.s 6
-			IL_01fc: stloc.s 10
-			IL_01fe: ldloc.s 7
-			IL_0200: stloc.s 11
-			IL_0202: ldarg.2
-			IL_0203: ldstr "major"
-			IL_0208: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_020d: stloc.s 18
-			IL_020f: ldloc.s 18
-			IL_0211: brtrue IL_0243
+			IL_0273: ldloc.s 5
+			IL_0275: stloc.s 9
+			IL_0277: ldloc.s 6
+			IL_0279: stloc.s 10
+			IL_027b: ldloc.s 7
+			IL_027d: stloc.s 11
+			IL_027f: ldarg.2
+			IL_0280: ldstr "major"
+			IL_0285: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_028a: stloc.s 18
+			IL_028c: ldloc.s 18
+			IL_028e: brtrue IL_02c0
 
-			IL_0216: ldarg.2
-			IL_0217: ldstr "minor"
-			IL_021c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0221: stloc.s 18
-			IL_0223: ldloc.s 18
-			IL_0225: brtrue IL_0290
+			IL_0293: ldarg.2
+			IL_0294: ldstr "minor"
+			IL_0299: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_029e: stloc.s 18
+			IL_02a0: ldloc.s 18
+			IL_02a2: brtrue IL_030d
 
-			IL_022a: ldarg.2
-			IL_022b: ldstr "patch"
-			IL_0230: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0235: stloc.s 18
-			IL_0237: ldloc.s 18
-			IL_0239: brtrue IL_02c9
+			IL_02a7: ldarg.2
+			IL_02a8: ldstr "patch"
+			IL_02ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_02b2: stloc.s 18
+			IL_02b4: ldloc.s 18
+			IL_02b6: brtrue IL_0346
 
-			IL_023e: br IL_02ee
+			IL_02bb: br IL_036b
 
-			IL_0243: ldloc.s 9
-			IL_0245: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_024a: ldc.r8 1
-			IL_0253: add
-			IL_0254: stloc.s 20
-			IL_0256: ldloc.s 20
-			IL_0258: box [System.Runtime]System.Double
-			IL_025d: stloc.s 21
-			IL_025f: ldloc.s 21
-			IL_0261: stloc.s 9
-			IL_0263: ldc.r8 0.0
-			IL_026c: box [System.Runtime]System.Double
-			IL_0271: stloc.s 21
-			IL_0273: ldloc.s 21
-			IL_0275: stloc.s 10
-			IL_0277: ldc.r8 0.0
-			IL_0280: box [System.Runtime]System.Double
-			IL_0285: stloc.s 21
-			IL_0287: ldloc.s 21
-			IL_0289: stloc.s 11
-			IL_028b: br IL_031b
+			IL_02c0: ldloc.s 9
+			IL_02c2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_02c7: ldc.r8 1
+			IL_02d0: add
+			IL_02d1: stloc.s 20
+			IL_02d3: ldloc.s 20
+			IL_02d5: box [System.Runtime]System.Double
+			IL_02da: stloc.s 21
+			IL_02dc: ldloc.s 21
+			IL_02de: stloc.s 9
+			IL_02e0: ldc.r8 0.0
+			IL_02e9: box [System.Runtime]System.Double
+			IL_02ee: stloc.s 21
+			IL_02f0: ldloc.s 21
+			IL_02f2: stloc.s 10
+			IL_02f4: ldc.r8 0.0
+			IL_02fd: box [System.Runtime]System.Double
+			IL_0302: stloc.s 21
+			IL_0304: ldloc.s 21
+			IL_0306: stloc.s 11
+			IL_0308: br IL_0398
 
-			IL_0290: ldloc.s 10
-			IL_0292: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0297: ldc.r8 1
-			IL_02a0: add
-			IL_02a1: stloc.s 20
-			IL_02a3: ldloc.s 20
-			IL_02a5: box [System.Runtime]System.Double
-			IL_02aa: stloc.s 21
-			IL_02ac: ldloc.s 21
-			IL_02ae: stloc.s 10
-			IL_02b0: ldc.r8 0.0
-			IL_02b9: box [System.Runtime]System.Double
-			IL_02be: stloc.s 21
-			IL_02c0: ldloc.s 21
-			IL_02c2: stloc.s 11
-			IL_02c4: br IL_031b
+			IL_030d: ldloc.s 10
+			IL_030f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0314: ldc.r8 1
+			IL_031d: add
+			IL_031e: stloc.s 20
+			IL_0320: ldloc.s 20
+			IL_0322: box [System.Runtime]System.Double
+			IL_0327: stloc.s 21
+			IL_0329: ldloc.s 21
+			IL_032b: stloc.s 10
+			IL_032d: ldc.r8 0.0
+			IL_0336: box [System.Runtime]System.Double
+			IL_033b: stloc.s 21
+			IL_033d: ldloc.s 21
+			IL_033f: stloc.s 11
+			IL_0341: br IL_0398
 
-			IL_02c9: ldloc.s 11
-			IL_02cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_02d0: ldc.r8 1
-			IL_02d9: add
-			IL_02da: stloc.s 20
-			IL_02dc: ldloc.s 20
-			IL_02de: box [System.Runtime]System.Double
-			IL_02e3: stloc.s 21
-			IL_02e5: ldloc.s 21
-			IL_02e7: stloc.s 11
-			IL_02e9: br IL_031b
+			IL_0346: ldloc.s 11
+			IL_0348: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_034d: ldc.r8 1
+			IL_0356: add
+			IL_0357: stloc.s 20
+			IL_0359: ldloc.s 20
+			IL_035b: box [System.Runtime]System.Double
+			IL_0360: stloc.s 21
+			IL_0362: ldloc.s 21
+			IL_0364: stloc.s 11
+			IL_0366: br IL_0398
 
-			IL_02ee: ldstr "Unknown bump kind: "
-			IL_02f3: ldarg.2
-			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02f9: stloc.s 19
-			IL_02fb: ldloc.s 19
-			IL_02fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(object)
-			IL_0302: stloc.s 12
-			IL_0304: ldloc.s 12
-			IL_0306: isinst [System.Runtime]System.Exception
-			IL_030b: dup
-			IL_030c: brtrue IL_031a
+			IL_036b: ldstr "Unknown bump kind: "
+			IL_0370: ldarg.2
+			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0376: stloc.s 19
+			IL_0378: ldloc.s 19
+			IL_037a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(object)
+			IL_037f: stloc.s 12
+			IL_0381: ldloc.s 12
+			IL_0383: isinst [System.Runtime]System.Exception
+			IL_0388: dup
+			IL_0389: brtrue IL_0397
 
-			IL_0311: pop
-			IL_0312: ldloc.s 12
-			IL_0314: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0319: throw
+			IL_038e: pop
+			IL_038f: ldloc.s 12
+			IL_0391: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0396: throw
 
-			IL_031a: throw
+			IL_0397: throw
 
-			IL_031b: ldloc.s 9
-			IL_031d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0322: stloc.s 22
-			IL_0324: ldstr ""
-			IL_0329: ldloc.s 22
-			IL_032b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0330: ldstr "."
-			IL_0335: call string [System.Runtime]System.String::Concat(string, string)
-			IL_033a: ldloc.s 10
-			IL_033c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0341: stloc.s 22
-			IL_0343: ldloc.s 22
-			IL_0345: call string [System.Runtime]System.String::Concat(string, string)
-			IL_034a: ldstr "."
-			IL_034f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0354: ldloc.s 11
-			IL_0356: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_035b: stloc.s 22
-			IL_035d: ldloc.s 22
-			IL_035f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0364: ret
+			IL_0398: ldloc.s 9
+			IL_039a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_039f: stloc.s 22
+			IL_03a1: ldstr ""
+			IL_03a6: ldloc.s 22
+			IL_03a8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03ad: ldstr "."
+			IL_03b2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03b7: ldloc.s 10
+			IL_03b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03be: stloc.s 22
+			IL_03c0: ldloc.s 22
+			IL_03c2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03c7: ldstr "."
+			IL_03cc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03d1: ldloc.s 11
+			IL_03d3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03d8: stloc.s 22
+			IL_03da: ldloc.s 22
+			IL_03dc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03e1: ret
 		} // end of method incVersion::__js_call__
 
 	} // end of class incVersion
@@ -2272,7 +2322,7 @@
 				74 61 54 6f 6b 65 6e 15 00 00 02
 			)
 			// Header size: 12
-			// Code size: 922 (0x39a)
+			// Code size: 963 (0x3c3)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2431,192 +2481,205 @@
 			IL_016f: ldstr ""
 			IL_0174: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0179: stloc.s 13
-			IL_017b: ldloc.s 8
-			IL_017d: ldstr "match"
-			IL_0182: ldloc.s 13
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0189: stloc.3
-			IL_018a: ldc.r8 1
-			IL_0193: neg
-			IL_0194: stloc.s 9
-			IL_0196: ldloc.s 9
-			IL_0198: box [System.Runtime]System.Double
-			IL_019d: stloc.s 4
-			IL_019f: ldloc.3
-			IL_01a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01a5: stloc.s 11
-			IL_01a7: ldloc.s 11
-			IL_01a9: brfalse IL_0213
+			IL_017b: volatile.
+			IL_017d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_0182: brfalse IL_019a
 
-			IL_01ae: ldloc.2
-			IL_01af: ldc.r8 1
-			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01bd: stloc.s 12
-			IL_01bf: volatile.
-			IL_01c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_01c6: brfalse IL_01db
+			IL_0187: ldloc.s 8
+			IL_0189: ldstr "match"
+			IL_018e: ldloc.s 13
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0195: br IL_01b2
 
-			IL_01cb: ldloc.3
-			IL_01cc: ldstr "index"
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d6: br IL_01f0
+			IL_019a: ldloc.s 8
+			IL_019c: ldstr "match"
+			IL_01a1: ldloc.s 13
+			IL_01a3: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M11>:__js_call__:34"
+			IL_01a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_01db: ldloc.3
-			IL_01dc: ldstr "index"
-			IL_01e1: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M11>:__js_call__:48"
-			IL_01e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01b2: stloc.3
+			IL_01b3: ldc.r8 1
+			IL_01bc: neg
+			IL_01bd: stloc.s 9
+			IL_01bf: ldloc.s 9
+			IL_01c1: box [System.Runtime]System.Double
+			IL_01c6: stloc.s 4
+			IL_01c8: ldloc.3
+			IL_01c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01ce: stloc.s 11
+			IL_01d0: ldloc.s 11
+			IL_01d2: brfalse IL_023c
 
-			IL_01f0: stloc.s 8
-			IL_01f2: ldloc.s 12
-			IL_01f4: ldloc.s 8
-			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01fb: stloc.s 12
-			IL_01fd: ldloc.s 12
-			IL_01ff: ldc.r8 1
-			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_020d: stloc.s 12
-			IL_020f: ldloc.s 12
-			IL_0211: stloc.s 4
+			IL_01d7: ldloc.2
+			IL_01d8: ldc.r8 1
+			IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01e6: stloc.s 12
+			IL_01e8: volatile.
+			IL_01ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_01ef: brfalse IL_0204
 
-			IL_0213: ldloc.s 4
-			IL_0215: stloc.s 12
-			IL_0217: ldc.r8 1
-			IL_0220: neg
-			IL_0221: stloc.s 9
-			IL_0223: ldloc.s 9
-			IL_0225: box [System.Runtime]System.Double
-			IL_022a: stloc.s 10
-			IL_022c: ldloc.s 12
-			IL_022e: ldloc.s 10
-			IL_0230: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0235: stloc.s 11
-			IL_0237: ldloc.s 11
-			IL_0239: brfalse IL_027a
+			IL_01f4: ldloc.3
+			IL_01f5: ldstr "index"
+			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ff: br IL_0219
 
-			IL_023e: volatile.
-			IL_0240: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_0245: brfalse IL_025a
+			IL_0204: ldloc.3
+			IL_0205: ldstr "index"
+			IL_020a: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M11>:__js_call__:48"
+			IL_020f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_024a: ldarg.2
-			IL_024b: ldstr "length"
-			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0255: br IL_026f
+			IL_0219: stloc.s 8
+			IL_021b: ldloc.s 12
+			IL_021d: ldloc.s 8
+			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0224: stloc.s 12
+			IL_0226: ldloc.s 12
+			IL_0228: ldc.r8 1
+			IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0236: stloc.s 12
+			IL_0238: ldloc.s 12
+			IL_023a: stloc.s 4
 
-			IL_025a: ldarg.2
-			IL_025b: ldstr "length"
-			IL_0260: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M11>:__js_call__:64"
-			IL_0265: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_023c: ldloc.s 4
+			IL_023e: stloc.s 12
+			IL_0240: ldc.r8 1
+			IL_0249: neg
+			IL_024a: stloc.s 9
+			IL_024c: ldloc.s 9
+			IL_024e: box [System.Runtime]System.Double
+			IL_0253: stloc.s 10
+			IL_0255: ldloc.s 12
+			IL_0257: ldloc.s 10
+			IL_0259: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_025e: stloc.s 11
+			IL_0260: ldloc.s 11
+			IL_0262: brfalse IL_02a3
 
-			IL_026f: stloc.s 8
-			IL_0271: ldloc.s 8
-			IL_0273: stloc.s 5
-			IL_0275: br IL_029e
+			IL_0267: volatile.
+			IL_0269: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_026e: brfalse IL_0283
 
-			IL_027a: ldloc.s 4
-			IL_027c: stloc.s 12
-			IL_027e: ldloc.s 12
-			IL_0280: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0285: ldc.r8 1
-			IL_028e: sub
-			IL_028f: stloc.s 9
-			IL_0291: ldloc.s 9
-			IL_0293: box [System.Runtime]System.Double
-			IL_0298: stloc.s 10
-			IL_029a: ldloc.s 10
+			IL_0273: ldarg.2
+			IL_0274: ldstr "length"
+			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027e: br IL_0298
+
+			IL_0283: ldarg.2
+			IL_0284: ldstr "length"
+			IL_0289: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M11>:__js_call__:64"
+			IL_028e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0298: stloc.s 8
+			IL_029a: ldloc.s 8
 			IL_029c: stloc.s 5
+			IL_029e: br IL_02c7
 
-			IL_029e: ldloc.s 5
-			IL_02a0: stloc.s 6
-			IL_02a2: ldarg.2
-			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a8: stloc.s 8
-			IL_02aa: ldloc.2
-			IL_02ab: ldc.r8 1
-			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_02b9: stloc.s 12
-			IL_02bb: ldc.i4.0
-			IL_02bc: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_02c1: brfalse IL_02f7
+			IL_02a3: ldloc.s 4
+			IL_02a5: stloc.s 12
+			IL_02a7: ldloc.s 12
+			IL_02a9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_02ae: ldc.r8 1
+			IL_02b7: sub
+			IL_02b8: stloc.s 9
+			IL_02ba: ldloc.s 9
+			IL_02bc: box [System.Runtime]System.Double
+			IL_02c1: stloc.s 10
+			IL_02c3: ldloc.s 10
+			IL_02c5: stloc.s 5
 
-			IL_02c6: ldloc.s 8
-			IL_02c8: isinst [System.Runtime]System.String
-			IL_02cd: dup
-			IL_02ce: brtrue IL_02e6
+			IL_02c7: ldloc.s 5
+			IL_02c9: stloc.s 6
+			IL_02cb: ldarg.2
+			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02d1: stloc.s 8
+			IL_02d3: ldloc.2
+			IL_02d4: ldc.r8 1
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_02e2: stloc.s 12
+			IL_02e4: ldc.i4.0
+			IL_02e5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_02ea: brfalse IL_0320
 
-			IL_02d3: pop
-			IL_02d4: ldloc.s 8
-			IL_02d6: ldstr "slice"
-			IL_02db: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_02e0: dup
-			IL_02e1: brfalse IL_02f6
+			IL_02ef: ldloc.s 8
+			IL_02f1: isinst [System.Runtime]System.String
+			IL_02f6: dup
+			IL_02f7: brtrue IL_030f
 
-			IL_02e6: ldloc.s 12
-			IL_02e8: ldloc.s 6
-			IL_02ea: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-			IL_02ef: stloc.s 8
-			IL_02f1: br IL_0309
+			IL_02fc: pop
+			IL_02fd: ldloc.s 8
+			IL_02ff: ldstr "slice"
+			IL_0304: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0309: dup
+			IL_030a: brfalse IL_031f
 
-			IL_02f6: pop
+			IL_030f: ldloc.s 12
+			IL_0311: ldloc.s 6
+			IL_0313: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_0318: stloc.s 8
+			IL_031a: br IL_0332
 
-			IL_02f7: ldloc.s 8
-			IL_02f9: ldstr "slice"
-			IL_02fe: ldloc.s 12
-			IL_0300: ldloc.s 6
-			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0307: stloc.s 8
+			IL_031f: pop
 
-			IL_0309: ldloc.s 8
-			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0310: stloc.s 8
-			IL_0312: ldc.i4.0
-			IL_0313: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0318: brfalse IL_034a
+			IL_0320: ldloc.s 8
+			IL_0322: ldstr "slice"
+			IL_0327: ldloc.s 12
+			IL_0329: ldloc.s 6
+			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0330: stloc.s 8
 
-			IL_031d: ldloc.s 8
-			IL_031f: isinst [System.Runtime]System.String
-			IL_0324: dup
-			IL_0325: brtrue IL_033d
+			IL_0332: ldloc.s 8
+			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0339: stloc.s 8
+			IL_033b: ldc.i4.0
+			IL_033c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0341: brfalse IL_0373
 
-			IL_032a: pop
-			IL_032b: ldloc.s 8
-			IL_032d: ldstr "trim"
-			IL_0332: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0337: dup
-			IL_0338: brfalse IL_0349
+			IL_0346: ldloc.s 8
+			IL_0348: isinst [System.Runtime]System.String
+			IL_034d: dup
+			IL_034e: brtrue IL_0366
 
-			IL_033d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0342: stloc.s 7
-			IL_0344: br IL_0358
+			IL_0353: pop
+			IL_0354: ldloc.s 8
+			IL_0356: ldstr "trim"
+			IL_035b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0360: dup
+			IL_0361: brfalse IL_0372
 
-			IL_0349: pop
+			IL_0366: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_036b: stloc.s 7
+			IL_036d: br IL_0381
 
-			IL_034a: ldloc.s 8
-			IL_034c: ldstr "trim"
-			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0356: stloc.s 7
+			IL_0372: pop
 
-			IL_0358: ldloc.2
-			IL_0359: ldc.r8 1
-			IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0367: stloc.s 12
-			IL_0369: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_036e: dup
-			IL_036f: ldstr "body"
-			IL_0374: ldloc.s 7
-			IL_0376: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_037b: dup
-			IL_037c: ldstr "start"
-			IL_0381: ldloc.s 12
-			IL_0383: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0388: dup
-			IL_0389: ldstr "end"
-			IL_038e: ldloc.s 6
-			IL_0390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0395: stloc.s 14
-			IL_0397: ldloc.s 14
-			IL_0399: ret
+			IL_0373: ldloc.s 8
+			IL_0375: ldstr "trim"
+			IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_037f: stloc.s 7
+
+			IL_0381: ldloc.2
+			IL_0382: ldc.r8 1
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0390: stloc.s 12
+			IL_0392: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0397: dup
+			IL_0398: ldstr "body"
+			IL_039d: ldloc.s 7
+			IL_039f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03a4: dup
+			IL_03a5: ldstr "start"
+			IL_03aa: ldloc.s 12
+			IL_03ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03b1: dup
+			IL_03b2: ldstr "end"
+			IL_03b7: ldloc.s 6
+			IL_03b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03be: stloc.s 14
+			IL_03c0: ldloc.s 14
+			IL_03c2: ret
 		} // end of method extractUnreleased::__js_call__
 
 	} // end of class extractUnreleased
@@ -2961,7 +3024,7 @@
 				IL_0047: stloc.0
 
 				IL_0048: volatile.
-				IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+				IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 				IL_004f: brfalse IL_0064
 
 				IL_0054: ldloc.0
@@ -2972,7 +3035,7 @@
 				IL_0064: ldloc.0
 				IL_0065: ldstr "length"
 				IL_006a: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M17>:__js_call__:4"
-				IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+				IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0079: stloc.0
@@ -3177,7 +3240,7 @@
 				74 61 54 6f 6b 65 6e 15 00 00 02
 			)
 			// Header size: 12
-			// Code size: 454 (0x1c6)
+			// Code size: 578 (0x242)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/Scope,
@@ -3200,7 +3263,7 @@
 			IL_000d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Date>(!!0)
 			IL_0012: stloc.3
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldloc.3
@@ -3211,7 +3274,7 @@
 			IL_002f: ldloc.3
 			IL_0030: ldstr "toISOString"
 			IL_0035: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M13>:__js_call__:4"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0044: stloc.s 4
@@ -3260,86 +3323,124 @@
 			IL_00d8: ldstr ""
 			IL_00dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_00e2: stloc.s 5
-			IL_00e4: ldloc.s 4
-			IL_00e6: ldstr "split"
-			IL_00eb: ldloc.s 5
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f2: stloc.s 4
-			IL_00f4: ldloc.s 4
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fb: stloc.s 4
-			IL_00fd: ldc.i4.2
-			IL_00fe: newarr [System.Runtime]System.Object
-			IL_0103: dup
-			IL_0104: ldc.i4.0
-			IL_0105: ldarg.0
-			IL_0106: stelem.ref
-			IL_0107: dup
-			IL_0108: ldc.i4.1
-			IL_0109: ldloc.0
-			IL_010a: stelem.ref
-			IL_010b: stloc.s 6
-			IL_010d: ldloc.s 6
-			IL_010f: ldc.i4.0
-			IL_0110: ldelem.ref
-			IL_0111: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0116: ldloc.s 6
-			IL_0118: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
-			IL_011d: ldc.i4.1
-			IL_011e: conv.r8
-			IL_011f: ldstr ""
-			IL_0124: ldc.i4.0
-			IL_0125: ldc.i4.0
-			IL_0126: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0)
-			IL_0130: stloc.s 7
-			IL_0132: ldloc.s 4
-			IL_0134: ldstr "filter"
-			IL_0139: ldloc.s 7
-			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0140: stloc.s 4
-			IL_0142: ldloc.s 4
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0149: ldstr "join"
-			IL_014e: ldstr "\n"
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0158: stloc.2
-			IL_0159: ldloc.2
-			IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_015f: ldc.i4.0
-			IL_0160: ceq
-			IL_0162: stloc.s 8
-			IL_0164: ldloc.s 8
-			IL_0166: brfalse IL_0175
+			IL_00e4: volatile.
+			IL_00e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_00eb: brfalse IL_0103
 
-			IL_016b: ldstr "\n"
-			IL_0170: stloc.s 9
-			IL_0172: ldloc.s 9
-			IL_0174: stloc.2
+			IL_00f0: ldloc.s 4
+			IL_00f2: ldstr "split"
+			IL_00f7: ldloc.s 5
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00fe: br IL_011b
 
-			IL_0175: ldarg.2
-			IL_0176: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_017b: stloc.s 9
-			IL_017d: ldstr "## v"
-			IL_0182: ldloc.s 9
-			IL_0184: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0189: ldstr " - "
-			IL_018e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0193: ldloc.1
-			IL_0194: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0199: stloc.s 9
-			IL_019b: ldloc.s 9
-			IL_019d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a2: ldstr "\n\n"
-			IL_01a7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ac: ldloc.2
-			IL_01ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
-			IL_01b6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01bb: ldstr "\n"
-			IL_01c0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01c5: ret
+			IL_0103: ldloc.s 4
+			IL_0105: ldstr "split"
+			IL_010a: ldloc.s 5
+			IL_010c: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M13>:__js_call__:18"
+			IL_0111: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_011b: stloc.s 4
+			IL_011d: ldloc.s 4
+			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0124: stloc.s 4
+			IL_0126: ldc.i4.2
+			IL_0127: newarr [System.Runtime]System.Object
+			IL_012c: dup
+			IL_012d: ldc.i4.0
+			IL_012e: ldarg.0
+			IL_012f: stelem.ref
+			IL_0130: dup
+			IL_0131: ldc.i4.1
+			IL_0132: ldloc.0
+			IL_0133: stelem.ref
+			IL_0134: stloc.s 6
+			IL_0136: ldloc.s 6
+			IL_0138: ldc.i4.0
+			IL_0139: ldelem.ref
+			IL_013a: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_013f: ldloc.s 6
+			IL_0141: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
+			IL_0146: ldc.i4.1
+			IL_0147: conv.r8
+			IL_0148: ldstr ""
+			IL_014d: ldc.i4.0
+			IL_014e: ldc.i4.0
+			IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0)
+			IL_0159: stloc.s 7
+			IL_015b: volatile.
+			IL_015d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_0162: brfalse IL_017a
+
+			IL_0167: ldloc.s 4
+			IL_0169: ldstr "filter"
+			IL_016e: ldloc.s 7
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0175: br IL_0192
+
+			IL_017a: ldloc.s 4
+			IL_017c: ldstr "filter"
+			IL_0181: ldloc.s 7
+			IL_0183: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M13>:__js_call__:22"
+			IL_0188: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0192: stloc.s 4
+			IL_0194: ldloc.s 4
+			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019b: volatile.
+			IL_019d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_01a2: brfalse IL_01bb
+
+			IL_01a7: ldstr "join"
+			IL_01ac: ldstr "\n"
+			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01b6: br IL_01d4
+
+			IL_01bb: ldstr "join"
+			IL_01c0: ldstr "\n"
+			IL_01c5: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M13>:__js_call__:25"
+			IL_01ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_01d4: stloc.2
+			IL_01d5: ldloc.2
+			IL_01d6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01db: ldc.i4.0
+			IL_01dc: ceq
+			IL_01de: stloc.s 8
+			IL_01e0: ldloc.s 8
+			IL_01e2: brfalse IL_01f1
+
+			IL_01e7: ldstr "\n"
+			IL_01ec: stloc.s 9
+			IL_01ee: ldloc.s 9
+			IL_01f0: stloc.2
+
+			IL_01f1: ldarg.2
+			IL_01f2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01f7: stloc.s 9
+			IL_01f9: ldstr "## v"
+			IL_01fe: ldloc.s 9
+			IL_0200: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0205: ldstr " - "
+			IL_020a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_020f: ldloc.1
+			IL_0210: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0215: stloc.s 9
+			IL_0217: ldloc.s 9
+			IL_0219: call string [System.Runtime]System.String::Concat(string, string)
+			IL_021e: ldstr "\n\n"
+			IL_0223: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0228: ldloc.2
+			IL_0229: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_022e: stloc.s 9
+			IL_0230: ldloc.s 9
+			IL_0232: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0237: ldstr "\n"
+			IL_023c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0241: ret
 		} // end of method generateReleaseSection::__js_call__
 
 	} // end of class generateReleaseSection
@@ -3503,7 +3604,7 @@
 				IL_0047: stloc.0
 
 				IL_0048: volatile.
-				IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+				IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 				IL_004f: brfalse IL_0064
 
 				IL_0054: ldloc.0
@@ -3514,7 +3615,7 @@
 				IL_0064: ldloc.0
 				IL_0065: ldstr "length"
 				IL_006a: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M18>:__js_call__:4"
-				IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+				IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0079: stloc.0
@@ -3737,7 +3838,7 @@
 				74 61 54 6f 6b 65 6e 15 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2319 (0x90f)
+			// Code size: 2493 (0x9bd)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/perform/Scope,
@@ -3788,7 +3889,7 @@
 			IL_0006: ldstr "process"
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_0017: brfalse IL_002b
 
 			IL_001c: ldstr "argv"
@@ -3797,7 +3898,7 @@
 
 			IL_002b: ldstr "argv"
 			IL_0030: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:5"
-			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_003f: stloc.s 30
@@ -3808,7 +3909,7 @@
 			IL_0052: ldstr "process"
 			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_005c: volatile.
-			IL_005e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_005e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
 			IL_0063: brfalse IL_0077
 
 			IL_0068: ldstr "argv"
@@ -3817,7 +3918,7 @@
 
 			IL_0077: ldstr "argv"
 			IL_007c: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:13"
-			IL_0081: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0081: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
 			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_008b: stloc.s 30
@@ -3978,7 +4079,7 @@
 			IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0201: stloc.s 32
 			IL_0203: ldloc.s 32
-			IL_0205: brfalse IL_0273
+			IL_0205: brfalse IL_02cf
 
 			IL_020a: ldstr "console"
 			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -3993,678 +4094,730 @@
 			IL_0230: ldstr "); aborting."
 			IL_0235: call string [System.Runtime]System.String::Concat(string, string)
 			IL_023a: stloc.s 33
-			IL_023c: ldloc.s 30
-			IL_023e: ldstr "error"
-			IL_0243: ldloc.s 33
-			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_024a: pop
-			IL_024b: ldstr "process"
-			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_025a: ldstr "exit"
-			IL_025f: ldc.r8 1
-			IL_0268: box [System.Runtime]System.Double
-			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0272: pop
+			IL_023c: volatile.
+			IL_023e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_0243: brfalse IL_025b
 
-			IL_0273: ldarg.0
-			IL_0274: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
-			IL_0279: ldc.i4.1
-			IL_027a: newarr [System.Runtime]System.Object
-			IL_027f: dup
-			IL_0280: ldc.i4.0
-			IL_0281: ldarg.0
-			IL_0282: stelem.ref
-			IL_0283: ldloc.s 8
-			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_028a: stloc.s 30
-			IL_028c: ldloc.s 30
-			IL_028e: brfalse IL_029f
+			IL_0248: ldloc.s 30
+			IL_024a: ldstr "error"
+			IL_024f: ldloc.s 33
+			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0256: br IL_0273
 
-			IL_0293: ldloc.s 30
-			IL_0295: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_029a: brfalse IL_02b0
+			IL_025b: ldloc.s 30
+			IL_025d: ldstr "error"
+			IL_0262: ldloc.s 33
+			IL_0264: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:76"
+			IL_0269: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_029f: ldloc.s 30
-			IL_02a1: ldstr ""
-			IL_02a6: ldstr "body"
-			IL_02ab: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0273: pop
+			IL_0274: ldstr "process"
+			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0283: volatile.
+			IL_0285: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_028a: brfalse IL_02ac
 
-			IL_02b0: volatile.
-			IL_02b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-			IL_02b7: brfalse IL_02cd
+			IL_028f: ldstr "exit"
+			IL_0294: ldc.r8 1
+			IL_029d: box [System.Runtime]System.Double
+			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02a7: br IL_02ce
 
-			IL_02bc: ldloc.s 30
-			IL_02be: ldstr "body"
-			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c8: br IL_02e3
+			IL_02ac: ldstr "exit"
+			IL_02b1: ldc.r8 1
+			IL_02ba: box [System.Runtime]System.Double
+			IL_02bf: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:83"
+			IL_02c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_02cd: ldloc.s 30
-			IL_02cf: ldstr "body"
-			IL_02d4: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:98"
-			IL_02d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02ce: pop
 
-			IL_02e3: stloc.s 11
-			IL_02e5: volatile.
-			IL_02e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-			IL_02ec: brfalse IL_0302
+			IL_02cf: ldarg.0
+			IL_02d0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
+			IL_02d5: ldc.i4.1
+			IL_02d6: newarr [System.Runtime]System.Object
+			IL_02db: dup
+			IL_02dc: ldc.i4.0
+			IL_02dd: ldarg.0
+			IL_02de: stelem.ref
+			IL_02df: ldloc.s 8
+			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_02e6: stloc.s 30
+			IL_02e8: ldloc.s 30
+			IL_02ea: brfalse IL_02fb
 
-			IL_02f1: ldloc.s 30
-			IL_02f3: ldstr "start"
-			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02fd: br IL_0318
+			IL_02ef: ldloc.s 30
+			IL_02f1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02f6: brfalse IL_030c
 
-			IL_0302: ldloc.s 30
-			IL_0304: ldstr "start"
-			IL_0309: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:100"
-			IL_030e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-			IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02fb: ldloc.s 30
+			IL_02fd: ldstr ""
+			IL_0302: ldstr "body"
+			IL_0307: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0318: stloc.s 12
-			IL_031a: volatile.
-			IL_031c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_0321: brfalse IL_0337
+			IL_030c: volatile.
+			IL_030e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_0313: brfalse IL_0329
 
-			IL_0326: ldloc.s 30
-			IL_0328: ldstr "end"
-			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0332: br IL_034d
+			IL_0318: ldloc.s 30
+			IL_031a: ldstr "body"
+			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0324: br IL_033f
 
-			IL_0337: ldloc.s 30
-			IL_0339: ldstr "end"
-			IL_033e: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:102"
-			IL_0343: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0329: ldloc.s 30
+			IL_032b: ldstr "body"
+			IL_0330: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:98"
+			IL_0335: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_034d: stloc.s 13
-			IL_034f: ldloc.s 11
-			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0356: stloc.s 30
-			IL_0358: ldstr "\\r?\\n"
-			IL_035d: ldstr ""
-			IL_0362: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0367: stloc.s 34
-			IL_0369: ldloc.s 30
-			IL_036b: ldstr "split"
-			IL_0370: ldloc.s 34
-			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0377: stloc.s 30
-			IL_0379: ldloc.s 30
-			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0380: stloc.s 30
-			IL_0382: ldc.i4.2
-			IL_0383: newarr [System.Runtime]System.Object
-			IL_0388: dup
-			IL_0389: ldc.i4.0
-			IL_038a: ldarg.0
-			IL_038b: stelem.ref
-			IL_038c: dup
-			IL_038d: ldc.i4.1
-			IL_038e: ldloc.0
-			IL_038f: stelem.ref
-			IL_0390: stloc.s 31
-			IL_0392: ldloc.s 31
-			IL_0394: ldc.i4.0
-			IL_0395: ldelem.ref
-			IL_0396: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_039b: ldloc.s 31
-			IL_039d: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
-			IL_03a2: ldc.i4.1
-			IL_03a3: conv.r8
-			IL_03a4: ldstr ""
-			IL_03a9: ldc.i4.0
-			IL_03aa: ldc.i4.0
-			IL_03ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_03b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0)
-			IL_03b5: stloc.s 35
-			IL_03b7: ldloc.s 30
-			IL_03b9: ldstr "some"
-			IL_03be: ldloc.s 35
-			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03c5: stloc.s 14
-			IL_03c7: ldloc.s 14
-			IL_03c9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_03ce: ldc.i4.0
-			IL_03cf: ceq
-			IL_03d1: stloc.s 32
-			IL_03d3: ldloc.s 32
-			IL_03d5: box [System.Runtime]System.Boolean
-			IL_03da: stloc.s 36
-			IL_03dc: ldloc.s 36
-			IL_03de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03e3: stloc.s 32
-			IL_03e5: ldloc.s 32
-			IL_03e7: brfalse IL_03f4
+			IL_033f: stloc.s 11
+			IL_0341: volatile.
+			IL_0343: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_0348: brfalse IL_035e
 
-			IL_03ec: ldloc.2
-			IL_03ed: stloc.s 38
-			IL_03ef: br IL_03f8
+			IL_034d: ldloc.s 30
+			IL_034f: ldstr "start"
+			IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0359: br IL_0374
 
-			IL_03f4: ldloc.s 36
-			IL_03f6: stloc.s 38
+			IL_035e: ldloc.s 30
+			IL_0360: ldstr "start"
+			IL_0365: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:100"
+			IL_036a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03f8: ldloc.s 38
-			IL_03fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03ff: stloc.s 32
-			IL_0401: ldloc.s 32
-			IL_0403: brfalse IL_0576
+			IL_0374: stloc.s 12
+			IL_0376: volatile.
+			IL_0378: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_037d: brfalse IL_0393
 
-			IL_0408: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_040d: stloc.s 39
-			IL_040f: ldloc.s 39
-			IL_0411: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
-			IL_0416: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_041b: pop
-			IL_041c: ldarg.0
-			IL_041d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0422: ldc.i4.1
-			IL_0423: newarr [System.Runtime]System.Object
-			IL_0428: dup
-			IL_0429: ldc.i4.0
-			IL_042a: ldarg.0
-			IL_042b: stelem.ref
-			IL_042c: ldloc.3
-			IL_042d: ldloc.s 10
-			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0434: stloc.s 15
-			IL_0436: ldarg.0
-			IL_0437: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_043c: ldc.i4.1
-			IL_043d: newarr [System.Runtime]System.Object
-			IL_0442: dup
-			IL_0443: ldc.i4.0
-			IL_0444: ldarg.0
-			IL_0445: stelem.ref
-			IL_0446: ldloc.s 4
-			IL_0448: ldloc.s 10
-			IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_044f: stloc.s 16
-			IL_0451: ldarg.0
-			IL_0452: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0457: ldc.i4.1
-			IL_0458: newarr [System.Runtime]System.Object
-			IL_045d: dup
-			IL_045e: ldc.i4.0
-			IL_045f: ldarg.0
-			IL_0460: stelem.ref
-			IL_0461: ldloc.s 5
-			IL_0463: ldloc.s 10
-			IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_046a: stloc.s 17
-			IL_046c: ldarg.0
-			IL_046d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0472: ldc.i4.1
-			IL_0473: newarr [System.Runtime]System.Object
-			IL_0478: dup
-			IL_0479: ldc.i4.0
-			IL_047a: ldarg.0
-			IL_047b: stelem.ref
-			IL_047c: ldloc.s 6
-			IL_047e: ldloc.s 10
-			IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0485: stloc.s 18
-			IL_0487: ldarg.0
-			IL_0488: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_048d: ldc.i4.1
-			IL_048e: newarr [System.Runtime]System.Object
-			IL_0493: dup
-			IL_0494: ldc.i4.0
-			IL_0495: ldarg.0
-			IL_0496: stelem.ref
-			IL_0497: ldloc.s 7
-			IL_0499: ldloc.s 10
-			IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04a0: stloc.s 19
-			IL_04a2: ldarg.0
-			IL_04a3: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_04a8: stloc.s 30
-			IL_04aa: ldc.i4.1
-			IL_04ab: newarr [System.Runtime]System.Object
-			IL_04b0: dup
-			IL_04b1: ldc.i4.0
-			IL_04b2: ldarg.0
-			IL_04b3: stelem.ref
-			IL_04b4: stloc.s 31
-			IL_04b6: ldarg.0
-			IL_04b7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_04bc: stloc.s 40
-			IL_04be: ldloc.s 30
-			IL_04c0: ldloc.s 31
-			IL_04c2: ldloc.s 40
-			IL_04c4: ldloc.s 15
-			IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04cb: pop
-			IL_04cc: ldarg.0
-			IL_04cd: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_04d2: stloc.s 40
-			IL_04d4: ldc.i4.1
-			IL_04d5: newarr [System.Runtime]System.Object
-			IL_04da: dup
-			IL_04db: ldc.i4.0
-			IL_04dc: ldarg.0
-			IL_04dd: stelem.ref
-			IL_04de: stloc.s 31
-			IL_04e0: ldarg.0
-			IL_04e1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_04e6: stloc.s 30
-			IL_04e8: ldloc.s 40
-			IL_04ea: ldloc.s 31
-			IL_04ec: ldloc.s 30
-			IL_04ee: ldloc.s 16
-			IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04f5: pop
-			IL_04f6: ldarg.0
-			IL_04f7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_04fc: stloc.s 30
-			IL_04fe: ldc.i4.1
-			IL_04ff: newarr [System.Runtime]System.Object
-			IL_0504: dup
-			IL_0505: ldc.i4.0
-			IL_0506: ldarg.0
-			IL_0507: stelem.ref
-			IL_0508: stloc.s 31
-			IL_050a: ldarg.0
-			IL_050b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0510: stloc.s 40
-			IL_0512: ldloc.s 30
-			IL_0514: ldloc.s 31
-			IL_0516: ldloc.s 40
-			IL_0518: ldloc.s 17
-			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_051f: pop
-			IL_0520: ldarg.0
-			IL_0521: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0526: stloc.s 40
-			IL_0528: ldc.i4.1
-			IL_0529: newarr [System.Runtime]System.Object
-			IL_052e: dup
-			IL_052f: ldc.i4.0
-			IL_0530: ldarg.0
-			IL_0531: stelem.ref
-			IL_0532: stloc.s 31
-			IL_0534: ldarg.0
-			IL_0535: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_053a: stloc.s 30
-			IL_053c: ldloc.s 40
-			IL_053e: ldloc.s 31
-			IL_0540: ldloc.s 30
-			IL_0542: ldloc.s 18
-			IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0549: pop
-			IL_054a: ldarg.0
-			IL_054b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0550: stloc.s 30
-			IL_0552: ldc.i4.1
-			IL_0553: newarr [System.Runtime]System.Object
-			IL_0558: dup
-			IL_0559: ldc.i4.0
-			IL_055a: ldarg.0
-			IL_055b: stelem.ref
-			IL_055c: stloc.s 31
-			IL_055e: ldarg.0
-			IL_055f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_0564: stloc.s 40
-			IL_0566: ldloc.s 30
-			IL_0568: ldloc.s 31
-			IL_056a: ldloc.s 40
-			IL_056c: ldloc.s 19
-			IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0573: pop
-			IL_0574: ldnull
-			IL_0575: ret
+			IL_0382: ldloc.s 30
+			IL_0384: ldstr "end"
+			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_038e: br IL_03a9
 
-			IL_0576: ldarg.0
-			IL_0577: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
-			IL_057c: ldc.i4.1
-			IL_057d: newarr [System.Runtime]System.Object
-			IL_0582: dup
-			IL_0583: ldc.i4.0
-			IL_0584: ldarg.0
-			IL_0585: stelem.ref
-			IL_0586: ldloc.s 10
-			IL_0588: ldloc.s 11
-			IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_058f: stloc.s 20
-			IL_0591: ldloc.s 8
-			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0598: stloc.s 40
-			IL_059a: ldc.i4.0
-			IL_059b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_05a0: brfalse IL_05e2
+			IL_0393: ldloc.s 30
+			IL_0395: ldstr "end"
+			IL_039a: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:102"
+			IL_039f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_05a5: ldloc.s 40
-			IL_05a7: isinst [System.Runtime]System.String
-			IL_05ac: dup
-			IL_05ad: brtrue IL_05c5
+			IL_03a9: stloc.s 13
+			IL_03ab: ldloc.s 11
+			IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b2: stloc.s 30
+			IL_03b4: ldstr "\\r?\\n"
+			IL_03b9: ldstr ""
+			IL_03be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_03c3: stloc.s 34
+			IL_03c5: volatile.
+			IL_03c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_03cc: brfalse IL_03e4
 
-			IL_05b2: pop
-			IL_05b3: ldloc.s 40
-			IL_05b5: ldstr "slice"
-			IL_05ba: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_05bf: dup
-			IL_05c0: brfalse IL_05e1
+			IL_03d1: ldloc.s 30
+			IL_03d3: ldstr "split"
+			IL_03d8: ldloc.s 34
+			IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03df: br IL_03fc
 
-			IL_05c5: ldc.r8 0.0
-			IL_05ce: box [System.Runtime]System.Double
-			IL_05d3: ldloc.s 12
-			IL_05d5: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-			IL_05da: stloc.s 21
-			IL_05dc: br IL_0600
+			IL_03e4: ldloc.s 30
+			IL_03e6: ldstr "split"
+			IL_03eb: ldloc.s 34
+			IL_03ed: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:108"
+			IL_03f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_05e1: pop
+			IL_03fc: stloc.s 30
+			IL_03fe: ldloc.s 30
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0405: stloc.s 30
+			IL_0407: ldc.i4.2
+			IL_0408: newarr [System.Runtime]System.Object
+			IL_040d: dup
+			IL_040e: ldc.i4.0
+			IL_040f: ldarg.0
+			IL_0410: stelem.ref
+			IL_0411: dup
+			IL_0412: ldc.i4.1
+			IL_0413: ldloc.0
+			IL_0414: stelem.ref
+			IL_0415: stloc.s 31
+			IL_0417: ldloc.s 31
+			IL_0419: ldc.i4.0
+			IL_041a: ldelem.ref
+			IL_041b: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0420: ldloc.s 31
+			IL_0422: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
+			IL_0427: ldc.i4.1
+			IL_0428: conv.r8
+			IL_0429: ldstr ""
+			IL_042e: ldc.i4.0
+			IL_042f: ldc.i4.0
+			IL_0430: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0435: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0)
+			IL_043a: stloc.s 35
+			IL_043c: volatile.
+			IL_043e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_0443: brfalse IL_045b
 
-			IL_05e2: ldloc.s 40
-			IL_05e4: ldstr "slice"
-			IL_05e9: ldc.r8 0.0
-			IL_05f2: box [System.Runtime]System.Double
-			IL_05f7: ldloc.s 12
-			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_05fe: stloc.s 21
+			IL_0448: ldloc.s 30
+			IL_044a: ldstr "some"
+			IL_044f: ldloc.s 35
+			IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0456: br IL_0473
 
-			IL_0600: ldloc.s 8
-			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0607: stloc.s 40
-			IL_0609: ldc.i4.0
-			IL_060a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_060f: brfalse IL_0643
+			IL_045b: ldloc.s 30
+			IL_045d: ldstr "some"
+			IL_0462: ldloc.s 35
+			IL_0464: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:112"
+			IL_0469: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0614: ldloc.s 40
-			IL_0616: isinst [System.Runtime]System.String
-			IL_061b: dup
-			IL_061c: brtrue IL_0634
+			IL_0473: stloc.s 14
+			IL_0475: ldloc.s 14
+			IL_0477: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_047c: ldc.i4.0
+			IL_047d: ceq
+			IL_047f: stloc.s 32
+			IL_0481: ldloc.s 32
+			IL_0483: box [System.Runtime]System.Boolean
+			IL_0488: stloc.s 36
+			IL_048a: ldloc.s 36
+			IL_048c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0491: stloc.s 32
+			IL_0493: ldloc.s 32
+			IL_0495: brfalse IL_04a2
 
+			IL_049a: ldloc.2
+			IL_049b: stloc.s 38
+			IL_049d: br IL_04a6
+
+			IL_04a2: ldloc.s 36
+			IL_04a4: stloc.s 38
+
+			IL_04a6: ldloc.s 38
+			IL_04a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04ad: stloc.s 32
+			IL_04af: ldloc.s 32
+			IL_04b1: brfalse IL_0624
+
+			IL_04b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04bb: stloc.s 39
+			IL_04bd: ldloc.s 39
+			IL_04bf: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
+			IL_04c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04c9: pop
+			IL_04ca: ldarg.0
+			IL_04cb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_04d0: ldc.i4.1
+			IL_04d1: newarr [System.Runtime]System.Object
+			IL_04d6: dup
+			IL_04d7: ldc.i4.0
+			IL_04d8: ldarg.0
+			IL_04d9: stelem.ref
+			IL_04da: ldloc.3
+			IL_04db: ldloc.s 10
+			IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04e2: stloc.s 15
+			IL_04e4: ldarg.0
+			IL_04e5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_04ea: ldc.i4.1
+			IL_04eb: newarr [System.Runtime]System.Object
+			IL_04f0: dup
+			IL_04f1: ldc.i4.0
+			IL_04f2: ldarg.0
+			IL_04f3: stelem.ref
+			IL_04f4: ldloc.s 4
+			IL_04f6: ldloc.s 10
+			IL_04f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04fd: stloc.s 16
+			IL_04ff: ldarg.0
+			IL_0500: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0505: ldc.i4.1
+			IL_0506: newarr [System.Runtime]System.Object
+			IL_050b: dup
+			IL_050c: ldc.i4.0
+			IL_050d: ldarg.0
+			IL_050e: stelem.ref
+			IL_050f: ldloc.s 5
+			IL_0511: ldloc.s 10
+			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0518: stloc.s 17
+			IL_051a: ldarg.0
+			IL_051b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0520: ldc.i4.1
+			IL_0521: newarr [System.Runtime]System.Object
+			IL_0526: dup
+			IL_0527: ldc.i4.0
+			IL_0528: ldarg.0
+			IL_0529: stelem.ref
+			IL_052a: ldloc.s 6
+			IL_052c: ldloc.s 10
+			IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0533: stloc.s 18
+			IL_0535: ldarg.0
+			IL_0536: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_053b: ldc.i4.1
+			IL_053c: newarr [System.Runtime]System.Object
+			IL_0541: dup
+			IL_0542: ldc.i4.0
+			IL_0543: ldarg.0
+			IL_0544: stelem.ref
+			IL_0545: ldloc.s 7
+			IL_0547: ldloc.s 10
+			IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_054e: stloc.s 19
+			IL_0550: ldarg.0
+			IL_0551: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0556: stloc.s 30
+			IL_0558: ldc.i4.1
+			IL_0559: newarr [System.Runtime]System.Object
+			IL_055e: dup
+			IL_055f: ldc.i4.0
+			IL_0560: ldarg.0
+			IL_0561: stelem.ref
+			IL_0562: stloc.s 31
+			IL_0564: ldarg.0
+			IL_0565: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_056a: stloc.s 40
+			IL_056c: ldloc.s 30
+			IL_056e: ldloc.s 31
+			IL_0570: ldloc.s 40
+			IL_0572: ldloc.s 15
+			IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0579: pop
+			IL_057a: ldarg.0
+			IL_057b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0580: stloc.s 40
+			IL_0582: ldc.i4.1
+			IL_0583: newarr [System.Runtime]System.Object
+			IL_0588: dup
+			IL_0589: ldc.i4.0
+			IL_058a: ldarg.0
+			IL_058b: stelem.ref
+			IL_058c: stloc.s 31
+			IL_058e: ldarg.0
+			IL_058f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0594: stloc.s 30
+			IL_0596: ldloc.s 40
+			IL_0598: ldloc.s 31
+			IL_059a: ldloc.s 30
+			IL_059c: ldloc.s 16
+			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05a3: pop
+			IL_05a4: ldarg.0
+			IL_05a5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_05aa: stloc.s 30
+			IL_05ac: ldc.i4.1
+			IL_05ad: newarr [System.Runtime]System.Object
+			IL_05b2: dup
+			IL_05b3: ldc.i4.0
+			IL_05b4: ldarg.0
+			IL_05b5: stelem.ref
+			IL_05b6: stloc.s 31
+			IL_05b8: ldarg.0
+			IL_05b9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_05be: stloc.s 40
+			IL_05c0: ldloc.s 30
+			IL_05c2: ldloc.s 31
+			IL_05c4: ldloc.s 40
+			IL_05c6: ldloc.s 17
+			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05cd: pop
+			IL_05ce: ldarg.0
+			IL_05cf: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_05d4: stloc.s 40
+			IL_05d6: ldc.i4.1
+			IL_05d7: newarr [System.Runtime]System.Object
+			IL_05dc: dup
+			IL_05dd: ldc.i4.0
+			IL_05de: ldarg.0
+			IL_05df: stelem.ref
+			IL_05e0: stloc.s 31
+			IL_05e2: ldarg.0
+			IL_05e3: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_05e8: stloc.s 30
+			IL_05ea: ldloc.s 40
+			IL_05ec: ldloc.s 31
+			IL_05ee: ldloc.s 30
+			IL_05f0: ldloc.s 18
+			IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05f7: pop
+			IL_05f8: ldarg.0
+			IL_05f9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_05fe: stloc.s 30
+			IL_0600: ldc.i4.1
+			IL_0601: newarr [System.Runtime]System.Object
+			IL_0606: dup
+			IL_0607: ldc.i4.0
+			IL_0608: ldarg.0
+			IL_0609: stelem.ref
+			IL_060a: stloc.s 31
+			IL_060c: ldarg.0
+			IL_060d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_0612: stloc.s 40
+			IL_0614: ldloc.s 30
+			IL_0616: ldloc.s 31
+			IL_0618: ldloc.s 40
+			IL_061a: ldloc.s 19
+			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_0621: pop
-			IL_0622: ldloc.s 40
-			IL_0624: ldstr "slice"
-			IL_0629: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_062e: dup
-			IL_062f: brfalse IL_0642
+			IL_0622: ldnull
+			IL_0623: ret
 
-			IL_0634: ldloc.s 13
-			IL_0636: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
-			IL_063b: stloc.s 22
-			IL_063d: br IL_0653
+			IL_0624: ldarg.0
+			IL_0625: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
+			IL_062a: ldc.i4.1
+			IL_062b: newarr [System.Runtime]System.Object
+			IL_0630: dup
+			IL_0631: ldc.i4.0
+			IL_0632: ldarg.0
+			IL_0633: stelem.ref
+			IL_0634: ldloc.s 10
+			IL_0636: ldloc.s 11
+			IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_063d: stloc.s 20
+			IL_063f: ldloc.s 8
+			IL_0641: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0646: stloc.s 40
+			IL_0648: ldc.i4.0
+			IL_0649: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_064e: brfalse IL_0690
 
-			IL_0642: pop
+			IL_0653: ldloc.s 40
+			IL_0655: isinst [System.Runtime]System.String
+			IL_065a: dup
+			IL_065b: brtrue IL_0673
 
-			IL_0643: ldloc.s 40
-			IL_0645: ldstr "slice"
-			IL_064a: ldloc.s 13
-			IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0651: stloc.s 22
+			IL_0660: pop
+			IL_0661: ldloc.s 40
+			IL_0663: ldstr "slice"
+			IL_0668: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_066d: dup
+			IL_066e: brfalse IL_068f
 
-			IL_0653: ldstr "\n_Nothing yet._\n\n"
-			IL_0658: stloc.s 23
-			IL_065a: ldloc.s 21
-			IL_065c: ldloc.s 23
-			IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0663: stloc.s 38
-			IL_0665: ldloc.s 38
-			IL_0667: ldloc.s 20
-			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_066e: stloc.s 38
-			IL_0670: ldloc.s 38
-			IL_0672: ldloc.s 22
-			IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0679: stloc.s 24
-			IL_067b: ldarg.0
-			IL_067c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0681: ldc.i4.1
-			IL_0682: newarr [System.Runtime]System.Object
-			IL_0687: dup
-			IL_0688: ldc.i4.0
-			IL_0689: ldarg.0
-			IL_068a: stelem.ref
-			IL_068b: ldloc.3
-			IL_068c: ldloc.s 10
-			IL_068e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0693: stloc.s 25
-			IL_0695: ldarg.0
-			IL_0696: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_069b: ldc.i4.1
-			IL_069c: newarr [System.Runtime]System.Object
-			IL_06a1: dup
-			IL_06a2: ldc.i4.0
-			IL_06a3: ldarg.0
-			IL_06a4: stelem.ref
-			IL_06a5: ldloc.s 4
-			IL_06a7: ldloc.s 10
-			IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06ae: stloc.s 26
-			IL_06b0: ldarg.0
-			IL_06b1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_06b6: ldc.i4.1
-			IL_06b7: newarr [System.Runtime]System.Object
-			IL_06bc: dup
-			IL_06bd: ldc.i4.0
-			IL_06be: ldarg.0
-			IL_06bf: stelem.ref
-			IL_06c0: ldloc.s 5
-			IL_06c2: ldloc.s 10
-			IL_06c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06c9: stloc.s 27
-			IL_06cb: ldarg.0
-			IL_06cc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_06d1: ldc.i4.1
-			IL_06d2: newarr [System.Runtime]System.Object
-			IL_06d7: dup
-			IL_06d8: ldc.i4.0
-			IL_06d9: ldarg.0
-			IL_06da: stelem.ref
-			IL_06db: ldloc.s 6
-			IL_06dd: ldloc.s 10
-			IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06e4: stloc.s 28
-			IL_06e6: ldarg.0
-			IL_06e7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_06ec: ldc.i4.1
-			IL_06ed: newarr [System.Runtime]System.Object
-			IL_06f2: dup
-			IL_06f3: ldc.i4.0
-			IL_06f4: ldarg.0
-			IL_06f5: stelem.ref
-			IL_06f6: ldloc.s 7
-			IL_06f8: ldloc.s 10
-			IL_06fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06ff: stloc.s 29
-			IL_0701: ldarg.0
-			IL_0702: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0707: stloc.s 40
-			IL_0709: ldc.i4.1
-			IL_070a: newarr [System.Runtime]System.Object
-			IL_070f: dup
-			IL_0710: ldc.i4.0
-			IL_0711: ldarg.0
-			IL_0712: stelem.ref
-			IL_0713: stloc.s 31
-			IL_0715: ldarg.0
-			IL_0716: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_071b: stloc.s 30
-			IL_071d: ldloc.s 40
-			IL_071f: ldloc.s 31
-			IL_0721: ldloc.s 30
-			IL_0723: ldloc.s 24
-			IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_072a: pop
-			IL_072b: ldarg.0
-			IL_072c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0731: stloc.s 30
-			IL_0733: ldc.i4.1
-			IL_0734: newarr [System.Runtime]System.Object
-			IL_0739: dup
-			IL_073a: ldc.i4.0
-			IL_073b: ldarg.0
-			IL_073c: stelem.ref
-			IL_073d: stloc.s 31
-			IL_073f: ldarg.0
-			IL_0740: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_0745: stloc.s 40
-			IL_0747: ldloc.s 30
-			IL_0749: ldloc.s 31
-			IL_074b: ldloc.s 40
-			IL_074d: ldloc.s 25
-			IL_074f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0754: pop
-			IL_0755: ldarg.0
-			IL_0756: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_075b: stloc.s 40
-			IL_075d: ldc.i4.1
-			IL_075e: newarr [System.Runtime]System.Object
-			IL_0763: dup
-			IL_0764: ldc.i4.0
-			IL_0765: ldarg.0
-			IL_0766: stelem.ref
-			IL_0767: stloc.s 31
-			IL_0769: ldarg.0
-			IL_076a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_076f: stloc.s 30
-			IL_0771: ldloc.s 40
-			IL_0773: ldloc.s 31
-			IL_0775: ldloc.s 30
-			IL_0777: ldloc.s 26
-			IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_077e: pop
-			IL_077f: ldarg.0
-			IL_0780: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0785: stloc.s 30
-			IL_0787: ldc.i4.1
-			IL_0788: newarr [System.Runtime]System.Object
-			IL_078d: dup
-			IL_078e: ldc.i4.0
-			IL_078f: ldarg.0
-			IL_0790: stelem.ref
-			IL_0791: stloc.s 31
-			IL_0793: ldarg.0
-			IL_0794: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0799: stloc.s 40
-			IL_079b: ldloc.s 30
-			IL_079d: ldloc.s 31
-			IL_079f: ldloc.s 40
-			IL_07a1: ldloc.s 27
-			IL_07a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07a8: pop
-			IL_07a9: ldarg.0
-			IL_07aa: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_07af: stloc.s 40
-			IL_07b1: ldc.i4.1
-			IL_07b2: newarr [System.Runtime]System.Object
-			IL_07b7: dup
-			IL_07b8: ldc.i4.0
-			IL_07b9: ldarg.0
-			IL_07ba: stelem.ref
-			IL_07bb: stloc.s 31
-			IL_07bd: ldarg.0
-			IL_07be: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_07c3: stloc.s 30
-			IL_07c5: ldloc.s 40
-			IL_07c7: ldloc.s 31
-			IL_07c9: ldloc.s 30
-			IL_07cb: ldloc.s 28
-			IL_07cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07d2: pop
-			IL_07d3: ldarg.0
-			IL_07d4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_07d9: stloc.s 30
-			IL_07db: ldc.i4.1
-			IL_07dc: newarr [System.Runtime]System.Object
-			IL_07e1: dup
-			IL_07e2: ldc.i4.0
-			IL_07e3: ldarg.0
-			IL_07e4: stelem.ref
-			IL_07e5: stloc.s 31
-			IL_07e7: ldarg.0
-			IL_07e8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_07ed: stloc.s 40
-			IL_07ef: ldloc.s 30
-			IL_07f1: ldloc.s 31
-			IL_07f3: ldloc.s 40
-			IL_07f5: ldloc.s 29
-			IL_07f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07fc: pop
-			IL_07fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0802: stloc.s 39
-			IL_0804: ldloc.s 9
-			IL_0806: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_080b: stloc.s 33
-			IL_080d: ldstr "Bumped version: "
-			IL_0812: ldloc.s 33
-			IL_0814: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0819: ldstr " -> "
-			IL_081e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0823: ldloc.s 10
-			IL_0825: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_082a: stloc.s 33
-			IL_082c: ldloc.s 33
-			IL_082e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0833: stloc.s 33
-			IL_0835: ldloc.s 39
-			IL_0837: ldloc.s 33
-			IL_0839: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_083e: pop
-			IL_083f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0844: stloc.s 39
-			IL_0846: ldloc.s 39
-			IL_0848: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_084d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0852: pop
-			IL_0853: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0858: stloc.s 39
-			IL_085a: ldloc.s 39
-			IL_085c: ldstr "\nNext steps:"
-			IL_0861: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0866: pop
-			IL_0867: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_086c: stloc.s 39
-			IL_086e: ldloc.s 39
-			IL_0870: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0875: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_087a: pop
-			IL_087b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0880: stloc.s 39
-			IL_0882: ldloc.s 10
-			IL_0884: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0889: stloc.s 33
-			IL_088b: ldstr "  git commit -m \"chore(release): cut "
-			IL_0890: ldloc.s 33
-			IL_0892: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0897: ldstr "\""
-			IL_089c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08a1: stloc.s 33
-			IL_08a3: ldloc.s 39
-			IL_08a5: ldloc.s 33
-			IL_08a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08ac: pop
-			IL_08ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08b2: stloc.s 39
-			IL_08b4: ldloc.s 10
-			IL_08b6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08bb: stloc.s 33
-			IL_08bd: ldstr "  git tag -a v"
-			IL_08c2: ldloc.s 33
-			IL_08c4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08c9: ldstr " -m \"Release "
-			IL_08ce: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08d3: ldloc.s 10
-			IL_08d5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08da: stloc.s 33
-			IL_08dc: ldloc.s 33
-			IL_08de: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08e3: ldstr "\""
-			IL_08e8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08ed: stloc.s 33
-			IL_08ef: ldloc.s 39
-			IL_08f1: ldloc.s 33
-			IL_08f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08f8: pop
-			IL_08f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08fe: stloc.s 39
-			IL_0900: ldloc.s 39
-			IL_0902: ldstr "  git push && git push --tags"
-			IL_0907: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_090c: pop
-			IL_090d: ldnull
-			IL_090e: ret
+			IL_0673: ldc.r8 0.0
+			IL_067c: box [System.Runtime]System.Double
+			IL_0681: ldloc.s 12
+			IL_0683: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_0688: stloc.s 21
+			IL_068a: br IL_06ae
+
+			IL_068f: pop
+
+			IL_0690: ldloc.s 40
+			IL_0692: ldstr "slice"
+			IL_0697: ldc.r8 0.0
+			IL_06a0: box [System.Runtime]System.Double
+			IL_06a5: ldloc.s 12
+			IL_06a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_06ac: stloc.s 21
+
+			IL_06ae: ldloc.s 8
+			IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06b5: stloc.s 40
+			IL_06b7: ldc.i4.0
+			IL_06b8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_06bd: brfalse IL_06f1
+
+			IL_06c2: ldloc.s 40
+			IL_06c4: isinst [System.Runtime]System.String
+			IL_06c9: dup
+			IL_06ca: brtrue IL_06e2
+
+			IL_06cf: pop
+			IL_06d0: ldloc.s 40
+			IL_06d2: ldstr "slice"
+			IL_06d7: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_06dc: dup
+			IL_06dd: brfalse IL_06f0
+
+			IL_06e2: ldloc.s 13
+			IL_06e4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_06e9: stloc.s 22
+			IL_06eb: br IL_0701
+
+			IL_06f0: pop
+
+			IL_06f1: ldloc.s 40
+			IL_06f3: ldstr "slice"
+			IL_06f8: ldloc.s 13
+			IL_06fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06ff: stloc.s 22
+
+			IL_0701: ldstr "\n_Nothing yet._\n\n"
+			IL_0706: stloc.s 23
+			IL_0708: ldloc.s 21
+			IL_070a: ldloc.s 23
+			IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0711: stloc.s 38
+			IL_0713: ldloc.s 38
+			IL_0715: ldloc.s 20
+			IL_0717: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_071c: stloc.s 38
+			IL_071e: ldloc.s 38
+			IL_0720: ldloc.s 22
+			IL_0722: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0727: stloc.s 24
+			IL_0729: ldarg.0
+			IL_072a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_072f: ldc.i4.1
+			IL_0730: newarr [System.Runtime]System.Object
+			IL_0735: dup
+			IL_0736: ldc.i4.0
+			IL_0737: ldarg.0
+			IL_0738: stelem.ref
+			IL_0739: ldloc.3
+			IL_073a: ldloc.s 10
+			IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0741: stloc.s 25
+			IL_0743: ldarg.0
+			IL_0744: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0749: ldc.i4.1
+			IL_074a: newarr [System.Runtime]System.Object
+			IL_074f: dup
+			IL_0750: ldc.i4.0
+			IL_0751: ldarg.0
+			IL_0752: stelem.ref
+			IL_0753: ldloc.s 4
+			IL_0755: ldloc.s 10
+			IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_075c: stloc.s 26
+			IL_075e: ldarg.0
+			IL_075f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0764: ldc.i4.1
+			IL_0765: newarr [System.Runtime]System.Object
+			IL_076a: dup
+			IL_076b: ldc.i4.0
+			IL_076c: ldarg.0
+			IL_076d: stelem.ref
+			IL_076e: ldloc.s 5
+			IL_0770: ldloc.s 10
+			IL_0772: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0777: stloc.s 27
+			IL_0779: ldarg.0
+			IL_077a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_077f: ldc.i4.1
+			IL_0780: newarr [System.Runtime]System.Object
+			IL_0785: dup
+			IL_0786: ldc.i4.0
+			IL_0787: ldarg.0
+			IL_0788: stelem.ref
+			IL_0789: ldloc.s 6
+			IL_078b: ldloc.s 10
+			IL_078d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0792: stloc.s 28
+			IL_0794: ldarg.0
+			IL_0795: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_079a: ldc.i4.1
+			IL_079b: newarr [System.Runtime]System.Object
+			IL_07a0: dup
+			IL_07a1: ldc.i4.0
+			IL_07a2: ldarg.0
+			IL_07a3: stelem.ref
+			IL_07a4: ldloc.s 7
+			IL_07a6: ldloc.s 10
+			IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_07ad: stloc.s 29
+			IL_07af: ldarg.0
+			IL_07b0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_07b5: stloc.s 40
+			IL_07b7: ldc.i4.1
+			IL_07b8: newarr [System.Runtime]System.Object
+			IL_07bd: dup
+			IL_07be: ldc.i4.0
+			IL_07bf: ldarg.0
+			IL_07c0: stelem.ref
+			IL_07c1: stloc.s 31
+			IL_07c3: ldarg.0
+			IL_07c4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_07c9: stloc.s 30
+			IL_07cb: ldloc.s 40
+			IL_07cd: ldloc.s 31
+			IL_07cf: ldloc.s 30
+			IL_07d1: ldloc.s 24
+			IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_07d8: pop
+			IL_07d9: ldarg.0
+			IL_07da: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_07df: stloc.s 30
+			IL_07e1: ldc.i4.1
+			IL_07e2: newarr [System.Runtime]System.Object
+			IL_07e7: dup
+			IL_07e8: ldc.i4.0
+			IL_07e9: ldarg.0
+			IL_07ea: stelem.ref
+			IL_07eb: stloc.s 31
+			IL_07ed: ldarg.0
+			IL_07ee: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_07f3: stloc.s 40
+			IL_07f5: ldloc.s 30
+			IL_07f7: ldloc.s 31
+			IL_07f9: ldloc.s 40
+			IL_07fb: ldloc.s 25
+			IL_07fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0802: pop
+			IL_0803: ldarg.0
+			IL_0804: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0809: stloc.s 40
+			IL_080b: ldc.i4.1
+			IL_080c: newarr [System.Runtime]System.Object
+			IL_0811: dup
+			IL_0812: ldc.i4.0
+			IL_0813: ldarg.0
+			IL_0814: stelem.ref
+			IL_0815: stloc.s 31
+			IL_0817: ldarg.0
+			IL_0818: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_081d: stloc.s 30
+			IL_081f: ldloc.s 40
+			IL_0821: ldloc.s 31
+			IL_0823: ldloc.s 30
+			IL_0825: ldloc.s 26
+			IL_0827: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_082c: pop
+			IL_082d: ldarg.0
+			IL_082e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0833: stloc.s 30
+			IL_0835: ldc.i4.1
+			IL_0836: newarr [System.Runtime]System.Object
+			IL_083b: dup
+			IL_083c: ldc.i4.0
+			IL_083d: ldarg.0
+			IL_083e: stelem.ref
+			IL_083f: stloc.s 31
+			IL_0841: ldarg.0
+			IL_0842: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_0847: stloc.s 40
+			IL_0849: ldloc.s 30
+			IL_084b: ldloc.s 31
+			IL_084d: ldloc.s 40
+			IL_084f: ldloc.s 27
+			IL_0851: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0856: pop
+			IL_0857: ldarg.0
+			IL_0858: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_085d: stloc.s 40
+			IL_085f: ldc.i4.1
+			IL_0860: newarr [System.Runtime]System.Object
+			IL_0865: dup
+			IL_0866: ldc.i4.0
+			IL_0867: ldarg.0
+			IL_0868: stelem.ref
+			IL_0869: stloc.s 31
+			IL_086b: ldarg.0
+			IL_086c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_0871: stloc.s 30
+			IL_0873: ldloc.s 40
+			IL_0875: ldloc.s 31
+			IL_0877: ldloc.s 30
+			IL_0879: ldloc.s 28
+			IL_087b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0880: pop
+			IL_0881: ldarg.0
+			IL_0882: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0887: stloc.s 30
+			IL_0889: ldc.i4.1
+			IL_088a: newarr [System.Runtime]System.Object
+			IL_088f: dup
+			IL_0890: ldc.i4.0
+			IL_0891: ldarg.0
+			IL_0892: stelem.ref
+			IL_0893: stloc.s 31
+			IL_0895: ldarg.0
+			IL_0896: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_089b: stloc.s 40
+			IL_089d: ldloc.s 30
+			IL_089f: ldloc.s 31
+			IL_08a1: ldloc.s 40
+			IL_08a3: ldloc.s 29
+			IL_08a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_08aa: pop
+			IL_08ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08b0: stloc.s 39
+			IL_08b2: ldloc.s 9
+			IL_08b4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08b9: stloc.s 33
+			IL_08bb: ldstr "Bumped version: "
+			IL_08c0: ldloc.s 33
+			IL_08c2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08c7: ldstr " -> "
+			IL_08cc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08d1: ldloc.s 10
+			IL_08d3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08d8: stloc.s 33
+			IL_08da: ldloc.s 33
+			IL_08dc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08e1: stloc.s 33
+			IL_08e3: ldloc.s 39
+			IL_08e5: ldloc.s 33
+			IL_08e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_08ec: pop
+			IL_08ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08f2: stloc.s 39
+			IL_08f4: ldloc.s 39
+			IL_08f6: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_08fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0900: pop
+			IL_0901: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0906: stloc.s 39
+			IL_0908: ldloc.s 39
+			IL_090a: ldstr "\nNext steps:"
+			IL_090f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0914: pop
+			IL_0915: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_091a: stloc.s 39
+			IL_091c: ldloc.s 39
+			IL_091e: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_0923: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0928: pop
+			IL_0929: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_092e: stloc.s 39
+			IL_0930: ldloc.s 10
+			IL_0932: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0937: stloc.s 33
+			IL_0939: ldstr "  git commit -m \"chore(release): cut "
+			IL_093e: ldloc.s 33
+			IL_0940: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0945: ldstr "\""
+			IL_094a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_094f: stloc.s 33
+			IL_0951: ldloc.s 39
+			IL_0953: ldloc.s 33
+			IL_0955: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_095a: pop
+			IL_095b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0960: stloc.s 39
+			IL_0962: ldloc.s 10
+			IL_0964: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0969: stloc.s 33
+			IL_096b: ldstr "  git tag -a v"
+			IL_0970: ldloc.s 33
+			IL_0972: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0977: ldstr " -m \"Release "
+			IL_097c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0981: ldloc.s 10
+			IL_0983: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0988: stloc.s 33
+			IL_098a: ldloc.s 33
+			IL_098c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0991: ldstr "\""
+			IL_0996: call string [System.Runtime]System.String::Concat(string, string)
+			IL_099b: stloc.s 33
+			IL_099d: ldloc.s 39
+			IL_099f: ldloc.s 33
+			IL_09a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_09a6: pop
+			IL_09a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09ac: stloc.s 39
+			IL_09ae: ldloc.s 39
+			IL_09b0: ldstr "  git push && git push --tags"
+			IL_09b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_09ba: pop
+			IL_09bb: ldnull
+			IL_09bc: ret
 		} // end of method perform::__js_call__
 
 	} // end of class perform
@@ -4779,7 +4932,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1056 (0x420)
+		// Code size: 1107 (0x453)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_BumpVersion/Scope,
@@ -5202,7 +5355,7 @@
 			IL_0353: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 			IL_035d: pop
-			IL_035e: leave IL_041c
+			IL_035e: leave IL_044f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -5258,17 +5411,30 @@
 			IL_03ef: ldstr "process"
 			IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03fe: ldstr "exit"
-			IL_0403: ldc.r8 1
-			IL_040c: box [System.Runtime]System.Double
-			IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0416: pop
-			IL_0417: leave IL_041c
+			IL_03fe: volatile.
+			IL_0400: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0405: brfalse IL_0427
+
+			IL_040a: ldstr "exit"
+			IL_040f: ldc.r8 1
+			IL_0418: box [System.Runtime]System.Double
+			IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0422: br IL_0449
+
+			IL_0427: ldstr "exit"
+			IL_042c: ldc.r8 1
+			IL_0435: box [System.Runtime]System.Double
+			IL_043a: ldstr "Compile_Scripts_BumpVersion:Modules.Compile_Scripts_BumpVersion:__js_module_init__:122"
+			IL_043f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0449: pop
+			IL_044a: leave IL_044f
 		} // end handler
 
-		IL_041c: ldnull
-		IL_041d: stloc.s 7
-		IL_041f: ret
+		IL_044f: ldnull
+		IL_0450: stloc.s 7
+		IL_0452: ret
 	} // end of method Compile_Scripts_BumpVersion::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_BumpVersion
@@ -5309,6 +5475,19 @@
 	.field assembly static int32 __jroc_dynamicLookup_41
 	.field assembly static int32 __jroc_dynamicLookup_42
 	.field assembly static int32 __jroc_dynamicLookup_43
+	.field assembly static int32 __jroc_dynamicLookup_44
+	.field assembly static int32 __jroc_dynamicLookup_45
+	.field assembly static int32 __jroc_dynamicLookup_46
+	.field assembly static int32 __jroc_dynamicLookup_47
+	.field assembly static int32 __jroc_dynamicLookup_48
+	.field assembly static int32 __jroc_dynamicLookup_49
+	.field assembly static int32 __jroc_dynamicLookup_50
+	.field assembly static int32 __jroc_dynamicLookup_51
+	.field assembly static int32 __jroc_dynamicLookup_52
+	.field assembly static int32 __jroc_dynamicLookup_53
+	.field assembly static int32 __jroc_dynamicLookup_54
+	.field assembly static int32 __jroc_dynamicLookup_55
+	.field assembly static int32 __jroc_dynamicLookup_56
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -836,7 +836,7 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 527 (0x20f)
+				// Code size: 571 (0x23b)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -857,7 +857,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 				IL_0007: brfalse IL_001c
 
 				IL_000c: ldarg.2
@@ -868,7 +868,7 @@
 				IL_001c: ldarg.2
 				IL_001d: ldstr "nodeName"
 				IL_0022: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M9>:__js_call__:3"
-				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0031: stloc.s 7
@@ -956,83 +956,96 @@
 				IL_011d: ldloc.s 4
 				IL_011f: box [System.Runtime]System.Double
 				IL_0124: stloc.s 11
-				IL_0126: ldstr "#"
-				IL_012b: ldstr "repeat"
-				IL_0130: ldloc.s 11
-				IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0137: stloc.s 5
-				IL_0139: ldarg.1
-				IL_013a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_013f: stloc.s 8
-				IL_0141: ldloc.s 8
-				IL_0143: brtrue IL_0154
+				IL_0126: volatile.
+				IL_0128: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_012d: brfalse IL_0148
 
-				IL_0148: ldstr ""
-				IL_014d: stloc.s 12
-				IL_014f: br IL_0157
+				IL_0132: ldstr "#"
+				IL_0137: ldstr "repeat"
+				IL_013c: ldloc.s 11
+				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0143: br IL_0163
 
-				IL_0154: ldarg.1
-				IL_0155: stloc.s 12
+				IL_0148: ldstr "#"
+				IL_014d: ldstr "repeat"
+				IL_0152: ldloc.s 11
+				IL_0154: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M9>:__js_call__:49"
+				IL_0159: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0157: ldloc.s 12
-				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_015e: stloc.s 7
-				IL_0160: ldstr "\\s+"
-				IL_0165: ldstr "g"
-				IL_016a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_016f: stloc.s 13
-				IL_0171: ldloc.s 7
-				IL_0173: ldstr "replace"
-				IL_0178: ldloc.s 13
-				IL_017a: ldstr " "
-				IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0184: stloc.s 7
-				IL_0186: ldloc.s 7
-				IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_018d: stloc.s 7
-				IL_018f: ldc.i4.0
-				IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0195: brfalse IL_01c7
+				IL_0163: stloc.s 5
+				IL_0165: ldarg.1
+				IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_016b: stloc.s 8
+				IL_016d: ldloc.s 8
+				IL_016f: brtrue IL_0180
 
-				IL_019a: ldloc.s 7
-				IL_019c: isinst [System.Runtime]System.String
-				IL_01a1: dup
-				IL_01a2: brtrue IL_01ba
+				IL_0174: ldstr ""
+				IL_0179: stloc.s 12
+				IL_017b: br IL_0183
 
-				IL_01a7: pop
-				IL_01a8: ldloc.s 7
-				IL_01aa: ldstr "trim"
-				IL_01af: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_01b4: dup
-				IL_01b5: brfalse IL_01c6
+				IL_0180: ldarg.1
+				IL_0181: stloc.s 12
 
-				IL_01ba: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_01bf: stloc.s 6
-				IL_01c1: br IL_01d5
+				IL_0183: ldloc.s 12
+				IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_018a: stloc.s 7
+				IL_018c: ldstr "\\s+"
+				IL_0191: ldstr "g"
+				IL_0196: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_019b: stloc.s 13
+				IL_019d: ldloc.s 7
+				IL_019f: ldstr "replace"
+				IL_01a4: ldloc.s 13
+				IL_01a6: ldstr " "
+				IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01b0: stloc.s 7
+				IL_01b2: ldloc.s 7
+				IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01b9: stloc.s 7
+				IL_01bb: ldc.i4.0
+				IL_01bc: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01c1: brfalse IL_01f3
 
-				IL_01c6: pop
+				IL_01c6: ldloc.s 7
+				IL_01c8: isinst [System.Runtime]System.String
+				IL_01cd: dup
+				IL_01ce: brtrue IL_01e6
 
-				IL_01c7: ldloc.s 7
-				IL_01c9: ldstr "trim"
-				IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_01d3: stloc.s 6
+				IL_01d3: pop
+				IL_01d4: ldloc.s 7
+				IL_01d6: ldstr "trim"
+				IL_01db: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01e0: dup
+				IL_01e1: brfalse IL_01f2
 
-				IL_01d5: ldloc.s 5
-				IL_01d7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01dc: stloc.s 14
-				IL_01de: ldstr "\n\n"
-				IL_01e3: ldloc.s 14
-				IL_01e5: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01ea: ldstr " "
-				IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01f4: ldloc.s 6
-				IL_01f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01fb: stloc.s 14
-				IL_01fd: ldloc.s 14
-				IL_01ff: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0204: ldstr "\n\n"
-				IL_0209: call string [System.Runtime]System.String::Concat(string, string)
-				IL_020e: ret
+				IL_01e6: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_01eb: stloc.s 6
+				IL_01ed: br IL_0201
+
+				IL_01f2: pop
+
+				IL_01f3: ldloc.s 7
+				IL_01f5: ldstr "trim"
+				IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01ff: stloc.s 6
+
+				IL_0201: ldloc.s 5
+				IL_0203: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0208: stloc.s 14
+				IL_020a: ldstr "\n\n"
+				IL_020f: ldloc.s 14
+				IL_0211: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0216: ldstr " "
+				IL_021b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0220: ldloc.s 6
+				IL_0222: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0227: stloc.s 14
+				IL_0229: ldloc.s 14
+				IL_022b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0230: ldstr "\n\n"
+				IL_0235: call string [System.Runtime]System.String::Concat(string, string)
+				IL_023a: ret
 			} // end of method FunctionExpression_L61C15::__js_call__
 
 		} // end of class FunctionExpression_L61C15
@@ -1321,7 +1334,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 				IL_0007: brfalse IL_001c
 
 				IL_000c: ldarg.1
@@ -1332,7 +1345,7 @@
 				IL_001c: ldarg.1
 				IL_001d: ldstr "nodeName"
 				IL_0022: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M11>:__js_call__:3"
-				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0031: stloc.0
@@ -1451,7 +1464,7 @@
 						01 00 00 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 254 (0xfe)
+					// Code size: 336 (0x150)
 					.maxstack 8
 					.locals init (
 						[0] object,
@@ -1473,7 +1486,7 @@
 					IL_0008: brfalse IL_0049
 
 					IL_000d: volatile.
-					IL_000f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+					IL_000f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 					IL_0014: brfalse IL_0029
 
 					IL_0019: ldarg.1
@@ -1484,7 +1497,7 @@
 					IL_0029: ldarg.1
 					IL_002a: ldstr "getAttribute"
 					IL_002f: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M13>:__js_call__:6"
-					IL_0034: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+					IL_0034: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 					IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_003e: stloc.s 4
@@ -1499,75 +1512,100 @@
 					IL_004e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_0053: stloc.3
 					IL_0054: ldloc.3
-					IL_0055: brfalse IL_0079
+					IL_0055: brfalse IL_00a3
 
 					IL_005a: ldarg.1
 					IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0060: ldstr "getAttribute"
-					IL_0065: ldstr "class"
-					IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_006f: stloc.s 4
-					IL_0071: ldloc.s 4
-					IL_0073: stloc.0
-					IL_0074: br IL_007f
+					IL_0060: volatile.
+					IL_0062: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+					IL_0067: brfalse IL_0080
 
-					IL_0079: ldstr ""
-					IL_007e: stloc.0
+					IL_006c: ldstr "getAttribute"
+					IL_0071: ldstr "class"
+					IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_007b: br IL_0099
 
-					IL_007f: ldloc.0
-					IL_0080: stloc.1
-					IL_0081: ldloc.1
-					IL_0082: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0087: stloc.3
-					IL_0088: ldloc.3
-					IL_0089: brfalse IL_00b7
+					IL_0080: ldstr "getAttribute"
+					IL_0085: ldstr "class"
+					IL_008a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M13>:__js_call__:17"
+					IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+					IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-					IL_008e: ldstr "(?:^|\\s)language-([^\\s]+)"
-					IL_0093: ldstr "i"
-					IL_0098: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-					IL_009d: stloc.s 7
-					IL_009f: ldloc.s 7
-					IL_00a1: ldstr "exec"
-					IL_00a6: ldloc.1
-					IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_00ac: stloc.s 4
-					IL_00ae: ldloc.s 4
-					IL_00b0: stloc.s 8
-					IL_00b2: br IL_00ba
+					IL_0099: stloc.s 4
+					IL_009b: ldloc.s 4
+					IL_009d: stloc.0
+					IL_009e: br IL_00a9
 
-					IL_00b7: ldloc.1
-					IL_00b8: stloc.s 8
+					IL_00a3: ldstr ""
+					IL_00a8: stloc.0
 
-					IL_00ba: ldloc.s 8
-					IL_00bc: stloc.2
-					IL_00bd: ldloc.2
-					IL_00be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00c3: stloc.3
-					IL_00c4: ldloc.3
-					IL_00c5: brfalse IL_00e4
+					IL_00a9: ldloc.0
+					IL_00aa: stloc.1
+					IL_00ab: ldloc.1
+					IL_00ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00b1: stloc.3
+					IL_00b2: ldloc.3
+					IL_00b3: brfalse IL_0109
 
-					IL_00ca: ldloc.2
-					IL_00cb: ldc.r8 1
-					IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-					IL_00d9: stloc.s 4
-					IL_00db: ldloc.s 4
-					IL_00dd: stloc.s 9
-					IL_00df: br IL_00e7
+					IL_00b8: ldstr "(?:^|\\s)language-([^\\s]+)"
+					IL_00bd: ldstr "i"
+					IL_00c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+					IL_00c7: stloc.s 7
+					IL_00c9: volatile.
+					IL_00cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+					IL_00d0: brfalse IL_00e7
 
-					IL_00e4: ldloc.2
-					IL_00e5: stloc.s 9
+					IL_00d5: ldloc.s 7
+					IL_00d7: ldstr "exec"
+					IL_00dc: ldloc.1
+					IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_00e2: br IL_00fe
 
-					IL_00e7: ldloc.s 9
-					IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00ee: stloc.3
-					IL_00ef: ldloc.3
-					IL_00f0: brtrue IL_00fb
+					IL_00e7: ldloc.s 7
+					IL_00e9: ldstr "exec"
+					IL_00ee: ldloc.1
+					IL_00ef: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M13>:__js_call__:31"
+					IL_00f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+					IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-					IL_00f5: ldstr ""
-					IL_00fa: ret
+					IL_00fe: stloc.s 4
+					IL_0100: ldloc.s 4
+					IL_0102: stloc.s 8
+					IL_0104: br IL_010c
 
-					IL_00fb: ldloc.s 9
-					IL_00fd: ret
+					IL_0109: ldloc.1
+					IL_010a: stloc.s 8
+
+					IL_010c: ldloc.s 8
+					IL_010e: stloc.2
+					IL_010f: ldloc.2
+					IL_0110: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0115: stloc.3
+					IL_0116: ldloc.3
+					IL_0117: brfalse IL_0136
+
+					IL_011c: ldloc.2
+					IL_011d: ldc.r8 1
+					IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_012b: stloc.s 4
+					IL_012d: ldloc.s 4
+					IL_012f: stloc.s 9
+					IL_0131: br IL_0139
+
+					IL_0136: ldloc.2
+					IL_0137: stloc.s 9
+
+					IL_0139: ldloc.s 9
+					IL_013b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0140: stloc.3
+					IL_0141: ldloc.3
+					IL_0142: brtrue IL_014d
+
+					IL_0147: ldstr ""
+					IL_014c: ret
+
+					IL_014d: ldloc.s 9
+					IL_014f: ret
 				} // end of method ArrowFunction_L90C29::__js_call__
 
 			} // end of class ArrowFunction_L90C29
@@ -1702,7 +1740,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 489 (0x1e9)
+				// Code size: 531 (0x213)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope,
@@ -1725,7 +1763,7 @@
 				IL_0000: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope::.ctor()
 				IL_0005: stloc.0
 				IL_0006: volatile.
-				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 				IL_000d: brfalse IL_0022
 
 				IL_0012: ldarg.3
@@ -1736,7 +1774,7 @@
 				IL_0022: ldarg.3
 				IL_0023: ldstr "textContent"
 				IL_0028: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M12>:__js_call__:4"
-				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0037: stloc.s 7
@@ -1786,7 +1824,7 @@
 				IL_00af: brfalse IL_00f0
 
 				IL_00b4: volatile.
-				IL_00b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_00b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_00bb: brfalse IL_00d0
 
 				IL_00c0: ldarg.3
@@ -1797,7 +1835,7 @@
 				IL_00d0: ldarg.3
 				IL_00d1: ldstr "querySelector"
 				IL_00d6: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M12>:__js_call__:33"
-				IL_00db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_00db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00e5: stloc.s 7
@@ -1812,83 +1850,95 @@
 				IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_00fb: stloc.s 8
 				IL_00fd: ldloc.s 8
-				IL_00ff: brfalse IL_0135
+				IL_00ff: brfalse IL_015f
 
 				IL_0104: ldarg.3
 				IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_010a: ldstr "querySelector"
-				IL_010f: ldstr "code"
-				IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0119: stloc.3
-				IL_011a: ldloc.3
-				IL_011b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0120: stloc.s 8
-				IL_0122: ldloc.s 8
-				IL_0124: brfalse IL_0135
+				IL_010a: volatile.
+				IL_010c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+				IL_0111: brfalse IL_012a
 
-				IL_0129: ldnull
-				IL_012a: ldloc.3
-				IL_012b: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/ArrowFunction_L90C29::__js_call__(object, object)
-				IL_0130: stloc.s 7
-				IL_0132: ldloc.s 7
-				IL_0134: stloc.2
+				IL_0116: ldstr "querySelector"
+				IL_011b: ldstr "code"
+				IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0125: br IL_0143
 
-				IL_0135: ldloc.2
-				IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_013b: stloc.s 8
-				IL_013d: ldloc.s 8
-				IL_013f: brfalse IL_0163
+				IL_012a: ldstr "querySelector"
+				IL_012f: ldstr "code"
+				IL_0134: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M12>:__js_call__:45"
+				IL_0139: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0144: ldloc.2
-				IL_0145: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_014a: stloc.s 14
-				IL_014c: ldstr " "
-				IL_0151: ldloc.s 14
-				IL_0153: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0158: stloc.s 14
-				IL_015a: ldloc.s 14
-				IL_015c: stloc.s 4
-				IL_015e: br IL_016a
+				IL_0143: stloc.3
+				IL_0144: ldloc.3
+				IL_0145: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_014a: stloc.s 8
+				IL_014c: ldloc.s 8
+				IL_014e: brfalse IL_015f
 
-				IL_0163: ldstr ""
-				IL_0168: stloc.s 4
+				IL_0153: ldnull
+				IL_0154: ldloc.3
+				IL_0155: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/ArrowFunction_L90C29::__js_call__(object, object)
+				IL_015a: stloc.s 7
+				IL_015c: ldloc.s 7
+				IL_015e: stloc.2
 
-				IL_016a: ldloc.s 4
-				IL_016c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0171: stloc.s 14
-				IL_0173: ldstr "\n\n```"
-				IL_0178: ldloc.s 14
-				IL_017a: call string [System.Runtime]System.String::Concat(string, string)
-				IL_017f: ldstr "\n"
-				IL_0184: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0189: stloc.s 5
-				IL_018b: ldloc.1
-				IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0191: stloc.s 7
-				IL_0193: ldstr "\\n$"
-				IL_0198: ldstr ""
-				IL_019d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_01a2: stloc.s 11
-				IL_01a4: ldloc.s 7
-				IL_01a6: ldstr "replace"
-				IL_01ab: ldloc.s 11
-				IL_01ad: ldstr ""
-				IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01b7: stloc.s 6
-				IL_01b9: ldloc.s 5
-				IL_01bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01c0: stloc.s 14
+				IL_015f: ldloc.2
+				IL_0160: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0165: stloc.s 8
+				IL_0167: ldloc.s 8
+				IL_0169: brfalse IL_018d
+
+				IL_016e: ldloc.2
+				IL_016f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0174: stloc.s 14
+				IL_0176: ldstr " "
+				IL_017b: ldloc.s 14
+				IL_017d: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0182: stloc.s 14
+				IL_0184: ldloc.s 14
+				IL_0186: stloc.s 4
+				IL_0188: br IL_0194
+
+				IL_018d: ldstr ""
+				IL_0192: stloc.s 4
+
+				IL_0194: ldloc.s 4
+				IL_0196: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_019b: stloc.s 14
+				IL_019d: ldstr "\n\n```"
+				IL_01a2: ldloc.s 14
+				IL_01a4: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01a9: ldstr "\n"
+				IL_01ae: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01b3: stloc.s 5
+				IL_01b5: ldloc.1
+				IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01bb: stloc.s 7
+				IL_01bd: ldstr "\\n$"
 				IL_01c2: ldstr ""
-				IL_01c7: ldloc.s 14
-				IL_01c9: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01ce: ldloc.s 6
-				IL_01d0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01d5: stloc.s 14
-				IL_01d7: ldloc.s 14
-				IL_01d9: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01de: ldstr "\n```\n\n"
-				IL_01e3: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01e8: ret
+				IL_01c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_01cc: stloc.s 11
+				IL_01ce: ldloc.s 7
+				IL_01d0: ldstr "replace"
+				IL_01d5: ldloc.s 11
+				IL_01d7: ldstr ""
+				IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01e1: stloc.s 6
+				IL_01e3: ldloc.s 5
+				IL_01e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01ea: stloc.s 14
+				IL_01ec: ldstr ""
+				IL_01f1: ldloc.s 14
+				IL_01f3: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01f8: ldloc.s 6
+				IL_01fa: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01ff: stloc.s 14
+				IL_0201: ldloc.s 14
+				IL_0203: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0208: ldstr "\n```\n\n"
+				IL_020d: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0212: ret
 			} // end of method FunctionExpression_L85C15::__js_call__
 
 		} // end of class FunctionExpression_L85C15
@@ -2034,7 +2084,7 @@
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
 			// Header size: 12
-			// Code size: 681 (0x2a9)
+			// Code size: 719 (0x2cf)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/Scope,
@@ -2242,59 +2292,71 @@
 			IL_0213: pop
 			IL_0214: ldloc.1
 			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021a: ldstr "turndown"
-			IL_021f: ldarg.2
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0225: stloc.2
-			IL_0226: ldloc.2
-			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022c: stloc.3
-			IL_022d: ldstr "\\n{4,}"
-			IL_0232: ldstr "g"
-			IL_0237: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_023c: stloc.s 11
-			IL_023e: ldloc.3
-			IL_023f: ldstr "replace"
-			IL_0244: ldloc.s 11
-			IL_0246: ldstr "\n\n\n"
-			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0250: stloc.3
-			IL_0251: ldloc.3
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0257: stloc.3
-			IL_0258: ldc.i4.0
-			IL_0259: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_025e: brfalse IL_028d
+			IL_021a: volatile.
+			IL_021c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0221: brfalse IL_0236
 
-			IL_0263: ldloc.3
-			IL_0264: isinst [System.Runtime]System.String
-			IL_0269: dup
-			IL_026a: brtrue IL_0281
+			IL_0226: ldstr "turndown"
+			IL_022b: ldarg.2
+			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0231: br IL_024b
 
-			IL_026f: pop
-			IL_0270: ldloc.3
-			IL_0271: ldstr "trim"
-			IL_0276: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_027b: dup
-			IL_027c: brfalse IL_028c
+			IL_0236: ldstr "turndown"
+			IL_023b: ldarg.2
+			IL_023c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M7>:__js_call__:56"
+			IL_0241: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0281: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0286: stloc.3
-			IL_0287: br IL_0299
+			IL_024b: stloc.2
+			IL_024c: ldloc.2
+			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0252: stloc.3
+			IL_0253: ldstr "\\n{4,}"
+			IL_0258: ldstr "g"
+			IL_025d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0262: stloc.s 11
+			IL_0264: ldloc.3
+			IL_0265: ldstr "replace"
+			IL_026a: ldloc.s 11
+			IL_026c: ldstr "\n\n\n"
+			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0276: stloc.3
+			IL_0277: ldloc.3
+			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_027d: stloc.3
+			IL_027e: ldc.i4.0
+			IL_027f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0284: brfalse IL_02b3
 
-			IL_028c: pop
+			IL_0289: ldloc.3
+			IL_028a: isinst [System.Runtime]System.String
+			IL_028f: dup
+			IL_0290: brtrue IL_02a7
 
-			IL_028d: ldloc.3
-			IL_028e: ldstr "trim"
-			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0298: stloc.3
+			IL_0295: pop
+			IL_0296: ldloc.3
+			IL_0297: ldstr "trim"
+			IL_029c: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_02a1: dup
+			IL_02a2: brfalse IL_02b2
 
-			IL_0299: ldloc.3
-			IL_029a: ldstr "\n"
-			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02a4: stloc.s 12
-			IL_02a6: ldloc.s 12
-			IL_02a8: ret
+			IL_02a7: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_02ac: stloc.3
+			IL_02ad: br IL_02bf
+
+			IL_02b2: pop
+
+			IL_02b3: ldloc.3
+			IL_02b4: ldstr "trim"
+			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_02be: stloc.3
+
+			IL_02bf: ldloc.3
+			IL_02c0: ldstr "\n"
+			IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ca: stloc.s 12
+			IL_02cc: ldloc.s 12
+			IL_02ce: ret
 		} // end of method convertHtmlToMarkdown::__js_call__
 
 	} // end of class convertHtmlToMarkdown
@@ -2437,7 +2499,7 @@
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1285 (0x505)
+			// Code size: 1365 (0x555)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2471,7 +2533,7 @@
 			IL_0012: ldstr "process"
 			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_001c: volatile.
-			IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0023: brfalse IL_0037
 
 			IL_0028: ldstr "argv"
@@ -2480,7 +2542,7 @@
 
 			IL_0037: ldstr "argv"
 			IL_003c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:6"
-			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004b: stloc.s 8
@@ -2489,7 +2551,7 @@
 			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_0056: stloc.0
 			IL_0057: volatile.
-			IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_005e: brfalse IL_0073
 
 			IL_0063: ldloc.0
@@ -2500,7 +2562,7 @@
 			IL_0073: ldloc.0
 			IL_0074: ldstr "inFile"
 			IL_0079: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:11"
-			IL_007e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_007e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0088: stloc.s 8
@@ -2528,7 +2590,7 @@
 			IL_00bc: throw
 
 			IL_00bd: volatile.
-			IL_00bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_00bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_00c4: brfalse IL_00d9
 
 			IL_00c9: ldloc.0
@@ -2539,7 +2601,7 @@
 			IL_00d9: ldloc.0
 			IL_00da: ldstr "outFile"
 			IL_00df: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:22"
-			IL_00e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_00e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00ee: stloc.s 8
@@ -2573,7 +2635,7 @@
 			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_013a: volatile.
-			IL_013c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_013c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_0141: brfalse IL_0155
 
 			IL_0146: ldstr "cwd"
@@ -2582,12 +2644,12 @@
 
 			IL_0155: ldstr "cwd"
 			IL_015a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:36"
-			IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0169: stloc.s 8
 			IL_016b: volatile.
-			IL_016d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_016d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0172: brfalse IL_0187
 
 			IL_0177: ldloc.0
@@ -2598,7 +2660,7 @@
 			IL_0187: ldloc.0
 			IL_0188: ldstr "inFile"
 			IL_018d: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:38"
-			IL_0192: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0192: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_019c: stloc.s 11
@@ -2644,7 +2706,7 @@
 			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0200: volatile.
-			IL_0202: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0202: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0207: brfalse IL_021b
 
 			IL_020c: ldstr "cwd"
@@ -2653,12 +2715,12 @@
 
 			IL_021b: ldstr "cwd"
 			IL_0220: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:46"
-			IL_0225: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0225: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_022f: stloc.s 11
 			IL_0231: volatile.
-			IL_0233: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0233: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_0238: brfalse IL_024d
 
 			IL_023d: ldloc.0
@@ -2669,7 +2731,7 @@
 			IL_024d: ldloc.0
 			IL_024e: ldstr "outFile"
 			IL_0253: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:48"
-			IL_0258: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0258: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0262: stloc.s 8
@@ -2754,168 +2816,193 @@
 			IL_031d: stloc.s 12
 			IL_031f: ldarg.0
 			IL_0320: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_0325: ldstr "dirname"
-			IL_032a: ldloc.s 4
-			IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0331: stloc.s 8
-			IL_0333: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0338: dup
-			IL_0339: ldstr "recursive"
-			IL_033e: ldc.i4.1
-			IL_033f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0344: stloc.s 13
-			IL_0346: ldloc.s 12
-			IL_0348: ldstr "mkdirSync"
-			IL_034d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0352: brtrue IL_0368
+			IL_0325: volatile.
+			IL_0327: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_032c: brfalse IL_0342
 
-			IL_0357: ldloc.s 12
-			IL_0359: ldloc.s 8
-			IL_035b: ldloc.s 13
-			IL_035d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-			IL_0362: pop
-			IL_0363: br IL_0385
+			IL_0331: ldstr "dirname"
+			IL_0336: ldloc.s 4
+			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_033d: br IL_0358
 
-			IL_0368: ldloc.s 12
-			IL_036a: ldstr "mkdirSync"
-			IL_036f: ldc.i4.2
-			IL_0370: newarr [System.Runtime]System.Object
-			IL_0375: dup
-			IL_0376: ldc.i4.0
-			IL_0377: ldloc.s 8
-			IL_0379: stelem.ref
-			IL_037a: dup
-			IL_037b: ldc.i4.1
-			IL_037c: ldloc.s 13
-			IL_037e: stelem.ref
-			IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0384: pop
+			IL_0342: ldstr "dirname"
+			IL_0347: ldloc.s 4
+			IL_0349: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:64"
+			IL_034e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0385: ldarg.0
-			IL_0386: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_038b: stloc.s 12
-			IL_038d: ldloc.s 12
-			IL_038f: ldstr "writeFileSync"
-			IL_0394: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0399: brtrue IL_03b3
+			IL_0358: stloc.s 8
+			IL_035a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_035f: dup
+			IL_0360: ldstr "recursive"
+			IL_0365: ldc.i4.1
+			IL_0366: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_036b: stloc.s 13
+			IL_036d: ldloc.s 12
+			IL_036f: ldstr "mkdirSync"
+			IL_0374: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0379: brtrue IL_038f
 
-			IL_039e: ldloc.s 12
-			IL_03a0: ldloc.s 4
-			IL_03a2: ldloc.s 6
-			IL_03a4: ldstr "utf8"
-			IL_03a9: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_03ae: br IL_03d8
+			IL_037e: ldloc.s 12
+			IL_0380: ldloc.s 8
+			IL_0382: ldloc.s 13
+			IL_0384: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+			IL_0389: pop
+			IL_038a: br IL_03ac
 
-			IL_03b3: ldloc.s 12
-			IL_03b5: ldstr "writeFileSync"
-			IL_03ba: ldc.i4.3
-			IL_03bb: newarr [System.Runtime]System.Object
-			IL_03c0: dup
-			IL_03c1: ldc.i4.0
-			IL_03c2: ldloc.s 4
-			IL_03c4: stelem.ref
-			IL_03c5: dup
-			IL_03c6: ldc.i4.1
-			IL_03c7: ldloc.s 6
-			IL_03c9: stelem.ref
-			IL_03ca: dup
-			IL_03cb: ldc.i4.2
-			IL_03cc: ldstr "utf8"
-			IL_03d1: stelem.ref
-			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_03d7: pop
+			IL_038f: ldloc.s 12
+			IL_0391: ldstr "mkdirSync"
+			IL_0396: ldc.i4.2
+			IL_0397: newarr [System.Runtime]System.Object
+			IL_039c: dup
+			IL_039d: ldc.i4.0
+			IL_039e: ldloc.s 8
+			IL_03a0: stelem.ref
+			IL_03a1: dup
+			IL_03a2: ldc.i4.1
+			IL_03a3: ldloc.s 13
+			IL_03a5: stelem.ref
+			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_03ab: pop
 
-			IL_03d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03dd: stloc.s 14
-			IL_03df: volatile.
-			IL_03e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_03e6: brfalse IL_03fb
+			IL_03ac: ldarg.0
+			IL_03ad: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_03b2: stloc.s 12
+			IL_03b4: ldloc.s 12
+			IL_03b6: ldstr "writeFileSync"
+			IL_03bb: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_03c0: brtrue IL_03da
 
-			IL_03eb: ldloc.0
-			IL_03ec: ldstr "inFile"
-			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03f6: br IL_0410
+			IL_03c5: ldloc.s 12
+			IL_03c7: ldloc.s 4
+			IL_03c9: ldloc.s 6
+			IL_03cb: ldstr "utf8"
+			IL_03d0: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_03d5: br IL_03ff
 
-			IL_03fb: ldloc.0
-			IL_03fc: ldstr "inFile"
-			IL_0401: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:76"
-			IL_0406: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03da: ldloc.s 12
+			IL_03dc: ldstr "writeFileSync"
+			IL_03e1: ldc.i4.3
+			IL_03e2: newarr [System.Runtime]System.Object
+			IL_03e7: dup
+			IL_03e8: ldc.i4.0
+			IL_03e9: ldloc.s 4
+			IL_03eb: stelem.ref
+			IL_03ec: dup
+			IL_03ed: ldc.i4.1
+			IL_03ee: ldloc.s 6
+			IL_03f0: stelem.ref
+			IL_03f1: dup
+			IL_03f2: ldc.i4.2
+			IL_03f3: ldstr "utf8"
+			IL_03f8: stelem.ref
+			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_03fe: pop
 
-			IL_0410: stloc.s 8
-			IL_0412: ldloc.s 8
-			IL_0414: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0419: stloc.s 15
-			IL_041b: ldstr "Converted "
-			IL_0420: ldloc.s 15
-			IL_0422: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0427: ldstr " -> "
-			IL_042c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0431: volatile.
-			IL_0433: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-			IL_0438: brfalse IL_044d
+			IL_03ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0404: stloc.s 14
+			IL_0406: volatile.
+			IL_0408: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_040d: brfalse IL_0422
 
-			IL_043d: ldloc.0
-			IL_043e: ldstr "outFile"
-			IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0448: br IL_0462
+			IL_0412: ldloc.0
+			IL_0413: ldstr "inFile"
+			IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_041d: br IL_0437
 
-			IL_044d: ldloc.0
-			IL_044e: ldstr "outFile"
-			IL_0453: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:82"
-			IL_0458: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0422: ldloc.0
+			IL_0423: ldstr "inFile"
+			IL_0428: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:76"
+			IL_042d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0462: stloc.s 8
-			IL_0464: ldloc.s 8
-			IL_0466: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_046b: stloc.s 15
-			IL_046d: ldloc.s 15
-			IL_046f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0474: ldstr " ("
-			IL_0479: call string [System.Runtime]System.String::Concat(string, string)
-			IL_047e: ldloc.s 6
-			IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0485: stloc.s 8
-			IL_0487: ldstr "\\n"
-			IL_048c: ldstr ""
-			IL_0491: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0496: stloc.s 16
-			IL_0498: ldloc.s 8
-			IL_049a: ldstr "split"
-			IL_049f: ldloc.s 16
-			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04a6: stloc.s 8
-			IL_04a8: volatile.
-			IL_04aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-			IL_04af: brfalse IL_04c5
+			IL_0437: stloc.s 8
+			IL_0439: ldloc.s 8
+			IL_043b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0440: stloc.s 15
+			IL_0442: ldstr "Converted "
+			IL_0447: ldloc.s 15
+			IL_0449: call string [System.Runtime]System.String::Concat(string, string)
+			IL_044e: ldstr " -> "
+			IL_0453: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0458: volatile.
+			IL_045a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_045f: brfalse IL_0474
 
-			IL_04b4: ldloc.s 8
-			IL_04b6: ldstr "length"
-			IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04c0: br IL_04db
+			IL_0464: ldloc.0
+			IL_0465: ldstr "outFile"
+			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_046f: br IL_0489
 
-			IL_04c5: ldloc.s 8
-			IL_04c7: ldstr "length"
-			IL_04cc: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:93"
-			IL_04d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0474: ldloc.0
+			IL_0475: ldstr "outFile"
+			IL_047a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:82"
+			IL_047f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04db: stloc.s 8
-			IL_04dd: ldloc.s 8
-			IL_04df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04e4: stloc.s 15
-			IL_04e6: ldloc.s 15
-			IL_04e8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04ed: ldstr " lines)"
-			IL_04f2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04f7: stloc.s 15
-			IL_04f9: ldloc.s 14
-			IL_04fb: ldloc.s 15
-			IL_04fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0502: pop
-			IL_0503: ldnull
-			IL_0504: ret
+			IL_0489: stloc.s 8
+			IL_048b: ldloc.s 8
+			IL_048d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0492: stloc.s 15
+			IL_0494: ldloc.s 15
+			IL_0496: call string [System.Runtime]System.String::Concat(string, string)
+			IL_049b: ldstr " ("
+			IL_04a0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04a5: ldloc.s 6
+			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ac: stloc.s 8
+			IL_04ae: ldstr "\\n"
+			IL_04b3: ldstr ""
+			IL_04b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_04bd: stloc.s 16
+			IL_04bf: volatile.
+			IL_04c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_04c6: brfalse IL_04de
+
+			IL_04cb: ldloc.s 8
+			IL_04cd: ldstr "split"
+			IL_04d2: ldloc.s 16
+			IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04d9: br IL_04f6
+
+			IL_04de: ldloc.s 8
+			IL_04e0: ldstr "split"
+			IL_04e5: ldloc.s 16
+			IL_04e7: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:91"
+			IL_04ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_04f6: stloc.s 8
+			IL_04f8: volatile.
+			IL_04fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_04ff: brfalse IL_0515
+
+			IL_0504: ldloc.s 8
+			IL_0506: ldstr "length"
+			IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0510: br IL_052b
+
+			IL_0515: ldloc.s 8
+			IL_0517: ldstr "length"
+			IL_051c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M8>:__js_call__:93"
+			IL_0521: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_052b: stloc.s 8
+			IL_052d: ldloc.s 8
+			IL_052f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0534: stloc.s 15
+			IL_0536: ldloc.s 15
+			IL_0538: call string [System.Runtime]System.String::Concat(string, string)
+			IL_053d: ldstr " lines)"
+			IL_0542: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0547: stloc.s 15
+			IL_0549: ldloc.s 14
+			IL_054b: ldloc.s 15
+			IL_054d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0552: pop
+			IL_0553: ldnull
+			IL_0554: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -3032,7 +3119,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 590 (0x24e)
+		// Code size: 631 (0x277)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope,
@@ -3167,7 +3254,7 @@
 		IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_011b: stloc.s 13
 		IL_011d: ldloc.s 13
-		IL_011f: brfalse IL_024a
+		IL_011f: brfalse IL_0273
 		.try
 		{
 			IL_0124: nop
@@ -3175,7 +3262,7 @@
 			IL_0126: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 			IL_0130: pop
-			IL_0131: leave IL_024a
+			IL_0131: leave IL_0273
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -3264,24 +3351,37 @@
 			IL_0213: ldloc.s 4
 			IL_0215: stloc.s 5
 
-			IL_0217: ldloc.s 12
-			IL_0219: ldstr "error"
-			IL_021e: ldloc.s 5
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0225: pop
-			IL_0226: ldstr "process"
-			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0230: ldstr "exitCode"
-			IL_0235: ldc.r8 1
-			IL_023e: ldc.i4.1
-			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0244: pop
-			IL_0245: leave IL_024a
+			IL_0217: volatile.
+			IL_0219: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_021e: brfalse IL_0236
+
+			IL_0223: ldloc.s 12
+			IL_0225: ldstr "error"
+			IL_022a: ldloc.s 5
+			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0231: br IL_024e
+
+			IL_0236: ldloc.s 12
+			IL_0238: ldstr "error"
+			IL_023d: ldloc.s 5
+			IL_023f: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:__js_module_init__:72"
+			IL_0244: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_024e: pop
+			IL_024f: ldstr "process"
+			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0259: ldstr "exitCode"
+			IL_025e: ldc.r8 1
+			IL_0267: ldc.i4.1
+			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_026d: pop
+			IL_026e: leave IL_0273
 		} // end handler
 
-		IL_024a: ldnull
-		IL_024b: stloc.s 6
-		IL_024d: ret
+		IL_0273: ldnull
+		IL_0274: stloc.s 6
+		IL_0276: ret
 	} // end of method Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
@@ -3835,7 +3935,7 @@
 		IL_0025: nop
 		IL_0026: nop
 		IL_0027: volatile.
-		IL_0029: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0029: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 		IL_002e: brfalse IL_0043
 
 		IL_0033: ldloc.1
@@ -3846,7 +3946,7 @@
 		IL_0043: ldloc.1
 		IL_0044: ldstr "prototype"
 		IL_0049: ldstr "turndown/index:Modules.m_7475726e646f776e2f696e646578:__js_module_init__:9"
-		IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0058: stloc.3
@@ -3872,7 +3972,7 @@
 		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
 		IL_0087: pop
 		IL_0088: volatile.
-		IL_008a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_008a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 		IL_008f: brfalse IL_00a4
 
 		IL_0094: ldloc.1
@@ -3883,7 +3983,7 @@
 		IL_00a4: ldloc.1
 		IL_00a5: ldstr "prototype"
 		IL_00aa: ldstr "turndown/index:Modules.m_7475726e646f776e2f696e646578:__js_module_init__:16"
-		IL_00af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_00af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_00b9: stloc.3
@@ -3964,6 +4064,14 @@
 	.field assembly static int32 __jroc_dynamicLookup_33
 	.field assembly static int32 __jroc_dynamicLookup_34
 	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
+	.field assembly static int32 __jroc_dynamicLookup_37
+	.field assembly static int32 __jroc_dynamicLookup_38
+	.field assembly static int32 __jroc_dynamicLookup_39
+	.field assembly static int32 __jroc_dynamicLookup_40
+	.field assembly static int32 __jroc_dynamicLookup_41
+	.field assembly static int32 __jroc_dynamicLookup_42
+	.field assembly static int32 __jroc_dynamicLookup_43
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -202,7 +202,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 269 (0x10d)
+			// Code size: 350 (0x15e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -231,74 +231,98 @@
 			IL_002f: stloc.0
 			IL_0030: ldloc.0
 			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0036: ldstr "split"
-			IL_003b: ldstr "/"
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0045: stloc.s 4
-			IL_0047: ldloc.s 4
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004e: ldstr "Boolean"
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0058: stloc.s 4
-			IL_005a: ldstr "filter"
-			IL_005f: ldloc.s 4
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0066: stloc.1
-			IL_0067: volatile.
-			IL_0069: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_006e: brfalse IL_0083
+			IL_0036: volatile.
+			IL_0038: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_003d: brfalse IL_0056
 
-			IL_0073: ldloc.1
-			IL_0074: ldstr "length"
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_007e: br IL_0098
+			IL_0042: ldstr "split"
+			IL_0047: ldstr "/"
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0051: br IL_006f
 
-			IL_0083: ldloc.1
-			IL_0084: ldstr "length"
-			IL_0089: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M4>:__js_call__:21"
-			IL_008e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0056: ldstr "split"
+			IL_005b: ldstr "/"
+			IL_0060: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M4>:__js_call__:13"
+			IL_0065: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0098: stloc.s 4
-			IL_009a: ldloc.s 4
-			IL_009c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00a1: ldc.r8 0.0
-			IL_00aa: cgt
-			IL_00ac: brfalse IL_0104
+			IL_006f: stloc.s 4
+			IL_0071: ldloc.s 4
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0078: ldstr "Boolean"
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0082: stloc.s 4
+			IL_0084: volatile.
+			IL_0086: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_008b: brfalse IL_00a1
 
-			IL_00b1: volatile.
-			IL_00b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_00b8: brfalse IL_00cd
+			IL_0090: ldstr "filter"
+			IL_0095: ldloc.s 4
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_009c: br IL_00b7
 
-			IL_00bd: ldloc.1
-			IL_00be: ldstr "length"
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c8: br IL_00e2
+			IL_00a1: ldstr "filter"
+			IL_00a6: ldloc.s 4
+			IL_00a8: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M4>:__js_call__:17"
+			IL_00ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_00cd: ldloc.1
-			IL_00ce: ldstr "length"
-			IL_00d3: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M4>:__js_call__:27"
-			IL_00d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00b7: stloc.1
+			IL_00b8: volatile.
+			IL_00ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_00bf: brfalse IL_00d4
 
-			IL_00e2: stloc.s 4
-			IL_00e4: ldloc.s 4
-			IL_00e6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00eb: ldc.r8 1
-			IL_00f4: sub
-			IL_00f5: stloc.s 5
-			IL_00f7: ldloc.1
-			IL_00f8: ldloc.s 5
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00ff: stloc.s 4
-			IL_0101: ldloc.s 4
-			IL_0103: ret
+			IL_00c4: ldloc.1
+			IL_00c5: ldstr "length"
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00cf: br IL_00e9
 
-			IL_0104: ldarg.1
-			IL_0105: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_010a: stloc.2
-			IL_010b: ldloc.2
-			IL_010c: ret
+			IL_00d4: ldloc.1
+			IL_00d5: ldstr "length"
+			IL_00da: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M4>:__js_call__:21"
+			IL_00df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_00e9: stloc.s 4
+			IL_00eb: ldloc.s 4
+			IL_00ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00f2: ldc.r8 0.0
+			IL_00fb: cgt
+			IL_00fd: brfalse IL_0155
+
+			IL_0102: volatile.
+			IL_0104: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0109: brfalse IL_011e
+
+			IL_010e: ldloc.1
+			IL_010f: ldstr "length"
+			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0119: br IL_0133
+
+			IL_011e: ldloc.1
+			IL_011f: ldstr "length"
+			IL_0124: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M4>:__js_call__:27"
+			IL_0129: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0133: stloc.s 4
+			IL_0135: ldloc.s 4
+			IL_0137: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_013c: ldc.r8 1
+			IL_0145: sub
+			IL_0146: stloc.s 5
+			IL_0148: ldloc.1
+			IL_0149: ldloc.s 5
+			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0150: stloc.s 4
+			IL_0152: ldloc.s 4
+			IL_0154: ret
+
+			IL_0155: ldarg.1
+			IL_0156: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_015b: stloc.2
+			IL_015c: ldloc.2
+			IL_015d: ret
 		} // end of method getAssemblyFileBaseName::__js_call__
 
 	} // end of class getAssemblyFileBaseName
@@ -469,7 +493,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 334 (0x14e)
+			// Code size: 498 (0x1f2)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -517,82 +541,130 @@
 			IL_005b: stloc.3
 			IL_005c: ldloc.3
 			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0062: ldstr "split"
-			IL_0067: ldstr "."
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0071: stloc.3
-			IL_0072: ldloc.3
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0078: ldstr "Boolean"
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0082: stloc.3
-			IL_0083: ldstr "filter"
-			IL_0088: ldloc.3
-			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_008e: stloc.0
-			IL_008f: volatile.
-			IL_0091: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-			IL_0096: brfalse IL_00ab
+			IL_0062: volatile.
+			IL_0064: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0069: brfalse IL_0082
 
-			IL_009b: ldloc.0
-			IL_009c: ldstr "length"
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a6: br IL_00c0
+			IL_006e: ldstr "split"
+			IL_0073: ldstr "."
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_007d: br IL_009b
 
-			IL_00ab: ldloc.0
-			IL_00ac: ldstr "length"
-			IL_00b1: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M5>:__js_call__:21"
-			IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0082: ldstr "split"
+			IL_0087: ldstr "."
+			IL_008c: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M5>:__js_call__:13"
+			IL_0091: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_00c0: stloc.3
-			IL_00c1: ldloc.3
-			IL_00c2: ldc.r8 0.0
-			IL_00cb: box [System.Runtime]System.Double
-			IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00d5: stloc.s 5
-			IL_00d7: ldloc.s 5
-			IL_00d9: brfalse IL_00fe
+			IL_009b: stloc.3
+			IL_009c: ldloc.3
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a2: ldstr "Boolean"
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ac: stloc.3
+			IL_00ad: volatile.
+			IL_00af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_00b4: brfalse IL_00c9
 
-			IL_00de: ldstr "Category must contain at least one name segment."
-			IL_00e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00e8: stloc.1
-			IL_00e9: ldloc.1
-			IL_00ea: isinst [System.Runtime]System.Exception
-			IL_00ef: dup
-			IL_00f0: brtrue IL_00fd
+			IL_00b9: ldstr "filter"
+			IL_00be: ldloc.3
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c4: br IL_00de
 
-			IL_00f5: pop
-			IL_00f6: ldloc.1
-			IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00fc: throw
+			IL_00c9: ldstr "filter"
+			IL_00ce: ldloc.3
+			IL_00cf: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M5>:__js_call__:17"
+			IL_00d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_00fd: throw
+			IL_00de: stloc.0
+			IL_00df: volatile.
+			IL_00e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_00e6: brfalse IL_00fb
 
-			IL_00fe: ldloc.0
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0104: ldstr "join"
-			IL_0109: ldstr "."
-			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0113: stloc.3
-			IL_0114: ldloc.0
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011a: ldstr "join"
-			IL_011f: ldstr "/"
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0129: stloc.s 6
-			IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0130: dup
-			IL_0131: ldstr "namespace"
-			IL_0136: ldloc.3
-			IL_0137: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_013c: dup
-			IL_013d: ldstr "path"
-			IL_0142: ldloc.s 6
-			IL_0144: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0149: stloc.s 7
-			IL_014b: ldloc.s 7
-			IL_014d: ret
+			IL_00eb: ldloc.0
+			IL_00ec: ldstr "length"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f6: br IL_0110
+
+			IL_00fb: ldloc.0
+			IL_00fc: ldstr "length"
+			IL_0101: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M5>:__js_call__:21"
+			IL_0106: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0110: stloc.3
+			IL_0111: ldloc.3
+			IL_0112: ldc.r8 0.0
+			IL_011b: box [System.Runtime]System.Double
+			IL_0120: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0125: stloc.s 5
+			IL_0127: ldloc.s 5
+			IL_0129: brfalse IL_014e
+
+			IL_012e: ldstr "Category must contain at least one name segment."
+			IL_0133: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0138: stloc.1
+			IL_0139: ldloc.1
+			IL_013a: isinst [System.Runtime]System.Exception
+			IL_013f: dup
+			IL_0140: brtrue IL_014d
+
+			IL_0145: pop
+			IL_0146: ldloc.1
+			IL_0147: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_014c: throw
+
+			IL_014d: throw
+
+			IL_014e: ldloc.0
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0154: volatile.
+			IL_0156: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_015b: brfalse IL_0174
+
+			IL_0160: ldstr "join"
+			IL_0165: ldstr "."
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_016f: br IL_018d
+
+			IL_0174: ldstr "join"
+			IL_0179: ldstr "."
+			IL_017e: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M5>:__js_call__:35"
+			IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_018d: stloc.3
+			IL_018e: ldloc.0
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0194: volatile.
+			IL_0196: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_019b: brfalse IL_01b4
+
+			IL_01a0: ldstr "join"
+			IL_01a5: ldstr "/"
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01af: br IL_01cd
+
+			IL_01b4: ldstr "join"
+			IL_01b9: ldstr "/"
+			IL_01be: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M5>:__js_call__:38"
+			IL_01c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_01cd: stloc.s 6
+			IL_01cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01d4: dup
+			IL_01d5: ldstr "namespace"
+			IL_01da: ldloc.3
+			IL_01db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01e0: dup
+			IL_01e1: ldstr "path"
+			IL_01e6: ldloc.s 6
+			IL_01e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01ed: stloc.s 7
+			IL_01ef: ldloc.s 7
+			IL_01f1: ret
 		} // end of method normalizeCategory::__js_call__
 
 	} // end of class normalizeCategory
@@ -997,7 +1069,7 @@
 			IL_0015: ldloc.3
 			IL_0016: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/Scope::tempDir
 			IL_001b: volatile.
-			IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_001d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 			IL_0022: brfalse IL_0037
 
 			IL_0027: ldarg.2
@@ -1008,12 +1080,12 @@
 			IL_0037: ldarg.2
 			IL_0038: ldstr "namespace"
 			IL_003d: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M6>:__js_call__:8"
-			IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004c: stloc.3
 			IL_004d: volatile.
-			IL_004f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_004f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 			IL_0054: brfalse IL_0069
 
 			IL_0059: ldarg.2
@@ -1024,7 +1096,7 @@
 			IL_0069: ldarg.2
 			IL_006a: ldstr "path"
 			IL_006f: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M6>:__js_call__:11"
-			IL_0074: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0074: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_007e: stloc.s 4
@@ -1202,7 +1274,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0006: volatile.
-				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 				IL_000d: brfalse IL_0021
 
 				IL_0012: ldstr "isDirectory"
@@ -1211,7 +1283,7 @@
 
 				IL_0021: ldstr "isDirectory"
 				IL_0026: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M14>:__js_call__:2"
-				IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+				IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0035: stloc.0
@@ -1362,7 +1434,7 @@
 				IL_0016: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope::categoryRoot
 				IL_001b: stloc.1
 				IL_001c: volatile.
-				IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+				IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 				IL_0023: brfalse IL_0038
 
 				IL_0028: ldarg.2
@@ -1373,7 +1445,7 @@
 				IL_0038: ldarg.2
 				IL_0039: ldstr "name"
 				IL_003e: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M15>:__js_call__:4"
-				IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+				IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_004d: stloc.2
@@ -1634,7 +1706,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 600 (0x258)
+			// Code size: 682 (0x2aa)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope,
@@ -1723,189 +1795,215 @@
 			IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L66C13/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L66C13/FunctionObject>(!!0)
 			IL_00a4: stloc.s 15
-			IL_00a6: ldloc.s 11
-			IL_00a8: ldstr "filter"
-			IL_00ad: ldloc.s 15
-			IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00b4: stloc.s 11
-			IL_00b6: ldloc.s 11
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00bd: stloc.s 11
-			IL_00bf: ldc.i4.2
-			IL_00c0: newarr [System.Runtime]System.Object
-			IL_00c5: dup
-			IL_00c6: ldc.i4.0
-			IL_00c7: ldarg.0
-			IL_00c8: stelem.ref
-			IL_00c9: dup
-			IL_00ca: ldc.i4.1
-			IL_00cb: ldloc.0
-			IL_00cc: stelem.ref
-			IL_00cd: stloc.s 14
-			IL_00cf: ldloc.s 14
-			IL_00d1: ldc.i4.0
-			IL_00d2: ldelem.ref
-			IL_00d3: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_00d8: ldloc.s 14
-			IL_00da: ldc.i4.1
-			IL_00db: ldelem.ref
-			IL_00dc: castclass Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope
-			IL_00e1: ldloc.s 14
-			IL_00e3: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L67C10/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope, object[])
-			IL_00e8: ldc.i4.1
-			IL_00e9: conv.r8
-			IL_00ea: ldstr ""
+			IL_00a6: volatile.
+			IL_00a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_00ad: brfalse IL_00c5
+
+			IL_00b2: ldloc.s 11
+			IL_00b4: ldstr "filter"
+			IL_00b9: ldloc.s 15
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c0: br IL_00dd
+
+			IL_00c5: ldloc.s 11
+			IL_00c7: ldstr "filter"
+			IL_00cc: ldloc.s 15
+			IL_00ce: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M7>:__js_call__:23"
+			IL_00d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00dd: stloc.s 11
+			IL_00df: ldloc.s 11
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e6: stloc.s 11
+			IL_00e8: ldc.i4.2
+			IL_00e9: newarr [System.Runtime]System.Object
+			IL_00ee: dup
 			IL_00ef: ldc.i4.0
-			IL_00f0: ldc.i4.0
-			IL_00f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L67C10/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L67C10/FunctionObject>(!!0)
-			IL_00fb: stloc.s 16
-			IL_00fd: ldloc.s 11
-			IL_00ff: ldstr "map"
-			IL_0104: ldloc.s 16
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_010b: stloc.1
-			IL_010c: ldc.i4.0
-			IL_010d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0112: stloc.2
-			IL_0113: ldc.r8 1
-			IL_011c: neg
-			IL_011d: stloc.s 17
-			IL_011f: ldloc.s 17
-			IL_0121: box [System.Runtime]System.Double
-			IL_0126: stloc.3
-			IL_0127: ldloc.1
-			IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_012d: stloc.s 4
-			IL_012f: ldc.i4.0
-			IL_0130: stloc.s 5
-			IL_0132: ldc.i4.0
-			IL_0133: stloc.s 6
+			IL_00f0: ldarg.0
+			IL_00f1: stelem.ref
+			IL_00f2: dup
+			IL_00f3: ldc.i4.1
+			IL_00f4: ldloc.0
+			IL_00f5: stelem.ref
+			IL_00f6: stloc.s 14
+			IL_00f8: ldloc.s 14
+			IL_00fa: ldc.i4.0
+			IL_00fb: ldelem.ref
+			IL_00fc: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_0101: ldloc.s 14
+			IL_0103: ldc.i4.1
+			IL_0104: ldelem.ref
+			IL_0105: castclass Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope
+			IL_010a: ldloc.s 14
+			IL_010c: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L67C10/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/Scope, object[])
+			IL_0111: ldc.i4.1
+			IL_0112: conv.r8
+			IL_0113: ldstr ""
+			IL_0118: ldc.i4.0
+			IL_0119: ldc.i4.0
+			IL_011a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L67C10/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/ArrowFunction_L67C10/FunctionObject>(!!0)
+			IL_0124: stloc.s 16
+			IL_0126: volatile.
+			IL_0128: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_012d: brfalse IL_0145
+
+			IL_0132: ldloc.s 11
+			IL_0134: ldstr "map"
+			IL_0139: ldloc.s 16
+			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0140: br IL_015d
+
+			IL_0145: ldloc.s 11
+			IL_0147: ldstr "map"
+			IL_014c: ldloc.s 16
+			IL_014e: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M7>:__js_call__:27"
+			IL_0153: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_015d: stloc.1
+			IL_015e: ldc.i4.0
+			IL_015f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0164: stloc.2
+			IL_0165: ldc.r8 1
+			IL_016e: neg
+			IL_016f: stloc.s 17
+			IL_0171: ldloc.s 17
+			IL_0173: box [System.Runtime]System.Double
+			IL_0178: stloc.3
+			IL_0179: ldloc.1
+			IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_017f: stloc.s 4
+			IL_0181: ldc.i4.0
+			IL_0182: stloc.s 5
+			IL_0184: ldc.i4.0
+			IL_0185: stloc.s 6
 			.try
 			{
-				// loop start (head: IL_0135)
-					IL_0135: ldc.i4.1
-					IL_0136: stloc.s 5
-					IL_0138: ldloc.s 4
-					IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_013f: stloc.s 11
-					IL_0141: ldloc.s 11
-					IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_0148: stloc.s 12
-					IL_014a: ldloc.s 12
-					IL_014c: brtrue IL_0238
+				// loop start (head: IL_0187)
+					IL_0187: ldc.i4.1
+					IL_0188: stloc.s 5
+					IL_018a: ldloc.s 4
+					IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_0191: stloc.s 11
+					IL_0193: ldloc.s 11
+					IL_0195: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_019a: stloc.s 12
+					IL_019c: ldloc.s 12
+					IL_019e: brtrue IL_028a
 
-					IL_0151: ldloc.s 11
-					IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_0158: stloc.s 11
-					IL_015a: ldc.i4.0
-					IL_015b: stloc.s 5
-					IL_015d: ldloc.s 11
-					IL_015f: stloc.s 7
-					IL_0161: ldarg.0
-					IL_0162: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-					IL_0167: stloc.s 18
-					IL_0169: ldloc.s 18
-					IL_016b: ldc.i4.2
-					IL_016c: newarr [System.Runtime]System.Object
-					IL_0171: dup
-					IL_0172: ldc.i4.0
-					IL_0173: ldloc.s 7
-					IL_0175: stelem.ref
-					IL_0176: dup
-					IL_0177: ldc.i4.1
-					IL_0178: ldarg.3
-					IL_0179: stelem.ref
-					IL_017a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-					IL_017f: stloc.s 8
-					IL_0181: ldarg.0
-					IL_0182: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_0187: stloc.s 10
-					IL_0189: ldloc.s 10
-					IL_018b: ldloc.s 8
-					IL_018d: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_0192: box [System.Runtime]System.Boolean
-					IL_0197: stloc.s 11
-					IL_0199: ldloc.s 11
-					IL_019b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_01a0: ldc.i4.0
-					IL_01a1: ceq
-					IL_01a3: stloc.s 12
-					IL_01a5: ldloc.s 12
-					IL_01a7: brfalse IL_01b1
+					IL_01a3: ldloc.s 11
+					IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_01aa: stloc.s 11
+					IL_01ac: ldc.i4.0
+					IL_01ad: stloc.s 5
+					IL_01af: ldloc.s 11
+					IL_01b1: stloc.s 7
+					IL_01b3: ldarg.0
+					IL_01b4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+					IL_01b9: stloc.s 18
+					IL_01bb: ldloc.s 18
+					IL_01bd: ldc.i4.2
+					IL_01be: newarr [System.Runtime]System.Object
+					IL_01c3: dup
+					IL_01c4: ldc.i4.0
+					IL_01c5: ldloc.s 7
+					IL_01c7: stelem.ref
+					IL_01c8: dup
+					IL_01c9: ldc.i4.1
+					IL_01ca: ldarg.3
+					IL_01cb: stelem.ref
+					IL_01cc: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+					IL_01d1: stloc.s 8
+					IL_01d3: ldarg.0
+					IL_01d4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_01d9: stloc.s 10
+					IL_01db: ldloc.s 10
+					IL_01dd: ldloc.s 8
+					IL_01df: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_01e4: box [System.Runtime]System.Boolean
+					IL_01e9: stloc.s 11
+					IL_01eb: ldloc.s 11
+					IL_01ed: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_01f2: ldc.i4.0
+					IL_01f3: ceq
+					IL_01f5: stloc.s 12
+					IL_01f7: ldloc.s 12
+					IL_01f9: brfalse IL_0203
 
-					IL_01ac: br IL_0224
+					IL_01fe: br IL_0276
 
-					IL_01b1: ldarg.0
-					IL_01b2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-					IL_01b7: stloc.s 10
-					IL_01b9: ldloc.s 10
-					IL_01bb: ldloc.s 8
-					IL_01bd: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
-					IL_01c2: stloc.s 9
-					IL_01c4: ldloc.s 9
-					IL_01c6: ldstr "mtimeMs"
-					IL_01cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-					IL_01d0: stloc.s 17
-					IL_01d2: ldloc.3
-					IL_01d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_01d8: stloc.s 19
-					IL_01da: ldloc.s 17
-					IL_01dc: ldloc.s 19
-					IL_01de: cgt
-					IL_01e0: brfalse IL_0224
+					IL_0203: ldarg.0
+					IL_0204: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+					IL_0209: stloc.s 10
+					IL_020b: ldloc.s 10
+					IL_020d: ldloc.s 8
+					IL_020f: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_0214: stloc.s 9
+					IL_0216: ldloc.s 9
+					IL_0218: ldstr "mtimeMs"
+					IL_021d: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+					IL_0222: stloc.s 17
+					IL_0224: ldloc.3
+					IL_0225: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_022a: stloc.s 19
+					IL_022c: ldloc.s 17
+					IL_022e: ldloc.s 19
+					IL_0230: cgt
+					IL_0232: brfalse IL_0276
 
-					IL_01e5: volatile.
-					IL_01e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-					IL_01ec: brfalse IL_0202
+					IL_0237: volatile.
+					IL_0239: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+					IL_023e: brfalse IL_0254
 
-					IL_01f1: ldloc.s 9
-					IL_01f3: ldstr "mtimeMs"
-					IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01fd: br IL_0218
+					IL_0243: ldloc.s 9
+					IL_0245: ldstr "mtimeMs"
+					IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_024f: br IL_026a
 
-					IL_0202: ldloc.s 9
-					IL_0204: ldstr "mtimeMs"
-					IL_0209: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M7>:__js_call__:79"
-					IL_020e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-					IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_0254: ldloc.s 9
+					IL_0256: ldstr "mtimeMs"
+					IL_025b: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M7>:__js_call__:79"
+					IL_0260: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+					IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_0218: stloc.s 11
-					IL_021a: ldloc.s 11
-					IL_021c: stloc.3
-					IL_021d: ldloc.s 8
-					IL_021f: stloc.s 11
-					IL_0221: ldloc.s 11
-					IL_0223: stloc.2
+					IL_026a: stloc.s 11
+					IL_026c: ldloc.s 11
+					IL_026e: stloc.3
+					IL_026f: ldloc.s 8
+					IL_0271: stloc.s 11
+					IL_0273: ldloc.s 11
+					IL_0275: stloc.2
 
-					IL_0224: br IL_0135
+					IL_0276: br IL_0187
 				// end loop
-				IL_0229: ldloc.s 4
-				IL_022b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0230: ldc.i4.1
-				IL_0231: stloc.s 6
-				IL_0233: leave IL_0256
+				IL_027b: ldloc.s 4
+				IL_027d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0282: ldc.i4.1
+				IL_0283: stloc.s 6
+				IL_0285: leave IL_02a8
 
-				IL_0238: ldc.i4.1
-				IL_0239: stloc.s 5
-				IL_023b: leave IL_0256
+				IL_028a: ldc.i4.1
+				IL_028b: stloc.s 5
+				IL_028d: leave IL_02a8
 			} // end .try
 			finally
 			{
-				IL_0240: ldloc.s 5
-				IL_0242: brtrue IL_0255
+				IL_0292: ldloc.s 5
+				IL_0294: brtrue IL_02a7
 
-				IL_0247: ldloc.s 6
-				IL_0249: brtrue IL_0255
+				IL_0299: ldloc.s 6
+				IL_029b: brtrue IL_02a7
 
-				IL_024e: ldloc.s 4
-				IL_0250: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_02a0: ldloc.s 4
+				IL_02a2: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0255: endfinally
+				IL_02a7: endfinally
 			} // end handler
 
-			IL_0256: ldloc.2
-			IL_0257: ret
+			IL_02a8: ldloc.2
+			IL_02a9: ret
 		} // end of method tryFindLatestGeneratedAssemblyInRoot::__js_call__
 
 	} // end of class tryFindLatestGeneratedAssemblyInRoot
@@ -2436,7 +2534,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 346 (0x15a)
+			// Code size: 384 (0x180)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2461,7 +2559,7 @@
 			IL_0001: stloc.0
 			// loop start (head: IL_0002)
 				IL_0002: ldc.i4.1
-				IL_0003: brfalse IL_0122
+				IL_0003: brfalse IL_0148
 
 				IL_0008: ldarg.0
 				IL_0009: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
@@ -2539,75 +2637,87 @@
 
 				IL_00b1: ldarg.0
 				IL_00b2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-				IL_00b7: ldstr "dirname"
-				IL_00bc: ldloc.0
-				IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00c2: stloc.3
-				IL_00c3: ldloc.3
-				IL_00c4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_00c9: ldc.i4.0
-				IL_00ca: ceq
-				IL_00cc: stloc.s 8
-				IL_00ce: ldloc.s 8
-				IL_00d0: box [System.Runtime]System.Boolean
-				IL_00d5: stloc.s 12
-				IL_00d7: ldloc.s 12
-				IL_00d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00de: stloc.s 8
-				IL_00e0: ldloc.s 8
-				IL_00e2: brtrue IL_0102
+				IL_00b7: volatile.
+				IL_00b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+				IL_00be: brfalse IL_00d3
 
-				IL_00e7: ldloc.3
-				IL_00e8: ldloc.0
-				IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00ee: stloc.s 8
-				IL_00f0: ldloc.s 8
-				IL_00f2: box [System.Runtime]System.Boolean
-				IL_00f7: stloc.s 13
-				IL_00f9: ldloc.s 13
-				IL_00fb: stloc.s 14
-				IL_00fd: br IL_0106
+				IL_00c3: ldstr "dirname"
+				IL_00c8: ldloc.0
+				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00ce: br IL_00e8
 
-				IL_0102: ldloc.s 12
-				IL_0104: stloc.s 14
+				IL_00d3: ldstr "dirname"
+				IL_00d8: ldloc.0
+				IL_00d9: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M9>:__js_call__:37"
+				IL_00de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0106: ldloc.s 14
-				IL_0108: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_010d: stloc.s 8
-				IL_010f: ldloc.s 8
-				IL_0111: brfalse IL_011b
+				IL_00e8: stloc.3
+				IL_00e9: ldloc.3
+				IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_00ef: ldc.i4.0
+				IL_00f0: ceq
+				IL_00f2: stloc.s 8
+				IL_00f4: ldloc.s 8
+				IL_00f6: box [System.Runtime]System.Boolean
+				IL_00fb: stloc.s 12
+				IL_00fd: ldloc.s 12
+				IL_00ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0104: stloc.s 8
+				IL_0106: ldloc.s 8
+				IL_0108: brtrue IL_0128
 
-				IL_0116: br IL_0122
+				IL_010d: ldloc.3
+				IL_010e: ldloc.0
+				IL_010f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0114: stloc.s 8
+				IL_0116: ldloc.s 8
+				IL_0118: box [System.Runtime]System.Boolean
+				IL_011d: stloc.s 13
+				IL_011f: ldloc.s 13
+				IL_0121: stloc.s 14
+				IL_0123: br IL_012c
 
-				IL_011b: ldloc.3
-				IL_011c: stloc.0
-				IL_011d: br IL_0002
+				IL_0128: ldloc.s 12
+				IL_012a: stloc.s 14
+
+				IL_012c: ldloc.s 14
+				IL_012e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0133: stloc.s 8
+				IL_0135: ldloc.s 8
+				IL_0137: brfalse IL_0141
+
+				IL_013c: br IL_0148
+
+				IL_0141: ldloc.3
+				IL_0142: stloc.0
+				IL_0143: br IL_0002
 			// end loop
 
-			IL_0122: ldarg.2
-			IL_0123: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0128: stloc.s 15
-			IL_012a: ldstr "Could not locate jroc repo root starting from: "
-			IL_012f: ldloc.s 15
-			IL_0131: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0136: stloc.s 15
-			IL_0138: ldloc.s 15
-			IL_013a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_013f: stloc.s 4
-			IL_0141: ldloc.s 4
-			IL_0143: isinst [System.Runtime]System.Exception
-			IL_0148: dup
-			IL_0149: brtrue IL_0157
+			IL_0148: ldarg.2
+			IL_0149: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_014e: stloc.s 15
+			IL_0150: ldstr "Could not locate jroc repo root starting from: "
+			IL_0155: ldloc.s 15
+			IL_0157: call string [System.Runtime]System.String::Concat(string, string)
+			IL_015c: stloc.s 15
+			IL_015e: ldloc.s 15
+			IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0165: stloc.s 4
+			IL_0167: ldloc.s 4
+			IL_0169: isinst [System.Runtime]System.Exception
+			IL_016e: dup
+			IL_016f: brtrue IL_017d
 
-			IL_014e: pop
-			IL_014f: ldloc.s 4
-			IL_0151: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0156: throw
+			IL_0174: pop
+			IL_0175: ldloc.s 4
+			IL_0177: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_017c: throw
 
-			IL_0157: throw
+			IL_017d: throw
 
-			IL_0158: ldnull
-			IL_0159: ret
+			IL_017e: ldnull
+			IL_017f: ret
 		} // end of method findProjectRoot::__js_call__
 
 	} // end of class findProjectRoot
@@ -2990,7 +3100,7 @@
 			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0024: volatile.
-			IL_0026: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_0026: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 			IL_002b: brfalse IL_003f
 
 			IL_0030: ldstr "cwd"
@@ -2999,7 +3109,7 @@
 
 			IL_003f: ldstr "cwd"
 			IL_0044: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M11>:__js_call__:11"
-			IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0053: stloc.3
@@ -3030,7 +3140,7 @@
 			IL_009e: ldloc.0
 			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00a4: volatile.
-			IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
 			IL_00ab: brfalse IL_00bf
 
 			IL_00b0: ldstr "unref"
@@ -3039,7 +3149,7 @@
 
 			IL_00bf: ldstr "unref"
 			IL_00c4: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M11>:__js_call__:17"
-			IL_00c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_00c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
 			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_00d3: pop
@@ -3364,7 +3474,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2472 (0x9a8)
+			// Code size: 3308 (0xcec)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3403,7 +3513,7 @@
 			IL_0000: ldstr "process"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_000a: volatile.
-			IL_000c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_000c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
 			IL_0011: brfalse IL_0025
 
 			IL_0016: ldstr "argv"
@@ -3412,7 +3522,7 @@
 
 			IL_0025: ldstr "argv"
 			IL_002a: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:4"
-			IL_002f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_002f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
 			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0039: stloc.s 18
@@ -3451,7 +3561,7 @@
 			IL_00a3: stloc.0
 
 			IL_00a4: volatile.
-			IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
 			IL_00ab: brfalse IL_00c0
 
 			IL_00b0: ldloc.0
@@ -3462,7 +3572,7 @@
 			IL_00c0: ldloc.0
 			IL_00c1: ldstr "length"
 			IL_00c6: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:12"
-			IL_00cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_00cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
 			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00d5: stloc.s 18
@@ -3470,716 +3580,953 @@
 			IL_00d9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_00de: ldc.r8 2
 			IL_00e7: clt
-			IL_00e9: brfalse IL_01b1
+			IL_00e9: brfalse IL_02b6
 
 			IL_00ee: ldstr "console"
 			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fd: ldstr "error"
-			IL_0102: ldstr "Usage: node scripts/decompileGeneratorTest.js <Category> <TestName>"
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_010c: pop
-			IL_010d: ldstr "console"
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011c: ldstr "error"
-			IL_0121: ldstr ""
-			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_012b: pop
-			IL_012c: ldstr "console"
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013b: ldstr "error"
-			IL_0140: ldstr "Examples:"
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_014a: pop
-			IL_014b: ldstr "console"
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015a: ldstr "error"
-			IL_015f: ldstr "  node scripts/decompileGeneratorTest.js Async Async_HelloWorld"
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0169: pop
-			IL_016a: ldstr "console"
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0179: ldstr "error"
-			IL_017e: ldstr "  node scripts/decompileGeneratorTest.js Function Function_ReturnsStaticValueAndLogs"
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0188: pop
-			IL_0189: ldstr "process"
-			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0198: ldstr "exit"
-			IL_019d: ldc.r8 1
-			IL_01a6: box [System.Runtime]System.Double
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01b0: pop
+			IL_00fd: volatile.
+			IL_00ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_0104: brfalse IL_011d
 
-			IL_01b1: ldarg.0
-			IL_01b2: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::normalizeCategory
-			IL_01b7: ldc.i4.1
-			IL_01b8: newarr [System.Runtime]System.Object
-			IL_01bd: dup
-			IL_01be: ldc.i4.0
-			IL_01bf: ldarg.0
-			IL_01c0: stelem.ref
-			IL_01c1: stloc.s 19
-			IL_01c3: ldloc.0
-			IL_01c4: ldc.r8 0.0
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01d2: stloc.s 18
-			IL_01d4: ldloc.s 19
-			IL_01d6: ldloc.s 18
-			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01dd: stloc.1
-			IL_01de: ldloc.0
-			IL_01df: ldc.r8 1
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01ed: stloc.2
-			IL_01ee: ldarg.0
-			IL_01ef: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getGeneratorTestSnapshotPath
-			IL_01f4: ldc.i4.1
-			IL_01f5: newarr [System.Runtime]System.Object
-			IL_01fa: dup
-			IL_01fb: ldc.i4.0
-			IL_01fc: ldarg.0
-			IL_01fd: stelem.ref
-			IL_01fe: stloc.s 19
-			IL_0200: volatile.
-			IL_0202: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-			IL_0207: brfalse IL_021c
+			IL_0109: ldstr "error"
+			IL_010e: ldstr "Usage: node scripts/decompileGeneratorTest.js <Category> <TestName>"
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0118: br IL_0136
 
-			IL_020c: ldloc.1
-			IL_020d: ldstr "path"
-			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0217: br IL_0231
+			IL_011d: ldstr "error"
+			IL_0122: ldstr "Usage: node scripts/decompileGeneratorTest.js <Category> <TestName>"
+			IL_0127: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:22"
+			IL_012c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_021c: ldloc.1
-			IL_021d: ldstr "path"
-			IL_0222: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:70"
-			IL_0227: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0136: pop
+			IL_0137: ldstr "console"
+			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0146: volatile.
+			IL_0148: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_014d: brfalse IL_0166
 
-			IL_0231: stloc.s 18
-			IL_0233: ldloc.s 19
-			IL_0235: ldloc.s 18
-			IL_0237: ldloc.2
-			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_023d: stloc.3
-			IL_023e: ldarg.0
-			IL_023f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_0244: stloc.s 20
-			IL_0246: ldloc.s 20
-			IL_0248: ldloc.3
-			IL_0249: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_024e: box [System.Runtime]System.Boolean
-			IL_0253: stloc.s 18
-			IL_0255: ldloc.s 18
-			IL_0257: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_025c: ldc.i4.0
-			IL_025d: ceq
-			IL_025f: stloc.s 21
-			IL_0261: ldloc.s 21
-			IL_0263: brfalse IL_02e5
+			IL_0152: ldstr "error"
+			IL_0157: ldstr ""
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0161: br IL_017f
 
-			IL_0268: ldstr "console"
-			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0277: stloc.s 18
-			IL_0279: ldloc.3
-			IL_027a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_027f: stloc.s 22
-			IL_0281: ldstr "Generator test snapshot not found: "
-			IL_0286: ldloc.s 22
-			IL_0288: call string [System.Runtime]System.String::Concat(string, string)
-			IL_028d: stloc.s 22
-			IL_028f: ldloc.s 18
-			IL_0291: ldstr "error"
-			IL_0296: ldloc.s 22
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_029d: pop
-			IL_029e: ldstr "console"
-			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ad: ldstr "error"
-			IL_02b2: ldstr "Check the category and test name before running the helper."
-			IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02bc: pop
-			IL_02bd: ldstr "process"
-			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02cc: ldstr "exit"
-			IL_02d1: ldc.r8 1
-			IL_02da: box [System.Runtime]System.Double
-			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02e4: pop
+			IL_0166: ldstr "error"
+			IL_016b: ldstr ""
+			IL_0170: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:28"
+			IL_0175: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_02e5: volatile.
-			IL_02e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-			IL_02ec: brfalse IL_0301
+			IL_017f: pop
+			IL_0180: ldstr "console"
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018f: volatile.
+			IL_0191: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_0196: brfalse IL_01af
 
-			IL_02f1: ldloc.1
-			IL_02f2: ldstr "namespace"
-			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02fc: br IL_0316
+			IL_019b: ldstr "error"
+			IL_01a0: ldstr "Examples:"
+			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01aa: br IL_01c8
 
-			IL_0301: ldloc.1
-			IL_0302: ldstr "namespace"
-			IL_0307: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:103"
-			IL_030c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01af: ldstr "error"
+			IL_01b4: ldstr "Examples:"
+			IL_01b9: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:34"
+			IL_01be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0316: stloc.s 18
-			IL_0318: ldloc.s 18
-			IL_031a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_031f: stloc.s 22
-			IL_0321: ldstr "Jroc.Tests."
-			IL_0326: ldloc.s 22
-			IL_0328: call string [System.Runtime]System.String::Concat(string, string)
-			IL_032d: ldstr ".GeneratorTests."
-			IL_0332: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0337: ldloc.2
-			IL_0338: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_033d: stloc.s 22
-			IL_033f: ldloc.s 22
-			IL_0341: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0346: stloc.s 4
-			IL_0348: ldarg.0
-			IL_0349: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_034e: stloc.s 23
-			IL_0350: ldarg.0
-			IL_0351: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0356: stloc.s 18
-			IL_0358: ldloc.s 23
-			IL_035a: ldc.i4.4
-			IL_035b: newarr [System.Runtime]System.Object
-			IL_0360: dup
+			IL_01c8: pop
+			IL_01c9: ldstr "console"
+			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d8: volatile.
+			IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_01df: brfalse IL_01f8
+
+			IL_01e4: ldstr "error"
+			IL_01e9: ldstr "  node scripts/decompileGeneratorTest.js Async Async_HelloWorld"
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01f3: br IL_0211
+
+			IL_01f8: ldstr "error"
+			IL_01fd: ldstr "  node scripts/decompileGeneratorTest.js Async Async_HelloWorld"
+			IL_0202: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:40"
+			IL_0207: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0211: pop
+			IL_0212: ldstr "console"
+			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0221: volatile.
+			IL_0223: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_0228: brfalse IL_0241
+
+			IL_022d: ldstr "error"
+			IL_0232: ldstr "  node scripts/decompileGeneratorTest.js Function Function_ReturnsStaticValueAndLogs"
+			IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_023c: br IL_025a
+
+			IL_0241: ldstr "error"
+			IL_0246: ldstr "  node scripts/decompileGeneratorTest.js Function Function_ReturnsStaticValueAndLogs"
+			IL_024b: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:46"
+			IL_0250: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_025a: pop
+			IL_025b: ldstr "process"
+			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_026a: volatile.
+			IL_026c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0271: brfalse IL_0293
+
+			IL_0276: ldstr "exit"
+			IL_027b: ldc.r8 1
+			IL_0284: box [System.Runtime]System.Double
+			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_028e: br IL_02b5
+
+			IL_0293: ldstr "exit"
+			IL_0298: ldc.r8 1
+			IL_02a1: box [System.Runtime]System.Double
+			IL_02a6: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:53"
+			IL_02ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_02b5: pop
+
+			IL_02b6: ldarg.0
+			IL_02b7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::normalizeCategory
+			IL_02bc: ldc.i4.1
+			IL_02bd: newarr [System.Runtime]System.Object
+			IL_02c2: dup
+			IL_02c3: ldc.i4.0
+			IL_02c4: ldarg.0
+			IL_02c5: stelem.ref
+			IL_02c6: stloc.s 19
+			IL_02c8: ldloc.0
+			IL_02c9: ldc.r8 0.0
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02d7: stloc.s 18
+			IL_02d9: ldloc.s 19
+			IL_02db: ldloc.s 18
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_02e2: stloc.1
+			IL_02e3: ldloc.0
+			IL_02e4: ldc.r8 1
+			IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02f2: stloc.2
+			IL_02f3: ldarg.0
+			IL_02f4: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getGeneratorTestSnapshotPath
+			IL_02f9: ldc.i4.1
+			IL_02fa: newarr [System.Runtime]System.Object
+			IL_02ff: dup
+			IL_0300: ldc.i4.0
+			IL_0301: ldarg.0
+			IL_0302: stelem.ref
+			IL_0303: stloc.s 19
+			IL_0305: volatile.
+			IL_0307: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_030c: brfalse IL_0321
+
+			IL_0311: ldloc.1
+			IL_0312: ldstr "path"
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_031c: br IL_0336
+
+			IL_0321: ldloc.1
+			IL_0322: ldstr "path"
+			IL_0327: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:70"
+			IL_032c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0336: stloc.s 18
+			IL_0338: ldloc.s 19
+			IL_033a: ldloc.s 18
+			IL_033c: ldloc.2
+			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0342: stloc.3
+			IL_0343: ldarg.0
+			IL_0344: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_0349: stloc.s 20
+			IL_034b: ldloc.s 20
+			IL_034d: ldloc.3
+			IL_034e: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_0353: box [System.Runtime]System.Boolean
+			IL_0358: stloc.s 18
+			IL_035a: ldloc.s 18
+			IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_0361: ldc.i4.0
-			IL_0362: ldloc.s 18
-			IL_0364: stelem.ref
-			IL_0365: dup
-			IL_0366: ldc.i4.1
-			IL_0367: ldstr "tests"
-			IL_036c: stelem.ref
-			IL_036d: dup
-			IL_036e: ldc.i4.2
-			IL_036f: ldstr "Jroc.Tests"
-			IL_0374: stelem.ref
-			IL_0375: dup
-			IL_0376: ldc.i4.3
-			IL_0377: ldstr "Jroc.Tests.csproj"
-			IL_037c: stelem.ref
-			IL_037d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0382: stloc.s 5
-			IL_0384: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0389: stloc.s 24
-			IL_038b: ldloc.s 4
-			IL_038d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0362: ceq
+			IL_0364: stloc.s 21
+			IL_0366: ldloc.s 21
+			IL_0368: brfalse IL_0470
+
+			IL_036d: ldstr "console"
+			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_037c: stloc.s 18
+			IL_037e: ldloc.3
+			IL_037f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0384: stloc.s 22
+			IL_0386: ldstr "Generator test snapshot not found: "
+			IL_038b: ldloc.s 22
+			IL_038d: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0392: stloc.s 22
-			IL_0394: ldstr "Running test: "
-			IL_0399: ldloc.s 22
-			IL_039b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03a0: stloc.s 22
-			IL_03a2: ldloc.s 24
-			IL_03a4: ldloc.s 22
-			IL_03a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03ab: pop
-			IL_03ac: ldstr "process"
-			IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03b6: volatile.
-			IL_03b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-			IL_03bd: brfalse IL_03d1
+			IL_0394: volatile.
+			IL_0396: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_039b: brfalse IL_03b3
 
-			IL_03c2: ldstr "env"
-			IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03cc: br IL_03e5
+			IL_03a0: ldloc.s 18
+			IL_03a2: ldstr "error"
+			IL_03a7: ldloc.s 22
+			IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03ae: br IL_03cb
 
-			IL_03d1: ldstr "env"
-			IL_03d6: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:129"
-			IL_03db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03b3: ldloc.s 18
+			IL_03b5: ldstr "error"
+			IL_03ba: ldloc.s 22
+			IL_03bc: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:85"
+			IL_03c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_03e5: stloc.s 18
-			IL_03e7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03ec: stloc.s 25
-			IL_03ee: ldloc.s 25
-			IL_03f0: ldloc.s 18
-			IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
-			IL_03f7: pop
-			IL_03f8: ldloc.s 25
-			IL_03fa: ldstr "JROC_WRITE_TEST_ARTIFACTS"
-			IL_03ff: ldstr "1"
-			IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0409: pop
-			IL_040a: ldloc.s 25
-			IL_040c: stloc.s 6
-			IL_040e: ldarg.0
-			IL_040f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0414: stloc.s 26
-			IL_0416: ldloc.s 4
-			IL_0418: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_041d: stloc.s 22
-			IL_041f: ldstr "FullyQualifiedName="
-			IL_0424: ldloc.s 22
-			IL_0426: call string [System.Runtime]System.String::Concat(string, string)
-			IL_042b: stloc.s 22
-			IL_042d: ldc.i4.5
-			IL_042e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0433: dup
-			IL_0434: ldstr "test"
-			IL_0439: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_043e: dup
-			IL_043f: ldloc.s 5
-			IL_0441: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0446: dup
-			IL_0447: ldstr "--filter"
-			IL_044c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0451: dup
-			IL_0452: ldloc.s 22
-			IL_0454: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0459: dup
-			IL_045a: ldstr "--no-build"
-			IL_045f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0464: stloc.s 27
-			IL_0466: ldarg.0
-			IL_0467: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_046c: stloc.s 18
-			IL_046e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0473: dup
-			IL_0474: ldstr "stdio"
-			IL_0479: ldstr "inherit"
-			IL_047e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0483: dup
-			IL_0484: ldstr "shell"
-			IL_0489: ldc.i4.1
-			IL_048a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_048f: dup
-			IL_0490: ldstr "cwd"
-			IL_0495: ldloc.s 18
-			IL_0497: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_049c: dup
-			IL_049d: ldstr "env"
-			IL_04a2: ldloc.s 6
-			IL_04a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04a9: stloc.s 25
-			IL_04ab: ldloc.s 26
-			IL_04ad: ldstr "dotnet"
-			IL_04b2: ldloc.s 27
-			IL_04b4: ldloc.s 25
-			IL_04b6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_04bb: stloc.s 7
-			IL_04bd: ldarg.0
-			IL_04be: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
-			IL_04c3: ldc.i4.1
-			IL_04c4: newarr [System.Runtime]System.Object
-			IL_04c9: dup
-			IL_04ca: ldc.i4.0
-			IL_04cb: ldarg.0
-			IL_04cc: stelem.ref
-			IL_04cd: ldloc.2
-			IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_04d3: stloc.s 8
-			IL_04d5: volatile.
-			IL_04d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-			IL_04dc: brfalse IL_04f2
+			IL_03cb: pop
+			IL_03cc: ldstr "console"
+			IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03db: volatile.
+			IL_03dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_03e2: brfalse IL_03fb
 
-			IL_04e1: ldloc.s 7
-			IL_04e3: ldstr "status"
-			IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04ed: br IL_0508
+			IL_03e7: ldstr "error"
+			IL_03ec: ldstr "Check the category and test name before running the helper."
+			IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03f6: br IL_0414
 
-			IL_04f2: ldloc.s 7
-			IL_04f4: ldstr "status"
-			IL_04f9: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:159"
-			IL_04fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-			IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03fb: ldstr "error"
+			IL_0400: ldstr "Check the category and test name before running the helper."
+			IL_0405: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:91"
+			IL_040a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0508: stloc.s 18
-			IL_050a: ldloc.s 18
-			IL_050c: ldc.r8 0.0
-			IL_0515: box [System.Runtime]System.Double
-			IL_051a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_051f: stloc.s 21
-			IL_0521: ldloc.s 21
-			IL_0523: brfalse IL_054b
+			IL_0414: pop
+			IL_0415: ldstr "process"
+			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0424: volatile.
+			IL_0426: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_042b: brfalse IL_044d
 
-			IL_0528: ldarg.0
-			IL_0529: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_052e: ldc.i4.1
-			IL_052f: newarr [System.Runtime]System.Object
-			IL_0534: dup
-			IL_0535: ldc.i4.0
-			IL_0536: ldarg.0
-			IL_0537: stelem.ref
-			IL_0538: ldloc.1
-			IL_0539: ldloc.s 8
-			IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0540: stloc.s 18
-			IL_0542: ldloc.s 18
-			IL_0544: stloc.s 9
-			IL_0546: br IL_0553
+			IL_0430: ldstr "exit"
+			IL_0435: ldc.r8 1
+			IL_043e: box [System.Runtime]System.Double
+			IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0448: br IL_046f
 
-			IL_054b: ldc.i4.0
-			IL_054c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0551: stloc.s 9
+			IL_044d: ldstr "exit"
+			IL_0452: ldc.r8 1
+			IL_045b: box [System.Runtime]System.Double
+			IL_0460: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:98"
+			IL_0465: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0553: ldloc.s 9
-			IL_0555: stloc.s 10
-			IL_0557: ldloc.s 10
-			IL_0559: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_055e: ldc.i4.0
-			IL_055f: ceq
-			IL_0561: stloc.s 21
-			IL_0563: ldloc.s 21
-			IL_0565: brfalse IL_06fc
+			IL_046f: pop
 
-			IL_056a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_056f: stloc.s 24
-			IL_0571: ldloc.s 24
-			IL_0573: ldstr "Test did not produce an assembly, retrying with build..."
-			IL_0578: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_057d: pop
-			IL_057e: ldarg.0
-			IL_057f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0584: stloc.s 26
-			IL_0586: ldloc.s 4
-			IL_0588: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_058d: stloc.s 22
-			IL_058f: ldstr "FullyQualifiedName="
-			IL_0594: ldloc.s 22
-			IL_0596: call string [System.Runtime]System.String::Concat(string, string)
-			IL_059b: stloc.s 22
-			IL_059d: ldc.i4.4
-			IL_059e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_05a3: dup
-			IL_05a4: ldstr "test"
-			IL_05a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05ae: dup
-			IL_05af: ldloc.s 5
-			IL_05b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05b6: dup
-			IL_05b7: ldstr "--filter"
-			IL_05bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05c1: dup
-			IL_05c2: ldloc.s 22
+			IL_0470: volatile.
+			IL_0472: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0477: brfalse IL_048c
+
+			IL_047c: ldloc.1
+			IL_047d: ldstr "namespace"
+			IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0487: br IL_04a1
+
+			IL_048c: ldloc.1
+			IL_048d: ldstr "namespace"
+			IL_0492: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:103"
+			IL_0497: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_04a1: stloc.s 18
+			IL_04a3: ldloc.s 18
+			IL_04a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04aa: stloc.s 22
+			IL_04ac: ldstr "Jroc.Tests."
+			IL_04b1: ldloc.s 22
+			IL_04b3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04b8: ldstr ".GeneratorTests."
+			IL_04bd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04c2: ldloc.2
+			IL_04c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04c8: stloc.s 22
+			IL_04ca: ldloc.s 22
+			IL_04cc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04d1: stloc.s 4
+			IL_04d3: ldarg.0
+			IL_04d4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_04d9: stloc.s 23
+			IL_04db: ldarg.0
+			IL_04dc: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_04e1: stloc.s 18
+			IL_04e3: ldloc.s 23
+			IL_04e5: ldc.i4.4
+			IL_04e6: newarr [System.Runtime]System.Object
+			IL_04eb: dup
+			IL_04ec: ldc.i4.0
+			IL_04ed: ldloc.s 18
+			IL_04ef: stelem.ref
+			IL_04f0: dup
+			IL_04f1: ldc.i4.1
+			IL_04f2: ldstr "tests"
+			IL_04f7: stelem.ref
+			IL_04f8: dup
+			IL_04f9: ldc.i4.2
+			IL_04fa: ldstr "Jroc.Tests"
+			IL_04ff: stelem.ref
+			IL_0500: dup
+			IL_0501: ldc.i4.3
+			IL_0502: ldstr "Jroc.Tests.csproj"
+			IL_0507: stelem.ref
+			IL_0508: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_050d: stloc.s 5
+			IL_050f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0514: stloc.s 24
+			IL_0516: ldloc.s 4
+			IL_0518: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_051d: stloc.s 22
+			IL_051f: ldstr "Running test: "
+			IL_0524: ldloc.s 22
+			IL_0526: call string [System.Runtime]System.String::Concat(string, string)
+			IL_052b: stloc.s 22
+			IL_052d: ldloc.s 24
+			IL_052f: ldloc.s 22
+			IL_0531: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0536: pop
+			IL_0537: ldstr "process"
+			IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0541: volatile.
+			IL_0543: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_0548: brfalse IL_055c
+
+			IL_054d: ldstr "env"
+			IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0557: br IL_0570
+
+			IL_055c: ldstr "env"
+			IL_0561: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:129"
+			IL_0566: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0570: stloc.s 18
+			IL_0572: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0577: stloc.s 25
+			IL_0579: ldloc.s 25
+			IL_057b: ldloc.s 18
+			IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
+			IL_0582: pop
+			IL_0583: ldloc.s 25
+			IL_0585: ldstr "JROC_WRITE_TEST_ARTIFACTS"
+			IL_058a: ldstr "1"
+			IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0594: pop
+			IL_0595: ldloc.s 25
+			IL_0597: stloc.s 6
+			IL_0599: ldarg.0
+			IL_059a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_059f: stloc.s 26
+			IL_05a1: ldloc.s 4
+			IL_05a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05a8: stloc.s 22
+			IL_05aa: ldstr "FullyQualifiedName="
+			IL_05af: ldloc.s 22
+			IL_05b1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05b6: stloc.s 22
+			IL_05b8: ldc.i4.5
+			IL_05b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_05be: dup
+			IL_05bf: ldstr "test"
 			IL_05c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05c9: stloc.s 27
-			IL_05cb: ldarg.0
-			IL_05cc: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_05d1: stloc.s 18
-			IL_05d3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05d8: dup
-			IL_05d9: ldstr "stdio"
-			IL_05de: ldstr "inherit"
-			IL_05e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05e8: dup
-			IL_05e9: ldstr "shell"
-			IL_05ee: ldc.i4.1
-			IL_05ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05f4: dup
-			IL_05f5: ldstr "cwd"
-			IL_05fa: ldloc.s 18
-			IL_05fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0601: dup
-			IL_0602: ldstr "env"
-			IL_0607: ldloc.s 6
+			IL_05c9: dup
+			IL_05ca: ldloc.s 5
+			IL_05cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05d1: dup
+			IL_05d2: ldstr "--filter"
+			IL_05d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05dc: dup
+			IL_05dd: ldloc.s 22
+			IL_05df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05e4: dup
+			IL_05e5: ldstr "--no-build"
+			IL_05ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05ef: stloc.s 27
+			IL_05f1: ldarg.0
+			IL_05f2: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_05f7: stloc.s 18
+			IL_05f9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05fe: dup
+			IL_05ff: ldstr "stdio"
+			IL_0604: ldstr "inherit"
 			IL_0609: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_060e: stloc.s 25
-			IL_0610: ldloc.s 26
-			IL_0612: ldstr "dotnet"
-			IL_0617: ldloc.s 27
-			IL_0619: ldloc.s 25
-			IL_061b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_0620: stloc.s 11
-			IL_0622: volatile.
-			IL_0624: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_0629: brfalse IL_063f
+			IL_060e: dup
+			IL_060f: ldstr "shell"
+			IL_0614: ldc.i4.1
+			IL_0615: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_061a: dup
+			IL_061b: ldstr "cwd"
+			IL_0620: ldloc.s 18
+			IL_0622: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0627: dup
+			IL_0628: ldstr "env"
+			IL_062d: ldloc.s 6
+			IL_062f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0634: stloc.s 25
+			IL_0636: ldloc.s 26
+			IL_0638: ldstr "dotnet"
+			IL_063d: ldloc.s 27
+			IL_063f: ldloc.s 25
+			IL_0641: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_0646: stloc.s 7
+			IL_0648: ldarg.0
+			IL_0649: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
+			IL_064e: ldc.i4.1
+			IL_064f: newarr [System.Runtime]System.Object
+			IL_0654: dup
+			IL_0655: ldc.i4.0
+			IL_0656: ldarg.0
+			IL_0657: stelem.ref
+			IL_0658: ldloc.2
+			IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_065e: stloc.s 8
+			IL_0660: volatile.
+			IL_0662: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_0667: brfalse IL_067d
 
-			IL_062e: ldloc.s 11
-			IL_0630: ldstr "status"
-			IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_063a: br IL_0655
+			IL_066c: ldloc.s 7
+			IL_066e: ldstr "status"
+			IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0678: br IL_0693
 
-			IL_063f: ldloc.s 11
-			IL_0641: ldstr "status"
-			IL_0646: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:199"
-			IL_064b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_067d: ldloc.s 7
+			IL_067f: ldstr "status"
+			IL_0684: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:159"
+			IL_0689: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_068e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0655: stloc.s 18
-			IL_0657: ldloc.s 18
-			IL_0659: ldc.r8 0.0
-			IL_0662: box [System.Runtime]System.Double
-			IL_0667: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_066c: stloc.s 21
-			IL_066e: ldloc.s 21
-			IL_0670: brfalse IL_06de
+			IL_0693: stloc.s 18
+			IL_0695: ldloc.s 18
+			IL_0697: ldc.r8 0.0
+			IL_06a0: box [System.Runtime]System.Double
+			IL_06a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_06aa: stloc.s 21
+			IL_06ac: ldloc.s 21
+			IL_06ae: brfalse IL_06d6
 
-			IL_0675: ldstr "console"
-			IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0684: stloc.s 18
-			IL_0686: ldloc.s 4
-			IL_0688: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_068d: stloc.s 22
-			IL_068f: ldstr "Test "
-			IL_0694: ldloc.s 22
-			IL_0696: call string [System.Runtime]System.String::Concat(string, string)
-			IL_069b: ldstr " failed or not found."
-			IL_06a0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06a5: stloc.s 22
-			IL_06a7: ldloc.s 18
-			IL_06a9: ldstr "error"
-			IL_06ae: ldloc.s 22
-			IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06b5: pop
-			IL_06b6: ldstr "process"
-			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06c5: ldstr "exit"
-			IL_06ca: ldc.r8 1
-			IL_06d3: box [System.Runtime]System.Double
-			IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06dd: pop
+			IL_06b3: ldarg.0
+			IL_06b4: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_06b9: ldc.i4.1
+			IL_06ba: newarr [System.Runtime]System.Object
+			IL_06bf: dup
+			IL_06c0: ldc.i4.0
+			IL_06c1: ldarg.0
+			IL_06c2: stelem.ref
+			IL_06c3: ldloc.1
+			IL_06c4: ldloc.s 8
+			IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_06cb: stloc.s 18
+			IL_06cd: ldloc.s 18
+			IL_06cf: stloc.s 9
+			IL_06d1: br IL_06de
 
-			IL_06de: ldarg.0
-			IL_06df: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_06e4: ldc.i4.1
-			IL_06e5: newarr [System.Runtime]System.Object
-			IL_06ea: dup
-			IL_06eb: ldc.i4.0
-			IL_06ec: ldarg.0
-			IL_06ed: stelem.ref
-			IL_06ee: ldloc.1
-			IL_06ef: ldloc.s 8
-			IL_06f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06f6: stloc.s 18
-			IL_06f8: ldloc.s 18
-			IL_06fa: stloc.s 10
+			IL_06d6: ldc.i4.0
+			IL_06d7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_06dc: stloc.s 9
 
-			IL_06fc: ldloc.s 10
-			IL_06fe: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0703: ldc.i4.0
-			IL_0704: ceq
-			IL_0706: stloc.s 21
-			IL_0708: ldloc.s 21
-			IL_070a: brfalse IL_0896
+			IL_06de: ldloc.s 9
+			IL_06e0: stloc.s 10
+			IL_06e2: ldloc.s 10
+			IL_06e4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06e9: ldc.i4.0
+			IL_06ea: ceq
+			IL_06ec: stloc.s 21
+			IL_06ee: ldloc.s 21
+			IL_06f0: brfalse IL_08e3
 
-			IL_070f: ldstr "console"
-			IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_071e: stloc.s 18
-			IL_0720: volatile.
-			IL_0722: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-			IL_0727: brfalse IL_073c
+			IL_06f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06fa: stloc.s 24
+			IL_06fc: ldloc.s 24
+			IL_06fe: ldstr "Test did not produce an assembly, retrying with build..."
+			IL_0703: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0708: pop
+			IL_0709: ldarg.0
+			IL_070a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_070f: stloc.s 26
+			IL_0711: ldloc.s 4
+			IL_0713: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0718: stloc.s 22
+			IL_071a: ldstr "FullyQualifiedName="
+			IL_071f: ldloc.s 22
+			IL_0721: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0726: stloc.s 22
+			IL_0728: ldc.i4.4
+			IL_0729: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_072e: dup
+			IL_072f: ldstr "test"
+			IL_0734: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0739: dup
+			IL_073a: ldloc.s 5
+			IL_073c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0741: dup
+			IL_0742: ldstr "--filter"
+			IL_0747: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_074c: dup
+			IL_074d: ldloc.s 22
+			IL_074f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0754: stloc.s 27
+			IL_0756: ldarg.0
+			IL_0757: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_075c: stloc.s 18
+			IL_075e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0763: dup
+			IL_0764: ldstr "stdio"
+			IL_0769: ldstr "inherit"
+			IL_076e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0773: dup
+			IL_0774: ldstr "shell"
+			IL_0779: ldc.i4.1
+			IL_077a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_077f: dup
+			IL_0780: ldstr "cwd"
+			IL_0785: ldloc.s 18
+			IL_0787: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_078c: dup
+			IL_078d: ldstr "env"
+			IL_0792: ldloc.s 6
+			IL_0794: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0799: stloc.s 25
+			IL_079b: ldloc.s 26
+			IL_079d: ldstr "dotnet"
+			IL_07a2: ldloc.s 27
+			IL_07a4: ldloc.s 25
+			IL_07a6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_07ab: stloc.s 11
+			IL_07ad: volatile.
+			IL_07af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_07b4: brfalse IL_07ca
 
-			IL_072c: ldloc.1
-			IL_072d: ldstr "path"
-			IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0737: br IL_0751
+			IL_07b9: ldloc.s 11
+			IL_07bb: ldstr "status"
+			IL_07c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07c5: br IL_07e0
 
-			IL_073c: ldloc.1
-			IL_073d: ldstr "path"
-			IL_0742: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:238"
-			IL_0747: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-			IL_074c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07ca: ldloc.s 11
+			IL_07cc: ldstr "status"
+			IL_07d1: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:199"
+			IL_07d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_07db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0751: stloc.s 28
-			IL_0753: ldloc.s 28
-			IL_0755: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_075a: stloc.s 22
-			IL_075c: ldstr "Assembly not found for category '"
-			IL_0761: ldloc.s 22
-			IL_0763: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0768: ldstr "' and test '"
-			IL_076d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0772: ldloc.2
-			IL_0773: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0778: stloc.s 22
-			IL_077a: ldloc.s 22
-			IL_077c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0781: ldstr "'."
-			IL_0786: call string [System.Runtime]System.String::Concat(string, string)
-			IL_078b: stloc.s 22
-			IL_078d: ldloc.s 18
-			IL_078f: ldstr "error"
-			IL_0794: ldloc.s 22
-			IL_0796: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_079b: pop
-			IL_079c: ldstr "console"
-			IL_07a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07ab: ldstr "error"
-			IL_07b0: ldstr "Looked under:"
-			IL_07b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07ba: pop
-			IL_07bb: ldarg.0
-			IL_07bc: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_07c1: ldc.i4.1
-			IL_07c2: newarr [System.Runtime]System.Object
-			IL_07c7: dup
-			IL_07c8: ldc.i4.0
-			IL_07c9: ldarg.0
-			IL_07ca: stelem.ref
-			IL_07cb: ldloc.1
-			IL_07cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_07d1: stloc.s 12
-			IL_07d3: ldc.r8 0.0
-			IL_07dc: stloc.s 13
-			// loop start (head: IL_07de)
-				IL_07de: ldloc.s 13
-				IL_07e0: stloc.s 29
-				IL_07e2: ldloc.s 12
-				IL_07e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-				IL_07e9: stloc.s 30
-				IL_07eb: ldloc.s 29
-				IL_07ed: ldloc.s 30
-				IL_07ef: clt
-				IL_07f1: brfalse IL_084f
+			IL_07e0: stloc.s 18
+			IL_07e2: ldloc.s 18
+			IL_07e4: ldc.r8 0.0
+			IL_07ed: box [System.Runtime]System.Double
+			IL_07f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_07f7: stloc.s 21
+			IL_07f9: ldloc.s 21
+			IL_07fb: brfalse IL_08c5
 
-				IL_07f6: ldstr "console"
-				IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0800: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0805: stloc.s 18
-				IL_0807: ldloc.s 12
-				IL_0809: ldloc.s 13
-				IL_080b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0810: stloc.s 28
-				IL_0812: ldloc.s 28
-				IL_0814: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0819: stloc.s 22
-				IL_081b: ldstr "  - "
-				IL_0820: ldloc.s 22
-				IL_0822: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0827: stloc.s 22
-				IL_0829: ldloc.s 18
-				IL_082b: ldstr "error"
-				IL_0830: ldloc.s 22
-				IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0837: pop
-				IL_0838: ldloc.s 13
-				IL_083a: ldc.r8 1
-				IL_0843: add
-				IL_0844: stloc.s 30
-				IL_0846: ldloc.s 30
-				IL_0848: stloc.s 13
-				IL_084a: br IL_07de
+			IL_0800: ldstr "console"
+			IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_080a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_080f: stloc.s 18
+			IL_0811: ldloc.s 4
+			IL_0813: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0818: stloc.s 22
+			IL_081a: ldstr "Test "
+			IL_081f: ldloc.s 22
+			IL_0821: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0826: ldstr " failed or not found."
+			IL_082b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0830: stloc.s 22
+			IL_0832: volatile.
+			IL_0834: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0839: brfalse IL_0851
+
+			IL_083e: ldloc.s 18
+			IL_0840: ldstr "error"
+			IL_0845: ldloc.s 22
+			IL_0847: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_084c: br IL_0869
+
+			IL_0851: ldloc.s 18
+			IL_0853: ldstr "error"
+			IL_0858: ldloc.s 22
+			IL_085a: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:213"
+			IL_085f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0869: pop
+			IL_086a: ldstr "process"
+			IL_086f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0874: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0879: volatile.
+			IL_087b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0880: brfalse IL_08a2
+
+			IL_0885: ldstr "exit"
+			IL_088a: ldc.r8 1
+			IL_0893: box [System.Runtime]System.Double
+			IL_0898: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_089d: br IL_08c4
+
+			IL_08a2: ldstr "exit"
+			IL_08a7: ldc.r8 1
+			IL_08b0: box [System.Runtime]System.Double
+			IL_08b5: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:220"
+			IL_08ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_08bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_08c4: pop
+
+			IL_08c5: ldarg.0
+			IL_08c6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_08cb: ldc.i4.1
+			IL_08cc: newarr [System.Runtime]System.Object
+			IL_08d1: dup
+			IL_08d2: ldc.i4.0
+			IL_08d3: ldarg.0
+			IL_08d4: stelem.ref
+			IL_08d5: ldloc.1
+			IL_08d6: ldloc.s 8
+			IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_08dd: stloc.s 18
+			IL_08df: ldloc.s 18
+			IL_08e1: stloc.s 10
+
+			IL_08e3: ldloc.s 10
+			IL_08e5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08ea: ldc.i4.0
+			IL_08eb: ceq
+			IL_08ed: stloc.s 21
+			IL_08ef: ldloc.s 21
+			IL_08f1: brfalse IL_0b56
+
+			IL_08f6: ldstr "console"
+			IL_08fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0900: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0905: stloc.s 18
+			IL_0907: volatile.
+			IL_0909: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_090e: brfalse IL_0923
+
+			IL_0913: ldloc.1
+			IL_0914: ldstr "path"
+			IL_0919: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_091e: br IL_0938
+
+			IL_0923: ldloc.1
+			IL_0924: ldstr "path"
+			IL_0929: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:238"
+			IL_092e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0933: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0938: stloc.s 28
+			IL_093a: ldloc.s 28
+			IL_093c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0941: stloc.s 22
+			IL_0943: ldstr "Assembly not found for category '"
+			IL_0948: ldloc.s 22
+			IL_094a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_094f: ldstr "' and test '"
+			IL_0954: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0959: ldloc.2
+			IL_095a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_095f: stloc.s 22
+			IL_0961: ldloc.s 22
+			IL_0963: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0968: ldstr "'."
+			IL_096d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0972: stloc.s 22
+			IL_0974: volatile.
+			IL_0976: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_097b: brfalse IL_0993
+
+			IL_0980: ldloc.s 18
+			IL_0982: ldstr "error"
+			IL_0987: ldloc.s 22
+			IL_0989: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_098e: br IL_09ab
+
+			IL_0993: ldloc.s 18
+			IL_0995: ldstr "error"
+			IL_099a: ldloc.s 22
+			IL_099c: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:247"
+			IL_09a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_09a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_09ab: pop
+			IL_09ac: ldstr "console"
+			IL_09b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_09b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09bb: volatile.
+			IL_09bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_09c2: brfalse IL_09db
+
+			IL_09c7: ldstr "error"
+			IL_09cc: ldstr "Looked under:"
+			IL_09d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09d6: br IL_09f4
+
+			IL_09db: ldstr "error"
+			IL_09e0: ldstr "Looked under:"
+			IL_09e5: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:253"
+			IL_09ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_09ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_09f4: pop
+			IL_09f5: ldarg.0
+			IL_09f6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_09fb: ldc.i4.1
+			IL_09fc: newarr [System.Runtime]System.Object
+			IL_0a01: dup
+			IL_0a02: ldc.i4.0
+			IL_0a03: ldarg.0
+			IL_0a04: stelem.ref
+			IL_0a05: ldloc.1
+			IL_0a06: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0a0b: stloc.s 12
+			IL_0a0d: ldc.r8 0.0
+			IL_0a16: stloc.s 13
+			// loop start (head: IL_0a18)
+				IL_0a18: ldloc.s 13
+				IL_0a1a: stloc.s 29
+				IL_0a1c: ldloc.s 12
+				IL_0a1e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
+				IL_0a23: stloc.s 30
+				IL_0a25: ldloc.s 29
+				IL_0a27: ldloc.s 30
+				IL_0a29: clt
+				IL_0a2b: brfalse IL_0ab2
+
+				IL_0a30: ldstr "console"
+				IL_0a35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0a3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0a3f: stloc.s 18
+				IL_0a41: ldloc.s 12
+				IL_0a43: ldloc.s 13
+				IL_0a45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0a4a: stloc.s 28
+				IL_0a4c: ldloc.s 28
+				IL_0a4e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0a53: stloc.s 22
+				IL_0a55: ldstr "  - "
+				IL_0a5a: ldloc.s 22
+				IL_0a5c: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0a61: stloc.s 22
+				IL_0a63: volatile.
+				IL_0a65: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+				IL_0a6a: brfalse IL_0a82
+
+				IL_0a6f: ldloc.s 18
+				IL_0a71: ldstr "error"
+				IL_0a76: ldloc.s 22
+				IL_0a78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0a7d: br IL_0a9a
+
+				IL_0a82: ldloc.s 18
+				IL_0a84: ldstr "error"
+				IL_0a89: ldloc.s 22
+				IL_0a8b: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:275"
+				IL_0a90: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+				IL_0a95: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0a9a: pop
+				IL_0a9b: ldloc.s 13
+				IL_0a9d: ldc.r8 1
+				IL_0aa6: add
+				IL_0aa7: stloc.s 30
+				IL_0aa9: ldloc.s 30
+				IL_0aab: stloc.s 13
+				IL_0aad: br IL_0a18
 			// end loop
 
-			IL_084f: ldstr "console"
-			IL_0854: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0859: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_085e: ldstr "error"
-			IL_0863: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_086d: pop
-			IL_086e: ldstr "process"
-			IL_0873: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0878: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_087d: ldstr "exit"
-			IL_0882: ldc.r8 1
-			IL_088b: box [System.Runtime]System.Double
-			IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0895: pop
+			IL_0ab2: ldstr "console"
+			IL_0ab7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0abc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ac1: volatile.
+			IL_0ac3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_0ac8: brfalse IL_0ae1
 
-			IL_0896: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_089b: stloc.s 24
-			IL_089d: ldloc.s 10
-			IL_089f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08a4: stloc.s 22
-			IL_08a6: ldstr "Found assembly: "
-			IL_08ab: ldloc.s 22
-			IL_08ad: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08b2: stloc.s 22
-			IL_08b4: ldloc.s 24
-			IL_08b6: ldloc.s 22
-			IL_08b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08bd: pop
+			IL_0acd: ldstr "error"
+			IL_0ad2: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_0ad7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0adc: br IL_0afa
+
+			IL_0ae1: ldstr "error"
+			IL_0ae6: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_0aeb: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:288"
+			IL_0af0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_0af5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0afa: pop
+			IL_0afb: ldstr "process"
+			IL_0b00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b0a: volatile.
+			IL_0b0c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0b11: brfalse IL_0b33
+
+			IL_0b16: ldstr "exit"
+			IL_0b1b: ldc.r8 1
+			IL_0b24: box [System.Runtime]System.Double
+			IL_0b29: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0b2e: br IL_0b55
+
+			IL_0b33: ldstr "exit"
+			IL_0b38: ldc.r8 1
+			IL_0b41: box [System.Runtime]System.Double
+			IL_0b46: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:295"
+			IL_0b4b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0b50: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0b55: pop
+
+			IL_0b56: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b5b: stloc.s 24
+			IL_0b5d: ldloc.s 10
+			IL_0b5f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b64: stloc.s 22
+			IL_0b66: ldstr "Found assembly: "
+			IL_0b6b: ldloc.s 22
+			IL_0b6d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b72: stloc.s 22
+			IL_0b74: ldloc.s 24
+			IL_0b76: ldloc.s 22
+			IL_0b78: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b7d: pop
 			.try
 			{
-				IL_08be: nop
-				IL_08bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_08c4: stloc.s 24
-				IL_08c6: ldloc.s 24
-				IL_08c8: ldstr "Opening in ILSpy..."
-				IL_08cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_08d2: pop
-				IL_08d3: ldarg.0
-				IL_08d4: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-				IL_08d9: stloc.s 18
-				IL_08db: ldloc.s 18
-				IL_08dd: ldc.i4.1
-				IL_08de: newarr [System.Runtime]System.Object
-				IL_08e3: dup
-				IL_08e4: ldc.i4.0
-				IL_08e5: ldarg.0
-				IL_08e6: stelem.ref
-				IL_08e7: ldloc.s 10
-				IL_08e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_08ee: pop
-				IL_08ef: leave IL_098e
+				IL_0b7e: nop
+				IL_0b7f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0b84: stloc.s 24
+				IL_0b86: ldloc.s 24
+				IL_0b88: ldstr "Opening in ILSpy..."
+				IL_0b8d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0b92: pop
+				IL_0b93: ldarg.0
+				IL_0b94: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+				IL_0b99: stloc.s 18
+				IL_0b9b: ldloc.s 18
+				IL_0b9d: ldc.i4.1
+				IL_0b9e: newarr [System.Runtime]System.Object
+				IL_0ba3: dup
+				IL_0ba4: ldc.i4.0
+				IL_0ba5: ldarg.0
+				IL_0ba6: stelem.ref
+				IL_0ba7: ldloc.s 10
+				IL_0ba9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0bae: pop
+				IL_0baf: leave IL_0cd2
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_08f4: stloc.s 14
-				IL_08f6: ldloc.s 14
-				IL_08f8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_08fd: dup
-				IL_08fe: brtrue IL_0914
+				IL_0bb4: stloc.s 14
+				IL_0bb6: ldloc.s 14
+				IL_0bb8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0bbd: dup
+				IL_0bbe: brtrue IL_0bd4
 
-				IL_0903: pop
-				IL_0904: ldloc.s 14
-				IL_0906: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_090b: dup
-				IL_090c: brtrue IL_0920
+				IL_0bc3: pop
+				IL_0bc4: ldloc.s 14
+				IL_0bc6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0bcb: dup
+				IL_0bcc: brtrue IL_0be0
 
-				IL_0911: pop
-				IL_0912: rethrow
+				IL_0bd1: pop
+				IL_0bd2: rethrow
 
-				IL_0914: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0919: stloc.s 15
-				IL_091b: br IL_0922
+				IL_0bd4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0bd9: stloc.s 15
+				IL_0bdb: br IL_0be2
 
-				IL_0920: stloc.s 15
+				IL_0be0: stloc.s 15
 
-				IL_0922: ldloc.s 15
-				IL_0924: stloc.s 16
-				IL_0926: ldstr "console"
-				IL_092b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0930: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0935: ldstr "error"
-				IL_093a: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_093f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0944: pop
-				IL_0945: ldstr "console"
-				IL_094a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_094f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0954: ldstr "error"
-				IL_0959: ldloc.s 16
-				IL_095b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0960: pop
-				IL_0961: ldstr "process"
-				IL_0966: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_096b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0970: ldstr "exit"
-				IL_0975: ldc.r8 1
-				IL_097e: box [System.Runtime]System.Double
-				IL_0983: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0988: pop
-				IL_0989: leave IL_098e
+				IL_0be2: ldloc.s 15
+				IL_0be4: stloc.s 16
+				IL_0be6: ldstr "console"
+				IL_0beb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0bf0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0bf5: volatile.
+				IL_0bf7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+				IL_0bfc: brfalse IL_0c15
+
+				IL_0c01: ldstr "error"
+				IL_0c06: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_0c0b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0c10: br IL_0c2e
+
+				IL_0c15: ldstr "error"
+				IL_0c1a: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_0c1f: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:326"
+				IL_0c24: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+				IL_0c29: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0c2e: pop
+				IL_0c2f: ldstr "console"
+				IL_0c34: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0c39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0c3e: volatile.
+				IL_0c40: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+				IL_0c45: brfalse IL_0c5b
+
+				IL_0c4a: ldstr "error"
+				IL_0c4f: ldloc.s 16
+				IL_0c51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0c56: br IL_0c71
+
+				IL_0c5b: ldstr "error"
+				IL_0c60: ldloc.s 16
+				IL_0c62: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:331"
+				IL_0c67: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+				IL_0c6c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0c71: pop
+				IL_0c72: ldstr "process"
+				IL_0c77: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0c7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0c81: volatile.
+				IL_0c83: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+				IL_0c88: brfalse IL_0caa
+
+				IL_0c8d: ldstr "exit"
+				IL_0c92: ldc.r8 1
+				IL_0c9b: box [System.Runtime]System.Double
+				IL_0ca0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0ca5: br IL_0ccc
+
+				IL_0caa: ldstr "exit"
+				IL_0caf: ldc.r8 1
+				IL_0cb8: box [System.Runtime]System.Double
+				IL_0cbd: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:338"
+				IL_0cc2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+				IL_0cc7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0ccc: pop
+				IL_0ccd: leave IL_0cd2
 			} // end handler
 
-			IL_098e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0993: stloc.s 24
-			IL_0995: ldloc.s 24
-			IL_0997: ldstr "Done!"
-			IL_099c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_09a1: pop
-			IL_09a2: ldnull
-			IL_09a3: stloc.s 17
-			IL_09a5: ldloc.s 17
-			IL_09a7: ret
+			IL_0cd2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0cd7: stloc.s 24
+			IL_0cd9: ldloc.s 24
+			IL_0cdb: ldstr "Done!"
+			IL_0ce0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ce5: pop
+			IL_0ce6: ldnull
+			IL_0ce7: stloc.s 17
+			IL_0ce9: ldloc.s 17
+			IL_0ceb: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -4563,6 +4910,34 @@
 	.field assembly static int32 __jroc_dynamicLookup_49
 	.field assembly static int32 __jroc_dynamicLookup_50
 	.field assembly static int32 __jroc_dynamicLookup_51
+	.field assembly static int32 __jroc_dynamicLookup_52
+	.field assembly static int32 __jroc_dynamicLookup_53
+	.field assembly static int32 __jroc_dynamicLookup_54
+	.field assembly static int32 __jroc_dynamicLookup_55
+	.field assembly static int32 __jroc_dynamicLookup_56
+	.field assembly static int32 __jroc_dynamicLookup_57
+	.field assembly static int32 __jroc_dynamicLookup_58
+	.field assembly static int32 __jroc_dynamicLookup_59
+	.field assembly static int32 __jroc_dynamicLookup_60
+	.field assembly static int32 __jroc_dynamicLookup_61
+	.field assembly static int32 __jroc_dynamicLookup_62
+	.field assembly static int32 __jroc_dynamicLookup_63
+	.field assembly static int32 __jroc_dynamicLookup_64
+	.field assembly static int32 __jroc_dynamicLookup_65
+	.field assembly static int32 __jroc_dynamicLookup_66
+	.field assembly static int32 __jroc_dynamicLookup_67
+	.field assembly static int32 __jroc_dynamicLookup_68
+	.field assembly static int32 __jroc_dynamicLookup_69
+	.field assembly static int32 __jroc_dynamicLookup_70
+	.field assembly static int32 __jroc_dynamicLookup_71
+	.field assembly static int32 __jroc_dynamicLookup_72
+	.field assembly static int32 __jroc_dynamicLookup_73
+	.field assembly static int32 __jroc_dynamicLookup_74
+	.field assembly static int32 __jroc_dynamicLookup_75
+	.field assembly static int32 __jroc_dynamicLookup_76
+	.field assembly static int32 __jroc_dynamicLookup_77
+	.field assembly static int32 __jroc_dynamicLookup_78
+	.field assembly static int32 __jroc_dynamicLookup_79
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -301,7 +301,7 @@
 			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00bf: stloc.3
 			IL_00c0: volatile.
-			IL_00c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_00c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_00c7: brfalse IL_00dc
 
 			IL_00cc: ldloc.3
@@ -312,7 +312,7 @@
 			IL_00dc: ldloc.3
 			IL_00dd: ldstr "runHarnessCli"
 			IL_00e2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M6>:__js_call__:8"
-			IL_00e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_00e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_00f1: stloc.3
@@ -468,7 +468,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 364 (0x16c)
+			// Code size: 403 (0x193)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -492,7 +492,7 @@
 			IL_0018: brfalse IL_0059
 
 			IL_001d: volatile.
-			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_0024: brfalse IL_0039
 
 			IL_0029: ldarg.1
@@ -503,7 +503,7 @@
 			IL_0039: ldarg.1
 			IL_003a: ldstr "stack"
 			IL_003f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M7>:__js_call__:9"
-			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004e: stloc.s 4
@@ -521,7 +521,7 @@
 			IL_0065: brfalse IL_00a5
 
 			IL_006a: volatile.
-			IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0071: brfalse IL_0086
 
 			IL_0076: ldarg.1
@@ -532,7 +532,7 @@
 			IL_0086: ldarg.1
 			IL_0087: ldstr "stack"
 			IL_008c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M7>:__js_call__:19"
-			IL_0091: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_0091: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_009b: stloc.s 4
@@ -547,7 +547,7 @@
 			IL_00ad: brfalse IL_00ee
 
 			IL_00b2: volatile.
-			IL_00b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_00b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_00b9: brfalse IL_00ce
 
 			IL_00be: ldarg.1
@@ -558,7 +558,7 @@
 			IL_00ce: ldarg.1
 			IL_00cf: ldstr "message"
 			IL_00d4: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M7>:__js_call__:28"
-			IL_00d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_00d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00e3: stloc.s 4
@@ -576,7 +576,7 @@
 			IL_00fa: brfalse IL_013a
 
 			IL_00ff: volatile.
-			IL_0101: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_0101: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_0106: brfalse IL_011b
 
 			IL_010b: ldarg.1
@@ -587,7 +587,7 @@
 			IL_011b: ldarg.1
 			IL_011c: ldstr "message"
 			IL_0121: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M7>:__js_call__:38"
-			IL_0126: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_0126: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0130: stloc.s 4
@@ -601,20 +601,33 @@
 			IL_013c: ldloc.1
 			IL_013d: stloc.0
 
-			IL_013e: ldloc.2
-			IL_013f: ldstr "error"
-			IL_0144: ldloc.0
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_014a: pop
-			IL_014b: ldstr "process"
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0155: ldstr "exitCode"
-			IL_015a: ldc.r8 1
-			IL_0163: ldc.i4.1
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0169: pop
-			IL_016a: ldnull
-			IL_016b: ret
+			IL_013e: volatile.
+			IL_0140: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0145: brfalse IL_015b
+
+			IL_014a: ldloc.2
+			IL_014b: ldstr "error"
+			IL_0150: ldloc.0
+			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0156: br IL_0171
+
+			IL_015b: ldloc.2
+			IL_015c: ldstr "error"
+			IL_0161: ldloc.0
+			IL_0162: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M7>:__js_call__:47"
+			IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0171: pop
+			IL_0172: ldstr "process"
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_017c: ldstr "exitCode"
+			IL_0181: ldc.r8 1
+			IL_018a: ldc.i4.1
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0190: pop
+			IL_0191: ldnull
+			IL_0192: ret
 		} // end of method ArrowFunction_L8C13::__js_call__
 
 	} // end of class ArrowFunction_L8C13
@@ -659,7 +672,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 136 (0x88)
+		// Code size: 176 (0xb0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope,
@@ -721,12 +734,25 @@
 		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/ArrowFunction_L8C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/ArrowFunction_L8C13/FunctionObject>(!!0)
 		IL_0077: stloc.s 4
-		IL_0079: ldloc.3
-		IL_007a: ldstr "catch"
-		IL_007f: ldloc.s 4
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0086: pop
-		IL_0087: ret
+		IL_0079: volatile.
+		IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_0080: brfalse IL_0097
+
+		IL_0085: ldloc.3
+		IL_0086: ldstr "catch"
+		IL_008b: ldloc.s 4
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0092: br IL_00ae
+
+		IL_0097: ldloc.3
+		IL_0098: ldstr "catch"
+		IL_009d: ldloc.s 4
+		IL_009f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:__js_module_init__:13"
+		IL_00a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ae: pop
+		IL_00af: ret
 	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_AutoMode::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
@@ -2215,7 +2241,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 1389 (0x56d)
+					// Code size: 1431 (0x597)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -2245,7 +2271,7 @@
 					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
 					IL_0005: stloc.0
 					IL_0006: volatile.
-					IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+					IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 					IL_000d: brfalse IL_0022
 
 					IL_0012: ldarg.2
@@ -2256,7 +2282,7 @@
 					IL_0022: ldarg.2
 					IL_0023: ldstr "statusCode"
 					IL_0028: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:4"
-					IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+					IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 					IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0037: stloc.s 4
@@ -2277,7 +2303,7 @@
 					IL_0062: ldloc.s 7
 					IL_0064: stloc.1
 					IL_0065: volatile.
-					IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+					IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 					IL_006c: brfalse IL_0081
 
 					IL_0071: ldarg.2
@@ -2288,12 +2314,12 @@
 					IL_0081: ldarg.2
 					IL_0082: ldstr "headers"
 					IL_0087: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:18"
-					IL_008c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+					IL_008c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 					IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0096: stloc.s 4
 					IL_0098: volatile.
-					IL_009a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+					IL_009a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 					IL_009f: brfalse IL_00b5
 
 					IL_00a4: ldloc.s 4
@@ -2304,7 +2330,7 @@
 					IL_00b5: ldloc.s 4
 					IL_00b7: ldstr "location"
 					IL_00bc: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:20"
-					IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+					IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 					IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_00cb: stloc.2
@@ -2370,7 +2396,7 @@
 					IL_0171: ldarg.2
 					IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0177: volatile.
-					IL_0179: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+					IL_0179: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 					IL_017e: brfalse IL_0192
 
 					IL_0183: ldstr "resume"
@@ -2379,7 +2405,7 @@
 
 					IL_0192: ldstr "resume"
 					IL_0197: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:56"
-					IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+					IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 					IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 					IL_01a6: pop
@@ -2455,7 +2481,7 @@
 					IL_0238: ldloc.s 13
 					IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_023f: volatile.
-					IL_0241: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+					IL_0241: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 					IL_0246: brfalse IL_025a
 
 					IL_024b: ldstr "toString"
@@ -2464,14 +2490,14 @@
 
 					IL_025a: ldstr "toString"
 					IL_025f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:75"
-					IL_0264: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+					IL_0264: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 					IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 					IL_026e: stloc.3
 					IL_026f: ldarg.2
 					IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0275: volatile.
-					IL_0277: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+					IL_0277: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 					IL_027c: brfalse IL_0290
 
 					IL_0281: ldstr "resume"
@@ -2480,7 +2506,7 @@
 
 					IL_0290: ldstr "resume"
 					IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:80"
-					IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+					IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 					IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 					IL_02a4: pop
@@ -2591,7 +2617,7 @@
 					IL_03a1: ldarg.2
 					IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_03a7: volatile.
-					IL_03a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+					IL_03a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 					IL_03ae: brfalse IL_03c2
 
 					IL_03b3: ldstr "resume"
@@ -2600,7 +2626,7 @@
 
 					IL_03c2: ldstr "resume"
 					IL_03c7: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:119"
-					IL_03cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+					IL_03cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 					IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 					IL_03d6: pop
@@ -2664,135 +2690,147 @@
 
 					IL_0456: ldarg.2
 					IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_045c: ldstr "setEncoding"
-					IL_0461: ldstr "utf8"
-					IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_046b: pop
-					IL_046c: ldloc.0
-					IL_046d: ldstr ""
-					IL_0472: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0477: ldarg.2
-					IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_047d: stloc.s 18
-					IL_047f: ldc.i4.4
-					IL_0480: newarr [System.Runtime]System.Object
-					IL_0485: dup
-					IL_0486: ldc.i4.0
-					IL_0487: ldarg.0
-					IL_0488: ldc.i4.0
-					IL_0489: ldelem.ref
-					IL_048a: stelem.ref
-					IL_048b: dup
-					IL_048c: ldc.i4.1
-					IL_048d: ldarg.0
-					IL_048e: ldc.i4.1
-					IL_048f: ldelem.ref
-					IL_0490: stelem.ref
-					IL_0491: dup
-					IL_0492: ldc.i4.2
-					IL_0493: ldarg.0
-					IL_0494: ldc.i4.2
-					IL_0495: ldelem.ref
-					IL_0496: stelem.ref
-					IL_0497: dup
-					IL_0498: ldc.i4.3
-					IL_0499: ldloc.0
-					IL_049a: stelem.ref
-					IL_049b: stloc.s 12
-					IL_049d: ldloc.s 12
-					IL_049f: ldc.i4.0
-					IL_04a0: ldelem.ref
-					IL_04a1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_04a6: ldloc.s 12
-					IL_04a8: ldc.i4.1
-					IL_04a9: ldelem.ref
-					IL_04aa: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_04af: ldloc.s 12
-					IL_04b1: ldc.i4.2
-					IL_04b2: ldelem.ref
-					IL_04b3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_04b8: ldloc.s 12
-					IL_04ba: ldc.i4.3
-					IL_04bb: ldelem.ref
-					IL_04bc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-					IL_04c1: ldloc.s 12
-					IL_04c3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
-					IL_04c8: ldc.i4.1
-					IL_04c9: conv.r8
-					IL_04ca: ldstr ""
-					IL_04cf: ldc.i4.0
-					IL_04d0: ldc.i4.0
-					IL_04d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0, float64, string, bool, bool)
-					IL_04d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0)
-					IL_04db: stloc.s 20
-					IL_04dd: ldloc.s 18
-					IL_04df: ldstr "on"
-					IL_04e4: ldstr "data"
-					IL_04e9: ldloc.s 20
-					IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_04f0: pop
-					IL_04f1: ldarg.2
-					IL_04f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_04f7: stloc.s 18
-					IL_04f9: ldc.i4.4
-					IL_04fa: newarr [System.Runtime]System.Object
-					IL_04ff: dup
-					IL_0500: ldc.i4.0
-					IL_0501: ldarg.0
-					IL_0502: ldc.i4.0
-					IL_0503: ldelem.ref
-					IL_0504: stelem.ref
-					IL_0505: dup
-					IL_0506: ldc.i4.1
-					IL_0507: ldarg.0
-					IL_0508: ldc.i4.1
-					IL_0509: ldelem.ref
-					IL_050a: stelem.ref
-					IL_050b: dup
-					IL_050c: ldc.i4.2
-					IL_050d: ldarg.0
-					IL_050e: ldc.i4.2
-					IL_050f: ldelem.ref
-					IL_0510: stelem.ref
-					IL_0511: dup
-					IL_0512: ldc.i4.3
-					IL_0513: ldloc.0
-					IL_0514: stelem.ref
-					IL_0515: stloc.s 12
-					IL_0517: ldloc.s 12
-					IL_0519: ldc.i4.0
-					IL_051a: ldelem.ref
-					IL_051b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0520: ldloc.s 12
-					IL_0522: ldc.i4.1
-					IL_0523: ldelem.ref
-					IL_0524: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0529: ldloc.s 12
-					IL_052b: ldc.i4.2
-					IL_052c: ldelem.ref
-					IL_052d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0532: ldloc.s 12
-					IL_0534: ldc.i4.3
-					IL_0535: ldelem.ref
-					IL_0536: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-					IL_053b: ldloc.s 12
-					IL_053d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
-					IL_0542: ldc.i4.0
-					IL_0543: conv.r8
-					IL_0544: ldstr ""
-					IL_0549: ldc.i4.0
-					IL_054a: ldc.i4.0
-					IL_054b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0, float64, string, bool, bool)
-					IL_0550: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0)
-					IL_0555: stloc.s 21
-					IL_0557: ldloc.s 18
-					IL_0559: ldstr "on"
-					IL_055e: ldstr "end"
-					IL_0563: ldloc.s 21
-					IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_056a: pop
-					IL_056b: ldnull
-					IL_056c: ret
+					IL_045c: volatile.
+					IL_045e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+					IL_0463: brfalse IL_047c
+
+					IL_0468: ldstr "setEncoding"
+					IL_046d: ldstr "utf8"
+					IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0477: br IL_0495
+
+					IL_047c: ldstr "setEncoding"
+					IL_0481: ldstr "utf8"
+					IL_0486: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:141"
+					IL_048b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+					IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_0495: pop
+					IL_0496: ldloc.0
+					IL_0497: ldstr ""
+					IL_049c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_04a1: ldarg.2
+					IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_04a7: stloc.s 18
+					IL_04a9: ldc.i4.4
+					IL_04aa: newarr [System.Runtime]System.Object
+					IL_04af: dup
+					IL_04b0: ldc.i4.0
+					IL_04b1: ldarg.0
+					IL_04b2: ldc.i4.0
+					IL_04b3: ldelem.ref
+					IL_04b4: stelem.ref
+					IL_04b5: dup
+					IL_04b6: ldc.i4.1
+					IL_04b7: ldarg.0
+					IL_04b8: ldc.i4.1
+					IL_04b9: ldelem.ref
+					IL_04ba: stelem.ref
+					IL_04bb: dup
+					IL_04bc: ldc.i4.2
+					IL_04bd: ldarg.0
+					IL_04be: ldc.i4.2
+					IL_04bf: ldelem.ref
+					IL_04c0: stelem.ref
+					IL_04c1: dup
+					IL_04c2: ldc.i4.3
+					IL_04c3: ldloc.0
+					IL_04c4: stelem.ref
+					IL_04c5: stloc.s 12
+					IL_04c7: ldloc.s 12
+					IL_04c9: ldc.i4.0
+					IL_04ca: ldelem.ref
+					IL_04cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_04d0: ldloc.s 12
+					IL_04d2: ldc.i4.1
+					IL_04d3: ldelem.ref
+					IL_04d4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_04d9: ldloc.s 12
+					IL_04db: ldc.i4.2
+					IL_04dc: ldelem.ref
+					IL_04dd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_04e2: ldloc.s 12
+					IL_04e4: ldc.i4.3
+					IL_04e5: ldelem.ref
+					IL_04e6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+					IL_04eb: ldloc.s 12
+					IL_04ed: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
+					IL_04f2: ldc.i4.1
+					IL_04f3: conv.r8
+					IL_04f4: ldstr ""
+					IL_04f9: ldc.i4.0
+					IL_04fa: ldc.i4.0
+					IL_04fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0, float64, string, bool, bool)
+					IL_0500: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0)
+					IL_0505: stloc.s 20
+					IL_0507: ldloc.s 18
+					IL_0509: ldstr "on"
+					IL_050e: ldstr "data"
+					IL_0513: ldloc.s 20
+					IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_051a: pop
+					IL_051b: ldarg.2
+					IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0521: stloc.s 18
+					IL_0523: ldc.i4.4
+					IL_0524: newarr [System.Runtime]System.Object
+					IL_0529: dup
+					IL_052a: ldc.i4.0
+					IL_052b: ldarg.0
+					IL_052c: ldc.i4.0
+					IL_052d: ldelem.ref
+					IL_052e: stelem.ref
+					IL_052f: dup
+					IL_0530: ldc.i4.1
+					IL_0531: ldarg.0
+					IL_0532: ldc.i4.1
+					IL_0533: ldelem.ref
+					IL_0534: stelem.ref
+					IL_0535: dup
+					IL_0536: ldc.i4.2
+					IL_0537: ldarg.0
+					IL_0538: ldc.i4.2
+					IL_0539: ldelem.ref
+					IL_053a: stelem.ref
+					IL_053b: dup
+					IL_053c: ldc.i4.3
+					IL_053d: ldloc.0
+					IL_053e: stelem.ref
+					IL_053f: stloc.s 12
+					IL_0541: ldloc.s 12
+					IL_0543: ldc.i4.0
+					IL_0544: ldelem.ref
+					IL_0545: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_054a: ldloc.s 12
+					IL_054c: ldc.i4.1
+					IL_054d: ldelem.ref
+					IL_054e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0553: ldloc.s 12
+					IL_0555: ldc.i4.2
+					IL_0556: ldelem.ref
+					IL_0557: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_055c: ldloc.s 12
+					IL_055e: ldc.i4.3
+					IL_055f: ldelem.ref
+					IL_0560: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+					IL_0565: ldloc.s 12
+					IL_0567: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
+					IL_056c: ldc.i4.0
+					IL_056d: conv.r8
+					IL_056e: ldstr ""
+					IL_0573: ldc.i4.0
+					IL_0574: ldc.i4.0
+					IL_0575: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0, float64, string, bool, bool)
+					IL_057a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0)
+					IL_057f: stloc.s 21
+					IL_0581: ldloc.s 18
+					IL_0583: ldstr "on"
+					IL_0588: ldstr "end"
+					IL_058d: ldloc.s 21
+					IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0594: pop
+					IL_0595: ldnull
+					IL_0596: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -3094,7 +3132,7 @@
 				IL_00e1: ldloc.0
 				IL_00e2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
 				IL_00e7: volatile.
-				IL_00e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+				IL_00e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 				IL_00ee: brfalse IL_0102
 
 				IL_00f3: ldstr "protocol"
@@ -3103,7 +3141,7 @@
 
 				IL_0102: ldstr "protocol"
 				IL_0107: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M17>:__js_call__:42"
-				IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+				IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 				IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0116: stloc.s 8
@@ -3222,7 +3260,7 @@
 				IL_023c: ldloc.s 6
 				IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0243: volatile.
-				IL_0245: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+				IL_0245: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 				IL_024a: brfalse IL_025e
 
 				IL_024f: ldstr "end"
@@ -3231,7 +3269,7 @@
 
 				IL_025e: ldstr "end"
 				IL_0263: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M17>:__js_call__:73"
-				IL_0268: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+				IL_0268: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 				IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0272: pop
@@ -3923,7 +3961,7 @@
 				IL_0079: ldloc.0
 				IL_007a: stloc.s 8
 				IL_007c: volatile.
-				IL_007e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+				IL_007e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 				IL_0083: brfalse IL_0098
 
 				IL_0088: ldarg.2
@@ -3934,7 +3972,7 @@
 				IL_0098: ldarg.2
 				IL_0099: ldstr "length"
 				IL_009e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M12>:__js_call__:34"
-				IL_00a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+				IL_00a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00ad: stloc.s 5
@@ -4457,7 +4495,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1345 (0x541)
+			// Code size: 1385 (0x569)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4762,210 +4800,223 @@
 			IL_02f7: stloc.s 10
 			// loop start (head: IL_02f9)
 				IL_02f9: ldc.i4.1
-				IL_02fa: brfalse IL_04e5
+				IL_02fa: brfalse IL_050d
 
-				IL_02ff: ldloc.s 8
-				IL_0301: ldstr "exec"
-				IL_0306: ldarg.2
-				IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_030c: stloc.s 11
-				IL_030e: ldloc.s 11
-				IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0315: ldc.i4.0
-				IL_0316: ceq
-				IL_0318: stloc.s 17
-				IL_031a: ldloc.s 17
-				IL_031c: brfalse IL_0326
+				IL_02ff: volatile.
+				IL_0301: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+				IL_0306: brfalse IL_031d
 
-				IL_0321: br IL_04e5
+				IL_030b: ldloc.s 8
+				IL_030d: ldstr "exec"
+				IL_0312: ldarg.2
+				IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0318: br IL_0334
 
-				IL_0326: ldloc.s 11
-				IL_0328: ldc.r8 0.0
-				IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0336: stloc.s 12
-				IL_0338: ldloc.s 10
-				IL_033a: stloc.s 19
-				IL_033c: ldloc.s 19
-				IL_033e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0343: ldc.r8 0.0
-				IL_034c: clt
-				IL_034e: brfalse IL_038c
+				IL_031d: ldloc.s 8
+				IL_031f: ldstr "exec"
+				IL_0324: ldarg.2
+				IL_0325: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:122"
+				IL_032a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+				IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0353: volatile.
-				IL_0355: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-				IL_035a: brfalse IL_0370
+				IL_0334: stloc.s 11
+				IL_0336: ldloc.s 11
+				IL_0338: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_033d: ldc.i4.0
+				IL_033e: ceq
+				IL_0340: stloc.s 17
+				IL_0342: ldloc.s 17
+				IL_0344: brfalse IL_034e
 
-				IL_035f: ldloc.s 11
-				IL_0361: ldstr "index"
-				IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_036b: br IL_0386
+				IL_0349: br IL_050d
 
-				IL_0370: ldloc.s 11
-				IL_0372: ldstr "index"
-				IL_0377: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:142"
-				IL_037c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-				IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_034e: ldloc.s 11
+				IL_0350: ldc.r8 0.0
+				IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_035e: stloc.s 12
+				IL_0360: ldloc.s 10
+				IL_0362: stloc.s 19
+				IL_0364: ldloc.s 19
+				IL_0366: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_036b: ldc.r8 0.0
+				IL_0374: clt
+				IL_0376: brfalse IL_03b4
 
-				IL_0386: stloc.s 15
-				IL_0388: ldloc.s 15
-				IL_038a: stloc.s 10
+				IL_037b: volatile.
+				IL_037d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+				IL_0382: brfalse IL_0398
 
-				IL_038c: ldloc.s 12
-				IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0393: stloc.s 15
-				IL_0395: ldc.i4.0
-				IL_0396: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_039b: brfalse IL_03d7
+				IL_0387: ldloc.s 11
+				IL_0389: ldstr "index"
+				IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0393: br IL_03ae
 
-				IL_03a0: ldloc.s 15
-				IL_03a2: isinst [System.Runtime]System.String
-				IL_03a7: dup
-				IL_03a8: brtrue IL_03c0
+				IL_0398: ldloc.s 11
+				IL_039a: ldstr "index"
+				IL_039f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:142"
+				IL_03a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_03ad: pop
-				IL_03ae: ldloc.s 15
-				IL_03b0: ldstr "startsWith"
-				IL_03b5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_03ba: dup
-				IL_03bb: brfalse IL_03d6
+				IL_03ae: stloc.s 15
+				IL_03b0: ldloc.s 15
+				IL_03b2: stloc.s 10
 
-				IL_03c0: ldstr "</"
-				IL_03c5: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-				IL_03ca: box [System.Runtime]System.Boolean
-				IL_03cf: stloc.s 15
-				IL_03d1: br IL_03ea
+				IL_03b4: ldloc.s 12
+				IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03bb: stloc.s 15
+				IL_03bd: ldc.i4.0
+				IL_03be: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_03c3: brfalse IL_03ff
 
-				IL_03d6: pop
+				IL_03c8: ldloc.s 15
+				IL_03ca: isinst [System.Runtime]System.String
+				IL_03cf: dup
+				IL_03d0: brtrue IL_03e8
 
-				IL_03d7: ldloc.s 15
-				IL_03d9: ldstr "startsWith"
-				IL_03de: ldstr "</"
-				IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_03e8: stloc.s 15
+				IL_03d5: pop
+				IL_03d6: ldloc.s 15
+				IL_03d8: ldstr "startsWith"
+				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_03e2: dup
+				IL_03e3: brfalse IL_03fe
 
-				IL_03ea: ldloc.s 15
-				IL_03ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03f1: stloc.s 17
-				IL_03f3: ldloc.s 17
-				IL_03f5: brfalse IL_04d2
+				IL_03e8: ldstr "</"
+				IL_03ed: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_03f2: box [System.Runtime]System.Boolean
+				IL_03f7: stloc.s 15
+				IL_03f9: br IL_0412
 
-				IL_03fa: ldloc.s 9
-				IL_03fc: ldc.r8 1
-				IL_0405: sub
-				IL_0406: stloc.s 9
-				IL_0408: ldloc.s 9
-				IL_040a: stloc.s 18
-				IL_040c: ldloc.s 18
-				IL_040e: ldc.r8 0.0
-				IL_0417: ceq
-				IL_0419: brfalse IL_04cd
+				IL_03fe: pop
 
-				IL_041e: ldarg.2
-				IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0424: stloc.s 15
-				IL_0426: volatile.
-				IL_0428: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-				IL_042d: brfalse IL_0443
+				IL_03ff: ldloc.s 15
+				IL_0401: ldstr "startsWith"
+				IL_0406: ldstr "</"
+				IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0410: stloc.s 15
 
-				IL_0432: ldloc.s 8
-				IL_0434: ldstr "lastIndex"
-				IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_043e: br IL_0459
+				IL_0412: ldloc.s 15
+				IL_0414: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0419: stloc.s 17
+				IL_041b: ldloc.s 17
+				IL_041d: brfalse IL_04fa
 
-				IL_0443: ldloc.s 8
-				IL_0445: ldstr "lastIndex"
-				IL_044a: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:165"
-				IL_044f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-				IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0422: ldloc.s 9
+				IL_0424: ldc.r8 1
+				IL_042d: sub
+				IL_042e: stloc.s 9
+				IL_0430: ldloc.s 9
+				IL_0432: stloc.s 18
+				IL_0434: ldloc.s 18
+				IL_0436: ldc.r8 0.0
+				IL_043f: ceq
+				IL_0441: brfalse IL_04f5
 
-				IL_0459: stloc.s 20
-				IL_045b: ldc.i4.0
-				IL_045c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0461: brfalse IL_0497
+				IL_0446: ldarg.2
+				IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_044c: stloc.s 15
+				IL_044e: volatile.
+				IL_0450: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+				IL_0455: brfalse IL_046b
 
-				IL_0466: ldloc.s 15
-				IL_0468: isinst [System.Runtime]System.String
-				IL_046d: dup
-				IL_046e: brtrue IL_0486
+				IL_045a: ldloc.s 8
+				IL_045c: ldstr "lastIndex"
+				IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0466: br IL_0481
 
-				IL_0473: pop
-				IL_0474: ldloc.s 15
-				IL_0476: ldstr "substring"
-				IL_047b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_0480: dup
-				IL_0481: brfalse IL_0496
+				IL_046b: ldloc.s 8
+				IL_046d: ldstr "lastIndex"
+				IL_0472: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:165"
+				IL_0477: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+				IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0486: ldloc.s 10
-				IL_0488: ldloc.s 20
-				IL_048a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_048f: stloc.s 20
-				IL_0491: br IL_04a9
+				IL_0481: stloc.s 20
+				IL_0483: ldc.i4.0
+				IL_0484: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0489: brfalse IL_04bf
 
-				IL_0496: pop
+				IL_048e: ldloc.s 15
+				IL_0490: isinst [System.Runtime]System.String
+				IL_0495: dup
+				IL_0496: brtrue IL_04ae
 
-				IL_0497: ldloc.s 15
-				IL_0499: ldstr "substring"
-				IL_049e: ldloc.s 10
-				IL_04a0: ldloc.s 20
-				IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_04a7: stloc.s 20
+				IL_049b: pop
+				IL_049c: ldloc.s 15
+				IL_049e: ldstr "substring"
+				IL_04a3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_04a8: dup
+				IL_04a9: brfalse IL_04be
 
-				IL_04a9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_04ae: dup
-				IL_04af: ldstr "tagName"
-				IL_04b4: ldloc.s 6
-				IL_04b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_04bb: dup
-				IL_04bc: ldstr "html"
-				IL_04c1: ldloc.s 20
-				IL_04c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_04c8: stloc.s 21
-				IL_04ca: ldloc.s 21
-				IL_04cc: ret
+				IL_04ae: ldloc.s 10
+				IL_04b0: ldloc.s 20
+				IL_04b2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_04b7: stloc.s 20
+				IL_04b9: br IL_04d1
 
-				IL_04cd: br IL_04e0
+				IL_04be: pop
 
-				IL_04d2: ldloc.s 9
-				IL_04d4: ldc.r8 1
-				IL_04dd: add
-				IL_04de: stloc.s 9
+				IL_04bf: ldloc.s 15
+				IL_04c1: ldstr "substring"
+				IL_04c6: ldloc.s 10
+				IL_04c8: ldloc.s 20
+				IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_04cf: stloc.s 20
 
-				IL_04e0: br IL_02f9
+				IL_04d1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_04d6: dup
+				IL_04d7: ldstr "tagName"
+				IL_04dc: ldloc.s 6
+				IL_04de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_04e3: dup
+				IL_04e4: ldstr "html"
+				IL_04e9: ldloc.s 20
+				IL_04eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_04f0: stloc.s 21
+				IL_04f2: ldloc.s 21
+				IL_04f4: ret
+
+				IL_04f5: br IL_0508
+
+				IL_04fa: ldloc.s 9
+				IL_04fc: ldc.r8 1
+				IL_0505: add
+				IL_0506: stloc.s 9
+
+				IL_0508: br IL_02f9
 			// end loop
 
-			IL_04e5: ldloc.s 6
-			IL_04e7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04ec: stloc.s 14
-			IL_04ee: ldstr "Could not find a matching closing </"
-			IL_04f3: ldloc.s 14
-			IL_04f5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04fa: ldstr "> for id '"
-			IL_04ff: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0504: ldarg.3
-			IL_0505: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_050a: stloc.s 14
-			IL_050c: ldloc.s 14
-			IL_050e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0513: ldstr "'."
-			IL_0518: call string [System.Runtime]System.String::Concat(string, string)
-			IL_051d: stloc.s 14
-			IL_051f: ldloc.s 14
-			IL_0521: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0526: stloc.s 13
-			IL_0528: ldloc.s 13
-			IL_052a: isinst [System.Runtime]System.Exception
-			IL_052f: dup
-			IL_0530: brtrue IL_053e
+			IL_050d: ldloc.s 6
+			IL_050f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0514: stloc.s 14
+			IL_0516: ldstr "Could not find a matching closing </"
+			IL_051b: ldloc.s 14
+			IL_051d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0522: ldstr "> for id '"
+			IL_0527: call string [System.Runtime]System.String::Concat(string, string)
+			IL_052c: ldarg.3
+			IL_052d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0532: stloc.s 14
+			IL_0534: ldloc.s 14
+			IL_0536: call string [System.Runtime]System.String::Concat(string, string)
+			IL_053b: ldstr "'."
+			IL_0540: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0545: stloc.s 14
+			IL_0547: ldloc.s 14
+			IL_0549: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_054e: stloc.s 13
+			IL_0550: ldloc.s 13
+			IL_0552: isinst [System.Runtime]System.Exception
+			IL_0557: dup
+			IL_0558: brtrue IL_0566
 
-			IL_0535: pop
-			IL_0536: ldloc.s 13
-			IL_0538: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_053d: throw
+			IL_055d: pop
+			IL_055e: ldloc.s 13
+			IL_0560: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0565: throw
 
-			IL_053e: throw
+			IL_0566: throw
 
-			IL_053f: ldnull
-			IL_0540: ret
+			IL_0567: ldnull
+			IL_0568: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -5143,7 +5194,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 584 (0x248)
+			// Code size: 623 (0x26f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5191,184 +5242,197 @@
 			IL_003d: ldstr "i"
 			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0047: stloc.1
-			IL_0048: ldloc.1
-			IL_0049: ldstr "exec"
-			IL_004e: ldarg.2
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0054: stloc.2
-			IL_0055: ldloc.2
-			IL_0056: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005b: stloc.s 9
-			IL_005d: ldloc.s 9
-			IL_005f: brfalse IL_00ac
+			IL_0048: volatile.
+			IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_004f: brfalse IL_0065
 
-			IL_0064: ldloc.2
-			IL_0065: ldc.r8 1
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0073: stloc.s 10
-			IL_0075: ldloc.s 10
-			IL_0077: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007c: stloc.s 9
-			IL_007e: ldloc.s 9
-			IL_0080: brtrue IL_009f
+			IL_0054: ldloc.1
+			IL_0055: ldstr "exec"
+			IL_005a: ldarg.2
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0060: br IL_007b
 
-			IL_0085: ldloc.2
-			IL_0086: ldc.r8 2
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0094: stloc.s 11
-			IL_0096: ldloc.s 11
-			IL_0098: stloc.s 13
-			IL_009a: br IL_00a3
+			IL_0065: ldloc.1
+			IL_0066: ldstr "exec"
+			IL_006b: ldarg.2
+			IL_006c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M14>:__js_call__:17"
+			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_009f: ldloc.s 10
-			IL_00a1: stloc.s 13
+			IL_007b: stloc.2
+			IL_007c: ldloc.2
+			IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0082: stloc.s 9
+			IL_0084: ldloc.s 9
+			IL_0086: brfalse IL_00d3
 
-			IL_00a3: ldloc.s 13
-			IL_00a5: stloc.s 14
-			IL_00a7: br IL_00af
+			IL_008b: ldloc.2
+			IL_008c: ldc.r8 1
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_009a: stloc.s 10
+			IL_009c: ldloc.s 10
+			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00a3: stloc.s 9
+			IL_00a5: ldloc.s 9
+			IL_00a7: brtrue IL_00c6
 
 			IL_00ac: ldloc.2
-			IL_00ad: stloc.s 14
+			IL_00ad: ldc.r8 2
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00bb: stloc.s 11
+			IL_00bd: ldloc.s 11
+			IL_00bf: stloc.s 13
+			IL_00c1: br IL_00ca
 
-			IL_00af: ldloc.s 14
-			IL_00b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b6: stloc.s 9
-			IL_00b8: ldloc.s 9
-			IL_00ba: brtrue IL_00cb
+			IL_00c6: ldloc.s 10
+			IL_00c8: stloc.s 13
 
-			IL_00bf: ldstr ""
-			IL_00c4: stloc.s 14
-			IL_00c6: br IL_00cb
+			IL_00ca: ldloc.s 13
+			IL_00cc: stloc.s 14
+			IL_00ce: br IL_00d6
 
-			IL_00cb: ldloc.s 14
-			IL_00cd: stloc.3
-			IL_00ce: ldloc.3
-			IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00d4: ldc.i4.0
-			IL_00d5: ceq
-			IL_00d7: stloc.s 9
-			IL_00d9: ldloc.s 9
-			IL_00db: brfalse IL_00e7
+			IL_00d3: ldloc.2
+			IL_00d4: stloc.s 14
 
-			IL_00e0: ldc.i4.0
-			IL_00e1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00e6: ret
+			IL_00d6: ldloc.s 14
+			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00dd: stloc.s 9
+			IL_00df: ldloc.s 9
+			IL_00e1: brtrue IL_00f2
 
-			IL_00e7: ldloc.3
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ed: stloc.s 10
-			IL_00ef: ldc.i4.0
-			IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00f5: brfalse IL_0117
+			IL_00e6: ldstr ""
+			IL_00eb: stloc.s 14
+			IL_00ed: br IL_00f2
 
-			IL_00fa: ldloc.s 10
-			IL_00fc: castclass [System.Runtime]System.String
-			IL_0101: ldstr "#"
-			IL_0106: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_010b: box [System.Runtime]System.Double
-			IL_0110: stloc.s 4
-			IL_0112: br IL_012a
+			IL_00f2: ldloc.s 14
+			IL_00f4: stloc.3
+			IL_00f5: ldloc.3
+			IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00fb: ldc.i4.0
+			IL_00fc: ceq
+			IL_00fe: stloc.s 9
+			IL_0100: ldloc.s 9
+			IL_0102: brfalse IL_010e
 
-			IL_0117: ldloc.s 10
-			IL_0119: ldstr "indexOf"
-			IL_011e: ldstr "#"
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0128: stloc.s 4
+			IL_0107: ldc.i4.0
+			IL_0108: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_010d: ret
 
-			IL_012a: ldloc.s 4
-			IL_012c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0131: ldc.r8 0.0
-			IL_013a: clt
-			IL_013c: ldc.i4.0
-			IL_013d: ceq
-			IL_013f: brfalse IL_01a1
+			IL_010e: ldloc.3
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0114: stloc.s 10
+			IL_0116: ldc.i4.0
+			IL_0117: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_011c: brfalse IL_013e
 
-			IL_0144: ldloc.3
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014a: stloc.s 10
-			IL_014c: ldc.i4.0
-			IL_014d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0152: brfalse IL_017a
+			IL_0121: ldloc.s 10
+			IL_0123: castclass [System.Runtime]System.String
+			IL_0128: ldstr "#"
+			IL_012d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0132: box [System.Runtime]System.Double
+			IL_0137: stloc.s 4
+			IL_0139: br IL_0151
 
-			IL_0157: ldloc.s 10
-			IL_0159: castclass [System.Runtime]System.String
-			IL_015e: ldc.r8 0.0
-			IL_0167: box [System.Runtime]System.Double
-			IL_016c: ldloc.s 4
-			IL_016e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_0173: stloc.s 10
-			IL_0175: br IL_0198
+			IL_013e: ldloc.s 10
+			IL_0140: ldstr "indexOf"
+			IL_0145: ldstr "#"
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_014f: stloc.s 4
 
-			IL_017a: ldloc.s 10
-			IL_017c: ldstr "substring"
-			IL_0181: ldc.r8 0.0
-			IL_018a: box [System.Runtime]System.Double
-			IL_018f: ldloc.s 4
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0196: stloc.s 10
+			IL_0151: ldloc.s 4
+			IL_0153: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0158: ldc.r8 0.0
+			IL_0161: clt
+			IL_0163: ldc.i4.0
+			IL_0164: ceq
+			IL_0166: brfalse IL_01c8
 
-			IL_0198: ldloc.s 10
-			IL_019a: stloc.s 5
-			IL_019c: br IL_01a4
+			IL_016b: ldloc.3
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0171: stloc.s 10
+			IL_0173: ldc.i4.0
+			IL_0174: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0179: brfalse IL_01a1
 
-			IL_01a1: ldloc.3
-			IL_01a2: stloc.s 5
+			IL_017e: ldloc.s 10
+			IL_0180: castclass [System.Runtime]System.String
+			IL_0185: ldc.r8 0.0
+			IL_018e: box [System.Runtime]System.Double
+			IL_0193: ldloc.s 4
+			IL_0195: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_019a: stloc.s 10
+			IL_019c: br IL_01bf
 
-			IL_01a4: ldloc.s 4
-			IL_01a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01ab: ldc.r8 0.0
-			IL_01b4: clt
-			IL_01b6: ldc.i4.0
-			IL_01b7: ceq
-			IL_01b9: brfalse IL_0211
+			IL_01a1: ldloc.s 10
+			IL_01a3: ldstr "substring"
+			IL_01a8: ldc.r8 0.0
+			IL_01b1: box [System.Runtime]System.Double
+			IL_01b6: ldloc.s 4
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01bd: stloc.s 10
 
-			IL_01be: ldloc.3
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c4: stloc.s 10
-			IL_01c6: ldloc.s 4
-			IL_01c8: ldc.r8 1
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01d6: stloc.s 14
-			IL_01d8: ldc.i4.0
-			IL_01d9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_01de: brfalse IL_01f8
+			IL_01bf: ldloc.s 10
+			IL_01c1: stloc.s 5
+			IL_01c3: br IL_01cb
 
-			IL_01e3: ldloc.s 10
-			IL_01e5: castclass [System.Runtime]System.String
-			IL_01ea: ldloc.s 14
-			IL_01ec: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_01f1: stloc.s 10
-			IL_01f3: br IL_0208
+			IL_01c8: ldloc.3
+			IL_01c9: stloc.s 5
 
-			IL_01f8: ldloc.s 10
-			IL_01fa: ldstr "substring"
-			IL_01ff: ldloc.s 14
-			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0206: stloc.s 10
+			IL_01cb: ldloc.s 4
+			IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01d2: ldc.r8 0.0
+			IL_01db: clt
+			IL_01dd: ldc.i4.0
+			IL_01de: ceq
+			IL_01e0: brfalse IL_0238
 
-			IL_0208: ldloc.s 10
-			IL_020a: stloc.s 6
-			IL_020c: br IL_0218
+			IL_01e5: ldloc.3
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01eb: stloc.s 10
+			IL_01ed: ldloc.s 4
+			IL_01ef: ldc.r8 1
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01fd: stloc.s 14
+			IL_01ff: ldc.i4.0
+			IL_0200: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0205: brfalse IL_021f
 
-			IL_0211: ldstr ""
-			IL_0216: stloc.s 6
+			IL_020a: ldloc.s 10
+			IL_020c: castclass [System.Runtime]System.String
+			IL_0211: ldloc.s 14
+			IL_0213: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_0218: stloc.s 10
+			IL_021a: br IL_022f
 
-			IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_021d: dup
-			IL_021e: ldstr "href"
-			IL_0223: ldloc.3
-			IL_0224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0229: dup
-			IL_022a: ldstr "filePart"
-			IL_022f: ldloc.s 5
-			IL_0231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0236: dup
-			IL_0237: ldstr "fragment"
-			IL_023c: ldloc.s 6
-			IL_023e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0243: stloc.s 16
-			IL_0245: ldloc.s 16
-			IL_0247: ret
+			IL_021f: ldloc.s 10
+			IL_0221: ldstr "substring"
+			IL_0226: ldloc.s 14
+			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_022d: stloc.s 10
+
+			IL_022f: ldloc.s 10
+			IL_0231: stloc.s 6
+			IL_0233: br IL_023f
+
+			IL_0238: ldstr ""
+			IL_023d: stloc.s 6
+
+			IL_023f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0244: dup
+			IL_0245: ldstr "href"
+			IL_024a: ldloc.3
+			IL_024b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0250: dup
+			IL_0251: ldstr "filePart"
+			IL_0256: ldloc.s 5
+			IL_0258: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_025d: dup
+			IL_025e: ldstr "fragment"
+			IL_0263: ldloc.s 6
+			IL_0265: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_026a: stloc.s 16
+			IL_026c: ldloc.s 16
+			IL_026e: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -6104,7 +6168,7 @@
 			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_01b2: stloc.s 22
 			IL_01b4: volatile.
-			IL_01b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_01b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_01bb: brfalse IL_01d1
 
 			IL_01c0: ldloc.s 22
@@ -6115,7 +6179,7 @@
 			IL_01d1: ldloc.s 22
 			IL_01d3: ldstr "argv"
 			IL_01d8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:7"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01e7: stloc.s 22
@@ -6124,7 +6188,7 @@
 			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_01f2: stloc.1
 			IL_01f3: volatile.
-			IL_01f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_01f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_01fa: brfalse IL_020f
 
 			IL_01ff: ldloc.1
@@ -6135,7 +6199,7 @@
 			IL_020f: ldloc.1
 			IL_0210: ldstr "section"
 			IL_0215: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:12"
-			IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0224: stloc.s 22
@@ -6171,7 +6235,7 @@
 			IL_0272: ret
 
 			IL_0273: volatile.
-			IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_027a: brfalse IL_028f
 
 			IL_027f: ldloc.1
@@ -6182,7 +6246,7 @@
 			IL_028f: ldloc.1
 			IL_0290: ldstr "outFile"
 			IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:23"
-			IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02a4: stloc.s 22
@@ -6218,7 +6282,7 @@
 			IL_02f2: ret
 
 			IL_02f3: volatile.
-			IL_02f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_02f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_02fa: brfalse IL_030f
 
 			IL_02ff: ldloc.1
@@ -6229,7 +6293,7 @@
 			IL_030f: ldloc.1
 			IL_0310: ldstr "url"
 			IL_0315: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:34"
-			IL_031a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_031a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0324: stloc.s 22
@@ -6251,7 +6315,7 @@
 			IL_035b: ldloc.s 4
 			IL_035d: stloc.s 24
 			IL_035f: volatile.
-			IL_0361: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0361: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_0366: brfalse IL_037b
 
 			IL_036b: ldloc.1
@@ -6262,7 +6326,7 @@
 			IL_037b: ldloc.1
 			IL_037c: ldstr "auto"
 			IL_0381: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:48"
-			IL_0386: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0386: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0390: stloc.s 22
@@ -6319,7 +6383,7 @@
 			IL_042c: ldnull
 			IL_042d: stloc.s 8
 			IL_042f: volatile.
-			IL_0431: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_0431: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_0436: brfalse IL_044b
 
 			IL_043b: ldloc.1
@@ -6330,7 +6394,7 @@
 			IL_044b: ldloc.1
 			IL_044c: ldstr "id"
 			IL_0451: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:78"
-			IL_0456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_0456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0460: stloc.s 22
@@ -6368,7 +6432,7 @@
 			IL_04b7: ldstr ""
 			IL_04bc: stloc.s 10
 			IL_04be: volatile.
-			IL_04c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_04c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_04c5: brfalse IL_04da
 
 			IL_04ca: ldloc.1
@@ -6379,7 +6443,7 @@
 			IL_04da: ldloc.1
 			IL_04db: ldstr "auto"
 			IL_04e0: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:95"
-			IL_04e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_04e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_04ef: stloc.s 22
@@ -6390,7 +6454,7 @@
 			IL_04fc: brfalse IL_0a6e
 
 			IL_0501: volatile.
-			IL_0503: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0503: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_0508: brfalse IL_051d
 
 			IL_050d: ldloc.1
@@ -6401,7 +6465,7 @@
 			IL_051d: ldloc.1
 			IL_051e: ldstr "indexUrl"
 			IL_0523: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:100"
-			IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0532: stloc.s 22
@@ -6623,7 +6687,7 @@
 			IL_06b4: stelem.ref
 			IL_06b5: stloc.s 21
 			IL_06b7: volatile.
-			IL_06b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_06b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_06be: brfalse IL_06d3
 
 			IL_06c3: ldloc.1
@@ -6634,7 +6698,7 @@
 			IL_06d3: ldloc.1
 			IL_06d4: ldstr "section"
 			IL_06d9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:114"
-			IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_06e8: stloc.s 26
@@ -6683,7 +6747,7 @@
 			IL_0756: brfalse IL_07f8
 
 			IL_075b: volatile.
-			IL_075d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_075d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_0762: brfalse IL_0777
 
 			IL_0767: ldloc.1
@@ -6694,7 +6758,7 @@
 			IL_0777: ldloc.1
 			IL_0778: ldstr "section"
 			IL_077d: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:125"
-			IL_0782: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0782: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_078c: stloc.s 26
@@ -6742,7 +6806,7 @@
 			IL_0800: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
 			IL_0805: stloc.s 26
 			IL_0807: volatile.
-			IL_0809: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0809: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_080e: brfalse IL_0824
 
 			IL_0813: ldloc.s 13
@@ -6753,7 +6817,7 @@
 			IL_0824: ldloc.s 13
 			IL_0826: ldstr "filePart"
 			IL_082b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:139"
-			IL_0830: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0830: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_083a: stloc.s 22
@@ -6764,7 +6828,7 @@
 			IL_0847: brtrue IL_088a
 
 			IL_084c: volatile.
-			IL_084e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_084e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_0853: brfalse IL_0869
 
 			IL_0858: ldloc.s 13
@@ -6775,7 +6839,7 @@
 			IL_0869: ldloc.s 13
 			IL_086b: ldstr "href"
 			IL_0870: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:143"
-			IL_0875: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_0875: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_087f: stloc.s 28
@@ -6796,7 +6860,7 @@
 			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_08a3: stloc.s 26
 			IL_08a5: volatile.
-			IL_08a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_08a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_08ac: brfalse IL_08c2
 
 			IL_08b1: ldloc.s 26
@@ -6807,7 +6871,7 @@
 			IL_08c2: ldloc.s 26
 			IL_08c4: ldstr "toString"
 			IL_08c9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:151"
-			IL_08ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_08ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_08d8: stloc.s 15
@@ -6998,7 +7062,7 @@
 			IL_0a0b: brfalse IL_0a69
 
 			IL_0a10: volatile.
-			IL_0a12: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0a12: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_0a17: brfalse IL_0a2d
 
 			IL_0a1c: ldloc.s 13
@@ -7009,7 +7073,7 @@
 			IL_0a2d: ldloc.s 13
 			IL_0a2f: ldstr "fragment"
 			IL_0a34: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:168"
-			IL_0a39: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0a39: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_0a3e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0a43: stloc.s 26
@@ -7032,7 +7096,7 @@
 			IL_0a69: br IL_0c13
 
 			IL_0a6e: volatile.
-			IL_0a70: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_0a70: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_0a75: brfalse IL_0a8a
 
 			IL_0a7a: ldloc.1
@@ -7043,7 +7107,7 @@
 			IL_0a8a: ldloc.1
 			IL_0a8b: ldstr "url"
 			IL_0a90: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:184"
-			IL_0a95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_0a95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0a9f: stloc.s 26
@@ -7265,7 +7329,7 @@
 			IL_0c21: brfalse IL_0cb3
 
 			IL_0c26: volatile.
-			IL_0c28: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_0c28: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_0c2d: brfalse IL_0c42
 
 			IL_0c32: ldloc.1
@@ -7276,7 +7340,7 @@
 			IL_0c42: ldloc.1
 			IL_0c43: ldstr "section"
 			IL_0c48: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:205"
-			IL_0c4d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_0c4d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_0c52: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0c57: stloc.s 26
@@ -7344,7 +7408,7 @@
 			IL_0cf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0cfd: stloc.s 26
 			IL_0cff: volatile.
-			IL_0d01: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0d01: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_0d06: brfalse IL_0d1c
 
 			IL_0d0b: ldloc.s 26
@@ -7355,12 +7419,12 @@
 			IL_0d1c: ldloc.s 26
 			IL_0d1e: ldstr "cwd"
 			IL_0d23: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:224"
-			IL_0d28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0d28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_0d2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0d32: stloc.s 26
 			IL_0d34: volatile.
-			IL_0d36: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_0d36: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_0d3b: brfalse IL_0d50
 
 			IL_0d40: ldloc.1
@@ -7371,7 +7435,7 @@
 			IL_0d50: ldloc.1
 			IL_0d51: ldstr "outFile"
 			IL_0d56: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:226"
-			IL_0d5b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_0d5b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_0d60: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0d65: stloc.s 22
@@ -7403,7 +7467,7 @@
 			IL_0d98: stelem.ref
 			IL_0d99: stloc.s 21
 			IL_0d9b: volatile.
-			IL_0d9d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0d9d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_0da2: brfalse IL_0db8
 
 			IL_0da7: ldloc.s 18
@@ -7414,12 +7478,12 @@
 			IL_0db8: ldloc.s 18
 			IL_0dba: ldstr "html"
 			IL_0dbf: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:233"
-			IL_0dc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0dc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_0dc9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0dce: stloc.s 22
 			IL_0dd0: volatile.
-			IL_0dd2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_0dd2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_0dd7: brfalse IL_0dec
 
 			IL_0ddc: ldloc.1
@@ -7430,7 +7494,7 @@
 			IL_0dec: ldloc.1
 			IL_0ded: ldstr "section"
 			IL_0df2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:236"
-			IL_0df7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_0df7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_0dfc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0e01: stloc.s 26
@@ -7475,7 +7539,7 @@
 			IL_0e67: stelem.ref
 			IL_0e68: stloc.s 21
 			IL_0e6a: volatile.
-			IL_0e6c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0e6c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0e71: brfalse IL_0e86
 
 			IL_0e76: ldloc.1
@@ -7486,7 +7550,7 @@
 			IL_0e86: ldloc.1
 			IL_0e87: ldstr "section"
 			IL_0e8c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:251"
-			IL_0e91: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0e91: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0e96: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0e9b: stloc.s 22
@@ -7506,7 +7570,7 @@
 			IL_0ecc: ldstr ", tag="
 			IL_0ed1: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0ed6: volatile.
-			IL_0ed8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0ed8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_0edd: brfalse IL_0ef3
 
 			IL_0ee2: ldloc.s 18
@@ -7517,7 +7581,7 @@
 			IL_0ef3: ldloc.s 18
 			IL_0ef5: ldstr "tagName"
 			IL_0efa: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:261"
-			IL_0eff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0eff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_0f04: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0f09: stloc.s 22
@@ -7914,7 +7978,7 @@
 		IL_021a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
 		IL_021f: volatile.
-		IL_0221: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_0221: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 		IL_0226: brfalse IL_023c
 
 		IL_022b: ldloc.s 15
@@ -7925,7 +7989,7 @@
 		IL_023c: ldloc.s 15
 		IL_023e: ldstr "URL"
 		IL_0243: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:__js_module_init__:63"
-		IL_0248: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_0248: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0252: stloc.s 16
@@ -8017,6 +8081,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_93
 	.field assembly static int32 __jroc_dynamicLookup_94
 	.field assembly static int32 __jroc_dynamicLookup_95
+	.field assembly static int32 __jroc_dynamicLookup_96
+	.field assembly static int32 __jroc_dynamicLookup_97
+	.field assembly static int32 __jroc_dynamicLookup_98
+	.field assembly static int32 __jroc_dynamicLookup_99
+	.field assembly static int32 __jroc_dynamicLookup_100
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -301,7 +301,7 @@
 			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00bf: stloc.3
 			IL_00c0: volatile.
-			IL_00c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_00c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_00c7: brfalse IL_00dc
 
 			IL_00cc: ldloc.3
@@ -312,7 +312,7 @@
 			IL_00dc: ldloc.3
 			IL_00dd: ldstr "runHarnessCli"
 			IL_00e2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M6>:__js_call__:8"
-			IL_00e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_00e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_00f1: stloc.3
@@ -468,7 +468,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 364 (0x16c)
+			// Code size: 403 (0x193)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -492,7 +492,7 @@
 			IL_0018: brfalse IL_0059
 
 			IL_001d: volatile.
-			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_0024: brfalse IL_0039
 
 			IL_0029: ldarg.1
@@ -503,7 +503,7 @@
 			IL_0039: ldarg.1
 			IL_003a: ldstr "stack"
 			IL_003f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M7>:__js_call__:9"
-			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004e: stloc.s 4
@@ -521,7 +521,7 @@
 			IL_0065: brfalse IL_00a5
 
 			IL_006a: volatile.
-			IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0071: brfalse IL_0086
 
 			IL_0076: ldarg.1
@@ -532,7 +532,7 @@
 			IL_0086: ldarg.1
 			IL_0087: ldstr "stack"
 			IL_008c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M7>:__js_call__:19"
-			IL_0091: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_0091: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_009b: stloc.s 4
@@ -547,7 +547,7 @@
 			IL_00ad: brfalse IL_00ee
 
 			IL_00b2: volatile.
-			IL_00b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_00b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_00b9: brfalse IL_00ce
 
 			IL_00be: ldarg.1
@@ -558,7 +558,7 @@
 			IL_00ce: ldarg.1
 			IL_00cf: ldstr "message"
 			IL_00d4: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M7>:__js_call__:28"
-			IL_00d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_00d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00e3: stloc.s 4
@@ -576,7 +576,7 @@
 			IL_00fa: brfalse IL_013a
 
 			IL_00ff: volatile.
-			IL_0101: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_0101: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_0106: brfalse IL_011b
 
 			IL_010b: ldarg.1
@@ -587,7 +587,7 @@
 			IL_011b: ldarg.1
 			IL_011c: ldstr "message"
 			IL_0121: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M7>:__js_call__:38"
-			IL_0126: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_0126: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0130: stloc.s 4
@@ -601,20 +601,33 @@
 			IL_013c: ldloc.1
 			IL_013d: stloc.0
 
-			IL_013e: ldloc.2
-			IL_013f: ldstr "error"
-			IL_0144: ldloc.0
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_014a: pop
-			IL_014b: ldstr "process"
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0155: ldstr "exitCode"
-			IL_015a: ldc.r8 1
-			IL_0163: ldc.i4.1
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0169: pop
-			IL_016a: ldnull
-			IL_016b: ret
+			IL_013e: volatile.
+			IL_0140: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0145: brfalse IL_015b
+
+			IL_014a: ldloc.2
+			IL_014b: ldstr "error"
+			IL_0150: ldloc.0
+			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0156: br IL_0171
+
+			IL_015b: ldloc.2
+			IL_015c: ldstr "error"
+			IL_0161: ldloc.0
+			IL_0162: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M7>:__js_call__:47"
+			IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0171: pop
+			IL_0172: ldstr "process"
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_017c: ldstr "exitCode"
+			IL_0181: ldc.r8 1
+			IL_018a: ldc.i4.1
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0190: pop
+			IL_0191: ldnull
+			IL_0192: ret
 		} // end of method ArrowFunction_L8C13::__js_call__
 
 	} // end of class ArrowFunction_L8C13
@@ -659,7 +672,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 136 (0x88)
+		// Code size: 176 (0xb0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope,
@@ -721,12 +734,25 @@
 		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/ArrowFunction_L8C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/ArrowFunction_L8C13/FunctionObject>(!!0)
 		IL_0077: stloc.s 4
-		IL_0079: ldloc.3
-		IL_007a: ldstr "catch"
-		IL_007f: ldloc.s 4
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0086: pop
-		IL_0087: ret
+		IL_0079: volatile.
+		IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_0080: brfalse IL_0097
+
+		IL_0085: ldloc.3
+		IL_0086: ldstr "catch"
+		IL_008b: ldloc.s 4
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0092: br IL_00ae
+
+		IL_0097: ldloc.3
+		IL_0098: ldstr "catch"
+		IL_009d: ldloc.s 4
+		IL_009f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:__js_module_init__:13"
+		IL_00a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ae: pop
+		IL_00af: ret
 	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_UrlMode::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
@@ -2215,7 +2241,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 1389 (0x56d)
+					// Code size: 1431 (0x597)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -2245,7 +2271,7 @@
 					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
 					IL_0005: stloc.0
 					IL_0006: volatile.
-					IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+					IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 					IL_000d: brfalse IL_0022
 
 					IL_0012: ldarg.2
@@ -2256,7 +2282,7 @@
 					IL_0022: ldarg.2
 					IL_0023: ldstr "statusCode"
 					IL_0028: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:4"
-					IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+					IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 					IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0037: stloc.s 4
@@ -2277,7 +2303,7 @@
 					IL_0062: ldloc.s 7
 					IL_0064: stloc.1
 					IL_0065: volatile.
-					IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+					IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 					IL_006c: brfalse IL_0081
 
 					IL_0071: ldarg.2
@@ -2288,12 +2314,12 @@
 					IL_0081: ldarg.2
 					IL_0082: ldstr "headers"
 					IL_0087: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:18"
-					IL_008c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+					IL_008c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 					IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0096: stloc.s 4
 					IL_0098: volatile.
-					IL_009a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+					IL_009a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 					IL_009f: brfalse IL_00b5
 
 					IL_00a4: ldloc.s 4
@@ -2304,7 +2330,7 @@
 					IL_00b5: ldloc.s 4
 					IL_00b7: ldstr "location"
 					IL_00bc: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:20"
-					IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+					IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 					IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_00cb: stloc.2
@@ -2370,7 +2396,7 @@
 					IL_0171: ldarg.2
 					IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0177: volatile.
-					IL_0179: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+					IL_0179: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 					IL_017e: brfalse IL_0192
 
 					IL_0183: ldstr "resume"
@@ -2379,7 +2405,7 @@
 
 					IL_0192: ldstr "resume"
 					IL_0197: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:56"
-					IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+					IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 					IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 					IL_01a6: pop
@@ -2455,7 +2481,7 @@
 					IL_0238: ldloc.s 13
 					IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_023f: volatile.
-					IL_0241: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+					IL_0241: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 					IL_0246: brfalse IL_025a
 
 					IL_024b: ldstr "toString"
@@ -2464,14 +2490,14 @@
 
 					IL_025a: ldstr "toString"
 					IL_025f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:75"
-					IL_0264: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+					IL_0264: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 					IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 					IL_026e: stloc.3
 					IL_026f: ldarg.2
 					IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0275: volatile.
-					IL_0277: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+					IL_0277: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 					IL_027c: brfalse IL_0290
 
 					IL_0281: ldstr "resume"
@@ -2480,7 +2506,7 @@
 
 					IL_0290: ldstr "resume"
 					IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:80"
-					IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+					IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 					IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 					IL_02a4: pop
@@ -2591,7 +2617,7 @@
 					IL_03a1: ldarg.2
 					IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_03a7: volatile.
-					IL_03a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+					IL_03a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 					IL_03ae: brfalse IL_03c2
 
 					IL_03b3: ldstr "resume"
@@ -2600,7 +2626,7 @@
 
 					IL_03c2: ldstr "resume"
 					IL_03c7: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:119"
-					IL_03cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+					IL_03cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 					IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 					IL_03d6: pop
@@ -2664,135 +2690,147 @@
 
 					IL_0456: ldarg.2
 					IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_045c: ldstr "setEncoding"
-					IL_0461: ldstr "utf8"
-					IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_046b: pop
-					IL_046c: ldloc.0
-					IL_046d: ldstr ""
-					IL_0472: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0477: ldarg.2
-					IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_047d: stloc.s 18
-					IL_047f: ldc.i4.4
-					IL_0480: newarr [System.Runtime]System.Object
-					IL_0485: dup
-					IL_0486: ldc.i4.0
-					IL_0487: ldarg.0
-					IL_0488: ldc.i4.0
-					IL_0489: ldelem.ref
-					IL_048a: stelem.ref
-					IL_048b: dup
-					IL_048c: ldc.i4.1
-					IL_048d: ldarg.0
-					IL_048e: ldc.i4.1
-					IL_048f: ldelem.ref
-					IL_0490: stelem.ref
-					IL_0491: dup
-					IL_0492: ldc.i4.2
-					IL_0493: ldarg.0
-					IL_0494: ldc.i4.2
-					IL_0495: ldelem.ref
-					IL_0496: stelem.ref
-					IL_0497: dup
-					IL_0498: ldc.i4.3
-					IL_0499: ldloc.0
-					IL_049a: stelem.ref
-					IL_049b: stloc.s 12
-					IL_049d: ldloc.s 12
-					IL_049f: ldc.i4.0
-					IL_04a0: ldelem.ref
-					IL_04a1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_04a6: ldloc.s 12
-					IL_04a8: ldc.i4.1
-					IL_04a9: ldelem.ref
-					IL_04aa: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_04af: ldloc.s 12
-					IL_04b1: ldc.i4.2
-					IL_04b2: ldelem.ref
-					IL_04b3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_04b8: ldloc.s 12
-					IL_04ba: ldc.i4.3
-					IL_04bb: ldelem.ref
-					IL_04bc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-					IL_04c1: ldloc.s 12
-					IL_04c3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
-					IL_04c8: ldc.i4.1
-					IL_04c9: conv.r8
-					IL_04ca: ldstr ""
-					IL_04cf: ldc.i4.0
-					IL_04d0: ldc.i4.0
-					IL_04d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0, float64, string, bool, bool)
-					IL_04d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0)
-					IL_04db: stloc.s 20
-					IL_04dd: ldloc.s 18
-					IL_04df: ldstr "on"
-					IL_04e4: ldstr "data"
-					IL_04e9: ldloc.s 20
-					IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_04f0: pop
-					IL_04f1: ldarg.2
-					IL_04f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_04f7: stloc.s 18
-					IL_04f9: ldc.i4.4
-					IL_04fa: newarr [System.Runtime]System.Object
-					IL_04ff: dup
-					IL_0500: ldc.i4.0
-					IL_0501: ldarg.0
-					IL_0502: ldc.i4.0
-					IL_0503: ldelem.ref
-					IL_0504: stelem.ref
-					IL_0505: dup
-					IL_0506: ldc.i4.1
-					IL_0507: ldarg.0
-					IL_0508: ldc.i4.1
-					IL_0509: ldelem.ref
-					IL_050a: stelem.ref
-					IL_050b: dup
-					IL_050c: ldc.i4.2
-					IL_050d: ldarg.0
-					IL_050e: ldc.i4.2
-					IL_050f: ldelem.ref
-					IL_0510: stelem.ref
-					IL_0511: dup
-					IL_0512: ldc.i4.3
-					IL_0513: ldloc.0
-					IL_0514: stelem.ref
-					IL_0515: stloc.s 12
-					IL_0517: ldloc.s 12
-					IL_0519: ldc.i4.0
-					IL_051a: ldelem.ref
-					IL_051b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0520: ldloc.s 12
-					IL_0522: ldc.i4.1
-					IL_0523: ldelem.ref
-					IL_0524: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0529: ldloc.s 12
-					IL_052b: ldc.i4.2
-					IL_052c: ldelem.ref
-					IL_052d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0532: ldloc.s 12
-					IL_0534: ldc.i4.3
-					IL_0535: ldelem.ref
-					IL_0536: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-					IL_053b: ldloc.s 12
-					IL_053d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
-					IL_0542: ldc.i4.0
-					IL_0543: conv.r8
-					IL_0544: ldstr ""
-					IL_0549: ldc.i4.0
-					IL_054a: ldc.i4.0
-					IL_054b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0, float64, string, bool, bool)
-					IL_0550: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0)
-					IL_0555: stloc.s 21
-					IL_0557: ldloc.s 18
-					IL_0559: ldstr "on"
-					IL_055e: ldstr "end"
-					IL_0563: ldloc.s 21
-					IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_056a: pop
-					IL_056b: ldnull
-					IL_056c: ret
+					IL_045c: volatile.
+					IL_045e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+					IL_0463: brfalse IL_047c
+
+					IL_0468: ldstr "setEncoding"
+					IL_046d: ldstr "utf8"
+					IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0477: br IL_0495
+
+					IL_047c: ldstr "setEncoding"
+					IL_0481: ldstr "utf8"
+					IL_0486: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M18>:__js_call__:141"
+					IL_048b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+					IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_0495: pop
+					IL_0496: ldloc.0
+					IL_0497: ldstr ""
+					IL_049c: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_04a1: ldarg.2
+					IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_04a7: stloc.s 18
+					IL_04a9: ldc.i4.4
+					IL_04aa: newarr [System.Runtime]System.Object
+					IL_04af: dup
+					IL_04b0: ldc.i4.0
+					IL_04b1: ldarg.0
+					IL_04b2: ldc.i4.0
+					IL_04b3: ldelem.ref
+					IL_04b4: stelem.ref
+					IL_04b5: dup
+					IL_04b6: ldc.i4.1
+					IL_04b7: ldarg.0
+					IL_04b8: ldc.i4.1
+					IL_04b9: ldelem.ref
+					IL_04ba: stelem.ref
+					IL_04bb: dup
+					IL_04bc: ldc.i4.2
+					IL_04bd: ldarg.0
+					IL_04be: ldc.i4.2
+					IL_04bf: ldelem.ref
+					IL_04c0: stelem.ref
+					IL_04c1: dup
+					IL_04c2: ldc.i4.3
+					IL_04c3: ldloc.0
+					IL_04c4: stelem.ref
+					IL_04c5: stloc.s 12
+					IL_04c7: ldloc.s 12
+					IL_04c9: ldc.i4.0
+					IL_04ca: ldelem.ref
+					IL_04cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_04d0: ldloc.s 12
+					IL_04d2: ldc.i4.1
+					IL_04d3: ldelem.ref
+					IL_04d4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_04d9: ldloc.s 12
+					IL_04db: ldc.i4.2
+					IL_04dc: ldelem.ref
+					IL_04dd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_04e2: ldloc.s 12
+					IL_04e4: ldc.i4.3
+					IL_04e5: ldelem.ref
+					IL_04e6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+					IL_04eb: ldloc.s 12
+					IL_04ed: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
+					IL_04f2: ldc.i4.1
+					IL_04f3: conv.r8
+					IL_04f4: ldstr ""
+					IL_04f9: ldc.i4.0
+					IL_04fa: ldc.i4.0
+					IL_04fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0, float64, string, bool, bool)
+					IL_0500: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0)
+					IL_0505: stloc.s 20
+					IL_0507: ldloc.s 18
+					IL_0509: ldstr "on"
+					IL_050e: ldstr "data"
+					IL_0513: ldloc.s 20
+					IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_051a: pop
+					IL_051b: ldarg.2
+					IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0521: stloc.s 18
+					IL_0523: ldc.i4.4
+					IL_0524: newarr [System.Runtime]System.Object
+					IL_0529: dup
+					IL_052a: ldc.i4.0
+					IL_052b: ldarg.0
+					IL_052c: ldc.i4.0
+					IL_052d: ldelem.ref
+					IL_052e: stelem.ref
+					IL_052f: dup
+					IL_0530: ldc.i4.1
+					IL_0531: ldarg.0
+					IL_0532: ldc.i4.1
+					IL_0533: ldelem.ref
+					IL_0534: stelem.ref
+					IL_0535: dup
+					IL_0536: ldc.i4.2
+					IL_0537: ldarg.0
+					IL_0538: ldc.i4.2
+					IL_0539: ldelem.ref
+					IL_053a: stelem.ref
+					IL_053b: dup
+					IL_053c: ldc.i4.3
+					IL_053d: ldloc.0
+					IL_053e: stelem.ref
+					IL_053f: stloc.s 12
+					IL_0541: ldloc.s 12
+					IL_0543: ldc.i4.0
+					IL_0544: ldelem.ref
+					IL_0545: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_054a: ldloc.s 12
+					IL_054c: ldc.i4.1
+					IL_054d: ldelem.ref
+					IL_054e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0553: ldloc.s 12
+					IL_0555: ldc.i4.2
+					IL_0556: ldelem.ref
+					IL_0557: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_055c: ldloc.s 12
+					IL_055e: ldc.i4.3
+					IL_055f: ldelem.ref
+					IL_0560: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+					IL_0565: ldloc.s 12
+					IL_0567: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
+					IL_056c: ldc.i4.0
+					IL_056d: conv.r8
+					IL_056e: ldstr ""
+					IL_0573: ldc.i4.0
+					IL_0574: ldc.i4.0
+					IL_0575: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0, float64, string, bool, bool)
+					IL_057a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0)
+					IL_057f: stloc.s 21
+					IL_0581: ldloc.s 18
+					IL_0583: ldstr "on"
+					IL_0588: ldstr "end"
+					IL_058d: ldloc.s 21
+					IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0594: pop
+					IL_0595: ldnull
+					IL_0596: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -3094,7 +3132,7 @@
 				IL_00e1: ldloc.0
 				IL_00e2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::urlObj
 				IL_00e7: volatile.
-				IL_00e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+				IL_00e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 				IL_00ee: brfalse IL_0102
 
 				IL_00f3: ldstr "protocol"
@@ -3103,7 +3141,7 @@
 
 				IL_0102: ldstr "protocol"
 				IL_0107: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M17>:__js_call__:42"
-				IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+				IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 				IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0116: stloc.s 8
@@ -3222,7 +3260,7 @@
 				IL_023c: ldloc.s 6
 				IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0243: volatile.
-				IL_0245: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+				IL_0245: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 				IL_024a: brfalse IL_025e
 
 				IL_024f: ldstr "end"
@@ -3231,7 +3269,7 @@
 
 				IL_025e: ldstr "end"
 				IL_0263: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M17>:__js_call__:73"
-				IL_0268: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+				IL_0268: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 				IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0272: pop
@@ -3923,7 +3961,7 @@
 				IL_0079: ldloc.0
 				IL_007a: stloc.s 8
 				IL_007c: volatile.
-				IL_007e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+				IL_007e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 				IL_0083: brfalse IL_0098
 
 				IL_0088: ldarg.2
@@ -3934,7 +3972,7 @@
 				IL_0098: ldarg.2
 				IL_0099: ldstr "length"
 				IL_009e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M12>:__js_call__:34"
-				IL_00a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+				IL_00a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00ad: stloc.s 5
@@ -4457,7 +4495,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1345 (0x541)
+			// Code size: 1385 (0x569)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4762,210 +4800,223 @@
 			IL_02f7: stloc.s 10
 			// loop start (head: IL_02f9)
 				IL_02f9: ldc.i4.1
-				IL_02fa: brfalse IL_04e5
+				IL_02fa: brfalse IL_050d
 
-				IL_02ff: ldloc.s 8
-				IL_0301: ldstr "exec"
-				IL_0306: ldarg.2
-				IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_030c: stloc.s 11
-				IL_030e: ldloc.s 11
-				IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0315: ldc.i4.0
-				IL_0316: ceq
-				IL_0318: stloc.s 17
-				IL_031a: ldloc.s 17
-				IL_031c: brfalse IL_0326
+				IL_02ff: volatile.
+				IL_0301: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+				IL_0306: brfalse IL_031d
 
-				IL_0321: br IL_04e5
+				IL_030b: ldloc.s 8
+				IL_030d: ldstr "exec"
+				IL_0312: ldarg.2
+				IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0318: br IL_0334
 
-				IL_0326: ldloc.s 11
-				IL_0328: ldc.r8 0.0
-				IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0336: stloc.s 12
-				IL_0338: ldloc.s 10
-				IL_033a: stloc.s 19
-				IL_033c: ldloc.s 19
-				IL_033e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0343: ldc.r8 0.0
-				IL_034c: clt
-				IL_034e: brfalse IL_038c
+				IL_031d: ldloc.s 8
+				IL_031f: ldstr "exec"
+				IL_0324: ldarg.2
+				IL_0325: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:122"
+				IL_032a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+				IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0353: volatile.
-				IL_0355: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-				IL_035a: brfalse IL_0370
+				IL_0334: stloc.s 11
+				IL_0336: ldloc.s 11
+				IL_0338: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_033d: ldc.i4.0
+				IL_033e: ceq
+				IL_0340: stloc.s 17
+				IL_0342: ldloc.s 17
+				IL_0344: brfalse IL_034e
 
-				IL_035f: ldloc.s 11
-				IL_0361: ldstr "index"
-				IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_036b: br IL_0386
+				IL_0349: br IL_050d
 
-				IL_0370: ldloc.s 11
-				IL_0372: ldstr "index"
-				IL_0377: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:142"
-				IL_037c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-				IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_034e: ldloc.s 11
+				IL_0350: ldc.r8 0.0
+				IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_035e: stloc.s 12
+				IL_0360: ldloc.s 10
+				IL_0362: stloc.s 19
+				IL_0364: ldloc.s 19
+				IL_0366: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_036b: ldc.r8 0.0
+				IL_0374: clt
+				IL_0376: brfalse IL_03b4
 
-				IL_0386: stloc.s 15
-				IL_0388: ldloc.s 15
-				IL_038a: stloc.s 10
+				IL_037b: volatile.
+				IL_037d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+				IL_0382: brfalse IL_0398
 
-				IL_038c: ldloc.s 12
-				IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0393: stloc.s 15
-				IL_0395: ldc.i4.0
-				IL_0396: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_039b: brfalse IL_03d7
+				IL_0387: ldloc.s 11
+				IL_0389: ldstr "index"
+				IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0393: br IL_03ae
 
-				IL_03a0: ldloc.s 15
-				IL_03a2: isinst [System.Runtime]System.String
-				IL_03a7: dup
-				IL_03a8: brtrue IL_03c0
+				IL_0398: ldloc.s 11
+				IL_039a: ldstr "index"
+				IL_039f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:142"
+				IL_03a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_03ad: pop
-				IL_03ae: ldloc.s 15
-				IL_03b0: ldstr "startsWith"
-				IL_03b5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_03ba: dup
-				IL_03bb: brfalse IL_03d6
+				IL_03ae: stloc.s 15
+				IL_03b0: ldloc.s 15
+				IL_03b2: stloc.s 10
 
-				IL_03c0: ldstr "</"
-				IL_03c5: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-				IL_03ca: box [System.Runtime]System.Boolean
-				IL_03cf: stloc.s 15
-				IL_03d1: br IL_03ea
+				IL_03b4: ldloc.s 12
+				IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03bb: stloc.s 15
+				IL_03bd: ldc.i4.0
+				IL_03be: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_03c3: brfalse IL_03ff
 
-				IL_03d6: pop
+				IL_03c8: ldloc.s 15
+				IL_03ca: isinst [System.Runtime]System.String
+				IL_03cf: dup
+				IL_03d0: brtrue IL_03e8
 
-				IL_03d7: ldloc.s 15
-				IL_03d9: ldstr "startsWith"
-				IL_03de: ldstr "</"
-				IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_03e8: stloc.s 15
+				IL_03d5: pop
+				IL_03d6: ldloc.s 15
+				IL_03d8: ldstr "startsWith"
+				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_03e2: dup
+				IL_03e3: brfalse IL_03fe
 
-				IL_03ea: ldloc.s 15
-				IL_03ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_03f1: stloc.s 17
-				IL_03f3: ldloc.s 17
-				IL_03f5: brfalse IL_04d2
+				IL_03e8: ldstr "</"
+				IL_03ed: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_03f2: box [System.Runtime]System.Boolean
+				IL_03f7: stloc.s 15
+				IL_03f9: br IL_0412
 
-				IL_03fa: ldloc.s 9
-				IL_03fc: ldc.r8 1
-				IL_0405: sub
-				IL_0406: stloc.s 9
-				IL_0408: ldloc.s 9
-				IL_040a: stloc.s 18
-				IL_040c: ldloc.s 18
-				IL_040e: ldc.r8 0.0
-				IL_0417: ceq
-				IL_0419: brfalse IL_04cd
+				IL_03fe: pop
 
-				IL_041e: ldarg.2
-				IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0424: stloc.s 15
-				IL_0426: volatile.
-				IL_0428: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-				IL_042d: brfalse IL_0443
+				IL_03ff: ldloc.s 15
+				IL_0401: ldstr "startsWith"
+				IL_0406: ldstr "</"
+				IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0410: stloc.s 15
 
-				IL_0432: ldloc.s 8
-				IL_0434: ldstr "lastIndex"
-				IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_043e: br IL_0459
+				IL_0412: ldloc.s 15
+				IL_0414: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0419: stloc.s 17
+				IL_041b: ldloc.s 17
+				IL_041d: brfalse IL_04fa
 
-				IL_0443: ldloc.s 8
-				IL_0445: ldstr "lastIndex"
-				IL_044a: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:165"
-				IL_044f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-				IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0422: ldloc.s 9
+				IL_0424: ldc.r8 1
+				IL_042d: sub
+				IL_042e: stloc.s 9
+				IL_0430: ldloc.s 9
+				IL_0432: stloc.s 18
+				IL_0434: ldloc.s 18
+				IL_0436: ldc.r8 0.0
+				IL_043f: ceq
+				IL_0441: brfalse IL_04f5
 
-				IL_0459: stloc.s 20
-				IL_045b: ldc.i4.0
-				IL_045c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0461: brfalse IL_0497
+				IL_0446: ldarg.2
+				IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_044c: stloc.s 15
+				IL_044e: volatile.
+				IL_0450: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+				IL_0455: brfalse IL_046b
 
-				IL_0466: ldloc.s 15
-				IL_0468: isinst [System.Runtime]System.String
-				IL_046d: dup
-				IL_046e: brtrue IL_0486
+				IL_045a: ldloc.s 8
+				IL_045c: ldstr "lastIndex"
+				IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0466: br IL_0481
 
-				IL_0473: pop
-				IL_0474: ldloc.s 15
-				IL_0476: ldstr "substring"
-				IL_047b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_0480: dup
-				IL_0481: brfalse IL_0496
+				IL_046b: ldloc.s 8
+				IL_046d: ldstr "lastIndex"
+				IL_0472: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M13>:__js_call__:165"
+				IL_0477: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+				IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0486: ldloc.s 10
-				IL_0488: ldloc.s 20
-				IL_048a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_048f: stloc.s 20
-				IL_0491: br IL_04a9
+				IL_0481: stloc.s 20
+				IL_0483: ldc.i4.0
+				IL_0484: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0489: brfalse IL_04bf
 
-				IL_0496: pop
+				IL_048e: ldloc.s 15
+				IL_0490: isinst [System.Runtime]System.String
+				IL_0495: dup
+				IL_0496: brtrue IL_04ae
 
-				IL_0497: ldloc.s 15
-				IL_0499: ldstr "substring"
-				IL_049e: ldloc.s 10
-				IL_04a0: ldloc.s 20
-				IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_04a7: stloc.s 20
+				IL_049b: pop
+				IL_049c: ldloc.s 15
+				IL_049e: ldstr "substring"
+				IL_04a3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_04a8: dup
+				IL_04a9: brfalse IL_04be
 
-				IL_04a9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_04ae: dup
-				IL_04af: ldstr "tagName"
-				IL_04b4: ldloc.s 6
-				IL_04b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_04bb: dup
-				IL_04bc: ldstr "html"
-				IL_04c1: ldloc.s 20
-				IL_04c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_04c8: stloc.s 21
-				IL_04ca: ldloc.s 21
-				IL_04cc: ret
+				IL_04ae: ldloc.s 10
+				IL_04b0: ldloc.s 20
+				IL_04b2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_04b7: stloc.s 20
+				IL_04b9: br IL_04d1
 
-				IL_04cd: br IL_04e0
+				IL_04be: pop
 
-				IL_04d2: ldloc.s 9
-				IL_04d4: ldc.r8 1
-				IL_04dd: add
-				IL_04de: stloc.s 9
+				IL_04bf: ldloc.s 15
+				IL_04c1: ldstr "substring"
+				IL_04c6: ldloc.s 10
+				IL_04c8: ldloc.s 20
+				IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_04cf: stloc.s 20
 
-				IL_04e0: br IL_02f9
+				IL_04d1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_04d6: dup
+				IL_04d7: ldstr "tagName"
+				IL_04dc: ldloc.s 6
+				IL_04de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_04e3: dup
+				IL_04e4: ldstr "html"
+				IL_04e9: ldloc.s 20
+				IL_04eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_04f0: stloc.s 21
+				IL_04f2: ldloc.s 21
+				IL_04f4: ret
+
+				IL_04f5: br IL_0508
+
+				IL_04fa: ldloc.s 9
+				IL_04fc: ldc.r8 1
+				IL_0505: add
+				IL_0506: stloc.s 9
+
+				IL_0508: br IL_02f9
 			// end loop
 
-			IL_04e5: ldloc.s 6
-			IL_04e7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04ec: stloc.s 14
-			IL_04ee: ldstr "Could not find a matching closing </"
-			IL_04f3: ldloc.s 14
-			IL_04f5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04fa: ldstr "> for id '"
-			IL_04ff: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0504: ldarg.3
-			IL_0505: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_050a: stloc.s 14
-			IL_050c: ldloc.s 14
-			IL_050e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0513: ldstr "'."
-			IL_0518: call string [System.Runtime]System.String::Concat(string, string)
-			IL_051d: stloc.s 14
-			IL_051f: ldloc.s 14
-			IL_0521: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0526: stloc.s 13
-			IL_0528: ldloc.s 13
-			IL_052a: isinst [System.Runtime]System.Exception
-			IL_052f: dup
-			IL_0530: brtrue IL_053e
+			IL_050d: ldloc.s 6
+			IL_050f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0514: stloc.s 14
+			IL_0516: ldstr "Could not find a matching closing </"
+			IL_051b: ldloc.s 14
+			IL_051d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0522: ldstr "> for id '"
+			IL_0527: call string [System.Runtime]System.String::Concat(string, string)
+			IL_052c: ldarg.3
+			IL_052d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0532: stloc.s 14
+			IL_0534: ldloc.s 14
+			IL_0536: call string [System.Runtime]System.String::Concat(string, string)
+			IL_053b: ldstr "'."
+			IL_0540: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0545: stloc.s 14
+			IL_0547: ldloc.s 14
+			IL_0549: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_054e: stloc.s 13
+			IL_0550: ldloc.s 13
+			IL_0552: isinst [System.Runtime]System.Exception
+			IL_0557: dup
+			IL_0558: brtrue IL_0566
 
-			IL_0535: pop
-			IL_0536: ldloc.s 13
-			IL_0538: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_053d: throw
+			IL_055d: pop
+			IL_055e: ldloc.s 13
+			IL_0560: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0565: throw
 
-			IL_053e: throw
+			IL_0566: throw
 
-			IL_053f: ldnull
-			IL_0540: ret
+			IL_0567: ldnull
+			IL_0568: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -5143,7 +5194,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 584 (0x248)
+			// Code size: 623 (0x26f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5191,184 +5242,197 @@
 			IL_003d: ldstr "i"
 			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 			IL_0047: stloc.1
-			IL_0048: ldloc.1
-			IL_0049: ldstr "exec"
-			IL_004e: ldarg.2
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0054: stloc.2
-			IL_0055: ldloc.2
-			IL_0056: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005b: stloc.s 9
-			IL_005d: ldloc.s 9
-			IL_005f: brfalse IL_00ac
+			IL_0048: volatile.
+			IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_004f: brfalse IL_0065
 
-			IL_0064: ldloc.2
-			IL_0065: ldc.r8 1
-			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0073: stloc.s 10
-			IL_0075: ldloc.s 10
-			IL_0077: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_007c: stloc.s 9
-			IL_007e: ldloc.s 9
-			IL_0080: brtrue IL_009f
+			IL_0054: ldloc.1
+			IL_0055: ldstr "exec"
+			IL_005a: ldarg.2
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0060: br IL_007b
 
-			IL_0085: ldloc.2
-			IL_0086: ldc.r8 2
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0094: stloc.s 11
-			IL_0096: ldloc.s 11
-			IL_0098: stloc.s 13
-			IL_009a: br IL_00a3
+			IL_0065: ldloc.1
+			IL_0066: ldstr "exec"
+			IL_006b: ldarg.2
+			IL_006c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M14>:__js_call__:17"
+			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_009f: ldloc.s 10
-			IL_00a1: stloc.s 13
+			IL_007b: stloc.2
+			IL_007c: ldloc.2
+			IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0082: stloc.s 9
+			IL_0084: ldloc.s 9
+			IL_0086: brfalse IL_00d3
 
-			IL_00a3: ldloc.s 13
-			IL_00a5: stloc.s 14
-			IL_00a7: br IL_00af
+			IL_008b: ldloc.2
+			IL_008c: ldc.r8 1
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_009a: stloc.s 10
+			IL_009c: ldloc.s 10
+			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00a3: stloc.s 9
+			IL_00a5: ldloc.s 9
+			IL_00a7: brtrue IL_00c6
 
 			IL_00ac: ldloc.2
-			IL_00ad: stloc.s 14
+			IL_00ad: ldc.r8 2
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00bb: stloc.s 11
+			IL_00bd: ldloc.s 11
+			IL_00bf: stloc.s 13
+			IL_00c1: br IL_00ca
 
-			IL_00af: ldloc.s 14
-			IL_00b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b6: stloc.s 9
-			IL_00b8: ldloc.s 9
-			IL_00ba: brtrue IL_00cb
+			IL_00c6: ldloc.s 10
+			IL_00c8: stloc.s 13
 
-			IL_00bf: ldstr ""
-			IL_00c4: stloc.s 14
-			IL_00c6: br IL_00cb
+			IL_00ca: ldloc.s 13
+			IL_00cc: stloc.s 14
+			IL_00ce: br IL_00d6
 
-			IL_00cb: ldloc.s 14
-			IL_00cd: stloc.3
-			IL_00ce: ldloc.3
-			IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00d4: ldc.i4.0
-			IL_00d5: ceq
-			IL_00d7: stloc.s 9
-			IL_00d9: ldloc.s 9
-			IL_00db: brfalse IL_00e7
+			IL_00d3: ldloc.2
+			IL_00d4: stloc.s 14
 
-			IL_00e0: ldc.i4.0
-			IL_00e1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00e6: ret
+			IL_00d6: ldloc.s 14
+			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00dd: stloc.s 9
+			IL_00df: ldloc.s 9
+			IL_00e1: brtrue IL_00f2
 
-			IL_00e7: ldloc.3
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ed: stloc.s 10
-			IL_00ef: ldc.i4.0
-			IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00f5: brfalse IL_0117
+			IL_00e6: ldstr ""
+			IL_00eb: stloc.s 14
+			IL_00ed: br IL_00f2
 
-			IL_00fa: ldloc.s 10
-			IL_00fc: castclass [System.Runtime]System.String
-			IL_0101: ldstr "#"
-			IL_0106: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_010b: box [System.Runtime]System.Double
-			IL_0110: stloc.s 4
-			IL_0112: br IL_012a
+			IL_00f2: ldloc.s 14
+			IL_00f4: stloc.3
+			IL_00f5: ldloc.3
+			IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00fb: ldc.i4.0
+			IL_00fc: ceq
+			IL_00fe: stloc.s 9
+			IL_0100: ldloc.s 9
+			IL_0102: brfalse IL_010e
 
-			IL_0117: ldloc.s 10
-			IL_0119: ldstr "indexOf"
-			IL_011e: ldstr "#"
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0128: stloc.s 4
+			IL_0107: ldc.i4.0
+			IL_0108: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_010d: ret
 
-			IL_012a: ldloc.s 4
-			IL_012c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0131: ldc.r8 0.0
-			IL_013a: clt
-			IL_013c: ldc.i4.0
-			IL_013d: ceq
-			IL_013f: brfalse IL_01a1
+			IL_010e: ldloc.3
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0114: stloc.s 10
+			IL_0116: ldc.i4.0
+			IL_0117: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_011c: brfalse IL_013e
 
-			IL_0144: ldloc.3
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014a: stloc.s 10
-			IL_014c: ldc.i4.0
-			IL_014d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0152: brfalse IL_017a
+			IL_0121: ldloc.s 10
+			IL_0123: castclass [System.Runtime]System.String
+			IL_0128: ldstr "#"
+			IL_012d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0132: box [System.Runtime]System.Double
+			IL_0137: stloc.s 4
+			IL_0139: br IL_0151
 
-			IL_0157: ldloc.s 10
-			IL_0159: castclass [System.Runtime]System.String
-			IL_015e: ldc.r8 0.0
-			IL_0167: box [System.Runtime]System.Double
-			IL_016c: ldloc.s 4
-			IL_016e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_0173: stloc.s 10
-			IL_0175: br IL_0198
+			IL_013e: ldloc.s 10
+			IL_0140: ldstr "indexOf"
+			IL_0145: ldstr "#"
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_014f: stloc.s 4
 
-			IL_017a: ldloc.s 10
-			IL_017c: ldstr "substring"
-			IL_0181: ldc.r8 0.0
-			IL_018a: box [System.Runtime]System.Double
-			IL_018f: ldloc.s 4
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0196: stloc.s 10
+			IL_0151: ldloc.s 4
+			IL_0153: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0158: ldc.r8 0.0
+			IL_0161: clt
+			IL_0163: ldc.i4.0
+			IL_0164: ceq
+			IL_0166: brfalse IL_01c8
 
-			IL_0198: ldloc.s 10
-			IL_019a: stloc.s 5
-			IL_019c: br IL_01a4
+			IL_016b: ldloc.3
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0171: stloc.s 10
+			IL_0173: ldc.i4.0
+			IL_0174: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0179: brfalse IL_01a1
 
-			IL_01a1: ldloc.3
-			IL_01a2: stloc.s 5
+			IL_017e: ldloc.s 10
+			IL_0180: castclass [System.Runtime]System.String
+			IL_0185: ldc.r8 0.0
+			IL_018e: box [System.Runtime]System.Double
+			IL_0193: ldloc.s 4
+			IL_0195: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_019a: stloc.s 10
+			IL_019c: br IL_01bf
 
-			IL_01a4: ldloc.s 4
-			IL_01a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01ab: ldc.r8 0.0
-			IL_01b4: clt
-			IL_01b6: ldc.i4.0
-			IL_01b7: ceq
-			IL_01b9: brfalse IL_0211
+			IL_01a1: ldloc.s 10
+			IL_01a3: ldstr "substring"
+			IL_01a8: ldc.r8 0.0
+			IL_01b1: box [System.Runtime]System.Double
+			IL_01b6: ldloc.s 4
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01bd: stloc.s 10
 
-			IL_01be: ldloc.3
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c4: stloc.s 10
-			IL_01c6: ldloc.s 4
-			IL_01c8: ldc.r8 1
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01d6: stloc.s 14
-			IL_01d8: ldc.i4.0
-			IL_01d9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_01de: brfalse IL_01f8
+			IL_01bf: ldloc.s 10
+			IL_01c1: stloc.s 5
+			IL_01c3: br IL_01cb
 
-			IL_01e3: ldloc.s 10
-			IL_01e5: castclass [System.Runtime]System.String
-			IL_01ea: ldloc.s 14
-			IL_01ec: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_01f1: stloc.s 10
-			IL_01f3: br IL_0208
+			IL_01c8: ldloc.3
+			IL_01c9: stloc.s 5
 
-			IL_01f8: ldloc.s 10
-			IL_01fa: ldstr "substring"
-			IL_01ff: ldloc.s 14
-			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0206: stloc.s 10
+			IL_01cb: ldloc.s 4
+			IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01d2: ldc.r8 0.0
+			IL_01db: clt
+			IL_01dd: ldc.i4.0
+			IL_01de: ceq
+			IL_01e0: brfalse IL_0238
 
-			IL_0208: ldloc.s 10
-			IL_020a: stloc.s 6
-			IL_020c: br IL_0218
+			IL_01e5: ldloc.3
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01eb: stloc.s 10
+			IL_01ed: ldloc.s 4
+			IL_01ef: ldc.r8 1
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01fd: stloc.s 14
+			IL_01ff: ldc.i4.0
+			IL_0200: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0205: brfalse IL_021f
 
-			IL_0211: ldstr ""
-			IL_0216: stloc.s 6
+			IL_020a: ldloc.s 10
+			IL_020c: castclass [System.Runtime]System.String
+			IL_0211: ldloc.s 14
+			IL_0213: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_0218: stloc.s 10
+			IL_021a: br IL_022f
 
-			IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_021d: dup
-			IL_021e: ldstr "href"
-			IL_0223: ldloc.3
-			IL_0224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0229: dup
-			IL_022a: ldstr "filePart"
-			IL_022f: ldloc.s 5
-			IL_0231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0236: dup
-			IL_0237: ldstr "fragment"
-			IL_023c: ldloc.s 6
-			IL_023e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0243: stloc.s 16
-			IL_0245: ldloc.s 16
-			IL_0247: ret
+			IL_021f: ldloc.s 10
+			IL_0221: ldstr "substring"
+			IL_0226: ldloc.s 14
+			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_022d: stloc.s 10
+
+			IL_022f: ldloc.s 10
+			IL_0231: stloc.s 6
+			IL_0233: br IL_023f
+
+			IL_0238: ldstr ""
+			IL_023d: stloc.s 6
+
+			IL_023f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0244: dup
+			IL_0245: ldstr "href"
+			IL_024a: ldloc.3
+			IL_024b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0250: dup
+			IL_0251: ldstr "filePart"
+			IL_0256: ldloc.s 5
+			IL_0258: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_025d: dup
+			IL_025e: ldstr "fragment"
+			IL_0263: ldloc.s 6
+			IL_0265: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_026a: stloc.s 16
+			IL_026c: ldloc.s 16
+			IL_026e: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -6104,7 +6168,7 @@
 			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_01b2: stloc.s 22
 			IL_01b4: volatile.
-			IL_01b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_01b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_01bb: brfalse IL_01d1
 
 			IL_01c0: ldloc.s 22
@@ -6115,7 +6179,7 @@
 			IL_01d1: ldloc.s 22
 			IL_01d3: ldstr "argv"
 			IL_01d8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:7"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01e7: stloc.s 22
@@ -6124,7 +6188,7 @@
 			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_01f2: stloc.1
 			IL_01f3: volatile.
-			IL_01f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_01f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_01fa: brfalse IL_020f
 
 			IL_01ff: ldloc.1
@@ -6135,7 +6199,7 @@
 			IL_020f: ldloc.1
 			IL_0210: ldstr "section"
 			IL_0215: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:12"
-			IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0224: stloc.s 22
@@ -6171,7 +6235,7 @@
 			IL_0272: ret
 
 			IL_0273: volatile.
-			IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_027a: brfalse IL_028f
 
 			IL_027f: ldloc.1
@@ -6182,7 +6246,7 @@
 			IL_028f: ldloc.1
 			IL_0290: ldstr "outFile"
 			IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:23"
-			IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02a4: stloc.s 22
@@ -6218,7 +6282,7 @@
 			IL_02f2: ret
 
 			IL_02f3: volatile.
-			IL_02f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_02f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_02fa: brfalse IL_030f
 
 			IL_02ff: ldloc.1
@@ -6229,7 +6293,7 @@
 			IL_030f: ldloc.1
 			IL_0310: ldstr "url"
 			IL_0315: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:34"
-			IL_031a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_031a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0324: stloc.s 22
@@ -6251,7 +6315,7 @@
 			IL_035b: ldloc.s 4
 			IL_035d: stloc.s 24
 			IL_035f: volatile.
-			IL_0361: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0361: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_0366: brfalse IL_037b
 
 			IL_036b: ldloc.1
@@ -6262,7 +6326,7 @@
 			IL_037b: ldloc.1
 			IL_037c: ldstr "auto"
 			IL_0381: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:48"
-			IL_0386: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0386: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0390: stloc.s 22
@@ -6319,7 +6383,7 @@
 			IL_042c: ldnull
 			IL_042d: stloc.s 8
 			IL_042f: volatile.
-			IL_0431: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_0431: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_0436: brfalse IL_044b
 
 			IL_043b: ldloc.1
@@ -6330,7 +6394,7 @@
 			IL_044b: ldloc.1
 			IL_044c: ldstr "id"
 			IL_0451: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:78"
-			IL_0456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_0456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0460: stloc.s 22
@@ -6368,7 +6432,7 @@
 			IL_04b7: ldstr ""
 			IL_04bc: stloc.s 10
 			IL_04be: volatile.
-			IL_04c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_04c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_04c5: brfalse IL_04da
 
 			IL_04ca: ldloc.1
@@ -6379,7 +6443,7 @@
 			IL_04da: ldloc.1
 			IL_04db: ldstr "auto"
 			IL_04e0: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:95"
-			IL_04e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_04e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_04ef: stloc.s 22
@@ -6390,7 +6454,7 @@
 			IL_04fc: brfalse IL_0a6e
 
 			IL_0501: volatile.
-			IL_0503: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0503: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_0508: brfalse IL_051d
 
 			IL_050d: ldloc.1
@@ -6401,7 +6465,7 @@
 			IL_051d: ldloc.1
 			IL_051e: ldstr "indexUrl"
 			IL_0523: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:100"
-			IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0532: stloc.s 22
@@ -6623,7 +6687,7 @@
 			IL_06b4: stelem.ref
 			IL_06b5: stloc.s 21
 			IL_06b7: volatile.
-			IL_06b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_06b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_06be: brfalse IL_06d3
 
 			IL_06c3: ldloc.1
@@ -6634,7 +6698,7 @@
 			IL_06d3: ldloc.1
 			IL_06d4: ldstr "section"
 			IL_06d9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:114"
-			IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_06e8: stloc.s 26
@@ -6683,7 +6747,7 @@
 			IL_0756: brfalse IL_07f8
 
 			IL_075b: volatile.
-			IL_075d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_075d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_0762: brfalse IL_0777
 
 			IL_0767: ldloc.1
@@ -6694,7 +6758,7 @@
 			IL_0777: ldloc.1
 			IL_0778: ldstr "section"
 			IL_077d: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:125"
-			IL_0782: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0782: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_078c: stloc.s 26
@@ -6742,7 +6806,7 @@
 			IL_0800: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
 			IL_0805: stloc.s 26
 			IL_0807: volatile.
-			IL_0809: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0809: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_080e: brfalse IL_0824
 
 			IL_0813: ldloc.s 13
@@ -6753,7 +6817,7 @@
 			IL_0824: ldloc.s 13
 			IL_0826: ldstr "filePart"
 			IL_082b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:139"
-			IL_0830: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0830: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_083a: stloc.s 22
@@ -6764,7 +6828,7 @@
 			IL_0847: brtrue IL_088a
 
 			IL_084c: volatile.
-			IL_084e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_084e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_0853: brfalse IL_0869
 
 			IL_0858: ldloc.s 13
@@ -6775,7 +6839,7 @@
 			IL_0869: ldloc.s 13
 			IL_086b: ldstr "href"
 			IL_0870: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:143"
-			IL_0875: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_0875: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_087f: stloc.s 28
@@ -6796,7 +6860,7 @@
 			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_08a3: stloc.s 26
 			IL_08a5: volatile.
-			IL_08a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_08a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_08ac: brfalse IL_08c2
 
 			IL_08b1: ldloc.s 26
@@ -6807,7 +6871,7 @@
 			IL_08c2: ldloc.s 26
 			IL_08c4: ldstr "toString"
 			IL_08c9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:151"
-			IL_08ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_08ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_08d8: stloc.s 15
@@ -6998,7 +7062,7 @@
 			IL_0a0b: brfalse IL_0a69
 
 			IL_0a10: volatile.
-			IL_0a12: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0a12: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_0a17: brfalse IL_0a2d
 
 			IL_0a1c: ldloc.s 13
@@ -7009,7 +7073,7 @@
 			IL_0a2d: ldloc.s 13
 			IL_0a2f: ldstr "fragment"
 			IL_0a34: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:168"
-			IL_0a39: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0a39: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_0a3e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0a43: stloc.s 26
@@ -7032,7 +7096,7 @@
 			IL_0a69: br IL_0c13
 
 			IL_0a6e: volatile.
-			IL_0a70: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_0a70: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_0a75: brfalse IL_0a8a
 
 			IL_0a7a: ldloc.1
@@ -7043,7 +7107,7 @@
 			IL_0a8a: ldloc.1
 			IL_0a8b: ldstr "url"
 			IL_0a90: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:184"
-			IL_0a95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_0a95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0a9f: stloc.s 26
@@ -7265,7 +7329,7 @@
 			IL_0c21: brfalse IL_0cb3
 
 			IL_0c26: volatile.
-			IL_0c28: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_0c28: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_0c2d: brfalse IL_0c42
 
 			IL_0c32: ldloc.1
@@ -7276,7 +7340,7 @@
 			IL_0c42: ldloc.1
 			IL_0c43: ldstr "section"
 			IL_0c48: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:205"
-			IL_0c4d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_0c4d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_0c52: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0c57: stloc.s 26
@@ -7344,7 +7408,7 @@
 			IL_0cf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0cfd: stloc.s 26
 			IL_0cff: volatile.
-			IL_0d01: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0d01: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_0d06: brfalse IL_0d1c
 
 			IL_0d0b: ldloc.s 26
@@ -7355,12 +7419,12 @@
 			IL_0d1c: ldloc.s 26
 			IL_0d1e: ldstr "cwd"
 			IL_0d23: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:224"
-			IL_0d28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0d28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_0d2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0d32: stloc.s 26
 			IL_0d34: volatile.
-			IL_0d36: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_0d36: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_0d3b: brfalse IL_0d50
 
 			IL_0d40: ldloc.1
@@ -7371,7 +7435,7 @@
 			IL_0d50: ldloc.1
 			IL_0d51: ldstr "outFile"
 			IL_0d56: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:226"
-			IL_0d5b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_0d5b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_0d60: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0d65: stloc.s 22
@@ -7403,7 +7467,7 @@
 			IL_0d98: stelem.ref
 			IL_0d99: stloc.s 21
 			IL_0d9b: volatile.
-			IL_0d9d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0d9d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_0da2: brfalse IL_0db8
 
 			IL_0da7: ldloc.s 18
@@ -7414,12 +7478,12 @@
 			IL_0db8: ldloc.s 18
 			IL_0dba: ldstr "html"
 			IL_0dbf: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:233"
-			IL_0dc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0dc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_0dc9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0dce: stloc.s 22
 			IL_0dd0: volatile.
-			IL_0dd2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_0dd2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_0dd7: brfalse IL_0dec
 
 			IL_0ddc: ldloc.1
@@ -7430,7 +7494,7 @@
 			IL_0dec: ldloc.1
 			IL_0ded: ldstr "section"
 			IL_0df2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:236"
-			IL_0df7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_0df7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_0dfc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0e01: stloc.s 26
@@ -7475,7 +7539,7 @@
 			IL_0e67: stelem.ref
 			IL_0e68: stloc.s 21
 			IL_0e6a: volatile.
-			IL_0e6c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0e6c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0e71: brfalse IL_0e86
 
 			IL_0e76: ldloc.1
@@ -7486,7 +7550,7 @@
 			IL_0e86: ldloc.1
 			IL_0e87: ldstr "section"
 			IL_0e8c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:251"
-			IL_0e91: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0e91: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0e96: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0e9b: stloc.s 22
@@ -7506,7 +7570,7 @@
 			IL_0ecc: ldstr ", tag="
 			IL_0ed1: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0ed6: volatile.
-			IL_0ed8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0ed8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_0edd: brfalse IL_0ef3
 
 			IL_0ee2: ldloc.s 18
@@ -7517,7 +7581,7 @@
 			IL_0ef3: ldloc.s 18
 			IL_0ef5: ldstr "tagName"
 			IL_0efa: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M16>:__js_call__:261"
-			IL_0eff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0eff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_0f04: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0f09: stloc.s 22
@@ -7914,7 +7978,7 @@
 		IL_021a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
 		IL_021f: volatile.
-		IL_0221: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_0221: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 		IL_0226: brfalse IL_023c
 
 		IL_022b: ldloc.s 15
@@ -7925,7 +7989,7 @@
 		IL_023c: ldloc.s 15
 		IL_023e: ldstr "URL"
 		IL_0243: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:__js_module_init__:63"
-		IL_0248: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_0248: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0252: stloc.s 16
@@ -8017,6 +8081,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_93
 	.field assembly static int32 __jroc_dynamicLookup_94
 	.field assembly static int32 __jroc_dynamicLookup_95
+	.field assembly static int32 __jroc_dynamicLookup_96
+	.field assembly static int32 __jroc_dynamicLookup_97
+	.field assembly static int32 __jroc_dynamicLookup_98
+	.field assembly static int32 __jroc_dynamicLookup_99
+	.field assembly static int32 __jroc_dynamicLookup_100
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -1376,7 +1376,7 @@
 				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 12
-			// Code size: 200 (0xc8)
+			// Code size: 282 (0x11a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/Scope,
@@ -1457,19 +1457,44 @@
 			IL_0096: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20/FunctionObject>(!!0)
 			IL_00a0: stloc.s 5
-			IL_00a2: ldloc.3
-			IL_00a3: ldstr "map"
-			IL_00a8: ldloc.s 5
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00af: stloc.3
-			IL_00b0: ldloc.3
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b6: ldstr "join"
-			IL_00bb: ldstr "\n"
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c5: stloc.3
-			IL_00c6: ldloc.3
-			IL_00c7: ret
+			IL_00a2: volatile.
+			IL_00a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_00a9: brfalse IL_00c0
+
+			IL_00ae: ldloc.3
+			IL_00af: ldstr "map"
+			IL_00b4: ldloc.s 5
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00bb: br IL_00d7
+
+			IL_00c0: ldloc.3
+			IL_00c1: ldstr "map"
+			IL_00c6: ldloc.s 5
+			IL_00c8: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M9>:__js_call__:20"
+			IL_00cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00d7: stloc.3
+			IL_00d8: ldloc.3
+			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00de: volatile.
+			IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_00e5: brfalse IL_00fe
+
+			IL_00ea: ldstr "join"
+			IL_00ef: ldstr "\n"
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00f9: br IL_0117
+
+			IL_00fe: ldstr "join"
+			IL_0103: ldstr "\n"
+			IL_0108: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M9>:__js_call__:23"
+			IL_010d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0117: stloc.3
+			IL_0118: ldloc.3
+			IL_0119: ret
 		} // end of method renderImplementation::__js_call__
 
 	} // end of class renderImplementation
@@ -1697,7 +1722,7 @@
 			IL_001f: brtrue IL_0075
 
 			IL_0024: volatile.
-			IL_0026: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0026: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 			IL_002b: brfalse IL_0040
 
 			IL_0030: ldarg.2
@@ -1708,7 +1733,7 @@
 			IL_0040: ldarg.2
 			IL_0041: ldstr "length"
 			IL_0046: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M10>:__js_call__:8"
-			IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0055: stloc.s 8
@@ -1776,7 +1801,7 @@
 					IL_00de: ldloc.s 8
 					IL_00e0: stloc.s 4
 					IL_00e2: volatile.
-					IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+					IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 					IL_00e9: brfalse IL_00ff
 
 					IL_00ee: ldloc.s 4
@@ -1787,7 +1812,7 @@
 					IL_00ff: ldloc.s 4
 					IL_0101: ldstr "name"
 					IL_0106: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M10>:__js_call__:51"
-					IL_010b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+					IL_010b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 					IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0115: stloc.s 8
@@ -1814,7 +1839,7 @@
 					IL_0151: call string [System.Runtime]System.String::Concat(string, string)
 					IL_0156: stloc.s 13
 					IL_0158: volatile.
-					IL_015a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+					IL_015a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 					IL_015f: brfalse IL_0175
 
 					IL_0164: ldloc.s 4
@@ -1825,7 +1850,7 @@
 					IL_0175: ldloc.s 4
 					IL_0177: ldstr "kind"
 					IL_017c: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M10>:__js_call__:65"
-					IL_0181: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+					IL_0181: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 					IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_018b: stloc.s 8
@@ -1852,7 +1877,7 @@
 					IL_01c4: call string [System.Runtime]System.String::Concat(string, string)
 					IL_01c9: stloc.s 15
 					IL_01cb: volatile.
-					IL_01cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+					IL_01cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 					IL_01d2: brfalse IL_01e8
 
 					IL_01d7: ldloc.s 4
@@ -1863,7 +1888,7 @@
 					IL_01e8: ldloc.s 4
 					IL_01ea: ldstr "status"
 					IL_01ef: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M10>:__js_call__:79"
-					IL_01f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+					IL_01f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 					IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_01fe: stloc.s 8
@@ -1890,7 +1915,7 @@
 					IL_0237: call string [System.Runtime]System.String::Concat(string, string)
 					IL_023c: stloc.s 13
 					IL_023e: volatile.
-					IL_0240: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+					IL_0240: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 					IL_0245: brfalse IL_025b
 
 					IL_024a: ldloc.s 4
@@ -1901,7 +1926,7 @@
 					IL_025b: ldloc.s 4
 					IL_025d: ldstr "docs"
 					IL_0262: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M10>:__js_call__:93"
-					IL_0267: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+					IL_0267: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 					IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0271: stloc.s 8
@@ -1921,7 +1946,7 @@
 					IL_0292: stelem.ref
 					IL_0293: stloc.s 17
 					IL_0295: volatile.
-					IL_0297: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+					IL_0297: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 					IL_029c: brfalse IL_02b2
 
 					IL_02a1: ldloc.s 4
@@ -1932,7 +1957,7 @@
 					IL_02b2: ldloc.s 4
 					IL_02b4: ldstr "docs"
 					IL_02b9: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M10>:__js_call__:99"
-					IL_02be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+					IL_02be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 					IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_02c8: stloc.s 8
@@ -2305,7 +2330,7 @@
 					IL_005b: ldloc.s 17
 					IL_005d: stloc.s 4
 					IL_005f: volatile.
-					IL_0061: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+					IL_0061: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 					IL_0066: brfalse IL_007c
 
 					IL_006b: ldloc.s 4
@@ -2316,7 +2341,7 @@
 					IL_007c: ldloc.s 4
 					IL_007e: ldstr "tests"
 					IL_0083: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:30"
-					IL_0088: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+					IL_0088: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 					IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0092: stloc.s 17
@@ -2335,7 +2360,7 @@
 					IL_00b4: brtrue IL_0141
 
 					IL_00b9: volatile.
-					IL_00bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+					IL_00bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
 					IL_00c0: brfalse IL_00d6
 
 					IL_00c5: ldloc.s 4
@@ -2346,12 +2371,12 @@
 					IL_00d6: ldloc.s 4
 					IL_00d8: ldstr "tests"
 					IL_00dd: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:36"
-					IL_00e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+					IL_00e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
 					IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_00ec: stloc.s 17
 					IL_00ee: volatile.
-					IL_00f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+					IL_00f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 					IL_00f5: brfalse IL_010b
 
 					IL_00fa: ldloc.s 17
@@ -2362,7 +2387,7 @@
 					IL_010b: ldloc.s 17
 					IL_010d: ldstr "length"
 					IL_0112: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:38"
-					IL_0117: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+					IL_0117: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 					IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0121: stloc.s 17
@@ -2400,7 +2425,7 @@
 					IL_016b: stelem.ref
 					IL_016c: stloc.s 21
 					IL_016e: volatile.
-					IL_0170: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+					IL_0170: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 					IL_0175: brfalse IL_018b
 
 					IL_017a: ldloc.s 4
@@ -2411,7 +2436,7 @@
 					IL_018b: ldloc.s 4
 					IL_018d: ldstr "name"
 					IL_0192: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:56"
-					IL_0197: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+					IL_0197: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 					IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_01a1: stloc.s 22
@@ -2445,7 +2470,7 @@
 					IL_01ea: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_01ef: pop
 					IL_01f0: volatile.
-					IL_01f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+					IL_01f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 					IL_01f7: brfalse IL_020d
 
 					IL_01fc: ldloc.s 4
@@ -2456,7 +2481,7 @@
 					IL_020d: ldloc.s 4
 					IL_020f: ldstr "tests"
 					IL_0214: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:71"
-					IL_0219: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+					IL_0219: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 					IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0223: stloc.s 17
@@ -2489,7 +2514,7 @@
 							IL_025c: ldloc.s 17
 							IL_025e: stloc.s 8
 							IL_0260: volatile.
-							IL_0262: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+							IL_0262: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 							IL_0267: brfalse IL_027d
 
 							IL_026c: ldloc.s 8
@@ -2500,7 +2525,7 @@
 							IL_027d: ldloc.s 8
 							IL_027f: ldstr "name"
 							IL_0284: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:89"
-							IL_0289: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+							IL_0289: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 							IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 							IL_0293: stloc.s 17
@@ -2520,7 +2545,7 @@
 							IL_02b4: stelem.ref
 							IL_02b5: stloc.s 21
 							IL_02b7: volatile.
-							IL_02b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+							IL_02b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 							IL_02be: brfalse IL_02d4
 
 							IL_02c3: ldloc.s 8
@@ -2531,7 +2556,7 @@
 							IL_02d4: ldloc.s 8
 							IL_02d6: ldstr "name"
 							IL_02db: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:95"
-							IL_02e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+							IL_02e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 							IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 							IL_02ea: stloc.s 17
@@ -2549,7 +2574,7 @@
 							IL_0307: ldloc.s 9
 							IL_0309: stloc.s 10
 							IL_030b: volatile.
-							IL_030d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+							IL_030d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 							IL_0312: brfalse IL_0328
 
 							IL_0317: ldloc.s 8
@@ -2560,7 +2585,7 @@
 							IL_0328: ldloc.s 8
 							IL_032a: ldstr "file"
 							IL_032f: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:106"
-							IL_0334: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+							IL_0334: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 							IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 							IL_033e: stloc.s 17
@@ -2580,7 +2605,7 @@
 							IL_035f: stelem.ref
 							IL_0360: stloc.s 21
 							IL_0362: volatile.
-							IL_0364: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+							IL_0364: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
 							IL_0369: brfalse IL_037f
 
 							IL_036e: ldloc.s 8
@@ -2591,7 +2616,7 @@
 							IL_037f: ldloc.s 8
 							IL_0381: ldstr "file"
 							IL_0386: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:113"
-							IL_038b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+							IL_038b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
 							IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 							IL_0395: stloc.s 17
@@ -2978,7 +3003,7 @@
 			IL_0019: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_001e: pop
 			IL_001f: volatile.
-			IL_0021: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_0021: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
 			IL_0026: brfalse IL_003b
 
 			IL_002b: ldarg.2
@@ -2989,7 +3014,7 @@
 			IL_003b: ldarg.2
 			IL_003c: ldstr "modules"
 			IL_0041: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:12"
-			IL_0046: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_0046: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
 			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0050: stloc.s 7
@@ -3038,7 +3063,7 @@
 					IL_00a8: ldloc.s 7
 					IL_00aa: stloc.s 4
 					IL_00ac: volatile.
-					IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+					IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 					IL_00b3: brfalse IL_00c9
 
 					IL_00b8: ldloc.s 4
@@ -3049,7 +3074,7 @@
 					IL_00c9: ldloc.s 4
 					IL_00cb: ldstr "name"
 					IL_00d0: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:39"
-					IL_00d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+					IL_00d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 					IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_00df: stloc.s 7
@@ -3062,7 +3087,7 @@
 					IL_00f6: ldstr " (status: "
 					IL_00fb: call string [System.Runtime]System.String::Concat(string, string)
 					IL_0100: volatile.
-					IL_0102: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+					IL_0102: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
 					IL_0107: brfalse IL_011d
 
 					IL_010c: ldloc.s 4
@@ -3073,7 +3098,7 @@
 					IL_011d: ldloc.s 4
 					IL_011f: ldstr "status"
 					IL_0124: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:45"
-					IL_0129: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+					IL_0129: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
 					IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0133: stloc.s 7
@@ -3090,7 +3115,7 @@
 					IL_0154: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_0159: pop
 					IL_015a: volatile.
-					IL_015c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+					IL_015c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
 					IL_0161: brfalse IL_0177
 
 					IL_0166: ldloc.s 4
@@ -3101,7 +3126,7 @@
 					IL_0177: ldloc.s 4
 					IL_0179: ldstr "docs"
 					IL_017e: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:53"
-					IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+					IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
 					IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_018d: stloc.s 7
@@ -3121,7 +3146,7 @@
 					IL_01ae: stelem.ref
 					IL_01af: stloc.s 13
 					IL_01b1: volatile.
-					IL_01b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+					IL_01b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
 					IL_01b8: brfalse IL_01ce
 
 					IL_01bd: ldloc.s 4
@@ -3132,7 +3157,7 @@
 					IL_01ce: ldloc.s 4
 					IL_01d0: ldstr "docs"
 					IL_01d5: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:61"
-					IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+					IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
 					IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_01e4: stloc.s 7
@@ -3153,7 +3178,7 @@
 					IL_0210: pop
 
 					IL_0211: volatile.
-					IL_0213: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+					IL_0213: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
 					IL_0218: brfalse IL_022e
 
 					IL_021d: ldloc.s 4
@@ -3164,7 +3189,7 @@
 					IL_022e: ldloc.s 4
 					IL_0230: ldstr "implementation"
 					IL_0235: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:69"
-					IL_023a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+					IL_023a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
 					IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0244: stloc.s 7
@@ -3188,7 +3213,7 @@
 					IL_0271: stelem.ref
 					IL_0272: stloc.s 13
 					IL_0274: volatile.
-					IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+					IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
 					IL_027b: brfalse IL_0291
 
 					IL_0280: ldloc.s 4
@@ -3199,7 +3224,7 @@
 					IL_0291: ldloc.s 4
 					IL_0293: ldstr "implementation"
 					IL_0298: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:79"
-					IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+					IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
 					IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_02a7: stloc.s 7
@@ -3227,7 +3252,7 @@
 					IL_02da: stelem.ref
 					IL_02db: stloc.s 13
 					IL_02dd: volatile.
-					IL_02df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+					IL_02df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 					IL_02e4: brfalse IL_02fa
 
 					IL_02e9: ldloc.s 4
@@ -3238,7 +3263,7 @@
 					IL_02fa: ldloc.s 4
 					IL_02fc: ldstr "apis"
 					IL_0301: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:90"
-					IL_0306: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+					IL_0306: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 					IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0310: stloc.s 14
@@ -3289,7 +3314,7 @@
 					IL_037a: stelem.ref
 					IL_037b: stloc.s 13
 					IL_037d: volatile.
-					IL_037f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+					IL_037f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 					IL_0384: brfalse IL_039a
 
 					IL_0389: ldloc.s 4
@@ -3300,7 +3325,7 @@
 					IL_039a: ldloc.s 4
 					IL_039c: ldstr "apis"
 					IL_03a1: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:114"
-					IL_03a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+					IL_03a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 					IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_03b0: stloc.s 14
@@ -3708,7 +3733,7 @@
 			IL_0019: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 			IL_001e: pop
 			IL_001f: volatile.
-			IL_0021: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_0021: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 			IL_0026: brfalse IL_003b
 
 			IL_002b: ldarg.2
@@ -3719,7 +3744,7 @@
 			IL_003b: ldarg.2
 			IL_003c: ldstr "globals"
 			IL_0041: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:12"
-			IL_0046: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_0046: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0050: stloc.s 13
@@ -3768,7 +3793,7 @@
 					IL_00a8: ldloc.s 13
 					IL_00aa: stloc.s 4
 					IL_00ac: volatile.
-					IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+					IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 					IL_00b3: brfalse IL_00c9
 
 					IL_00b8: ldloc.s 4
@@ -3779,7 +3804,7 @@
 					IL_00c9: ldloc.s 4
 					IL_00cb: ldstr "name"
 					IL_00d0: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:39"
-					IL_00d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+					IL_00d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 					IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_00df: stloc.s 13
@@ -3792,7 +3817,7 @@
 					IL_00f6: ldstr " (status: "
 					IL_00fb: call string [System.Runtime]System.String::Concat(string, string)
 					IL_0100: volatile.
-					IL_0102: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+					IL_0102: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 					IL_0107: brfalse IL_011d
 
 					IL_010c: ldloc.s 4
@@ -3803,7 +3828,7 @@
 					IL_011d: ldloc.s 4
 					IL_011f: ldstr "status"
 					IL_0124: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:45"
-					IL_0129: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+					IL_0129: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 					IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0133: stloc.s 13
@@ -3820,7 +3845,7 @@
 					IL_0154: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_0159: pop
 					IL_015a: volatile.
-					IL_015c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+					IL_015c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 					IL_0161: brfalse IL_0177
 
 					IL_0166: ldloc.s 4
@@ -3831,7 +3856,7 @@
 					IL_0177: ldloc.s 4
 					IL_0179: ldstr "docs"
 					IL_017e: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:53"
-					IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+					IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 					IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_018d: stloc.s 13
@@ -3851,7 +3876,7 @@
 					IL_01ae: stelem.ref
 					IL_01af: stloc.s 19
 					IL_01b1: volatile.
-					IL_01b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+					IL_01b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 					IL_01b8: brfalse IL_01ce
 
 					IL_01bd: ldloc.s 4
@@ -3862,7 +3887,7 @@
 					IL_01ce: ldloc.s 4
 					IL_01d0: ldstr "docs"
 					IL_01d5: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:61"
-					IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+					IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 					IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_01e4: stloc.s 13
@@ -3883,7 +3908,7 @@
 					IL_0210: pop
 
 					IL_0211: volatile.
-					IL_0213: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+					IL_0213: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 					IL_0218: brfalse IL_022e
 
 					IL_021d: ldloc.s 4
@@ -3894,7 +3919,7 @@
 					IL_022e: ldloc.s 4
 					IL_0230: ldstr "implementation"
 					IL_0235: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:69"
-					IL_023a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+					IL_023a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 					IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0244: stloc.s 13
@@ -3918,7 +3943,7 @@
 					IL_0271: stelem.ref
 					IL_0272: stloc.s 19
 					IL_0274: volatile.
-					IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+					IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 					IL_027b: brfalse IL_0291
 
 					IL_0280: ldloc.s 4
@@ -3929,7 +3954,7 @@
 					IL_0291: ldloc.s 4
 					IL_0293: ldstr "implementation"
 					IL_0298: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:79"
-					IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+					IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 					IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_02a7: stloc.s 13
@@ -3943,7 +3968,7 @@
 					IL_02bc: pop
 
 					IL_02bd: volatile.
-					IL_02bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+					IL_02bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 					IL_02c4: brfalse IL_02da
 
 					IL_02c9: ldloc.s 4
@@ -3954,7 +3979,7 @@
 					IL_02da: ldloc.s 4
 					IL_02dc: ldstr "notes"
 					IL_02e1: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:85"
-					IL_02e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+					IL_02e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 					IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_02f0: stloc.s 13
@@ -3969,7 +3994,7 @@
 					IL_0308: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_030d: pop
 					IL_030e: volatile.
-					IL_0310: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+					IL_0310: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 					IL_0315: brfalse IL_032b
 
 					IL_031a: ldloc.s 4
@@ -3980,7 +4005,7 @@
 					IL_032b: ldloc.s 4
 					IL_032d: ldstr "notes"
 					IL_0332: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:93"
-					IL_0337: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+					IL_0337: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 					IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0341: stloc.s 13
@@ -3990,7 +4015,7 @@
 					IL_034b: pop
 
 					IL_034c: volatile.
-					IL_034e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+					IL_034e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 					IL_0353: brfalse IL_0369
 
 					IL_0358: ldloc.s 4
@@ -4001,7 +4026,7 @@
 					IL_0369: ldloc.s 4
 					IL_036b: ldstr "tests"
 					IL_0370: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:98"
-					IL_0375: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+					IL_0375: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 					IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_037f: stloc.s 13
@@ -4012,7 +4037,7 @@
 					IL_038c: brfalse IL_0404
 
 					IL_0391: volatile.
-					IL_0393: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+					IL_0393: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 					IL_0398: brfalse IL_03ae
 
 					IL_039d: ldloc.s 4
@@ -4023,12 +4048,12 @@
 					IL_03ae: ldloc.s 4
 					IL_03b0: ldstr "tests"
 					IL_03b5: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:102"
-					IL_03ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+					IL_03ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 					IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_03c4: stloc.s 20
 					IL_03c6: volatile.
-					IL_03c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+					IL_03c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 					IL_03cd: brfalse IL_03e3
 
 					IL_03d2: ldloc.s 20
@@ -4039,7 +4064,7 @@
 					IL_03e3: ldloc.s 20
 					IL_03e5: ldstr "length"
 					IL_03ea: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:104"
-					IL_03ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+					IL_03ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 					IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_03f9: stloc.s 20
@@ -4061,7 +4086,7 @@
 					IL_041e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
 					IL_0423: pop
 					IL_0424: volatile.
-					IL_0426: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+					IL_0426: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 					IL_042b: brfalse IL_0441
 
 					IL_0430: ldloc.s 4
@@ -4072,7 +4097,7 @@
 					IL_0441: ldloc.s 4
 					IL_0443: ldstr "tests"
 					IL_0448: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:117"
-					IL_044d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+					IL_044d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 					IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0457: stloc.s 13
@@ -4105,7 +4130,7 @@
 							IL_0490: ldloc.s 13
 							IL_0492: stloc.s 8
 							IL_0494: volatile.
-							IL_0496: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+							IL_0496: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 							IL_049b: brfalse IL_04b1
 
 							IL_04a0: ldloc.s 8
@@ -4116,7 +4141,7 @@
 							IL_04b1: ldloc.s 8
 							IL_04b3: ldstr "name"
 							IL_04b8: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:135"
-							IL_04bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+							IL_04bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 							IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 							IL_04c7: stloc.s 13
@@ -4136,7 +4161,7 @@
 							IL_04e8: stelem.ref
 							IL_04e9: stloc.s 19
 							IL_04eb: volatile.
-							IL_04ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+							IL_04ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 							IL_04f2: brfalse IL_0508
 
 							IL_04f7: ldloc.s 8
@@ -4147,7 +4172,7 @@
 							IL_0508: ldloc.s 8
 							IL_050a: ldstr "name"
 							IL_050f: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:141"
-							IL_0514: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+							IL_0514: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 							IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 							IL_051e: stloc.s 13
@@ -4165,7 +4190,7 @@
 							IL_053b: ldloc.s 9
 							IL_053d: stloc.s 10
 							IL_053f: volatile.
-							IL_0541: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+							IL_0541: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 							IL_0546: brfalse IL_055c
 
 							IL_054b: ldloc.s 8
@@ -4176,7 +4201,7 @@
 							IL_055c: ldloc.s 8
 							IL_055e: ldstr "file"
 							IL_0563: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:152"
-							IL_0568: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+							IL_0568: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 							IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 							IL_0572: stloc.s 13
@@ -4196,7 +4221,7 @@
 							IL_0593: stelem.ref
 							IL_0594: stloc.s 19
 							IL_0596: volatile.
-							IL_0598: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+							IL_0598: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 							IL_059d: brfalse IL_05b3
 
 							IL_05a2: ldloc.s 8
@@ -4207,7 +4232,7 @@
 							IL_05b3: ldloc.s 8
 							IL_05b5: ldstr "file"
 							IL_05ba: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:159"
-							IL_05bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+							IL_05bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 							IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 							IL_05c9: stloc.s 13
@@ -4487,7 +4512,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_0007: brfalse IL_001c
 
 			IL_000c: ldarg.1
@@ -4498,7 +4523,7 @@
 			IL_001c: ldarg.1
 			IL_001d: ldstr "limitations"
 			IL_0022: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M14>:__js_call__:3"
-			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0031: stloc.s 6
@@ -4521,7 +4546,7 @@
 			IL_0058: ldloc.s 10
 			IL_005a: stloc.0
 			IL_005b: volatile.
-			IL_005d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_005d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_0062: brfalse IL_0077
 
 			IL_0067: ldloc.0
@@ -4532,7 +4557,7 @@
 			IL_0077: ldloc.0
 			IL_0078: ldstr "length"
 			IL_007d: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M14>:__js_call__:15"
-			IL_0082: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_0082: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_008c: stloc.s 6
@@ -5444,6 +5469,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_71
 	.field assembly static int32 __jroc_dynamicLookup_72
 	.field assembly static int32 __jroc_dynamicLookup_73
+	.field assembly static int32 __jroc_dynamicLookup_74
+	.field assembly static int32 __jroc_dynamicLookup_75
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Intl/Snapshots/GeneratorTests.Intl_NumberFormat_And_Segmenter_Basic.verified.txt
+++ b/tests/Jroc.Tests/Intl/Snapshots/GeneratorTests.Intl_NumberFormat_And_Segmenter_Basic.verified.txt
@@ -143,7 +143,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 426 (0x1aa)
+		// Code size: 519 (0x207)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Intl_NumberFormat_And_Segmenter_Basic/Scope,
@@ -184,130 +184,155 @@
 		IL_004f: stloc.s 8
 		IL_0051: ldloc.1
 		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0057: ldstr "format"
-		IL_005c: ldc.r8 1234567
-		IL_0065: box [System.Runtime]System.Double
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006f: stloc.s 7
-		IL_0071: ldloc.s 8
-		IL_0073: ldloc.s 7
-		IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007a: pop
-		IL_007b: ldstr "Intl"
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0085: volatile.
-		IL_0087: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_008c: brfalse IL_00a0
+		IL_0057: volatile.
+		IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_005e: brfalse IL_0080
 
-		IL_0091: ldstr "Segmenter"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009b: br IL_00b4
+		IL_0063: ldstr "format"
+		IL_0068: ldc.r8 1234567
+		IL_0071: box [System.Runtime]System.Double
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007b: br IL_00a2
 
-		IL_00a0: ldstr "Segmenter"
-		IL_00a5: ldstr "Intl_NumberFormat_And_Segmenter_Basic:Modules.Intl_NumberFormat_And_Segmenter_Basic:__js_module_init__:19"
-		IL_00aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0080: ldstr "format"
+		IL_0085: ldc.r8 1234567
+		IL_008e: box [System.Runtime]System.Double
+		IL_0093: ldstr "Intl_NumberFormat_And_Segmenter_Basic:Modules.Intl_NumberFormat_And_Segmenter_Basic:__js_module_init__:13"
+		IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00b4: stloc.s 7
-		IL_00b6: ldloc.s 7
-		IL_00b8: dup
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_00be: stloc.2
-		IL_00bf: ldloc.2
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c5: ldstr "segment"
-		IL_00ca: ldstr "A\ud83d\ude00B"
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d4: stloc.s 7
-		IL_00d6: ldloc.s 7
-		IL_00d8: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-		IL_00dd: stloc.3
-		IL_00de: ldc.i4.0
-		IL_00df: stloc.s 4
-		IL_00e1: ldc.i4.0
-		IL_00e2: stloc.s 5
+		IL_00a2: stloc.s 7
+		IL_00a4: ldloc.s 8
+		IL_00a6: ldloc.s 7
+		IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ad: pop
+		IL_00ae: ldstr "Intl"
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b8: volatile.
+		IL_00ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00bf: brfalse IL_00d3
+
+		IL_00c4: ldstr "Segmenter"
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ce: br IL_00e7
+
+		IL_00d3: ldstr "Segmenter"
+		IL_00d8: ldstr "Intl_NumberFormat_And_Segmenter_Basic:Modules.Intl_NumberFormat_And_Segmenter_Basic:__js_module_init__:19"
+		IL_00dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_00e7: stloc.s 7
+		IL_00e9: ldloc.s 7
+		IL_00eb: dup
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_00f1: stloc.2
+		IL_00f2: ldloc.2
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f8: volatile.
+		IL_00fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00ff: brfalse IL_0118
+
+		IL_0104: ldstr "segment"
+		IL_0109: ldstr "A\ud83d\ude00B"
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0113: br IL_0131
+
+		IL_0118: ldstr "segment"
+		IL_011d: ldstr "A\ud83d\ude00B"
+		IL_0122: ldstr "Intl_NumberFormat_And_Segmenter_Basic:Modules.Intl_NumberFormat_And_Segmenter_Basic:__js_module_init__:25"
+		IL_0127: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0131: stloc.s 7
+		IL_0133: ldloc.s 7
+		IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_013a: stloc.3
+		IL_013b: ldc.i4.0
+		IL_013c: stloc.s 4
+		IL_013e: ldc.i4.0
+		IL_013f: stloc.s 5
 		.try
 		{
-			// loop start (head: IL_00e4)
-				IL_00e4: ldc.i4.1
-				IL_00e5: stloc.s 4
-				IL_00e7: ldloc.3
-				IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-				IL_00ed: stloc.s 7
-				IL_00ef: ldloc.s 7
-				IL_00f1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-				IL_00f6: stloc.s 9
-				IL_00f8: ldloc.s 9
-				IL_00fa: brtrue IL_018c
-
-				IL_00ff: ldloc.s 7
-				IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-				IL_0106: stloc.s 7
-				IL_0108: ldc.i4.0
-				IL_0109: stloc.s 4
-				IL_010b: ldloc.s 7
-				IL_010d: brfalse IL_011e
-
-				IL_0112: ldloc.s 7
-				IL_0114: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0119: brfalse IL_012f
-
-				IL_011e: ldloc.s 7
-				IL_0120: ldstr ""
-				IL_0125: ldstr "segment"
-				IL_012a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
-
-				IL_012f: volatile.
-				IL_0131: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-				IL_0136: brfalse IL_014c
-
-				IL_013b: ldloc.s 7
-				IL_013d: ldstr "segment"
-				IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0147: br IL_0162
-
+			// loop start (head: IL_0141)
+				IL_0141: ldc.i4.1
+				IL_0142: stloc.s 4
+				IL_0144: ldloc.3
+				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+				IL_014a: stloc.s 7
 				IL_014c: ldloc.s 7
-				IL_014e: ldstr "segment"
-				IL_0153: ldstr "Intl_NumberFormat_And_Segmenter_Basic:Modules.Intl_NumberFormat_And_Segmenter_Basic:__js_module_init__:48"
-				IL_0158: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-				IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+				IL_0153: stloc.s 9
+				IL_0155: ldloc.s 9
+				IL_0157: brtrue IL_01e9
 
-				IL_0162: stloc.s 7
-				IL_0164: ldloc.s 7
-				IL_0166: stloc.s 6
-				IL_0168: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_016d: stloc.s 8
-				IL_016f: ldloc.s 8
-				IL_0171: ldloc.s 6
-				IL_0173: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0178: pop
-				IL_0179: br IL_00e4
+				IL_015c: ldloc.s 7
+				IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+				IL_0163: stloc.s 7
+				IL_0165: ldc.i4.0
+				IL_0166: stloc.s 4
+				IL_0168: ldloc.s 7
+				IL_016a: brfalse IL_017b
+
+				IL_016f: ldloc.s 7
+				IL_0171: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0176: brfalse IL_018c
+
+				IL_017b: ldloc.s 7
+				IL_017d: ldstr ""
+				IL_0182: ldstr "segment"
+				IL_0187: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+
+				IL_018c: volatile.
+				IL_018e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+				IL_0193: brfalse IL_01a9
+
+				IL_0198: ldloc.s 7
+				IL_019a: ldstr "segment"
+				IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01a4: br IL_01bf
+
+				IL_01a9: ldloc.s 7
+				IL_01ab: ldstr "segment"
+				IL_01b0: ldstr "Intl_NumberFormat_And_Segmenter_Basic:Modules.Intl_NumberFormat_And_Segmenter_Basic:__js_module_init__:48"
+				IL_01b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+				IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_01bf: stloc.s 7
+				IL_01c1: ldloc.s 7
+				IL_01c3: stloc.s 6
+				IL_01c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_01ca: stloc.s 8
+				IL_01cc: ldloc.s 8
+				IL_01ce: ldloc.s 6
+				IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_01d5: pop
+				IL_01d6: br IL_0141
 			// end loop
-			IL_017e: ldloc.3
-			IL_017f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-			IL_0184: ldc.i4.1
-			IL_0185: stloc.s 5
-			IL_0187: leave IL_01a9
+			IL_01db: ldloc.3
+			IL_01dc: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+			IL_01e1: ldc.i4.1
+			IL_01e2: stloc.s 5
+			IL_01e4: leave IL_0206
 
-			IL_018c: ldc.i4.1
-			IL_018d: stloc.s 4
-			IL_018f: leave IL_01a9
+			IL_01e9: ldc.i4.1
+			IL_01ea: stloc.s 4
+			IL_01ec: leave IL_0206
 		} // end .try
 		finally
 		{
-			IL_0194: ldloc.s 4
-			IL_0196: brtrue IL_01a8
+			IL_01f1: ldloc.s 4
+			IL_01f3: brtrue IL_0205
 
-			IL_019b: ldloc.s 5
-			IL_019d: brtrue IL_01a8
+			IL_01f8: ldloc.s 5
+			IL_01fa: brtrue IL_0205
 
-			IL_01a2: ldloc.3
-			IL_01a3: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+			IL_01ff: ldloc.3
+			IL_0200: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-			IL_01a8: endfinally
+			IL_0205: endfinally
 		} // end handler
 
-		IL_01a9: ret
+		IL_0206: ret
 	} // end of method Intl_NumberFormat_And_Segmenter_Basic::__js_module_init__
 
 } // end of class Modules.Intl_NumberFormat_And_Segmenter_Basic
@@ -340,6 +365,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_Error_ConstructorSurface.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_Error_ConstructorSurface.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1391 (0x56f)
+		// Code size: 1623 (0x657)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_Error_ConstructorSurface/Scope,
@@ -183,354 +183,426 @@
 		IL_00bc: ldstr "Error"
 		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: ldstr "isError"
-		IL_00d0: ldloc.2
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d6: stloc.s 5
-		IL_00d8: ldloc.s 4
-		IL_00da: ldloc.s 5
-		IL_00dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e1: pop
-		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e7: stloc.s 4
-		IL_00e9: ldstr "Error"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00fd: stloc.s 7
-		IL_00ff: ldstr "isError"
-		IL_0104: ldloc.s 7
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010b: stloc.s 5
-		IL_010d: ldloc.s 4
-		IL_010f: ldloc.s 5
-		IL_0111: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0116: pop
-		IL_0117: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011c: stloc.s 4
-		IL_011e: ldstr "Error"
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0128: volatile.
-		IL_012a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_012f: brfalse IL_0143
+		IL_00cb: volatile.
+		IL_00cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d2: brfalse IL_00e7
 
-		IL_0134: ldstr "prototype"
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013e: br IL_0157
+		IL_00d7: ldstr "isError"
+		IL_00dc: ldloc.2
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e2: br IL_00fc
 
-		IL_0143: ldstr "prototype"
-		IL_0148: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:42"
-		IL_014d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00e7: ldstr "isError"
+		IL_00ec: ldloc.2
+		IL_00ed: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:27"
+		IL_00f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0157: stloc.s 5
-		IL_0159: volatile.
-		IL_015b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0160: brfalse IL_0176
+		IL_00fc: stloc.s 5
+		IL_00fe: ldloc.s 4
+		IL_0100: ldloc.s 5
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0107: pop
+		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010d: stloc.s 4
+		IL_010f: ldstr "Error"
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0123: stloc.s 7
+		IL_0125: volatile.
+		IL_0127: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_012c: brfalse IL_0142
 
-		IL_0165: ldloc.s 5
-		IL_0167: ldstr "constructor"
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0171: br IL_018c
+		IL_0131: ldstr "isError"
+		IL_0136: ldloc.s 7
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013d: br IL_0158
 
-		IL_0176: ldloc.s 5
-		IL_0178: ldstr "constructor"
-		IL_017d: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:44"
-		IL_0182: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0142: ldstr "isError"
+		IL_0147: ldloc.s 7
+		IL_0149: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:35"
+		IL_014e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_018c: stloc.s 5
-		IL_018e: ldstr "Error"
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0198: stloc.s 8
-		IL_019a: ldloc.s 5
-		IL_019c: ldloc.s 8
-		IL_019e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01a3: stloc.s 9
-		IL_01a5: ldloc.s 9
-		IL_01a7: box [System.Runtime]System.Boolean
-		IL_01ac: stloc.s 10
-		IL_01ae: ldloc.s 4
-		IL_01b0: ldloc.s 10
-		IL_01b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b7: pop
-		IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01bd: stloc.s 4
-		IL_01bf: ldstr "Error"
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c9: volatile.
-		IL_01cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01d0: brfalse IL_01e4
+		IL_0158: stloc.s 5
+		IL_015a: ldloc.s 4
+		IL_015c: ldloc.s 5
+		IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0163: pop
+		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0169: stloc.s 4
+		IL_016b: ldstr "Error"
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0175: volatile.
+		IL_0177: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_017c: brfalse IL_0190
 
-		IL_01d5: ldstr "prototype"
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01df: br IL_01f8
+		IL_0181: ldstr "prototype"
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018b: br IL_01a4
 
-		IL_01e4: ldstr "prototype"
-		IL_01e9: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:55"
-		IL_01ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0190: ldstr "prototype"
+		IL_0195: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:42"
+		IL_019a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01f8: stloc.s 8
-		IL_01fa: volatile.
-		IL_01fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0201: brfalse IL_0217
+		IL_01a4: stloc.s 5
+		IL_01a6: volatile.
+		IL_01a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01ad: brfalse IL_01c3
 
-		IL_0206: ldloc.s 8
-		IL_0208: ldstr "name"
-		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0212: br IL_022d
+		IL_01b2: ldloc.s 5
+		IL_01b4: ldstr "constructor"
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01be: br IL_01d9
 
-		IL_0217: ldloc.s 8
-		IL_0219: ldstr "name"
-		IL_021e: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:57"
-		IL_0223: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01c3: ldloc.s 5
+		IL_01c5: ldstr "constructor"
+		IL_01ca: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:44"
+		IL_01cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_022d: stloc.s 8
-		IL_022f: ldloc.s 8
-		IL_0231: ldstr ":"
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_023b: stloc.s 6
-		IL_023d: ldstr "Error"
-		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d9: stloc.s 5
+		IL_01db: ldstr "Error"
+		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e5: stloc.s 8
+		IL_01e7: ldloc.s 5
+		IL_01e9: ldloc.s 8
+		IL_01eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01f0: stloc.s 9
+		IL_01f2: ldloc.s 9
+		IL_01f4: box [System.Runtime]System.Boolean
+		IL_01f9: stloc.s 10
+		IL_01fb: ldloc.s 4
+		IL_01fd: ldloc.s 10
+		IL_01ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0204: pop
+		IL_0205: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_020a: stloc.s 4
+		IL_020c: ldstr "Error"
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0216: volatile.
+		IL_0218: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_021d: brfalse IL_0231
+
+		IL_0222: ldstr "prototype"
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_022c: br IL_0245
+
+		IL_0231: ldstr "prototype"
+		IL_0236: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:55"
+		IL_023b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0245: stloc.s 8
 		IL_0247: volatile.
-		IL_0249: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_024e: brfalse IL_0262
+		IL_0249: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_024e: brfalse IL_0264
 
-		IL_0253: ldstr "prototype"
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_025d: br IL_0276
+		IL_0253: ldloc.s 8
+		IL_0255: ldstr "name"
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_025f: br IL_027a
 
-		IL_0262: ldstr "prototype"
-		IL_0267: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:63"
-		IL_026c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0264: ldloc.s 8
+		IL_0266: ldstr "name"
+		IL_026b: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:57"
+		IL_0270: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0276: stloc.s 8
-		IL_0278: volatile.
-		IL_027a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_027f: brfalse IL_0295
+		IL_027a: stloc.s 8
+		IL_027c: ldloc.s 8
+		IL_027e: ldstr ":"
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0288: stloc.s 6
+		IL_028a: ldstr "Error"
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0294: volatile.
+		IL_0296: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_029b: brfalse IL_02af
 
-		IL_0284: ldloc.s 8
-		IL_0286: ldstr "message"
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0290: br IL_02ab
+		IL_02a0: ldstr "prototype"
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02aa: br IL_02c3
 
-		IL_0295: ldloc.s 8
-		IL_0297: ldstr "message"
-		IL_029c: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:65"
-		IL_02a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02af: ldstr "prototype"
+		IL_02b4: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:63"
+		IL_02b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02ab: stloc.s 8
-		IL_02ad: ldloc.s 6
-		IL_02af: ldloc.s 8
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02b6: stloc.s 6
-		IL_02b8: ldloc.s 4
-		IL_02ba: ldloc.s 6
-		IL_02bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c1: pop
-		IL_02c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c7: stloc.s 4
-		IL_02c9: ldstr "Error"
-		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d3: volatile.
-		IL_02d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02da: brfalse IL_02ee
+		IL_02c3: stloc.s 8
+		IL_02c5: volatile.
+		IL_02c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02cc: brfalse IL_02e2
 
-		IL_02df: ldstr "prototype"
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e9: br IL_0302
+		IL_02d1: ldloc.s 8
+		IL_02d3: ldstr "message"
+		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02dd: br IL_02f8
 
-		IL_02ee: ldstr "prototype"
-		IL_02f3: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:73"
-		IL_02f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02e2: ldloc.s 8
+		IL_02e4: ldstr "message"
+		IL_02e9: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:65"
+		IL_02ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0302: stloc.s 8
-		IL_0304: volatile.
-		IL_0306: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_030b: brfalse IL_0321
+		IL_02f8: stloc.s 8
+		IL_02fa: ldloc.s 6
+		IL_02fc: ldloc.s 8
+		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0303: stloc.s 6
+		IL_0305: ldloc.s 4
+		IL_0307: ldloc.s 6
+		IL_0309: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_030e: pop
+		IL_030f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0314: stloc.s 4
+		IL_0316: ldstr "Error"
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0320: volatile.
+		IL_0322: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0327: brfalse IL_033b
 
-		IL_0310: ldloc.s 8
-		IL_0312: ldstr "toString"
-		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_031c: br IL_0337
+		IL_032c: ldstr "prototype"
+		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0336: br IL_034f
 
-		IL_0321: ldloc.s 8
-		IL_0323: ldstr "toString"
-		IL_0328: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:75"
-		IL_032d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_033b: ldstr "prototype"
+		IL_0340: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:73"
+		IL_0345: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0337: stloc.s 8
-		IL_0339: ldloc.s 8
-		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0340: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0345: dup
-		IL_0346: ldstr "name"
-		IL_034b: ldstr "X"
-		IL_0350: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0355: dup
-		IL_0356: ldstr "message"
-		IL_035b: ldstr "Y"
-		IL_0360: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0365: stloc.s 7
-		IL_0367: ldstr "call"
-		IL_036c: ldloc.s 7
-		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0373: stloc.s 8
-		IL_0375: ldloc.s 4
-		IL_0377: ldloc.s 8
-		IL_0379: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_037e: pop
-		IL_037f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0384: stloc.s 4
-		IL_0386: ldstr "Error"
-		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0390: volatile.
-		IL_0392: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0397: brfalse IL_03ab
+		IL_034f: stloc.s 8
+		IL_0351: volatile.
+		IL_0353: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0358: brfalse IL_036e
 
-		IL_039c: ldstr "prototype"
-		IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03a6: br IL_03bf
+		IL_035d: ldloc.s 8
+		IL_035f: ldstr "toString"
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0369: br IL_0384
 
-		IL_03ab: ldstr "prototype"
-		IL_03b0: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:87"
-		IL_03b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_036e: ldloc.s 8
+		IL_0370: ldstr "toString"
+		IL_0375: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:75"
+		IL_037a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03bf: stloc.s 8
-		IL_03c1: volatile.
-		IL_03c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_03c8: brfalse IL_03de
+		IL_0384: stloc.s 8
+		IL_0386: ldloc.s 8
+		IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_038d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0392: dup
+		IL_0393: ldstr "name"
+		IL_0398: ldstr "X"
+		IL_039d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03a2: dup
+		IL_03a3: ldstr "message"
+		IL_03a8: ldstr "Y"
+		IL_03ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03b2: stloc.s 7
+		IL_03b4: volatile.
+		IL_03b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_03bb: brfalse IL_03d1
 
-		IL_03cd: ldloc.s 8
-		IL_03cf: ldstr "toString"
-		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d9: br IL_03f4
+		IL_03c0: ldstr "call"
+		IL_03c5: ldloc.s 7
+		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03cc: br IL_03e7
 
-		IL_03de: ldloc.s 8
-		IL_03e0: ldstr "toString"
-		IL_03e5: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:89"
-		IL_03ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03d1: ldstr "call"
+		IL_03d6: ldloc.s 7
+		IL_03d8: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:80"
+		IL_03dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03f4: stloc.s 8
-		IL_03f6: ldloc.s 8
-		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03fd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0402: dup
-		IL_0403: ldstr "message"
-		IL_0408: ldstr "Y"
-		IL_040d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0412: stloc.s 7
-		IL_0414: ldstr "call"
-		IL_0419: ldloc.s 7
-		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0420: stloc.s 8
-		IL_0422: ldloc.s 4
-		IL_0424: ldloc.s 8
-		IL_0426: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_042b: pop
-		IL_042c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0431: stloc.s 4
-		IL_0433: ldstr "Error"
-		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_043d: volatile.
-		IL_043f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0444: brfalse IL_0458
+		IL_03e7: stloc.s 8
+		IL_03e9: ldloc.s 4
+		IL_03eb: ldloc.s 8
+		IL_03ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03f2: pop
+		IL_03f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03f8: stloc.s 4
+		IL_03fa: ldstr "Error"
+		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0404: volatile.
+		IL_0406: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_040b: brfalse IL_041f
 
-		IL_0449: ldstr "prototype"
-		IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0453: br IL_046c
+		IL_0410: ldstr "prototype"
+		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_041a: br IL_0433
 
-		IL_0458: ldstr "prototype"
-		IL_045d: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:100"
-		IL_0462: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_041f: ldstr "prototype"
+		IL_0424: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:87"
+		IL_0429: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_046c: stloc.s 8
-		IL_046e: volatile.
-		IL_0470: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0475: brfalse IL_048b
+		IL_0433: stloc.s 8
+		IL_0435: volatile.
+		IL_0437: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_043c: brfalse IL_0452
 
-		IL_047a: ldloc.s 8
-		IL_047c: ldstr "toString"
-		IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0486: br IL_04a1
+		IL_0441: ldloc.s 8
+		IL_0443: ldstr "toString"
+		IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_044d: br IL_0468
 
-		IL_048b: ldloc.s 8
-		IL_048d: ldstr "toString"
-		IL_0492: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:102"
-		IL_0497: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0452: ldloc.s 8
+		IL_0454: ldstr "toString"
+		IL_0459: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:89"
+		IL_045e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04a1: stloc.s 8
-		IL_04a3: ldloc.s 8
-		IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04af: dup
-		IL_04b0: ldstr "name"
-		IL_04b5: ldstr "X"
-		IL_04ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_04bf: stloc.s 7
-		IL_04c1: ldstr "call"
-		IL_04c6: ldloc.s 7
-		IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04cd: stloc.s 8
-		IL_04cf: ldloc.s 4
-		IL_04d1: ldloc.s 8
-		IL_04d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04d8: pop
-		IL_04d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04de: stloc.s 4
-		IL_04e0: ldstr "Error"
-		IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04ea: volatile.
-		IL_04ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_04f1: brfalse IL_0505
+		IL_0468: stloc.s 8
+		IL_046a: ldloc.s 8
+		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0471: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0476: dup
+		IL_0477: ldstr "message"
+		IL_047c: ldstr "Y"
+		IL_0481: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0486: stloc.s 7
+		IL_0488: volatile.
+		IL_048a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_048f: brfalse IL_04a5
 
-		IL_04f6: ldstr "prototype"
-		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0500: br IL_0519
+		IL_0494: ldstr "call"
+		IL_0499: ldloc.s 7
+		IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04a0: br IL_04bb
 
-		IL_0505: ldstr "prototype"
-		IL_050a: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:113"
-		IL_050f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04a5: ldstr "call"
+		IL_04aa: ldloc.s 7
+		IL_04ac: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:93"
+		IL_04b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_04b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0519: stloc.s 8
-		IL_051b: volatile.
-		IL_051d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0522: brfalse IL_0538
+		IL_04bb: stloc.s 8
+		IL_04bd: ldloc.s 4
+		IL_04bf: ldloc.s 8
+		IL_04c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04c6: pop
+		IL_04c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04cc: stloc.s 4
+		IL_04ce: ldstr "Error"
+		IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04d8: volatile.
+		IL_04da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_04df: brfalse IL_04f3
 
-		IL_0527: ldloc.s 8
-		IL_0529: ldstr "toString"
-		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0533: br IL_054e
+		IL_04e4: ldstr "prototype"
+		IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04ee: br IL_0507
 
-		IL_0538: ldloc.s 8
-		IL_053a: ldstr "toString"
-		IL_053f: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:115"
-		IL_0544: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04f3: ldstr "prototype"
+		IL_04f8: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:100"
+		IL_04fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_054e: stloc.s 8
-		IL_0550: ldloc.s 8
-		IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0557: ldstr "call"
-		IL_055c: ldloc.2
-		IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0562: stloc.s 8
-		IL_0564: ldloc.s 4
-		IL_0566: ldloc.s 8
-		IL_0568: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_056d: pop
-		IL_056e: ret
+		IL_0507: stloc.s 8
+		IL_0509: volatile.
+		IL_050b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0510: brfalse IL_0526
+
+		IL_0515: ldloc.s 8
+		IL_0517: ldstr "toString"
+		IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0521: br IL_053c
+
+		IL_0526: ldloc.s 8
+		IL_0528: ldstr "toString"
+		IL_052d: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:102"
+		IL_0532: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_053c: stloc.s 8
+		IL_053e: ldloc.s 8
+		IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0545: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_054a: dup
+		IL_054b: ldstr "name"
+		IL_0550: ldstr "X"
+		IL_0555: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_055a: stloc.s 7
+		IL_055c: volatile.
+		IL_055e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0563: brfalse IL_0579
+
+		IL_0568: ldstr "call"
+		IL_056d: ldloc.s 7
+		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0574: br IL_058f
+
+		IL_0579: ldstr "call"
+		IL_057e: ldloc.s 7
+		IL_0580: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:106"
+		IL_0585: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_058f: stloc.s 8
+		IL_0591: ldloc.s 4
+		IL_0593: ldloc.s 8
+		IL_0595: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_059a: pop
+		IL_059b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05a0: stloc.s 4
+		IL_05a2: ldstr "Error"
+		IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05ac: volatile.
+		IL_05ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_05b3: brfalse IL_05c7
+
+		IL_05b8: ldstr "prototype"
+		IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05c2: br IL_05db
+
+		IL_05c7: ldstr "prototype"
+		IL_05cc: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:113"
+		IL_05d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05db: stloc.s 8
+		IL_05dd: volatile.
+		IL_05df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_05e4: brfalse IL_05fa
+
+		IL_05e9: ldloc.s 8
+		IL_05eb: ldstr "toString"
+		IL_05f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05f5: br IL_0610
+
+		IL_05fa: ldloc.s 8
+		IL_05fc: ldstr "toString"
+		IL_0601: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:115"
+		IL_0606: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0610: stloc.s 8
+		IL_0612: ldloc.s 8
+		IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0619: volatile.
+		IL_061b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0620: brfalse IL_0635
+
+		IL_0625: ldstr "call"
+		IL_062a: ldloc.2
+		IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0630: br IL_064a
+
+		IL_0635: ldstr "call"
+		IL_063a: ldloc.2
+		IL_063b: ldstr "IntrinsicCallables_Error_ConstructorSurface:Modules.IntrinsicCallables_Error_ConstructorSurface:__js_module_init__:117"
+		IL_0640: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_064a: stloc.s 8
+		IL_064c: ldloc.s 4
+		IL_064e: ldloc.s 8
+		IL_0650: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0655: pop
+		IL_0656: ret
 	} // end of method IntrinsicCallables_Error_ConstructorSurface::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_Error_ConstructorSurface
@@ -576,6 +648,12 @@
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_GlobalThis_Basic.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_GlobalThis_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 427 (0x1ab)
+		// Code size: 587 (0x24b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_GlobalThis_Basic/Scope,
@@ -141,96 +141,147 @@
 		IL_005e: stloc.1
 		IL_005f: ldloc.1
 		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0065: ldstr "log"
-		IL_006a: ldstr "globalThis ok"
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0074: pop
-		IL_0075: ldstr "globalThis"
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_007f: ldstr "__jroc_test"
-		IL_0084: ldc.r8 123
-		IL_008d: ldc.i4.1
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0093: pop
-		IL_0094: ldstr "console"
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a3: stloc.1
-		IL_00a4: ldstr "globalThis"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ae: volatile.
-		IL_00b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00b5: brfalse IL_00c9
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_006c: brfalse IL_0085
 
-		IL_00ba: ldstr "__jroc_test"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c4: br IL_00dd
+		IL_0071: ldstr "log"
+		IL_0076: ldstr "globalThis ok"
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: br IL_009e
 
-		IL_00c9: ldstr "__jroc_test"
-		IL_00ce: ldstr "IntrinsicCallables_GlobalThis_Basic:Modules.IntrinsicCallables_GlobalThis_Basic:__js_module_init__:30"
-		IL_00d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0085: ldstr "log"
+		IL_008a: ldstr "globalThis ok"
+		IL_008f: ldstr "IntrinsicCallables_GlobalThis_Basic:Modules.IntrinsicCallables_GlobalThis_Basic:__js_module_init__:16"
+		IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00dd: stloc.2
-		IL_00de: ldloc.1
-		IL_00df: ldstr "log"
-		IL_00e4: ldloc.2
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ea: pop
-		IL_00eb: ldstr "console"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fa: stloc.2
-		IL_00fb: ldstr "globalThis"
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0105: volatile.
-		IL_0107: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_010c: brfalse IL_0120
+		IL_009e: pop
+		IL_009f: ldstr "globalThis"
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00a9: ldstr "__jroc_test"
+		IL_00ae: ldc.r8 123
+		IL_00b7: ldc.i4.1
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_00bd: pop
+		IL_00be: ldstr "console"
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cd: stloc.1
+		IL_00ce: ldstr "globalThis"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d8: volatile.
+		IL_00da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00df: brfalse IL_00f3
 
-		IL_0111: ldstr "globalThis"
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_011b: br IL_0134
+		IL_00e4: ldstr "__jroc_test"
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ee: br IL_0107
 
-		IL_0120: ldstr "globalThis"
-		IL_0125: ldstr "IntrinsicCallables_GlobalThis_Basic:Modules.IntrinsicCallables_GlobalThis_Basic:__js_module_init__:39"
-		IL_012a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00f3: ldstr "__jroc_test"
+		IL_00f8: ldstr "IntrinsicCallables_GlobalThis_Basic:Modules.IntrinsicCallables_GlobalThis_Basic:__js_module_init__:30"
+		IL_00fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0134: stloc.1
-		IL_0135: ldstr "globalThis"
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_013f: stloc.3
-		IL_0140: ldloc.1
-		IL_0141: ldloc.3
-		IL_0142: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0147: stloc.s 4
-		IL_0149: ldloc.s 4
-		IL_014b: box [System.Runtime]System.Boolean
-		IL_0150: stloc.s 5
-		IL_0152: ldloc.2
-		IL_0153: ldstr "log"
-		IL_0158: ldloc.s 5
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015f: pop
-		IL_0160: ldstr "console"
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016f: stloc.2
-		IL_0170: ldstr "globalThis"
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017f: ldstr "parseInt"
-		IL_0184: ldstr "11"
-		IL_0189: ldc.r8 2
-		IL_0192: box [System.Runtime]System.Double
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_019c: stloc.3
-		IL_019d: ldloc.2
-		IL_019e: ldstr "log"
-		IL_01a3: ldloc.3
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a9: pop
-		IL_01aa: ret
+		IL_0107: stloc.2
+		IL_0108: volatile.
+		IL_010a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_010f: brfalse IL_0125
+
+		IL_0114: ldloc.1
+		IL_0115: ldstr "log"
+		IL_011a: ldloc.2
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0120: br IL_013b
+
+		IL_0125: ldloc.1
+		IL_0126: ldstr "log"
+		IL_012b: ldloc.2
+		IL_012c: ldstr "IntrinsicCallables_GlobalThis_Basic:Modules.IntrinsicCallables_GlobalThis_Basic:__js_module_init__:31"
+		IL_0131: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_013b: pop
+		IL_013c: ldstr "console"
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014b: stloc.2
+		IL_014c: ldstr "globalThis"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0156: volatile.
+		IL_0158: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_015d: brfalse IL_0171
+
+		IL_0162: ldstr "globalThis"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016c: br IL_0185
+
+		IL_0171: ldstr "globalThis"
+		IL_0176: ldstr "IntrinsicCallables_GlobalThis_Basic:Modules.IntrinsicCallables_GlobalThis_Basic:__js_module_init__:39"
+		IL_017b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0185: stloc.1
+		IL_0186: ldstr "globalThis"
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0190: stloc.3
+		IL_0191: ldloc.1
+		IL_0192: ldloc.3
+		IL_0193: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0198: stloc.s 4
+		IL_019a: ldloc.s 4
+		IL_019c: box [System.Runtime]System.Boolean
+		IL_01a1: stloc.s 5
+		IL_01a3: volatile.
+		IL_01a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01aa: brfalse IL_01c1
+
+		IL_01af: ldloc.2
+		IL_01b0: ldstr "log"
+		IL_01b5: ldloc.s 5
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bc: br IL_01d8
+
+		IL_01c1: ldloc.2
+		IL_01c2: ldstr "log"
+		IL_01c7: ldloc.s 5
+		IL_01c9: ldstr "IntrinsicCallables_GlobalThis_Basic:Modules.IntrinsicCallables_GlobalThis_Basic:__js_module_init__:44"
+		IL_01ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01d8: pop
+		IL_01d9: ldstr "console"
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e8: stloc.2
+		IL_01e9: ldstr "globalThis"
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f8: ldstr "parseInt"
+		IL_01fd: ldstr "11"
+		IL_0202: ldc.r8 2
+		IL_020b: box [System.Runtime]System.Double
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0215: stloc.3
+		IL_0216: volatile.
+		IL_0218: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_021d: brfalse IL_0233
+
+		IL_0222: ldloc.2
+		IL_0223: ldstr "log"
+		IL_0228: ldloc.3
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022e: br IL_0249
+
+		IL_0233: ldloc.2
+		IL_0234: ldstr "log"
+		IL_0239: ldloc.3
+		IL_023a: ldstr "IntrinsicCallables_GlobalThis_Basic:Modules.IntrinsicCallables_GlobalThis_Basic:__js_module_init__:56"
+		IL_023f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0249: pop
+		IL_024a: ret
 	} // end of method IntrinsicCallables_GlobalThis_Basic::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_GlobalThis_Basic
@@ -263,6 +314,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_GlobalThis_Enumerability.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_GlobalThis_Enumerability.verified.txt
@@ -225,7 +225,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 310 (0x136)
+		// Code size: 388 (0x184)
 		.maxstack 13
 		.locals init (
 			[0] class Modules.IntrinsicCallables_GlobalThis_Enumerability/Scope,
@@ -289,62 +289,86 @@
 		IL_0085: ldloc.1
 		IL_0086: box [System.Runtime]System.Boolean
 		IL_008b: stloc.s 9
-		IL_008d: ldstr "log"
-		IL_0092: ldloc.s 9
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0099: pop
-		IL_009a: ldstr "globalThis"
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a4: ldstr "__jroc_enum_test"
-		IL_00a9: ldc.r8 1
-		IL_00b2: ldc.i4.1
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_00b8: pop
-		IL_00b9: ldc.i4.0
-		IL_00ba: stloc.s 4
-		IL_00bc: ldstr "globalThis"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::EnumerateObjectProperties(object)
-		IL_00cb: stloc.s 5
-		// loop start (head: IL_00cd)
-			IL_00cd: ldloc.s 5
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-			IL_00d4: stloc.s 7
-			IL_00d6: ldloc.s 7
-			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-			IL_00dd: stloc.s 8
-			IL_00df: ldloc.s 8
-			IL_00e1: brtrue IL_0110
+		IL_008d: volatile.
+		IL_008f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0094: brfalse IL_00aa
 
-			IL_00e6: ldloc.s 7
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-			IL_00ed: stloc.s 7
-			IL_00ef: ldloc.s 7
-			IL_00f1: stloc.s 6
-			IL_00f3: ldloc.s 6
-			IL_00f5: ldstr "__jroc_enum_test"
-			IL_00fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00ff: stloc.s 8
-			IL_0101: ldloc.s 8
-			IL_0103: brfalse IL_010b
+		IL_0099: ldstr "log"
+		IL_009e: ldloc.s 9
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a5: br IL_00c0
 
-			IL_0108: ldc.i4.1
-			IL_0109: stloc.s 4
+		IL_00aa: ldstr "log"
+		IL_00af: ldloc.s 9
+		IL_00b1: ldstr "IntrinsicCallables_GlobalThis_Enumerability:Modules.IntrinsicCallables_GlobalThis_Enumerability:__js_module_init__:40"
+		IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_010b: br IL_00cd
+		IL_00c0: pop
+		IL_00c1: ldstr "globalThis"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00cb: ldstr "__jroc_enum_test"
+		IL_00d0: ldc.r8 1
+		IL_00d9: ldc.i4.1
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_00df: pop
+		IL_00e0: ldc.i4.0
+		IL_00e1: stloc.s 4
+		IL_00e3: ldstr "globalThis"
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::EnumerateObjectProperties(object)
+		IL_00f2: stloc.s 5
+		// loop start (head: IL_00f4)
+			IL_00f4: ldloc.s 5
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+			IL_00fb: stloc.s 7
+			IL_00fd: ldloc.s 7
+			IL_00ff: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+			IL_0104: stloc.s 8
+			IL_0106: ldloc.s 8
+			IL_0108: brtrue IL_0137
+
+			IL_010d: ldloc.s 7
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+			IL_0114: stloc.s 7
+			IL_0116: ldloc.s 7
+			IL_0118: stloc.s 6
+			IL_011a: ldloc.s 6
+			IL_011c: ldstr "__jroc_enum_test"
+			IL_0121: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0126: stloc.s 8
+			IL_0128: ldloc.s 8
+			IL_012a: brfalse IL_0132
+
+			IL_012f: ldc.i4.1
+			IL_0130: stloc.s 4
+
+			IL_0132: br IL_00f4
 		// end loop
 
-		IL_0110: ldstr "console"
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011f: ldloc.s 4
-		IL_0121: box [System.Runtime]System.Boolean
-		IL_0126: stloc.s 9
-		IL_0128: ldstr "log"
-		IL_012d: ldloc.s 9
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0134: pop
-		IL_0135: ret
+		IL_0137: ldstr "console"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0146: ldloc.s 4
+		IL_0148: box [System.Runtime]System.Boolean
+		IL_014d: stloc.s 9
+		IL_014f: volatile.
+		IL_0151: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0156: brfalse IL_016c
+
+		IL_015b: ldstr "log"
+		IL_0160: ldloc.s 9
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0167: br IL_0182
+
+		IL_016c: ldstr "log"
+		IL_0171: ldloc.s 9
+		IL_0173: ldstr "IntrinsicCallables_GlobalThis_Enumerability:Modules.IntrinsicCallables_GlobalThis_Enumerability:__js_module_init__:78"
+		IL_0178: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0182: pop
+		IL_0183: ret
 	} // end of method IntrinsicCallables_GlobalThis_Enumerability::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_GlobalThis_Enumerability
@@ -369,4 +393,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Callable_CreatesRegex.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Callable_CreatesRegex.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 91 (0x5b)
+		// Code size: 175 (0xaf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_Callable_CreatesRegex/Scope,
@@ -122,27 +122,51 @@
 		IL_0017: stloc.2
 		IL_0018: ldloc.1
 		IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_001e: ldstr "test"
-		IL_0023: ldstr "aa"
-		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_002d: stloc.3
-		IL_002e: ldloc.2
-		IL_002f: ldloc.3
-		IL_0030: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0035: pop
-		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003b: stloc.2
-		IL_003c: ldloc.1
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0042: ldstr "test"
-		IL_0047: ldstr "b"
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0051: stloc.3
-		IL_0052: ldloc.2
-		IL_0053: ldloc.3
-		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0059: pop
-		IL_005a: ret
+		IL_001e: volatile.
+		IL_0020: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0025: brfalse IL_003e
+
+		IL_002a: ldstr "test"
+		IL_002f: ldstr "aa"
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0039: br IL_0057
+
+		IL_003e: ldstr "test"
+		IL_0043: ldstr "aa"
+		IL_0048: ldstr "IntrinsicCallables_RegExp_Callable_CreatesRegex:Modules.IntrinsicCallables_RegExp_Callable_CreatesRegex:__js_module_init__:11"
+		IL_004d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0057: stloc.3
+		IL_0058: ldloc.2
+		IL_0059: ldloc.3
+		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005f: pop
+		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0065: stloc.2
+		IL_0066: ldloc.1
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006c: volatile.
+		IL_006e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0073: brfalse IL_008c
+
+		IL_0078: ldstr "test"
+		IL_007d: ldstr "b"
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0087: br IL_00a5
+
+		IL_008c: ldstr "test"
+		IL_0091: ldstr "b"
+		IL_0096: ldstr "IntrinsicCallables_RegExp_Callable_CreatesRegex:Modules.IntrinsicCallables_RegExp_Callable_CreatesRegex:__js_module_init__:17"
+		IL_009b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a5: stloc.3
+		IL_00a6: ldloc.2
+		IL_00a7: ldloc.3
+		IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ad: pop
+		IL_00ae: ret
 	} // end of method IntrinsicCallables_RegExp_Callable_CreatesRegex::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_Callable_CreatesRegex
@@ -167,4 +191,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Indices_Exec.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_Indices_Exec.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 973 (0x3cd)
+		// Code size: 1059 (0x423)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_Indices_Exec/Scope,
@@ -123,289 +123,315 @@
 		IL_000c: ldstr "d"
 		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_0016: stloc.3
-		IL_0017: ldloc.3
-		IL_0018: ldstr "exec"
-		IL_001d: ldstr "b"
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0027: stloc.1
-		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_002d: stloc.s 4
-		IL_002f: ldloc.1
-		IL_0030: stloc.s 5
-		IL_0032: ldloc.s 5
-		IL_0034: ldc.i4.0
-		IL_0035: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_003a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_003f: stloc.s 6
-		IL_0041: ldloc.s 6
-		IL_0043: box [System.Runtime]System.Boolean
-		IL_0048: stloc.s 7
-		IL_004a: ldloc.s 4
-		IL_004c: ldloc.s 7
-		IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0053: pop
-		IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0059: stloc.s 4
-		IL_005b: volatile.
-		IL_005d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0062: brfalse IL_0077
+		IL_0017: volatile.
+		IL_0019: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_001e: brfalse IL_0038
 
-		IL_0067: ldloc.1
-		IL_0068: ldstr "indices"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0072: br IL_008c
+		IL_0023: ldloc.3
+		IL_0024: ldstr "exec"
+		IL_0029: ldstr "b"
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0033: br IL_0052
 
-		IL_0077: ldloc.1
-		IL_0078: ldstr "indices"
-		IL_007d: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:21"
-		IL_0082: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0038: ldloc.3
+		IL_0039: ldstr "exec"
+		IL_003e: ldstr "b"
+		IL_0043: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:8"
+		IL_0048: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_008c: stloc.s 5
-		IL_008e: volatile.
-		IL_0090: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0095: brfalse IL_00ab
+		IL_0052: stloc.1
+		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0058: stloc.s 4
+		IL_005a: ldloc.1
+		IL_005b: stloc.s 5
+		IL_005d: ldloc.s 5
+		IL_005f: ldc.i4.0
+		IL_0060: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0065: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_006a: stloc.s 6
+		IL_006c: ldloc.s 6
+		IL_006e: box [System.Runtime]System.Boolean
+		IL_0073: stloc.s 7
+		IL_0075: ldloc.s 4
+		IL_0077: ldloc.s 7
+		IL_0079: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007e: pop
+		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0084: stloc.s 4
+		IL_0086: volatile.
+		IL_0088: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_008d: brfalse IL_00a2
 
-		IL_009a: ldloc.s 5
-		IL_009c: ldstr "length"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a6: br IL_00c1
+		IL_0092: ldloc.1
+		IL_0093: ldstr "indices"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009d: br IL_00b7
 
-		IL_00ab: ldloc.s 5
-		IL_00ad: ldstr "length"
-		IL_00b2: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:23"
-		IL_00b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00a2: ldloc.1
+		IL_00a3: ldstr "indices"
+		IL_00a8: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:21"
+		IL_00ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00c1: stloc.s 5
-		IL_00c3: ldloc.s 4
+		IL_00b7: stloc.s 5
+		IL_00b9: volatile.
+		IL_00bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00c0: brfalse IL_00d6
+
 		IL_00c5: ldloc.s 5
-		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cc: pop
-		IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d2: stloc.s 4
-		IL_00d4: volatile.
-		IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00db: brfalse IL_00f0
+		IL_00c7: ldstr "length"
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d1: br IL_00ec
 
-		IL_00e0: ldloc.1
-		IL_00e1: ldstr "indices"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00eb: br IL_0105
+		IL_00d6: ldloc.s 5
+		IL_00d8: ldstr "length"
+		IL_00dd: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:23"
+		IL_00e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00f0: ldloc.1
-		IL_00f1: ldstr "indices"
-		IL_00f6: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:28"
-		IL_00fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00ec: stloc.s 5
+		IL_00ee: ldloc.s 4
+		IL_00f0: ldloc.s 5
+		IL_00f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f7: pop
+		IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fd: stloc.s 4
+		IL_00ff: volatile.
+		IL_0101: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0106: brfalse IL_011b
 
-		IL_0105: stloc.s 5
-		IL_0107: ldloc.s 5
-		IL_0109: ldc.r8 0.0
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0117: stloc.s 5
-		IL_0119: ldloc.s 5
-		IL_011b: ldc.r8 0.0
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0129: stloc.s 5
-		IL_012b: ldloc.s 4
-		IL_012d: ldloc.s 5
-		IL_012f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0134: pop
-		IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013a: stloc.s 4
-		IL_013c: volatile.
-		IL_013e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0143: brfalse IL_0158
+		IL_010b: ldloc.1
+		IL_010c: ldstr "indices"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0116: br IL_0130
 
-		IL_0148: ldloc.1
-		IL_0149: ldstr "indices"
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0153: br IL_016d
+		IL_011b: ldloc.1
+		IL_011c: ldstr "indices"
+		IL_0121: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:28"
+		IL_0126: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0158: ldloc.1
-		IL_0159: ldstr "indices"
-		IL_015e: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:37"
-		IL_0163: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0130: stloc.s 5
+		IL_0132: ldloc.s 5
+		IL_0134: ldc.r8 0.0
+		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0142: stloc.s 5
+		IL_0144: ldloc.s 5
+		IL_0146: ldc.r8 0.0
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0154: stloc.s 5
+		IL_0156: ldloc.s 4
+		IL_0158: ldloc.s 5
+		IL_015a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015f: pop
+		IL_0160: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0165: stloc.s 4
+		IL_0167: volatile.
+		IL_0169: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_016e: brfalse IL_0183
 
-		IL_016d: stloc.s 5
-		IL_016f: ldloc.s 5
-		IL_0171: ldc.r8 0.0
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_017f: stloc.s 5
-		IL_0181: ldloc.s 5
-		IL_0183: ldc.r8 1
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0191: stloc.s 5
-		IL_0193: ldloc.s 4
-		IL_0195: ldloc.s 5
-		IL_0197: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019c: pop
-		IL_019d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a2: stloc.s 4
-		IL_01a4: volatile.
-		IL_01a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01ab: brfalse IL_01c0
+		IL_0173: ldloc.1
+		IL_0174: ldstr "indices"
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_017e: br IL_0198
 
-		IL_01b0: ldloc.1
-		IL_01b1: ldstr "indices"
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01bb: br IL_01d5
+		IL_0183: ldloc.1
+		IL_0184: ldstr "indices"
+		IL_0189: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:37"
+		IL_018e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01c0: ldloc.1
-		IL_01c1: ldstr "indices"
-		IL_01c6: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:46"
-		IL_01cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0198: stloc.s 5
+		IL_019a: ldloc.s 5
+		IL_019c: ldc.r8 0.0
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01aa: stloc.s 5
+		IL_01ac: ldloc.s 5
+		IL_01ae: ldc.r8 1
+		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01bc: stloc.s 5
+		IL_01be: ldloc.s 4
+		IL_01c0: ldloc.s 5
+		IL_01c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c7: pop
+		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cd: stloc.s 4
+		IL_01cf: volatile.
+		IL_01d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01d6: brfalse IL_01eb
 
-		IL_01d5: stloc.s 5
-		IL_01d7: ldloc.s 5
-		IL_01d9: ldc.r8 1
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01e7: stloc.s 5
-		IL_01e9: ldloc.s 5
-		IL_01eb: ldc.i4.0
-		IL_01ec: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_01f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01f6: stloc.s 6
-		IL_01f8: ldloc.s 6
-		IL_01fa: box [System.Runtime]System.Boolean
-		IL_01ff: stloc.s 7
-		IL_0201: ldloc.s 4
-		IL_0203: ldloc.s 7
-		IL_0205: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_020a: pop
-		IL_020b: ldstr "a(d)?"
-		IL_0210: ldstr "d"
-		IL_0215: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_021a: stloc.3
-		IL_021b: ldloc.3
-		IL_021c: ldstr "exec"
-		IL_0221: ldstr "bad"
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_022b: stloc.2
-		IL_022c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0231: stloc.s 4
-		IL_0233: volatile.
-		IL_0235: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_023a: brfalse IL_024f
+		IL_01db: ldloc.1
+		IL_01dc: ldstr "indices"
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e6: br IL_0200
 
-		IL_023f: ldloc.2
-		IL_0240: ldstr "indices"
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_024a: br IL_0264
+		IL_01eb: ldloc.1
+		IL_01ec: ldstr "indices"
+		IL_01f1: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:46"
+		IL_01f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_024f: ldloc.2
-		IL_0250: ldstr "indices"
-		IL_0255: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:64"
-		IL_025a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0200: stloc.s 5
+		IL_0202: ldloc.s 5
+		IL_0204: ldc.r8 1
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0212: stloc.s 5
+		IL_0214: ldloc.s 5
+		IL_0216: ldc.i4.0
+		IL_0217: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_021c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0221: stloc.s 6
+		IL_0223: ldloc.s 6
+		IL_0225: box [System.Runtime]System.Boolean
+		IL_022a: stloc.s 7
+		IL_022c: ldloc.s 4
+		IL_022e: ldloc.s 7
+		IL_0230: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0235: pop
+		IL_0236: ldstr "a(d)?"
+		IL_023b: ldstr "d"
+		IL_0240: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0245: stloc.3
+		IL_0246: volatile.
+		IL_0248: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_024d: brfalse IL_0267
 
-		IL_0264: stloc.s 5
-		IL_0266: ldloc.s 5
-		IL_0268: ldc.r8 0.0
-		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0276: stloc.s 5
-		IL_0278: ldloc.s 5
-		IL_027a: ldc.r8 0.0
-		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0288: stloc.s 5
-		IL_028a: ldloc.s 4
-		IL_028c: ldloc.s 5
-		IL_028e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0293: pop
-		IL_0294: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0299: stloc.s 4
-		IL_029b: volatile.
-		IL_029d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_02a2: brfalse IL_02b7
+		IL_0252: ldloc.3
+		IL_0253: ldstr "exec"
+		IL_0258: ldstr "bad"
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0262: br IL_0281
 
-		IL_02a7: ldloc.2
-		IL_02a8: ldstr "indices"
-		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b2: br IL_02cc
+		IL_0267: ldloc.3
+		IL_0268: ldstr "exec"
+		IL_026d: ldstr "bad"
+		IL_0272: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:59"
+		IL_0277: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02b7: ldloc.2
-		IL_02b8: ldstr "indices"
-		IL_02bd: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:73"
-		IL_02c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0281: stloc.2
+		IL_0282: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0287: stloc.s 4
+		IL_0289: volatile.
+		IL_028b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0290: brfalse IL_02a5
 
+		IL_0295: ldloc.2
+		IL_0296: ldstr "indices"
+		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a0: br IL_02ba
+
+		IL_02a5: ldloc.2
+		IL_02a6: ldstr "indices"
+		IL_02ab: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:64"
+		IL_02b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02ba: stloc.s 5
+		IL_02bc: ldloc.s 5
+		IL_02be: ldc.r8 0.0
+		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 		IL_02cc: stloc.s 5
 		IL_02ce: ldloc.s 5
 		IL_02d0: ldc.r8 0.0
 		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 		IL_02de: stloc.s 5
-		IL_02e0: ldloc.s 5
-		IL_02e2: ldc.r8 1
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02f0: stloc.s 5
-		IL_02f2: ldloc.s 4
-		IL_02f4: ldloc.s 5
-		IL_02f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02fb: pop
-		IL_02fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0301: stloc.s 4
-		IL_0303: volatile.
-		IL_0305: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_030a: brfalse IL_031f
+		IL_02e0: ldloc.s 4
+		IL_02e2: ldloc.s 5
+		IL_02e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e9: pop
+		IL_02ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ef: stloc.s 4
+		IL_02f1: volatile.
+		IL_02f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02f8: brfalse IL_030d
 
-		IL_030f: ldloc.2
-		IL_0310: ldstr "indices"
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_031a: br IL_0334
+		IL_02fd: ldloc.2
+		IL_02fe: ldstr "indices"
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0308: br IL_0322
 
-		IL_031f: ldloc.2
-		IL_0320: ldstr "indices"
-		IL_0325: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:82"
-		IL_032a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_030d: ldloc.2
+		IL_030e: ldstr "indices"
+		IL_0313: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:73"
+		IL_0318: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
+		IL_0322: stloc.s 5
+		IL_0324: ldloc.s 5
+		IL_0326: ldc.r8 0.0
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 		IL_0334: stloc.s 5
 		IL_0336: ldloc.s 5
 		IL_0338: ldc.r8 1
 		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 		IL_0346: stloc.s 5
-		IL_0348: ldloc.s 5
-		IL_034a: ldc.r8 0.0
-		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0358: stloc.s 5
-		IL_035a: ldloc.s 4
-		IL_035c: ldloc.s 5
-		IL_035e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0363: pop
-		IL_0364: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0369: stloc.s 4
-		IL_036b: volatile.
-		IL_036d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0372: brfalse IL_0387
+		IL_0348: ldloc.s 4
+		IL_034a: ldloc.s 5
+		IL_034c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0351: pop
+		IL_0352: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0357: stloc.s 4
+		IL_0359: volatile.
+		IL_035b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0360: brfalse IL_0375
 
-		IL_0377: ldloc.2
-		IL_0378: ldstr "indices"
-		IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0382: br IL_039c
+		IL_0365: ldloc.2
+		IL_0366: ldstr "indices"
+		IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0370: br IL_038a
 
-		IL_0387: ldloc.2
-		IL_0388: ldstr "indices"
-		IL_038d: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:91"
-		IL_0392: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0375: ldloc.2
+		IL_0376: ldstr "indices"
+		IL_037b: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:82"
+		IL_0380: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
+		IL_038a: stloc.s 5
+		IL_038c: ldloc.s 5
+		IL_038e: ldc.r8 1
+		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 		IL_039c: stloc.s 5
 		IL_039e: ldloc.s 5
-		IL_03a0: ldc.r8 1
+		IL_03a0: ldc.r8 0.0
 		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 		IL_03ae: stloc.s 5
-		IL_03b0: ldloc.s 5
-		IL_03b2: ldc.r8 1
-		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03c0: stloc.s 5
-		IL_03c2: ldloc.s 4
-		IL_03c4: ldloc.s 5
-		IL_03c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03cb: pop
-		IL_03cc: ret
+		IL_03b0: ldloc.s 4
+		IL_03b2: ldloc.s 5
+		IL_03b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03b9: pop
+		IL_03ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03bf: stloc.s 4
+		IL_03c1: volatile.
+		IL_03c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_03c8: brfalse IL_03dd
+
+		IL_03cd: ldloc.2
+		IL_03ce: ldstr "indices"
+		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03d8: br IL_03f2
+
+		IL_03dd: ldloc.2
+		IL_03de: ldstr "indices"
+		IL_03e3: ldstr "IntrinsicCallables_RegExp_Indices_Exec:Modules.IntrinsicCallables_RegExp_Indices_Exec:__js_module_init__:91"
+		IL_03e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_03f2: stloc.s 5
+		IL_03f4: ldloc.s 5
+		IL_03f6: ldc.r8 1
+		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0404: stloc.s 5
+		IL_0406: ldloc.s 5
+		IL_0408: ldc.r8 1
+		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0416: stloc.s 5
+		IL_0418: ldloc.s 4
+		IL_041a: ldloc.s 5
+		IL_041c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0421: pop
+		IL_0422: ret
 	} // end of method IntrinsicCallables_RegExp_Indices_Exec::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_Indices_Exec
@@ -444,6 +470,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_ExplicitReceiverAbi.verified.txt
@@ -1494,7 +1494,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 4867 (0x1303)
+		// Code size: 5432 (0x1538)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_ExplicitReceiverAbi/Scope,
@@ -1633,1385 +1633,1555 @@
 		IL_013d: stloc.s 17
 		IL_013f: ldloc.s 17
 		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0146: ldstr "join"
-		IL_014b: ldstr ","
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0155: stloc.s 17
-		IL_0157: ldloc.s 20
-		IL_0159: ldloc.s 17
-		IL_015b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0160: pop
-		IL_0161: ldc.i4.4
-		IL_0162: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0167: dup
-		IL_0168: ldc.r8 1
-		IL_0171: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0176: dup
-		IL_0177: ldc.r8 2
-		IL_0180: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0185: dup
-		IL_0186: ldc.r8 3
-		IL_018f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0194: dup
-		IL_0195: ldc.r8 4
-		IL_019e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01a3: stloc.s 16
-		IL_01a5: ldstr "iterator"
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_01af: stloc.s 17
-		IL_01b1: ldloc.s 16
-		IL_01b3: ldloc.s 17
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
-		IL_01ba: stloc.3
-		IL_01bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c0: stloc.s 20
-		IL_01c2: ldstr "Iterator"
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01cc: volatile.
-		IL_01ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_01d3: brfalse IL_01e7
-
-		IL_01d8: ldstr "prototype"
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e2: br IL_01fb
-
-		IL_01e7: ldstr "prototype"
-		IL_01ec: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:47"
-		IL_01f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_01fb: stloc.s 17
-		IL_01fd: volatile.
-		IL_01ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0204: brfalse IL_021a
-
-		IL_0209: ldloc.s 17
-		IL_020b: ldstr "filter"
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0215: br IL_0230
-
-		IL_021a: ldloc.s 17
-		IL_021c: ldstr "filter"
-		IL_0221: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:49"
-		IL_0226: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0230: stloc.s 17
-		IL_0232: ldloc.s 17
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0239: stloc.s 17
-		IL_023b: ldc.i4.1
-		IL_023c: newarr [System.Runtime]System.Object
-		IL_0241: dup
-		IL_0242: ldc.i4.0
-		IL_0243: ldloc.0
-		IL_0244: stelem.ref
-		IL_0245: stloc.s 18
-		IL_0247: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L9C49/FunctionObject::.ctor()
-		IL_024c: ldc.i4.1
-		IL_024d: conv.r8
-		IL_024e: ldstr ""
-		IL_0253: ldc.i4.0
-		IL_0254: ldc.i4.0
-		IL_0255: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L9C49/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L9C49/FunctionObject>(!!0)
-		IL_025f: stloc.s 21
-		IL_0261: ldloc.s 17
-		IL_0263: ldstr "call"
-		IL_0268: ldloc.3
-		IL_0269: ldloc.s 21
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0270: stloc.s 17
-		IL_0272: ldloc.s 17
-		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0279: volatile.
-		IL_027b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0280: brfalse IL_0294
-
-		IL_0285: ldstr "toArray"
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_028f: br IL_02a8
-
-		IL_0294: ldstr "toArray"
-		IL_0299: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:55"
-		IL_029e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
-
-		IL_02a8: stloc.s 17
-		IL_02aa: ldloc.s 17
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b1: ldstr "join"
-		IL_02b6: ldstr ","
-		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c0: stloc.s 17
-		IL_02c2: ldloc.s 20
-		IL_02c4: ldloc.s 17
-		IL_02c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02cb: pop
-		IL_02cc: ldc.i4.3
-		IL_02cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02d2: dup
-		IL_02d3: ldc.r8 1
-		IL_02dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02e1: dup
-		IL_02e2: ldc.r8 2
-		IL_02eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02f0: dup
-		IL_02f1: ldc.r8 3
-		IL_02fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ff: stloc.s 16
-		IL_0301: ldstr "iterator"
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_030b: stloc.s 17
-		IL_030d: ldloc.s 16
-		IL_030f: ldloc.s 17
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
-		IL_0316: stloc.s 4
-		IL_0318: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_031d: stloc.s 20
-		IL_031f: ldstr "Iterator"
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0329: volatile.
-		IL_032b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0330: brfalse IL_0344
-
-		IL_0335: ldstr "prototype"
-		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_033f: br IL_0358
-
-		IL_0344: ldstr "prototype"
-		IL_0349: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:74"
-		IL_034e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0358: stloc.s 17
-		IL_035a: volatile.
-		IL_035c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0361: brfalse IL_0377
-
-		IL_0366: ldloc.s 17
-		IL_0368: ldstr "find"
-		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0372: br IL_038d
-
-		IL_0377: ldloc.s 17
-		IL_0379: ldstr "find"
-		IL_037e: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:76"
-		IL_0383: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_038d: stloc.s 17
-		IL_038f: ldloc.s 17
-		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0396: stloc.s 17
-		IL_0398: ldc.i4.1
-		IL_0399: newarr [System.Runtime]System.Object
-		IL_039e: dup
-		IL_039f: ldc.i4.0
-		IL_03a0: ldloc.0
-		IL_03a1: stelem.ref
-		IL_03a2: stloc.s 18
-		IL_03a4: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L12C47/FunctionObject::.ctor()
-		IL_03a9: ldc.i4.1
-		IL_03aa: conv.r8
-		IL_03ab: ldstr ""
-		IL_03b0: ldc.i4.0
-		IL_03b1: ldc.i4.0
-		IL_03b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L12C47/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L12C47/FunctionObject>(!!0)
-		IL_03bc: stloc.s 22
-		IL_03be: ldloc.s 17
-		IL_03c0: ldstr "call"
-		IL_03c5: ldloc.s 4
-		IL_03c7: ldloc.s 22
-		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03ce: stloc.s 17
-		IL_03d0: ldloc.s 20
-		IL_03d2: ldloc.s 17
-		IL_03d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03d9: pop
-		IL_03da: ldc.i4.3
-		IL_03db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_03e0: dup
-		IL_03e1: ldc.r8 1
-		IL_03ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_03ef: dup
-		IL_03f0: ldc.r8 2
-		IL_03f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_03fe: dup
-		IL_03ff: ldc.r8 3
-		IL_0408: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_040d: stloc.s 16
-		IL_040f: ldstr "iterator"
-		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0419: stloc.s 17
-		IL_041b: ldloc.s 16
-		IL_041d: ldloc.s 17
-		IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
-		IL_0424: stloc.s 5
-		IL_0426: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_042b: stloc.s 20
-		IL_042d: ldstr "Iterator"
-		IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0437: volatile.
-		IL_0439: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_043e: brfalse IL_0452
-
-		IL_0443: ldstr "prototype"
-		IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_044d: br IL_0466
-
-		IL_0452: ldstr "prototype"
-		IL_0457: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:96"
-		IL_045c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0466: stloc.s 17
-		IL_0468: volatile.
-		IL_046a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_046f: brfalse IL_0485
-
-		IL_0474: ldloc.s 17
-		IL_0476: ldstr "some"
-		IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0480: br IL_049b
-
-		IL_0485: ldloc.s 17
-		IL_0487: ldstr "some"
-		IL_048c: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:98"
-		IL_0491: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_049b: stloc.s 17
-		IL_049d: ldloc.s 17
-		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04a4: stloc.s 17
-		IL_04a6: ldc.i4.1
-		IL_04a7: newarr [System.Runtime]System.Object
-		IL_04ac: dup
-		IL_04ad: ldc.i4.0
-		IL_04ae: ldloc.0
-		IL_04af: stelem.ref
-		IL_04b0: stloc.s 18
-		IL_04b2: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L15C47/FunctionObject::.ctor()
-		IL_04b7: ldc.i4.1
-		IL_04b8: conv.r8
-		IL_04b9: ldstr ""
-		IL_04be: ldc.i4.0
-		IL_04bf: ldc.i4.0
-		IL_04c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L15C47/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L15C47/FunctionObject>(!!0)
-		IL_04ca: stloc.s 23
-		IL_04cc: ldloc.s 17
-		IL_04ce: ldstr "call"
-		IL_04d3: ldloc.s 5
-		IL_04d5: ldloc.s 23
-		IL_04d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04dc: stloc.s 17
-		IL_04de: ldloc.s 20
-		IL_04e0: ldloc.s 17
-		IL_04e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04e7: pop
-		IL_04e8: ldc.i4.3
-		IL_04e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_04ee: dup
-		IL_04ef: ldc.r8 1
-		IL_04f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_04fd: dup
-		IL_04fe: ldc.r8 2
-		IL_0507: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_050c: dup
-		IL_050d: ldc.r8 3
-		IL_0516: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_051b: stloc.s 16
-		IL_051d: ldstr "iterator"
-		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0527: stloc.s 17
-		IL_0529: ldloc.s 16
-		IL_052b: ldloc.s 17
-		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
-		IL_0532: stloc.s 6
-		IL_0534: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0539: stloc.s 20
-		IL_053b: ldstr "Iterator"
-		IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0545: volatile.
-		IL_0547: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_054c: brfalse IL_0560
-
-		IL_0551: ldstr "prototype"
-		IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_055b: br IL_0574
-
-		IL_0560: ldstr "prototype"
-		IL_0565: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:118"
-		IL_056a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0574: stloc.s 17
-		IL_0576: volatile.
-		IL_0578: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_057d: brfalse IL_0593
-
-		IL_0582: ldloc.s 17
-		IL_0584: ldstr "every"
-		IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_058e: br IL_05a9
-
-		IL_0593: ldloc.s 17
-		IL_0595: ldstr "every"
-		IL_059a: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:120"
-		IL_059f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_05a9: stloc.s 17
-		IL_05ab: ldloc.s 17
-		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05b2: stloc.s 17
-		IL_05b4: ldc.i4.1
-		IL_05b5: newarr [System.Runtime]System.Object
-		IL_05ba: dup
-		IL_05bb: ldc.i4.0
-		IL_05bc: ldloc.0
-		IL_05bd: stelem.ref
-		IL_05be: stloc.s 18
-		IL_05c0: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L18C48/FunctionObject::.ctor()
-		IL_05c5: ldc.i4.1
-		IL_05c6: conv.r8
-		IL_05c7: ldstr ""
-		IL_05cc: ldc.i4.0
-		IL_05cd: ldc.i4.0
-		IL_05ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L18C48/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L18C48/FunctionObject>(!!0)
-		IL_05d8: stloc.s 24
-		IL_05da: ldloc.s 17
-		IL_05dc: ldstr "call"
-		IL_05e1: ldloc.s 6
-		IL_05e3: ldloc.s 24
-		IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_05ea: stloc.s 17
-		IL_05ec: ldloc.s 20
-		IL_05ee: ldloc.s 17
-		IL_05f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05f5: pop
-		IL_05f6: ldc.i4.2
-		IL_05f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_05fc: dup
-		IL_05fd: ldc.r8 1
-		IL_0606: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_060b: dup
-		IL_060c: ldc.r8 2
-		IL_0615: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_061a: stloc.s 16
-		IL_061c: ldstr "iterator"
-		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0626: stloc.s 17
-		IL_0628: ldloc.s 16
-		IL_062a: ldloc.s 17
-		IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
-		IL_0631: stloc.s 7
-		IL_0633: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0638: stloc.s 20
-		IL_063a: ldstr "Iterator"
-		IL_063f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0644: volatile.
-		IL_0646: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_064b: brfalse IL_065f
-
-		IL_0650: ldstr "prototype"
-		IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_065a: br IL_0673
-
-		IL_065f: ldstr "prototype"
-		IL_0664: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:139"
-		IL_0669: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_066e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0673: stloc.s 17
-		IL_0675: volatile.
-		IL_0677: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_067c: brfalse IL_0692
-
-		IL_0681: ldloc.s 17
-		IL_0683: ldstr "flatMap"
-		IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_068d: br IL_06a8
-
-		IL_0692: ldloc.s 17
-		IL_0694: ldstr "flatMap"
-		IL_0699: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:141"
-		IL_069e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_06a8: stloc.s 17
-		IL_06aa: ldloc.s 17
-		IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06b1: stloc.s 17
-		IL_06b3: ldc.i4.1
-		IL_06b4: newarr [System.Runtime]System.Object
-		IL_06b9: dup
-		IL_06ba: ldc.i4.0
-		IL_06bb: ldloc.0
-		IL_06bc: stelem.ref
-		IL_06bd: stloc.s 18
-		IL_06bf: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L21C50/FunctionObject::.ctor()
-		IL_06c4: ldc.i4.1
-		IL_06c5: conv.r8
-		IL_06c6: ldstr ""
-		IL_06cb: ldc.i4.0
-		IL_06cc: ldc.i4.0
-		IL_06cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L21C50/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L21C50/FunctionObject>(!!0)
-		IL_06d7: stloc.s 25
-		IL_06d9: ldloc.s 17
-		IL_06db: ldstr "call"
-		IL_06e0: ldloc.s 7
-		IL_06e2: ldloc.s 25
-		IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06e9: stloc.s 17
-		IL_06eb: ldloc.s 17
-		IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06f2: volatile.
-		IL_06f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_06f9: brfalse IL_070d
-
-		IL_06fe: ldstr "toArray"
-		IL_0703: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0708: br IL_0721
-
-		IL_070d: ldstr "toArray"
-		IL_0712: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:147"
-		IL_0717: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_071c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
-
-		IL_0721: stloc.s 17
-		IL_0723: ldloc.s 17
-		IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_072a: ldstr "join"
-		IL_072f: ldstr ","
-		IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0739: stloc.s 17
-		IL_073b: ldloc.s 20
-		IL_073d: ldloc.s 17
-		IL_073f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0744: pop
-		IL_0745: ldloc.0
-		IL_0746: ldc.r8 0.0
-		IL_074f: box [System.Runtime]System.Double
-		IL_0754: stfld object Modules.Iterator_ExplicitReceiverAbi/Scope::total
-		IL_0759: ldc.i4.3
-		IL_075a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_075f: dup
-		IL_0760: ldc.r8 1
-		IL_0769: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_076e: dup
-		IL_076f: ldc.r8 2
-		IL_0778: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_077d: dup
-		IL_077e: ldc.r8 3
-		IL_0787: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_078c: stloc.s 16
-		IL_078e: ldstr "iterator"
-		IL_0793: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0798: stloc.s 17
-		IL_079a: ldloc.s 16
-		IL_079c: ldloc.s 17
-		IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
-		IL_07a3: stloc.s 8
-		IL_07a5: ldstr "Iterator"
-		IL_07aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07af: volatile.
-		IL_07b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_07b6: brfalse IL_07ca
-
-		IL_07bb: ldstr "prototype"
-		IL_07c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07c5: br IL_07de
-
-		IL_07ca: ldstr "prototype"
-		IL_07cf: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:169"
-		IL_07d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_07de: stloc.s 17
-		IL_07e0: volatile.
-		IL_07e2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_07e7: brfalse IL_07fd
-
-		IL_07ec: ldloc.s 17
-		IL_07ee: ldstr "forEach"
-		IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07f8: br IL_0813
-
-		IL_07fd: ldloc.s 17
-		IL_07ff: ldstr "forEach"
-		IL_0804: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:171"
-		IL_0809: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_080e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0813: stloc.s 17
-		IL_0815: ldloc.s 17
-		IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_081c: stloc.s 17
-		IL_081e: ldc.i4.1
-		IL_081f: newarr [System.Runtime]System.Object
-		IL_0824: dup
-		IL_0825: ldc.i4.0
-		IL_0826: ldloc.0
-		IL_0827: stelem.ref
-		IL_0828: stloc.s 18
-		IL_082a: ldloc.s 18
-		IL_082c: ldc.i4.0
-		IL_082d: ldelem.ref
-		IL_082e: castclass Modules.Iterator_ExplicitReceiverAbi/Scope
-		IL_0833: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L25C38/FunctionObject::.ctor(class Modules.Iterator_ExplicitReceiverAbi/Scope)
-		IL_0838: ldc.i4.1
-		IL_0839: conv.r8
-		IL_083a: ldstr ""
-		IL_083f: ldc.i4.0
-		IL_0840: ldc.i4.0
-		IL_0841: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L25C38/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0846: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L25C38/FunctionObject>(!!0)
-		IL_084b: stloc.s 26
-		IL_084d: ldloc.s 17
-		IL_084f: ldstr "call"
-		IL_0854: ldloc.s 8
-		IL_0856: ldloc.s 26
-		IL_0858: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_085d: pop
-		IL_085e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0863: stloc.s 20
-		IL_0865: ldloc.0
-		IL_0866: ldfld object Modules.Iterator_ExplicitReceiverAbi/Scope::total
-		IL_086b: stloc.s 17
-		IL_086d: ldloc.s 20
-		IL_086f: ldloc.s 17
-		IL_0871: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0876: pop
-		IL_0877: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_087c: stloc.s 20
-		IL_087e: ldstr "Iterator"
-		IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0888: volatile.
-		IL_088a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_088f: brfalse IL_08a3
-
-		IL_0894: ldstr "prototype"
-		IL_0899: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_089e: br IL_08b7
-
-		IL_08a3: ldstr "prototype"
-		IL_08a8: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:185"
-		IL_08ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_08b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_08b7: stloc.s 17
-		IL_08b9: ldstr "iterator"
-		IL_08be: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_08c3: stloc.s 27
-		IL_08c5: ldloc.s 17
-		IL_08c7: ldloc.s 27
-		IL_08c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_08ce: stloc.s 27
-		IL_08d0: ldloc.s 27
-		IL_08d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08d7: stloc.s 27
-		IL_08d9: ldstr "Iterator"
-		IL_08de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08e8: ldc.i4.2
-		IL_08e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_08ee: dup
-		IL_08ef: ldc.r8 1
-		IL_08f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_08fd: dup
-		IL_08fe: ldc.r8 2
-		IL_0907: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_090c: stloc.s 16
-		IL_090e: ldstr "from"
-		IL_0913: ldloc.s 16
-		IL_0915: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_091a: stloc.s 17
-		IL_091c: ldloc.s 27
-		IL_091e: ldstr "call"
-		IL_0923: ldloc.s 17
-		IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_092a: stloc.s 17
-		IL_092c: ldloc.s 17
-		IL_092e: ldnull
-		IL_092f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0934: stloc.s 28
-		IL_0936: ldloc.s 28
-		IL_0938: box [System.Runtime]System.Boolean
-		IL_093d: stloc.s 29
-		IL_093f: ldloc.s 20
-		IL_0941: ldloc.s 29
-		IL_0943: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0948: pop
-		IL_0949: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_094e: stloc.s 20
-		IL_0950: ldstr "Iterator"
-		IL_0955: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_095a: volatile.
-		IL_095c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0961: brfalse IL_0975
-
-		IL_0966: ldstr "prototype"
-		IL_096b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0970: br IL_0989
-
-		IL_0975: ldstr "prototype"
-		IL_097a: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:207"
-		IL_097f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0984: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0989: stloc.s 17
-		IL_098b: volatile.
-		IL_098d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_0992: brfalse IL_09a8
-
-		IL_0997: ldloc.s 17
-		IL_0999: ldstr "take"
-		IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09a3: br IL_09be
-
-		IL_09a8: ldloc.s 17
-		IL_09aa: ldstr "take"
-		IL_09af: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:209"
-		IL_09b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_09b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_09be: stloc.s 17
-		IL_09c0: ldloc.s 17
-		IL_09c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_09c7: stloc.s 17
-		IL_09c9: ldstr "Iterator"
-		IL_09ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_09d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_09d8: ldc.i4.3
-		IL_09d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_09de: dup
-		IL_09df: ldc.r8 1
-		IL_09e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_09ed: dup
-		IL_09ee: ldc.r8 2
-		IL_09f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_09fc: dup
-		IL_09fd: ldc.r8 3
-		IL_0a06: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0a0b: stloc.s 16
-		IL_0a0d: ldstr "from"
-		IL_0a12: ldloc.s 16
-		IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0a19: stloc.s 27
-		IL_0a1b: ldc.i4.1
-		IL_0a1c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0a21: dup
-		IL_0a22: ldc.r8 2
-		IL_0a2b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0a30: stloc.s 16
-		IL_0a32: ldloc.s 17
-		IL_0a34: ldstr "apply"
-		IL_0a39: ldloc.s 27
-		IL_0a3b: ldloc.s 16
-		IL_0a3d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0a42: stloc.s 27
-		IL_0a44: ldloc.s 27
-		IL_0a46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0a4b: volatile.
-		IL_0a4d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_0a52: brfalse IL_0a66
-
-		IL_0a57: ldstr "toArray"
-		IL_0a5c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0a61: br IL_0a7a
-
-		IL_0a66: ldstr "toArray"
-		IL_0a6b: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:223"
-		IL_0a70: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_0a75: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
-
-		IL_0a7a: stloc.s 27
-		IL_0a7c: ldloc.s 27
-		IL_0a7e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0a83: ldstr "join"
-		IL_0a88: ldstr ","
-		IL_0a8d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0a92: stloc.s 27
-		IL_0a94: ldloc.s 20
-		IL_0a96: ldloc.s 27
-		IL_0a98: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0a9d: pop
-		IL_0a9e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0aa3: stloc.s 20
-		IL_0aa5: ldstr "Iterator"
-		IL_0aaa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0aaf: volatile.
-		IL_0ab1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_0ab6: brfalse IL_0aca
-
-		IL_0abb: ldstr "prototype"
-		IL_0ac0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ac5: br IL_0ade
-
-		IL_0aca: ldstr "prototype"
-		IL_0acf: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:233"
-		IL_0ad4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_0ad9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0ade: stloc.s 27
-		IL_0ae0: volatile.
-		IL_0ae2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_0ae7: brfalse IL_0afd
-
-		IL_0aec: ldloc.s 27
-		IL_0aee: ldstr "reduce"
-		IL_0af3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0af8: br IL_0b13
-
-		IL_0afd: ldloc.s 27
-		IL_0aff: ldstr "reduce"
-		IL_0b04: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:235"
-		IL_0b09: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_0b0e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0b13: stloc.s 27
-		IL_0b15: ldloc.s 27
-		IL_0b17: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b1c: stloc.s 27
-		IL_0b1e: ldstr "Iterator"
-		IL_0b23: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b2d: ldc.i4.3
-		IL_0b2e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0b33: dup
-		IL_0b34: ldc.r8 1
-		IL_0b3d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0b42: dup
-		IL_0b43: ldc.r8 2
-		IL_0b4c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0b51: dup
-		IL_0b52: ldc.r8 3
-		IL_0b5b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0b60: stloc.s 16
-		IL_0b62: ldstr "from"
-		IL_0b67: ldloc.s 16
-		IL_0b69: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0b6e: stloc.s 17
-		IL_0b70: ldc.i4.1
-		IL_0b71: newarr [System.Runtime]System.Object
-		IL_0b76: dup
-		IL_0b77: ldc.i4.0
-		IL_0b78: ldloc.0
-		IL_0b79: stelem.ref
-		IL_0b7a: stloc.s 18
-		IL_0b7c: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L33C70/FunctionObject::.ctor()
-		IL_0b81: ldc.i4.2
-		IL_0b82: conv.r8
-		IL_0b83: ldstr ""
-		IL_0b88: ldc.i4.0
-		IL_0b89: ldc.i4.0
-		IL_0b8a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L33C70/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b8f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L33C70/FunctionObject>(!!0)
-		IL_0b94: stloc.s 30
-		IL_0b96: ldloc.s 27
-		IL_0b98: ldstr "call"
-		IL_0b9d: ldloc.s 17
-		IL_0b9f: ldloc.s 30
-		IL_0ba1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0ba6: stloc.s 17
-		IL_0ba8: ldloc.s 20
-		IL_0baa: ldloc.s 17
-		IL_0bac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0bb1: pop
-		IL_0bb2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0bb7: stloc.s 20
-		IL_0bb9: ldstr "Iterator"
-		IL_0bbe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0bc3: volatile.
-		IL_0bc5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_0bca: brfalse IL_0bde
-
-		IL_0bcf: ldstr "prototype"
-		IL_0bd4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0bd9: br IL_0bf2
-
-		IL_0bde: ldstr "prototype"
-		IL_0be3: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:254"
-		IL_0be8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_0bed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0bf2: stloc.s 17
-		IL_0bf4: volatile.
-		IL_0bf6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-		IL_0bfb: brfalse IL_0c11
-
-		IL_0c00: ldloc.s 17
-		IL_0c02: ldstr "reduce"
-		IL_0c07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c0c: br IL_0c27
-
-		IL_0c11: ldloc.s 17
-		IL_0c13: ldstr "reduce"
-		IL_0c18: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:256"
-		IL_0c1d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-		IL_0c22: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0c27: stloc.s 17
-		IL_0c29: ldloc.s 17
-		IL_0c2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0c30: stloc.s 17
-		IL_0c32: ldstr "Iterator"
-		IL_0c37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0c3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0c41: ldc.i4.3
-		IL_0c42: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0c47: dup
-		IL_0c48: ldc.r8 1
-		IL_0c51: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0c56: dup
-		IL_0c57: ldc.r8 2
-		IL_0c60: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0c65: dup
-		IL_0c66: ldc.r8 3
-		IL_0c6f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0c74: stloc.s 16
-		IL_0c76: ldstr "from"
-		IL_0c7b: ldloc.s 16
-		IL_0c7d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0c82: stloc.s 27
-		IL_0c84: ldc.i4.1
-		IL_0c85: newarr [System.Runtime]System.Object
-		IL_0c8a: dup
-		IL_0c8b: ldc.i4.0
-		IL_0c8c: ldloc.0
-		IL_0c8d: stelem.ref
-		IL_0c8e: stloc.s 18
-		IL_0c90: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L34C70/FunctionObject::.ctor()
-		IL_0c95: ldc.i4.2
-		IL_0c96: conv.r8
-		IL_0c97: ldstr ""
-		IL_0c9c: ldc.i4.0
-		IL_0c9d: ldc.i4.0
-		IL_0c9e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L34C70/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0ca3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L34C70/FunctionObject>(!!0)
-		IL_0ca8: stloc.s 31
-		IL_0caa: ldloc.s 17
-		IL_0cac: ldstr "call"
-		IL_0cb1: ldloc.s 27
-		IL_0cb3: ldloc.s 31
-		IL_0cb5: ldc.r8 10
-		IL_0cbe: box [System.Runtime]System.Double
-		IL_0cc3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0cc8: stloc.s 27
-		IL_0cca: ldloc.s 20
-		IL_0ccc: ldloc.s 27
-		IL_0cce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0cd3: pop
-		IL_0cd4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0cd9: stloc.s 20
-		IL_0cdb: ldstr "Iterator"
-		IL_0ce0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0ce5: volatile.
-		IL_0ce7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-		IL_0cec: brfalse IL_0d00
-
-		IL_0cf1: ldstr "prototype"
-		IL_0cf6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0cfb: br IL_0d14
-
-		IL_0d00: ldstr "prototype"
-		IL_0d05: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:277"
-		IL_0d0a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-		IL_0d0f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0d14: stloc.s 27
-		IL_0d16: volatile.
-		IL_0d18: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-		IL_0d1d: brfalse IL_0d33
-
-		IL_0d22: ldloc.s 27
-		IL_0d24: ldstr "reduce"
-		IL_0d29: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0d2e: br IL_0d49
-
-		IL_0d33: ldloc.s 27
-		IL_0d35: ldstr "reduce"
-		IL_0d3a: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:279"
-		IL_0d3f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-		IL_0d44: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0d49: stloc.s 27
-		IL_0d4b: ldloc.s 27
-		IL_0d4d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0d52: stloc.s 27
-		IL_0d54: ldstr "Iterator"
-		IL_0d59: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0d5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0d63: ldc.i4.3
-		IL_0d64: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0d69: dup
-		IL_0d6a: ldc.r8 1
-		IL_0d73: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0d78: dup
-		IL_0d79: ldc.r8 2
-		IL_0d82: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0d87: dup
-		IL_0d88: ldc.r8 3
-		IL_0d91: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0d96: stloc.s 16
-		IL_0d98: ldstr "from"
-		IL_0d9d: ldloc.s 16
-		IL_0d9f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0da4: stloc.s 17
-		IL_0da6: ldc.i4.1
-		IL_0da7: newarr [System.Runtime]System.Object
-		IL_0dac: dup
-		IL_0dad: ldc.i4.0
-		IL_0dae: ldloc.0
-		IL_0daf: stelem.ref
-		IL_0db0: stloc.s 18
-		IL_0db2: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L35C83/FunctionObject::.ctor()
-		IL_0db7: ldc.i4.2
-		IL_0db8: conv.r8
-		IL_0db9: ldstr ""
-		IL_0dbe: ldc.i4.0
-		IL_0dbf: ldc.i4.0
-		IL_0dc0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L35C83/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0dc5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L35C83/FunctionObject>(!!0)
-		IL_0dca: stloc.s 32
-		IL_0dcc: ldloc.s 27
-		IL_0dce: ldstr "call"
-		IL_0dd3: ldloc.s 17
-		IL_0dd5: ldloc.s 32
-		IL_0dd7: ldnull
-		IL_0dd8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0ddd: stloc.s 17
-		IL_0ddf: ldloc.s 17
-		IL_0de1: call bool [JavaScriptRuntime]JavaScriptRuntime.Number::isNaN(object)
-		IL_0de6: box [System.Runtime]System.Boolean
-		IL_0deb: stloc.s 29
-		IL_0ded: ldloc.s 20
-		IL_0def: ldloc.s 29
-		IL_0df1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0df6: pop
-		IL_0df7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0dfc: stloc.s 20
-		IL_0dfe: ldstr "Iterator"
-		IL_0e03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0e08: volatile.
-		IL_0e0a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-		IL_0e0f: brfalse IL_0e23
-
-		IL_0e14: ldstr "prototype"
-		IL_0e19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0e1e: br IL_0e37
-
-		IL_0e23: ldstr "prototype"
-		IL_0e28: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:301"
-		IL_0e2d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-		IL_0e32: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0e37: stloc.s 17
-		IL_0e39: volatile.
-		IL_0e3b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-		IL_0e40: brfalse IL_0e56
-
-		IL_0e45: ldloc.s 17
-		IL_0e47: ldstr "toArray"
-		IL_0e4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0e51: br IL_0e6c
-
-		IL_0e56: ldloc.s 17
-		IL_0e58: ldstr "toArray"
-		IL_0e5d: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:303"
-		IL_0e62: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-		IL_0e67: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0e6c: stloc.s 17
-		IL_0e6e: ldloc.s 17
-		IL_0e70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0e75: stloc.s 17
-		IL_0e77: ldstr "Iterator"
-		IL_0e7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0e81: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0e86: ldc.i4.2
-		IL_0e87: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0e8c: dup
-		IL_0e8d: ldc.r8 9
-		IL_0e96: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0e9b: dup
-		IL_0e9c: ldc.r8 8
-		IL_0ea5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0eaa: stloc.s 16
-		IL_0eac: ldstr "from"
-		IL_0eb1: ldloc.s 16
-		IL_0eb3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0eb8: stloc.s 27
-		IL_0eba: ldloc.s 17
-		IL_0ebc: ldstr "call"
-		IL_0ec1: ldloc.s 27
-		IL_0ec3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0ec8: stloc.s 27
-		IL_0eca: ldloc.s 27
-		IL_0ecc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0ed1: ldstr "join"
-		IL_0ed6: ldstr ","
-		IL_0edb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0ee0: stloc.s 27
-		IL_0ee2: ldloc.s 20
-		IL_0ee4: ldloc.s 27
-		IL_0ee6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0eeb: pop
+		IL_0146: volatile.
+		IL_0148: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_014d: brfalse IL_0166
+
+		IL_0152: ldstr "join"
+		IL_0157: ldstr ","
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0161: br IL_017f
+
+		IL_0166: ldstr "join"
+		IL_016b: ldstr ","
+		IL_0170: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:30"
+		IL_0175: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_017f: stloc.s 17
+		IL_0181: ldloc.s 20
+		IL_0183: ldloc.s 17
+		IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_018a: pop
+		IL_018b: ldc.i4.4
+		IL_018c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0191: dup
+		IL_0192: ldc.r8 1
+		IL_019b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01a0: dup
+		IL_01a1: ldc.r8 2
+		IL_01aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01af: dup
+		IL_01b0: ldc.r8 3
+		IL_01b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01be: dup
+		IL_01bf: ldc.r8 4
+		IL_01c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01cd: stloc.s 16
+		IL_01cf: ldstr "iterator"
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_01d9: stloc.s 17
+		IL_01db: ldloc.s 16
+		IL_01dd: ldloc.s 17
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
+		IL_01e4: stloc.3
+		IL_01e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ea: stloc.s 20
+		IL_01ec: ldstr "Iterator"
+		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f6: volatile.
+		IL_01f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_01fd: brfalse IL_0211
+
+		IL_0202: ldstr "prototype"
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_020c: br IL_0225
+
+		IL_0211: ldstr "prototype"
+		IL_0216: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:47"
+		IL_021b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0225: stloc.s 17
+		IL_0227: volatile.
+		IL_0229: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_022e: brfalse IL_0244
+
+		IL_0233: ldloc.s 17
+		IL_0235: ldstr "filter"
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023f: br IL_025a
+
+		IL_0244: ldloc.s 17
+		IL_0246: ldstr "filter"
+		IL_024b: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:49"
+		IL_0250: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_025a: stloc.s 17
+		IL_025c: ldloc.s 17
+		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0263: stloc.s 17
+		IL_0265: ldc.i4.1
+		IL_0266: newarr [System.Runtime]System.Object
+		IL_026b: dup
+		IL_026c: ldc.i4.0
+		IL_026d: ldloc.0
+		IL_026e: stelem.ref
+		IL_026f: stloc.s 18
+		IL_0271: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L9C49/FunctionObject::.ctor()
+		IL_0276: ldc.i4.1
+		IL_0277: conv.r8
+		IL_0278: ldstr ""
+		IL_027d: ldc.i4.0
+		IL_027e: ldc.i4.0
+		IL_027f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L9C49/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0284: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L9C49/FunctionObject>(!!0)
+		IL_0289: stloc.s 21
+		IL_028b: ldloc.s 17
+		IL_028d: ldstr "call"
+		IL_0292: ldloc.3
+		IL_0293: ldloc.s 21
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_029a: stloc.s 17
+		IL_029c: ldloc.s 17
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a3: volatile.
+		IL_02a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_02aa: brfalse IL_02be
+
+		IL_02af: ldstr "toArray"
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02b9: br IL_02d2
+
+		IL_02be: ldstr "toArray"
+		IL_02c3: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:55"
+		IL_02c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_02d2: stloc.s 17
+		IL_02d4: ldloc.s 17
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02db: volatile.
+		IL_02dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_02e2: brfalse IL_02fb
+
+		IL_02e7: ldstr "join"
+		IL_02ec: ldstr ","
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02f6: br IL_0314
+
+		IL_02fb: ldstr "join"
+		IL_0300: ldstr ","
+		IL_0305: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:58"
+		IL_030a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0314: stloc.s 17
+		IL_0316: ldloc.s 20
+		IL_0318: ldloc.s 17
+		IL_031a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_031f: pop
+		IL_0320: ldc.i4.3
+		IL_0321: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0326: dup
+		IL_0327: ldc.r8 1
+		IL_0330: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0335: dup
+		IL_0336: ldc.r8 2
+		IL_033f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0344: dup
+		IL_0345: ldc.r8 3
+		IL_034e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0353: stloc.s 16
+		IL_0355: ldstr "iterator"
+		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_035f: stloc.s 17
+		IL_0361: ldloc.s 16
+		IL_0363: ldloc.s 17
+		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
+		IL_036a: stloc.s 4
+		IL_036c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0371: stloc.s 20
+		IL_0373: ldstr "Iterator"
+		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_037d: volatile.
+		IL_037f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0384: brfalse IL_0398
+
+		IL_0389: ldstr "prototype"
+		IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0393: br IL_03ac
+
+		IL_0398: ldstr "prototype"
+		IL_039d: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:74"
+		IL_03a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_03ac: stloc.s 17
+		IL_03ae: volatile.
+		IL_03b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_03b5: brfalse IL_03cb
+
+		IL_03ba: ldloc.s 17
+		IL_03bc: ldstr "find"
+		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03c6: br IL_03e1
+
+		IL_03cb: ldloc.s 17
+		IL_03cd: ldstr "find"
+		IL_03d2: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:76"
+		IL_03d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_03e1: stloc.s 17
+		IL_03e3: ldloc.s 17
+		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ea: stloc.s 17
+		IL_03ec: ldc.i4.1
+		IL_03ed: newarr [System.Runtime]System.Object
+		IL_03f2: dup
+		IL_03f3: ldc.i4.0
+		IL_03f4: ldloc.0
+		IL_03f5: stelem.ref
+		IL_03f6: stloc.s 18
+		IL_03f8: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L12C47/FunctionObject::.ctor()
+		IL_03fd: ldc.i4.1
+		IL_03fe: conv.r8
+		IL_03ff: ldstr ""
+		IL_0404: ldc.i4.0
+		IL_0405: ldc.i4.0
+		IL_0406: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L12C47/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_040b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L12C47/FunctionObject>(!!0)
+		IL_0410: stloc.s 22
+		IL_0412: ldloc.s 17
+		IL_0414: ldstr "call"
+		IL_0419: ldloc.s 4
+		IL_041b: ldloc.s 22
+		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0422: stloc.s 17
+		IL_0424: ldloc.s 20
+		IL_0426: ldloc.s 17
+		IL_0428: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_042d: pop
+		IL_042e: ldc.i4.3
+		IL_042f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0434: dup
+		IL_0435: ldc.r8 1
+		IL_043e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0443: dup
+		IL_0444: ldc.r8 2
+		IL_044d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0452: dup
+		IL_0453: ldc.r8 3
+		IL_045c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0461: stloc.s 16
+		IL_0463: ldstr "iterator"
+		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_046d: stloc.s 17
+		IL_046f: ldloc.s 16
+		IL_0471: ldloc.s 17
+		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
+		IL_0478: stloc.s 5
+		IL_047a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_047f: stloc.s 20
+		IL_0481: ldstr "Iterator"
+		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_048b: volatile.
+		IL_048d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0492: brfalse IL_04a6
+
+		IL_0497: ldstr "prototype"
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04a1: br IL_04ba
+
+		IL_04a6: ldstr "prototype"
+		IL_04ab: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:96"
+		IL_04b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04ba: stloc.s 17
+		IL_04bc: volatile.
+		IL_04be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_04c3: brfalse IL_04d9
+
+		IL_04c8: ldloc.s 17
+		IL_04ca: ldstr "some"
+		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04d4: br IL_04ef
+
+		IL_04d9: ldloc.s 17
+		IL_04db: ldstr "some"
+		IL_04e0: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:98"
+		IL_04e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04ef: stloc.s 17
+		IL_04f1: ldloc.s 17
+		IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04f8: stloc.s 17
+		IL_04fa: ldc.i4.1
+		IL_04fb: newarr [System.Runtime]System.Object
+		IL_0500: dup
+		IL_0501: ldc.i4.0
+		IL_0502: ldloc.0
+		IL_0503: stelem.ref
+		IL_0504: stloc.s 18
+		IL_0506: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L15C47/FunctionObject::.ctor()
+		IL_050b: ldc.i4.1
+		IL_050c: conv.r8
+		IL_050d: ldstr ""
+		IL_0512: ldc.i4.0
+		IL_0513: ldc.i4.0
+		IL_0514: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L15C47/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0519: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L15C47/FunctionObject>(!!0)
+		IL_051e: stloc.s 23
+		IL_0520: ldloc.s 17
+		IL_0522: ldstr "call"
+		IL_0527: ldloc.s 5
+		IL_0529: ldloc.s 23
+		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0530: stloc.s 17
+		IL_0532: ldloc.s 20
+		IL_0534: ldloc.s 17
+		IL_0536: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_053b: pop
+		IL_053c: ldc.i4.3
+		IL_053d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0542: dup
+		IL_0543: ldc.r8 1
+		IL_054c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0551: dup
+		IL_0552: ldc.r8 2
+		IL_055b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0560: dup
+		IL_0561: ldc.r8 3
+		IL_056a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_056f: stloc.s 16
+		IL_0571: ldstr "iterator"
+		IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_057b: stloc.s 17
+		IL_057d: ldloc.s 16
+		IL_057f: ldloc.s 17
+		IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
+		IL_0586: stloc.s 6
+		IL_0588: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_058d: stloc.s 20
+		IL_058f: ldstr "Iterator"
+		IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0599: volatile.
+		IL_059b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_05a0: brfalse IL_05b4
+
+		IL_05a5: ldstr "prototype"
+		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05af: br IL_05c8
+
+		IL_05b4: ldstr "prototype"
+		IL_05b9: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:118"
+		IL_05be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05c8: stloc.s 17
+		IL_05ca: volatile.
+		IL_05cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_05d1: brfalse IL_05e7
+
+		IL_05d6: ldloc.s 17
+		IL_05d8: ldstr "every"
+		IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05e2: br IL_05fd
+
+		IL_05e7: ldloc.s 17
+		IL_05e9: ldstr "every"
+		IL_05ee: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:120"
+		IL_05f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05fd: stloc.s 17
+		IL_05ff: ldloc.s 17
+		IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0606: stloc.s 17
+		IL_0608: ldc.i4.1
+		IL_0609: newarr [System.Runtime]System.Object
+		IL_060e: dup
+		IL_060f: ldc.i4.0
+		IL_0610: ldloc.0
+		IL_0611: stelem.ref
+		IL_0612: stloc.s 18
+		IL_0614: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L18C48/FunctionObject::.ctor()
+		IL_0619: ldc.i4.1
+		IL_061a: conv.r8
+		IL_061b: ldstr ""
+		IL_0620: ldc.i4.0
+		IL_0621: ldc.i4.0
+		IL_0622: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L18C48/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0627: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L18C48/FunctionObject>(!!0)
+		IL_062c: stloc.s 24
+		IL_062e: ldloc.s 17
+		IL_0630: ldstr "call"
+		IL_0635: ldloc.s 6
+		IL_0637: ldloc.s 24
+		IL_0639: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_063e: stloc.s 17
+		IL_0640: ldloc.s 20
+		IL_0642: ldloc.s 17
+		IL_0644: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0649: pop
+		IL_064a: ldc.i4.2
+		IL_064b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0650: dup
+		IL_0651: ldc.r8 1
+		IL_065a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_065f: dup
+		IL_0660: ldc.r8 2
+		IL_0669: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_066e: stloc.s 16
+		IL_0670: ldstr "iterator"
+		IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_067a: stloc.s 17
+		IL_067c: ldloc.s 16
+		IL_067e: ldloc.s 17
+		IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
+		IL_0685: stloc.s 7
+		IL_0687: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_068c: stloc.s 20
+		IL_068e: ldstr "Iterator"
+		IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0698: volatile.
+		IL_069a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_069f: brfalse IL_06b3
+
+		IL_06a4: ldstr "prototype"
+		IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06ae: br IL_06c7
+
+		IL_06b3: ldstr "prototype"
+		IL_06b8: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:139"
+		IL_06bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06c7: stloc.s 17
+		IL_06c9: volatile.
+		IL_06cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_06d0: brfalse IL_06e6
+
+		IL_06d5: ldloc.s 17
+		IL_06d7: ldstr "flatMap"
+		IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06e1: br IL_06fc
+
+		IL_06e6: ldloc.s 17
+		IL_06e8: ldstr "flatMap"
+		IL_06ed: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:141"
+		IL_06f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06fc: stloc.s 17
+		IL_06fe: ldloc.s 17
+		IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0705: stloc.s 17
+		IL_0707: ldc.i4.1
+		IL_0708: newarr [System.Runtime]System.Object
+		IL_070d: dup
+		IL_070e: ldc.i4.0
+		IL_070f: ldloc.0
+		IL_0710: stelem.ref
+		IL_0711: stloc.s 18
+		IL_0713: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L21C50/FunctionObject::.ctor()
+		IL_0718: ldc.i4.1
+		IL_0719: conv.r8
+		IL_071a: ldstr ""
+		IL_071f: ldc.i4.0
+		IL_0720: ldc.i4.0
+		IL_0721: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L21C50/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0726: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L21C50/FunctionObject>(!!0)
+		IL_072b: stloc.s 25
+		IL_072d: ldloc.s 17
+		IL_072f: ldstr "call"
+		IL_0734: ldloc.s 7
+		IL_0736: ldloc.s 25
+		IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_073d: stloc.s 17
+		IL_073f: ldloc.s 17
+		IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0746: volatile.
+		IL_0748: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_074d: brfalse IL_0761
+
+		IL_0752: ldstr "toArray"
+		IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_075c: br IL_0775
+
+		IL_0761: ldstr "toArray"
+		IL_0766: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:147"
+		IL_076b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0770: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0775: stloc.s 17
+		IL_0777: ldloc.s 17
+		IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_077e: volatile.
+		IL_0780: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0785: brfalse IL_079e
+
+		IL_078a: ldstr "join"
+		IL_078f: ldstr ","
+		IL_0794: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0799: br IL_07b7
+
+		IL_079e: ldstr "join"
+		IL_07a3: ldstr ","
+		IL_07a8: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:150"
+		IL_07ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_07b7: stloc.s 17
+		IL_07b9: ldloc.s 20
+		IL_07bb: ldloc.s 17
+		IL_07bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07c2: pop
+		IL_07c3: ldloc.0
+		IL_07c4: ldc.r8 0.0
+		IL_07cd: box [System.Runtime]System.Double
+		IL_07d2: stfld object Modules.Iterator_ExplicitReceiverAbi/Scope::total
+		IL_07d7: ldc.i4.3
+		IL_07d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_07dd: dup
+		IL_07de: ldc.r8 1
+		IL_07e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_07ec: dup
+		IL_07ed: ldc.r8 2
+		IL_07f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_07fb: dup
+		IL_07fc: ldc.r8 3
+		IL_0805: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_080a: stloc.s 16
+		IL_080c: ldstr "iterator"
+		IL_0811: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0816: stloc.s 17
+		IL_0818: ldloc.s 16
+		IL_081a: ldloc.s 17
+		IL_081c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
+		IL_0821: stloc.s 8
+		IL_0823: ldstr "Iterator"
+		IL_0828: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_082d: volatile.
+		IL_082f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0834: brfalse IL_0848
+
+		IL_0839: ldstr "prototype"
+		IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0843: br IL_085c
+
+		IL_0848: ldstr "prototype"
+		IL_084d: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:169"
+		IL_0852: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_085c: stloc.s 17
+		IL_085e: volatile.
+		IL_0860: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0865: brfalse IL_087b
+
+		IL_086a: ldloc.s 17
+		IL_086c: ldstr "forEach"
+		IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0876: br IL_0891
+
+		IL_087b: ldloc.s 17
+		IL_087d: ldstr "forEach"
+		IL_0882: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:171"
+		IL_0887: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_088c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0891: stloc.s 17
+		IL_0893: ldloc.s 17
+		IL_0895: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_089a: stloc.s 17
+		IL_089c: ldc.i4.1
+		IL_089d: newarr [System.Runtime]System.Object
+		IL_08a2: dup
+		IL_08a3: ldc.i4.0
+		IL_08a4: ldloc.0
+		IL_08a5: stelem.ref
+		IL_08a6: stloc.s 18
+		IL_08a8: ldloc.s 18
+		IL_08aa: ldc.i4.0
+		IL_08ab: ldelem.ref
+		IL_08ac: castclass Modules.Iterator_ExplicitReceiverAbi/Scope
+		IL_08b1: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L25C38/FunctionObject::.ctor(class Modules.Iterator_ExplicitReceiverAbi/Scope)
+		IL_08b6: ldc.i4.1
+		IL_08b7: conv.r8
+		IL_08b8: ldstr ""
+		IL_08bd: ldc.i4.0
+		IL_08be: ldc.i4.0
+		IL_08bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L25C38/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L25C38/FunctionObject>(!!0)
+		IL_08c9: stloc.s 26
+		IL_08cb: ldloc.s 17
+		IL_08cd: ldstr "call"
+		IL_08d2: ldloc.s 8
+		IL_08d4: ldloc.s 26
+		IL_08d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_08db: pop
+		IL_08dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08e1: stloc.s 20
+		IL_08e3: ldloc.0
+		IL_08e4: ldfld object Modules.Iterator_ExplicitReceiverAbi/Scope::total
+		IL_08e9: stloc.s 17
+		IL_08eb: ldloc.s 20
+		IL_08ed: ldloc.s 17
+		IL_08ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08f4: pop
+		IL_08f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08fa: stloc.s 20
+		IL_08fc: ldstr "Iterator"
+		IL_0901: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0906: volatile.
+		IL_0908: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_090d: brfalse IL_0921
+
+		IL_0912: ldstr "prototype"
+		IL_0917: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_091c: br IL_0935
+
+		IL_0921: ldstr "prototype"
+		IL_0926: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:185"
+		IL_092b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_0930: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0935: stloc.s 17
+		IL_0937: ldstr "iterator"
+		IL_093c: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0941: stloc.s 27
+		IL_0943: ldloc.s 17
+		IL_0945: ldloc.s 27
+		IL_0947: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_094c: stloc.s 27
+		IL_094e: ldloc.s 27
+		IL_0950: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0955: stloc.s 27
+		IL_0957: ldstr "Iterator"
+		IL_095c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0961: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0966: ldc.i4.2
+		IL_0967: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_096c: dup
+		IL_096d: ldc.r8 1
+		IL_0976: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_097b: dup
+		IL_097c: ldc.r8 2
+		IL_0985: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_098a: stloc.s 16
+		IL_098c: volatile.
+		IL_098e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_0993: brfalse IL_09a9
+
+		IL_0998: ldstr "from"
+		IL_099d: ldloc.s 16
+		IL_099f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_09a4: br IL_09bf
+
+		IL_09a9: ldstr "from"
+		IL_09ae: ldloc.s 16
+		IL_09b0: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:196"
+		IL_09b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_09ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_09bf: stloc.s 17
+		IL_09c1: volatile.
+		IL_09c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_09c8: brfalse IL_09e0
+
+		IL_09cd: ldloc.s 27
+		IL_09cf: ldstr "call"
+		IL_09d4: ldloc.s 17
+		IL_09d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_09db: br IL_09f8
+
+		IL_09e0: ldloc.s 27
+		IL_09e2: ldstr "call"
+		IL_09e7: ldloc.s 17
+		IL_09e9: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:197"
+		IL_09ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_09f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_09f8: stloc.s 17
+		IL_09fa: ldloc.s 17
+		IL_09fc: ldnull
+		IL_09fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0a02: stloc.s 28
+		IL_0a04: ldloc.s 28
+		IL_0a06: box [System.Runtime]System.Boolean
+		IL_0a0b: stloc.s 29
+		IL_0a0d: ldloc.s 20
+		IL_0a0f: ldloc.s 29
+		IL_0a11: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0a16: pop
+		IL_0a17: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0a1c: stloc.s 20
+		IL_0a1e: ldstr "Iterator"
+		IL_0a23: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a28: volatile.
+		IL_0a2a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0a2f: brfalse IL_0a43
+
+		IL_0a34: ldstr "prototype"
+		IL_0a39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a3e: br IL_0a57
+
+		IL_0a43: ldstr "prototype"
+		IL_0a48: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:207"
+		IL_0a4d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0a52: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0a57: stloc.s 17
+		IL_0a59: volatile.
+		IL_0a5b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_0a60: brfalse IL_0a76
+
+		IL_0a65: ldloc.s 17
+		IL_0a67: ldstr "take"
+		IL_0a6c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a71: br IL_0a8c
+
+		IL_0a76: ldloc.s 17
+		IL_0a78: ldstr "take"
+		IL_0a7d: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:209"
+		IL_0a82: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_0a87: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0a8c: stloc.s 17
+		IL_0a8e: ldloc.s 17
+		IL_0a90: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a95: stloc.s 17
+		IL_0a97: ldstr "Iterator"
+		IL_0a9c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0aa1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0aa6: ldc.i4.3
+		IL_0aa7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0aac: dup
+		IL_0aad: ldc.r8 1
+		IL_0ab6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0abb: dup
+		IL_0abc: ldc.r8 2
+		IL_0ac5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0aca: dup
+		IL_0acb: ldc.r8 3
+		IL_0ad4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0ad9: stloc.s 16
+		IL_0adb: volatile.
+		IL_0add: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_0ae2: brfalse IL_0af8
+
+		IL_0ae7: ldstr "from"
+		IL_0aec: ldloc.s 16
+		IL_0aee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0af3: br IL_0b0e
+
+		IL_0af8: ldstr "from"
+		IL_0afd: ldloc.s 16
+		IL_0aff: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:218"
+		IL_0b04: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_0b09: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0b0e: stloc.s 27
+		IL_0b10: ldc.i4.1
+		IL_0b11: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0b16: dup
+		IL_0b17: ldc.r8 2
+		IL_0b20: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0b25: stloc.s 16
+		IL_0b27: ldloc.s 17
+		IL_0b29: ldstr "apply"
+		IL_0b2e: ldloc.s 27
+		IL_0b30: ldloc.s 16
+		IL_0b32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0b37: stloc.s 27
+		IL_0b39: ldloc.s 27
+		IL_0b3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b40: volatile.
+		IL_0b42: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_0b47: brfalse IL_0b5b
+
+		IL_0b4c: ldstr "toArray"
+		IL_0b51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0b56: br IL_0b6f
+
+		IL_0b5b: ldstr "toArray"
+		IL_0b60: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:223"
+		IL_0b65: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_0b6a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0b6f: stloc.s 27
+		IL_0b71: ldloc.s 27
+		IL_0b73: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b78: volatile.
+		IL_0b7a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_0b7f: brfalse IL_0b98
+
+		IL_0b84: ldstr "join"
+		IL_0b89: ldstr ","
+		IL_0b8e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0b93: br IL_0bb1
+
+		IL_0b98: ldstr "join"
+		IL_0b9d: ldstr ","
+		IL_0ba2: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:226"
+		IL_0ba7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+		IL_0bac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0bb1: stloc.s 27
+		IL_0bb3: ldloc.s 20
+		IL_0bb5: ldloc.s 27
+		IL_0bb7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0bbc: pop
+		IL_0bbd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0bc2: stloc.s 20
+		IL_0bc4: ldstr "Iterator"
+		IL_0bc9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0bce: volatile.
+		IL_0bd0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+		IL_0bd5: brfalse IL_0be9
+
+		IL_0bda: ldstr "prototype"
+		IL_0bdf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0be4: br IL_0bfd
+
+		IL_0be9: ldstr "prototype"
+		IL_0bee: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:233"
+		IL_0bf3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+		IL_0bf8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0bfd: stloc.s 27
+		IL_0bff: volatile.
+		IL_0c01: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+		IL_0c06: brfalse IL_0c1c
+
+		IL_0c0b: ldloc.s 27
+		IL_0c0d: ldstr "reduce"
+		IL_0c12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c17: br IL_0c32
+
+		IL_0c1c: ldloc.s 27
+		IL_0c1e: ldstr "reduce"
+		IL_0c23: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:235"
+		IL_0c28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+		IL_0c2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0c32: stloc.s 27
+		IL_0c34: ldloc.s 27
+		IL_0c36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0c3b: stloc.s 27
+		IL_0c3d: ldstr "Iterator"
+		IL_0c42: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0c47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0c4c: ldc.i4.3
+		IL_0c4d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0c52: dup
+		IL_0c53: ldc.r8 1
+		IL_0c5c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0c61: dup
+		IL_0c62: ldc.r8 2
+		IL_0c6b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0c70: dup
+		IL_0c71: ldc.r8 3
+		IL_0c7a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0c7f: stloc.s 16
+		IL_0c81: volatile.
+		IL_0c83: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+		IL_0c88: brfalse IL_0c9e
+
+		IL_0c8d: ldstr "from"
+		IL_0c92: ldloc.s 16
+		IL_0c94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0c99: br IL_0cb4
+
+		IL_0c9e: ldstr "from"
+		IL_0ca3: ldloc.s 16
+		IL_0ca5: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:244"
+		IL_0caa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+		IL_0caf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0cb4: stloc.s 17
+		IL_0cb6: ldc.i4.1
+		IL_0cb7: newarr [System.Runtime]System.Object
+		IL_0cbc: dup
+		IL_0cbd: ldc.i4.0
+		IL_0cbe: ldloc.0
+		IL_0cbf: stelem.ref
+		IL_0cc0: stloc.s 18
+		IL_0cc2: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L33C70/FunctionObject::.ctor()
+		IL_0cc7: ldc.i4.2
+		IL_0cc8: conv.r8
+		IL_0cc9: ldstr ""
+		IL_0cce: ldc.i4.0
+		IL_0ccf: ldc.i4.0
+		IL_0cd0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L33C70/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0cd5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L33C70/FunctionObject>(!!0)
+		IL_0cda: stloc.s 30
+		IL_0cdc: ldloc.s 27
+		IL_0cde: ldstr "call"
+		IL_0ce3: ldloc.s 17
+		IL_0ce5: ldloc.s 30
+		IL_0ce7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0cec: stloc.s 17
+		IL_0cee: ldloc.s 20
+		IL_0cf0: ldloc.s 17
+		IL_0cf2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0cf7: pop
+		IL_0cf8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0cfd: stloc.s 20
+		IL_0cff: ldstr "Iterator"
+		IL_0d04: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0d09: volatile.
+		IL_0d0b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+		IL_0d10: brfalse IL_0d24
+
+		IL_0d15: ldstr "prototype"
+		IL_0d1a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d1f: br IL_0d38
+
+		IL_0d24: ldstr "prototype"
+		IL_0d29: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:254"
+		IL_0d2e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+		IL_0d33: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0d38: stloc.s 17
+		IL_0d3a: volatile.
+		IL_0d3c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+		IL_0d41: brfalse IL_0d57
+
+		IL_0d46: ldloc.s 17
+		IL_0d48: ldstr "reduce"
+		IL_0d4d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d52: br IL_0d6d
+
+		IL_0d57: ldloc.s 17
+		IL_0d59: ldstr "reduce"
+		IL_0d5e: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:256"
+		IL_0d63: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+		IL_0d68: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0d6d: stloc.s 17
+		IL_0d6f: ldloc.s 17
+		IL_0d71: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0d76: stloc.s 17
+		IL_0d78: ldstr "Iterator"
+		IL_0d7d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0d82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0d87: ldc.i4.3
+		IL_0d88: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0d8d: dup
+		IL_0d8e: ldc.r8 1
+		IL_0d97: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0d9c: dup
+		IL_0d9d: ldc.r8 2
+		IL_0da6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0dab: dup
+		IL_0dac: ldc.r8 3
+		IL_0db5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0dba: stloc.s 16
+		IL_0dbc: volatile.
+		IL_0dbe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+		IL_0dc3: brfalse IL_0dd9
+
+		IL_0dc8: ldstr "from"
+		IL_0dcd: ldloc.s 16
+		IL_0dcf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0dd4: br IL_0def
+
+		IL_0dd9: ldstr "from"
+		IL_0dde: ldloc.s 16
+		IL_0de0: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:265"
+		IL_0de5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+		IL_0dea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0def: stloc.s 27
+		IL_0df1: ldc.i4.1
+		IL_0df2: newarr [System.Runtime]System.Object
+		IL_0df7: dup
+		IL_0df8: ldc.i4.0
+		IL_0df9: ldloc.0
+		IL_0dfa: stelem.ref
+		IL_0dfb: stloc.s 18
+		IL_0dfd: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L34C70/FunctionObject::.ctor()
+		IL_0e02: ldc.i4.2
+		IL_0e03: conv.r8
+		IL_0e04: ldstr ""
+		IL_0e09: ldc.i4.0
+		IL_0e0a: ldc.i4.0
+		IL_0e0b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L34C70/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e10: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L34C70/FunctionObject>(!!0)
+		IL_0e15: stloc.s 31
+		IL_0e17: ldloc.s 17
+		IL_0e19: ldstr "call"
+		IL_0e1e: ldloc.s 27
+		IL_0e20: ldloc.s 31
+		IL_0e22: ldc.r8 10
+		IL_0e2b: box [System.Runtime]System.Double
+		IL_0e30: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0e35: stloc.s 27
+		IL_0e37: ldloc.s 20
+		IL_0e39: ldloc.s 27
+		IL_0e3b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0e40: pop
+		IL_0e41: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0e46: stloc.s 20
+		IL_0e48: ldstr "Iterator"
+		IL_0e4d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0e52: volatile.
+		IL_0e54: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+		IL_0e59: brfalse IL_0e6d
+
+		IL_0e5e: ldstr "prototype"
+		IL_0e63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0e68: br IL_0e81
+
+		IL_0e6d: ldstr "prototype"
+		IL_0e72: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:277"
+		IL_0e77: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+		IL_0e7c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0e81: stloc.s 27
+		IL_0e83: volatile.
+		IL_0e85: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+		IL_0e8a: brfalse IL_0ea0
+
+		IL_0e8f: ldloc.s 27
+		IL_0e91: ldstr "reduce"
+		IL_0e96: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0e9b: br IL_0eb6
+
+		IL_0ea0: ldloc.s 27
+		IL_0ea2: ldstr "reduce"
+		IL_0ea7: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:279"
+		IL_0eac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+		IL_0eb1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0eb6: stloc.s 27
+		IL_0eb8: ldloc.s 27
+		IL_0eba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0ebf: stloc.s 27
+		IL_0ec1: ldstr "Iterator"
+		IL_0ec6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0ecb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0ed0: ldc.i4.3
+		IL_0ed1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0ed6: dup
+		IL_0ed7: ldc.r8 1
+		IL_0ee0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0ee5: dup
+		IL_0ee6: ldc.r8 2
+		IL_0eef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0ef4: dup
+		IL_0ef5: ldc.r8 3
+		IL_0efe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0f03: stloc.s 16
+		IL_0f05: volatile.
+		IL_0f07: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+		IL_0f0c: brfalse IL_0f22
+
+		IL_0f11: ldstr "from"
+		IL_0f16: ldloc.s 16
+		IL_0f18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0f1d: br IL_0f38
+
+		IL_0f22: ldstr "from"
+		IL_0f27: ldloc.s 16
+		IL_0f29: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:288"
+		IL_0f2e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+		IL_0f33: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0f38: stloc.s 17
+		IL_0f3a: ldc.i4.1
+		IL_0f3b: newarr [System.Runtime]System.Object
+		IL_0f40: dup
+		IL_0f41: ldc.i4.0
+		IL_0f42: ldloc.0
+		IL_0f43: stelem.ref
+		IL_0f44: stloc.s 18
+		IL_0f46: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L35C83/FunctionObject::.ctor()
+		IL_0f4b: ldc.i4.2
+		IL_0f4c: conv.r8
+		IL_0f4d: ldstr ""
+		IL_0f52: ldc.i4.0
+		IL_0f53: ldc.i4.0
+		IL_0f54: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L35C83/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0f59: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L35C83/FunctionObject>(!!0)
+		IL_0f5e: stloc.s 32
+		IL_0f60: ldloc.s 27
+		IL_0f62: ldstr "call"
+		IL_0f67: ldloc.s 17
+		IL_0f69: ldloc.s 32
+		IL_0f6b: ldnull
+		IL_0f6c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0f71: stloc.s 17
+		IL_0f73: ldloc.s 17
+		IL_0f75: call bool [JavaScriptRuntime]JavaScriptRuntime.Number::isNaN(object)
+		IL_0f7a: box [System.Runtime]System.Boolean
+		IL_0f7f: stloc.s 29
+		IL_0f81: ldloc.s 20
+		IL_0f83: ldloc.s 29
+		IL_0f85: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0f8a: pop
+		IL_0f8b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0f90: stloc.s 20
+		IL_0f92: ldstr "Iterator"
+		IL_0f97: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0f9c: volatile.
+		IL_0f9e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+		IL_0fa3: brfalse IL_0fb7
+
+		IL_0fa8: ldstr "prototype"
+		IL_0fad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0fb2: br IL_0fcb
+
+		IL_0fb7: ldstr "prototype"
+		IL_0fbc: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:301"
+		IL_0fc1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+		IL_0fc6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0fcb: stloc.s 17
+		IL_0fcd: volatile.
+		IL_0fcf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+		IL_0fd4: brfalse IL_0fea
+
+		IL_0fd9: ldloc.s 17
+		IL_0fdb: ldstr "toArray"
+		IL_0fe0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0fe5: br IL_1000
+
+		IL_0fea: ldloc.s 17
+		IL_0fec: ldstr "toArray"
+		IL_0ff1: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:303"
+		IL_0ff6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+		IL_0ffb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_1000: stloc.s 17
+		IL_1002: ldloc.s 17
+		IL_1004: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_1009: stloc.s 17
+		IL_100b: ldstr "Iterator"
+		IL_1010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_1015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_101a: ldc.i4.2
+		IL_101b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_1020: dup
+		IL_1021: ldc.r8 9
+		IL_102a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_102f: dup
+		IL_1030: ldc.r8 8
+		IL_1039: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_103e: stloc.s 16
+		IL_1040: volatile.
+		IL_1042: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_1047: brfalse IL_105d
+
+		IL_104c: ldstr "from"
+		IL_1051: ldloc.s 16
+		IL_1053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_1058: br IL_1073
+
+		IL_105d: ldstr "from"
+		IL_1062: ldloc.s 16
+		IL_1064: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:311"
+		IL_1069: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_106e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_1073: stloc.s 27
+		IL_1075: volatile.
+		IL_1077: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+		IL_107c: brfalse IL_1094
+
+		IL_1081: ldloc.s 17
+		IL_1083: ldstr "call"
+		IL_1088: ldloc.s 27
+		IL_108a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_108f: br IL_10ac
+
+		IL_1094: ldloc.s 17
+		IL_1096: ldstr "call"
+		IL_109b: ldloc.s 27
+		IL_109d: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:312"
+		IL_10a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+		IL_10a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_10ac: stloc.s 27
+		IL_10ae: ldloc.s 27
+		IL_10b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_10b5: volatile.
+		IL_10b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+		IL_10bc: brfalse IL_10d5
+
+		IL_10c1: ldstr "join"
+		IL_10c6: ldstr ","
+		IL_10cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_10d0: br IL_10ee
+
+		IL_10d5: ldstr "join"
+		IL_10da: ldstr ","
+		IL_10df: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:315"
+		IL_10e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+		IL_10e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_10ee: stloc.s 27
+		IL_10f0: ldloc.s 20
+		IL_10f2: ldloc.s 27
+		IL_10f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_10f9: pop
 		.try
 		{
-			IL_0eec: nop
-			IL_0eed: ldstr "Iterator"
-			IL_0ef2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ef7: volatile.
-			IL_0ef9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-			IL_0efe: brfalse IL_0f12
+			IL_10fa: nop
+			IL_10fb: ldstr "Iterator"
+			IL_1100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1105: volatile.
+			IL_1107: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_110c: brfalse IL_1120
 
-			IL_0f03: ldstr "prototype"
-			IL_0f08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f0d: br IL_0f26
+			IL_1111: ldstr "prototype"
+			IL_1116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_111b: br IL_1134
 
-			IL_0f12: ldstr "prototype"
-			IL_0f17: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:324"
-			IL_0f1c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-			IL_0f21: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1120: ldstr "prototype"
+			IL_1125: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:324"
+			IL_112a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_112f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f26: stloc.s 27
-			IL_0f28: volatile.
-			IL_0f2a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-			IL_0f2f: brfalse IL_0f45
+			IL_1134: stloc.s 27
+			IL_1136: volatile.
+			IL_1138: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_113d: brfalse IL_1153
 
-			IL_0f34: ldloc.s 27
-			IL_0f36: ldstr "next"
-			IL_0f3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f40: br IL_0f5b
+			IL_1142: ldloc.s 27
+			IL_1144: ldstr "next"
+			IL_1149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_114e: br IL_1169
 
-			IL_0f45: ldloc.s 27
-			IL_0f47: ldstr "next"
-			IL_0f4c: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:326"
-			IL_0f51: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-			IL_0f56: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1153: ldloc.s 27
+			IL_1155: ldstr "next"
+			IL_115a: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:326"
+			IL_115f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_1164: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f5b: stloc.s 27
-			IL_0f5d: ldloc.s 27
-			IL_0f5f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0f64: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0f69: stloc.s 33
-			IL_0f6b: ldstr "call"
-			IL_0f70: ldloc.s 33
-			IL_0f72: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0f77: pop
-			IL_0f78: leave IL_0fe9
+			IL_1169: stloc.s 27
+			IL_116b: ldloc.s 27
+			IL_116d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1172: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_1177: stloc.s 33
+			IL_1179: volatile.
+			IL_117b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_1180: brfalse IL_1196
+
+			IL_1185: ldstr "call"
+			IL_118a: ldloc.s 33
+			IL_118c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_1191: br IL_11ac
+
+			IL_1196: ldstr "call"
+			IL_119b: ldloc.s 33
+			IL_119d: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:329"
+			IL_11a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_11a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_11ac: pop
+			IL_11ad: leave IL_121e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0f7d: stloc.s 9
-			IL_0f7f: ldloc.s 9
-			IL_0f81: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0f86: dup
-			IL_0f87: brtrue IL_0f9d
+			IL_11b2: stloc.s 9
+			IL_11b4: ldloc.s 9
+			IL_11b6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_11bb: dup
+			IL_11bc: brtrue IL_11d2
 
-			IL_0f8c: pop
-			IL_0f8d: ldloc.s 9
-			IL_0f8f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0f94: dup
-			IL_0f95: brtrue IL_0fa9
+			IL_11c1: pop
+			IL_11c2: ldloc.s 9
+			IL_11c4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_11c9: dup
+			IL_11ca: brtrue IL_11de
 
-			IL_0f9a: pop
-			IL_0f9b: rethrow
+			IL_11cf: pop
+			IL_11d0: rethrow
 
-			IL_0f9d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0fa2: stloc.s 10
-			IL_0fa4: br IL_0fab
+			IL_11d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_11d7: stloc.s 10
+			IL_11d9: br IL_11e0
 
-			IL_0fa9: stloc.s 10
+			IL_11de: stloc.s 10
 
-			IL_0fab: ldloc.s 10
-			IL_0fad: stloc.s 11
-			IL_0faf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0fb4: stloc.s 20
-			IL_0fb6: ldloc.s 11
-			IL_0fb8: stloc.s 27
-			IL_0fba: ldstr "TypeError"
-			IL_0fbf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0fc4: stloc.s 17
-			IL_0fc6: ldloc.s 27
-			IL_0fc8: ldloc.s 17
-			IL_0fca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0fcf: stloc.s 28
-			IL_0fd1: ldloc.s 28
-			IL_0fd3: box [System.Runtime]System.Boolean
-			IL_0fd8: stloc.s 29
-			IL_0fda: ldloc.s 20
-			IL_0fdc: ldloc.s 29
-			IL_0fde: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0fe3: pop
-			IL_0fe4: leave IL_0fe9
+			IL_11e0: ldloc.s 10
+			IL_11e2: stloc.s 11
+			IL_11e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_11e9: stloc.s 20
+			IL_11eb: ldloc.s 11
+			IL_11ed: stloc.s 27
+			IL_11ef: ldstr "TypeError"
+			IL_11f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_11f9: stloc.s 17
+			IL_11fb: ldloc.s 27
+			IL_11fd: ldloc.s 17
+			IL_11ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_1204: stloc.s 28
+			IL_1206: ldloc.s 28
+			IL_1208: box [System.Runtime]System.Boolean
+			IL_120d: stloc.s 29
+			IL_120f: ldloc.s 20
+			IL_1211: ldloc.s 29
+			IL_1213: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_1218: pop
+			IL_1219: leave IL_121e
 		} // end handler
 		.try
 		{
-			IL_0fe9: nop
-			IL_0fea: ldstr "Iterator"
-			IL_0fef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ff4: volatile.
-			IL_0ff6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_0ffb: brfalse IL_100f
+			IL_121e: nop
+			IL_121f: ldstr "Iterator"
+			IL_1224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1229: volatile.
+			IL_122b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_1230: brfalse IL_1244
 
-			IL_1000: ldstr "prototype"
-			IL_1005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_100a: br IL_1023
+			IL_1235: ldstr "prototype"
+			IL_123a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_123f: br IL_1258
 
-			IL_100f: ldstr "prototype"
-			IL_1014: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:356"
-			IL_1019: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_101e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1244: ldstr "prototype"
+			IL_1249: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:356"
+			IL_124e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_1253: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1023: stloc.s 17
-			IL_1025: volatile.
-			IL_1027: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-			IL_102c: brfalse IL_1042
+			IL_1258: stloc.s 17
+			IL_125a: volatile.
+			IL_125c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_1261: brfalse IL_1277
 
-			IL_1031: ldloc.s 17
-			IL_1033: ldstr "map"
-			IL_1038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_103d: br IL_1058
+			IL_1266: ldloc.s 17
+			IL_1268: ldstr "map"
+			IL_126d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1272: br IL_128d
 
-			IL_1042: ldloc.s 17
-			IL_1044: ldstr "map"
-			IL_1049: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:358"
-			IL_104e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-			IL_1053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1277: ldloc.s 17
+			IL_1279: ldstr "map"
+			IL_127e: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:358"
+			IL_1283: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_1288: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1058: stloc.s 17
-			IL_105a: ldloc.s 17
-			IL_105c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1061: stloc.s 17
-			IL_1063: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_1068: stloc.s 33
-			IL_106a: ldc.i4.1
-			IL_106b: newarr [System.Runtime]System.Object
-			IL_1070: dup
-			IL_1071: ldc.i4.0
-			IL_1072: ldloc.0
-			IL_1073: stelem.ref
-			IL_1074: stloc.s 18
-			IL_1076: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L45C37/FunctionObject::.ctor()
-			IL_107b: ldc.i4.1
-			IL_107c: conv.r8
-			IL_107d: ldstr ""
-			IL_1082: ldc.i4.0
-			IL_1083: ldc.i4.0
-			IL_1084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L45C37/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_1089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L45C37/FunctionObject>(!!0)
-			IL_108e: stloc.s 34
-			IL_1090: ldloc.s 17
-			IL_1092: ldstr "call"
-			IL_1097: ldloc.s 33
-			IL_1099: ldloc.s 34
-			IL_109b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_10a0: pop
-			IL_10a1: leave IL_1112
+			IL_128d: stloc.s 17
+			IL_128f: ldloc.s 17
+			IL_1291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1296: stloc.s 17
+			IL_1298: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_129d: stloc.s 33
+			IL_129f: ldc.i4.1
+			IL_12a0: newarr [System.Runtime]System.Object
+			IL_12a5: dup
+			IL_12a6: ldc.i4.0
+			IL_12a7: ldloc.0
+			IL_12a8: stelem.ref
+			IL_12a9: stloc.s 18
+			IL_12ab: newobj instance void Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L45C37/FunctionObject::.ctor()
+			IL_12b0: ldc.i4.1
+			IL_12b1: conv.r8
+			IL_12b2: ldstr ""
+			IL_12b7: ldc.i4.0
+			IL_12b8: ldc.i4.0
+			IL_12b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L45C37/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_12be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_ExplicitReceiverAbi/ArrowFunction_L45C37/FunctionObject>(!!0)
+			IL_12c3: stloc.s 34
+			IL_12c5: ldloc.s 17
+			IL_12c7: ldstr "call"
+			IL_12cc: ldloc.s 33
+			IL_12ce: ldloc.s 34
+			IL_12d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_12d5: pop
+			IL_12d6: leave IL_1347
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_10a6: stloc.s 12
-			IL_10a8: ldloc.s 12
-			IL_10aa: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_10af: dup
-			IL_10b0: brtrue IL_10c6
+			IL_12db: stloc.s 12
+			IL_12dd: ldloc.s 12
+			IL_12df: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_12e4: dup
+			IL_12e5: brtrue IL_12fb
 
-			IL_10b5: pop
-			IL_10b6: ldloc.s 12
-			IL_10b8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_10bd: dup
-			IL_10be: brtrue IL_10d2
+			IL_12ea: pop
+			IL_12eb: ldloc.s 12
+			IL_12ed: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_12f2: dup
+			IL_12f3: brtrue IL_1307
 
-			IL_10c3: pop
-			IL_10c4: rethrow
+			IL_12f8: pop
+			IL_12f9: rethrow
 
-			IL_10c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_10cb: stloc.s 13
-			IL_10cd: br IL_10d4
+			IL_12fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_1300: stloc.s 13
+			IL_1302: br IL_1309
 
-			IL_10d2: stloc.s 13
+			IL_1307: stloc.s 13
 
-			IL_10d4: ldloc.s 13
-			IL_10d6: stloc.s 14
-			IL_10d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_10dd: stloc.s 20
-			IL_10df: ldloc.s 14
-			IL_10e1: stloc.s 17
-			IL_10e3: ldstr "TypeError"
-			IL_10e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_10ed: stloc.s 27
-			IL_10ef: ldloc.s 17
-			IL_10f1: ldloc.s 27
-			IL_10f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_10f8: stloc.s 28
-			IL_10fa: ldloc.s 28
-			IL_10fc: box [System.Runtime]System.Boolean
-			IL_1101: stloc.s 29
-			IL_1103: ldloc.s 20
-			IL_1105: ldloc.s 29
-			IL_1107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_110c: pop
-			IL_110d: leave IL_1112
+			IL_1309: ldloc.s 13
+			IL_130b: stloc.s 14
+			IL_130d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1312: stloc.s 20
+			IL_1314: ldloc.s 14
+			IL_1316: stloc.s 17
+			IL_1318: ldstr "TypeError"
+			IL_131d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1322: stloc.s 27
+			IL_1324: ldloc.s 17
+			IL_1326: ldloc.s 27
+			IL_1328: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_132d: stloc.s 28
+			IL_132f: ldloc.s 28
+			IL_1331: box [System.Runtime]System.Boolean
+			IL_1336: stloc.s 29
+			IL_1338: ldloc.s 20
+			IL_133a: ldloc.s 29
+			IL_133c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_1341: pop
+			IL_1342: leave IL_1347
 		} // end handler
 
-		IL_1112: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_1117: stloc.s 20
-		IL_1119: ldstr "Iterator"
-		IL_111e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_1123: volatile.
-		IL_1125: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-		IL_112a: brfalse IL_113e
+		IL_1347: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_134c: stloc.s 20
+		IL_134e: ldstr "Iterator"
+		IL_1353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_1358: volatile.
+		IL_135a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_135f: brfalse IL_1373
 
-		IL_112f: ldstr "prototype"
-		IL_1134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1139: br IL_1152
+		IL_1364: ldstr "prototype"
+		IL_1369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_136e: br IL_1387
 
-		IL_113e: ldstr "prototype"
-		IL_1143: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:388"
-		IL_1148: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-		IL_114d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1373: ldstr "prototype"
+		IL_1378: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:388"
+		IL_137d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_1382: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1152: stloc.s 27
-		IL_1154: volatile.
-		IL_1156: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-		IL_115b: brfalse IL_1171
+		IL_1387: stloc.s 27
+		IL_1389: volatile.
+		IL_138b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_1390: brfalse IL_13a6
 
-		IL_1160: ldloc.s 27
-		IL_1162: ldstr "map"
-		IL_1167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_116c: br IL_1187
+		IL_1395: ldloc.s 27
+		IL_1397: ldstr "map"
+		IL_139c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_13a1: br IL_13bc
 
-		IL_1171: ldloc.s 27
-		IL_1173: ldstr "map"
-		IL_1178: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:390"
-		IL_117d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-		IL_1182: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_13a6: ldloc.s 27
+		IL_13a8: ldstr "map"
+		IL_13ad: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:390"
+		IL_13b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_13b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1187: stloc.s 27
-		IL_1189: volatile.
-		IL_118b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-		IL_1190: brfalse IL_11a6
+		IL_13bc: stloc.s 27
+		IL_13be: volatile.
+		IL_13c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+		IL_13c5: brfalse IL_13db
 
-		IL_1195: ldloc.s 27
-		IL_1197: ldstr "length"
-		IL_119c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_11a1: br IL_11bc
+		IL_13ca: ldloc.s 27
+		IL_13cc: ldstr "length"
+		IL_13d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_13d6: br IL_13f1
 
-		IL_11a6: ldloc.s 27
-		IL_11a8: ldstr "length"
-		IL_11ad: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:392"
-		IL_11b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-		IL_11b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_13db: ldloc.s 27
+		IL_13dd: ldstr "length"
+		IL_13e2: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:392"
+		IL_13e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+		IL_13ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_11bc: stloc.s 27
-		IL_11be: ldloc.s 20
-		IL_11c0: ldloc.s 27
-		IL_11c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_11c7: pop
-		IL_11c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_11cd: stloc.s 20
-		IL_11cf: ldstr "Iterator"
-		IL_11d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_11d9: volatile.
-		IL_11db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-		IL_11e0: brfalse IL_11f4
+		IL_13f1: stloc.s 27
+		IL_13f3: ldloc.s 20
+		IL_13f5: ldloc.s 27
+		IL_13f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_13fc: pop
+		IL_13fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_1402: stloc.s 20
+		IL_1404: ldstr "Iterator"
+		IL_1409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_140e: volatile.
+		IL_1410: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+		IL_1415: brfalse IL_1429
 
-		IL_11e5: ldstr "prototype"
-		IL_11ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_11ef: br IL_1208
+		IL_141a: ldstr "prototype"
+		IL_141f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1424: br IL_143d
 
-		IL_11f4: ldstr "prototype"
-		IL_11f9: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:399"
-		IL_11fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-		IL_1203: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1429: ldstr "prototype"
+		IL_142e: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:399"
+		IL_1433: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+		IL_1438: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1208: stloc.s 27
-		IL_120a: volatile.
-		IL_120c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-		IL_1211: brfalse IL_1227
+		IL_143d: stloc.s 27
+		IL_143f: volatile.
+		IL_1441: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+		IL_1446: brfalse IL_145c
 
-		IL_1216: ldloc.s 27
-		IL_1218: ldstr "next"
-		IL_121d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1222: br IL_123d
+		IL_144b: ldloc.s 27
+		IL_144d: ldstr "next"
+		IL_1452: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1457: br IL_1472
 
-		IL_1227: ldloc.s 27
-		IL_1229: ldstr "next"
-		IL_122e: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:401"
-		IL_1233: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-		IL_1238: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_145c: ldloc.s 27
+		IL_145e: ldstr "next"
+		IL_1463: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:401"
+		IL_1468: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+		IL_146d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_123d: stloc.s 27
-		IL_123f: volatile.
-		IL_1241: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-		IL_1246: brfalse IL_125c
+		IL_1472: stloc.s 27
+		IL_1474: volatile.
+		IL_1476: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_147b: brfalse IL_1491
 
-		IL_124b: ldloc.s 27
-		IL_124d: ldstr "length"
-		IL_1252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1257: br IL_1272
+		IL_1480: ldloc.s 27
+		IL_1482: ldstr "length"
+		IL_1487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_148c: br IL_14a7
 
-		IL_125c: ldloc.s 27
-		IL_125e: ldstr "length"
-		IL_1263: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:403"
-		IL_1268: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-		IL_126d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1491: ldloc.s 27
+		IL_1493: ldstr "length"
+		IL_1498: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:403"
+		IL_149d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_14a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1272: stloc.s 27
-		IL_1274: ldloc.s 20
-		IL_1276: ldloc.s 27
-		IL_1278: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_127d: pop
-		IL_127e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_1283: stloc.s 20
-		IL_1285: ldstr "Iterator"
-		IL_128a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_128f: volatile.
-		IL_1291: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-		IL_1296: brfalse IL_12aa
+		IL_14a7: stloc.s 27
+		IL_14a9: ldloc.s 20
+		IL_14ab: ldloc.s 27
+		IL_14ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_14b2: pop
+		IL_14b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_14b8: stloc.s 20
+		IL_14ba: ldstr "Iterator"
+		IL_14bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_14c4: volatile.
+		IL_14c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_14cb: brfalse IL_14df
 
-		IL_129b: ldstr "from"
-		IL_12a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_12a5: br IL_12be
+		IL_14d0: ldstr "from"
+		IL_14d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_14da: br IL_14f3
 
-		IL_12aa: ldstr "from"
-		IL_12af: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:410"
-		IL_12b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-		IL_12b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_14df: ldstr "from"
+		IL_14e4: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:410"
+		IL_14e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_14ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_12be: stloc.s 27
-		IL_12c0: volatile.
-		IL_12c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-		IL_12c7: brfalse IL_12dd
+		IL_14f3: stloc.s 27
+		IL_14f5: volatile.
+		IL_14f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+		IL_14fc: brfalse IL_1512
 
-		IL_12cc: ldloc.s 27
-		IL_12ce: ldstr "length"
-		IL_12d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_12d8: br IL_12f3
+		IL_1501: ldloc.s 27
+		IL_1503: ldstr "length"
+		IL_1508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_150d: br IL_1528
 
-		IL_12dd: ldloc.s 27
-		IL_12df: ldstr "length"
-		IL_12e4: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:412"
-		IL_12e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-		IL_12ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1512: ldloc.s 27
+		IL_1514: ldstr "length"
+		IL_1519: ldstr "Iterator_ExplicitReceiverAbi:Modules.Iterator_ExplicitReceiverAbi:__js_module_init__:412"
+		IL_151e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+		IL_1523: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_12f3: stloc.s 27
-		IL_12f5: ldloc.s 20
-		IL_12f7: ldloc.s 27
-		IL_12f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_12fe: pop
-		IL_12ff: ldnull
-		IL_1300: stloc.s 15
-		IL_1302: ret
+		IL_1528: stloc.s 27
+		IL_152a: ldloc.s 20
+		IL_152c: ldloc.s 27
+		IL_152e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_1533: pop
+		IL_1534: ldnull
+		IL_1535: stloc.s 15
+		IL_1537: ret
 	} // end of method Iterator_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.Iterator_ExplicitReceiverAbi
@@ -3082,6 +3252,20 @@
 	.field assembly static int32 __jroc_dynamicLookup_55
 	.field assembly static int32 __jroc_dynamicLookup_56
 	.field assembly static int32 __jroc_dynamicLookup_57
+	.field assembly static int32 __jroc_dynamicLookup_58
+	.field assembly static int32 __jroc_dynamicLookup_59
+	.field assembly static int32 __jroc_dynamicLookup_60
+	.field assembly static int32 __jroc_dynamicLookup_61
+	.field assembly static int32 __jroc_dynamicLookup_62
+	.field assembly static int32 __jroc_dynamicLookup_63
+	.field assembly static int32 __jroc_dynamicLookup_64
+	.field assembly static int32 __jroc_dynamicLookup_65
+	.field assembly static int32 __jroc_dynamicLookup_66
+	.field assembly static int32 __jroc_dynamicLookup_67
+	.field assembly static int32 __jroc_dynamicLookup_68
+	.field assembly static int32 __jroc_dynamicLookup_69
+	.field assembly static int32 __jroc_dynamicLookup_70
+	.field assembly static int32 __jroc_dynamicLookup_71
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_From_HelperChain.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_From_HelperChain.verified.txt
@@ -1064,7 +1064,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1723 (0x6bb)
+		// Code size: 2378 (0x94a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_From_HelperChain/Scope,
@@ -1105,507 +1105,708 @@
 		IL_004a: ldc.r8 4
 		IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0058: stloc.3
-		IL_0059: ldstr "from"
-		IL_005e: ldloc.3
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0064: stloc.s 4
-		IL_0066: ldloc.s 4
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006d: stloc.s 4
-		IL_006f: ldc.i4.1
-		IL_0070: newarr [System.Runtime]System.Object
-		IL_0075: dup
-		IL_0076: ldc.i4.0
-		IL_0077: ldloc.0
-		IL_0078: stelem.ref
-		IL_0079: stloc.s 5
-		IL_007b: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L4C10/FunctionObject::.ctor()
-		IL_0080: ldc.i4.1
-		IL_0081: conv.r8
-		IL_0082: ldstr ""
-		IL_0087: ldc.i4.0
-		IL_0088: ldc.i4.0
-		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L4C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L4C10/FunctionObject>(!!0)
-		IL_0093: stloc.s 6
-		IL_0095: ldloc.s 4
-		IL_0097: ldstr "map"
-		IL_009c: ldloc.s 6
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a3: stloc.s 4
-		IL_00a5: ldloc.s 4
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ac: stloc.s 4
-		IL_00ae: ldc.i4.1
-		IL_00af: newarr [System.Runtime]System.Object
-		IL_00b4: dup
-		IL_00b5: ldc.i4.0
-		IL_00b6: ldloc.0
-		IL_00b7: stelem.ref
-		IL_00b8: stloc.s 5
-		IL_00ba: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L5C13/FunctionObject::.ctor()
-		IL_00bf: ldc.i4.1
-		IL_00c0: conv.r8
-		IL_00c1: ldstr ""
-		IL_00c6: ldc.i4.0
-		IL_00c7: ldc.i4.0
-		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L5C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L5C13/FunctionObject>(!!0)
-		IL_00d2: stloc.s 7
-		IL_00d4: ldloc.s 4
-		IL_00d6: ldstr "filter"
-		IL_00db: ldloc.s 7
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e2: stloc.s 4
-		IL_00e4: ldloc.s 4
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00eb: ldstr "drop"
-		IL_00f0: ldc.r8 1
-		IL_00f9: box [System.Runtime]System.Double
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0103: stloc.s 4
-		IL_0105: ldloc.s 4
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010c: ldstr "take"
-		IL_0111: ldc.r8 2
-		IL_011a: box [System.Runtime]System.Double
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0124: stloc.s 4
-		IL_0126: ldloc.s 4
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012d: volatile.
-		IL_012f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0134: brfalse IL_0148
+		IL_0059: volatile.
+		IL_005b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0060: brfalse IL_0075
 
-		IL_0139: ldstr "toArray"
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0143: br IL_015c
+		IL_0065: ldstr "from"
+		IL_006a: ldloc.3
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0070: br IL_008a
 
-		IL_0148: ldstr "toArray"
-		IL_014d: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:30"
-		IL_0152: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0075: ldstr "from"
+		IL_007a: ldloc.3
+		IL_007b: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:12"
+		IL_0080: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_015c: stloc.1
-		IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0162: stloc.s 8
-		IL_0164: volatile.
-		IL_0166: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_016b: brfalse IL_0180
+		IL_008a: stloc.s 4
+		IL_008c: ldloc.s 4
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0093: stloc.s 4
+		IL_0095: ldc.i4.1
+		IL_0096: newarr [System.Runtime]System.Object
+		IL_009b: dup
+		IL_009c: ldc.i4.0
+		IL_009d: ldloc.0
+		IL_009e: stelem.ref
+		IL_009f: stloc.s 5
+		IL_00a1: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L4C10/FunctionObject::.ctor()
+		IL_00a6: ldc.i4.1
+		IL_00a7: conv.r8
+		IL_00a8: ldstr ""
+		IL_00ad: ldc.i4.0
+		IL_00ae: ldc.i4.0
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L4C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L4C10/FunctionObject>(!!0)
+		IL_00b9: stloc.s 6
+		IL_00bb: volatile.
+		IL_00bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00c2: brfalse IL_00da
 
-		IL_0170: ldloc.1
-		IL_0171: ldstr "length"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017b: br IL_0195
+		IL_00c7: ldloc.s 4
+		IL_00c9: ldstr "map"
+		IL_00ce: ldloc.s 6
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d5: br IL_00f2
 
-		IL_0180: ldloc.1
-		IL_0181: ldstr "length"
-		IL_0186: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:35"
-		IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00da: ldloc.s 4
+		IL_00dc: ldstr "map"
+		IL_00e1: ldloc.s 6
+		IL_00e3: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:16"
+		IL_00e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0195: stloc.s 4
-		IL_0197: ldloc.s 8
-		IL_0199: ldloc.s 4
-		IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a0: pop
-		IL_01a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a6: stloc.s 8
-		IL_01a8: ldloc.1
-		IL_01a9: ldc.r8 0.0
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01b7: stloc.s 4
-		IL_01b9: ldloc.s 8
-		IL_01bb: ldloc.s 4
-		IL_01bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01c2: pop
-		IL_01c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c8: stloc.s 8
-		IL_01ca: ldloc.1
-		IL_01cb: ldc.r8 1
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01d9: stloc.s 4
-		IL_01db: ldloc.s 8
-		IL_01dd: ldloc.s 4
-		IL_01df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e4: pop
-		IL_01e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ea: stloc.s 8
-		IL_01ec: ldstr "Iterator"
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fb: ldc.i4.3
-		IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0201: dup
-		IL_0202: ldc.r8 1
-		IL_020b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0210: dup
-		IL_0211: ldc.r8 2
-		IL_021a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_021f: dup
-		IL_0220: ldc.r8 3
-		IL_0229: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_022e: stloc.3
-		IL_022f: ldstr "from"
-		IL_0234: ldloc.3
-		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023a: stloc.s 4
-		IL_023c: ldloc.s 4
-		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0243: stloc.s 4
-		IL_0245: ldc.i4.1
-		IL_0246: newarr [System.Runtime]System.Object
-		IL_024b: dup
-		IL_024c: ldc.i4.0
-		IL_024d: ldloc.0
-		IL_024e: stelem.ref
-		IL_024f: stloc.s 5
-		IL_0251: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L14C45/FunctionObject::.ctor()
-		IL_0256: ldc.i4.2
-		IL_0257: conv.r8
-		IL_0258: ldstr ""
-		IL_025d: ldc.i4.0
-		IL_025e: ldc.i4.0
-		IL_025f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L14C45/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0264: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L14C45/FunctionObject>(!!0)
-		IL_0269: stloc.s 9
-		IL_026b: ldloc.s 4
-		IL_026d: ldstr "reduce"
-		IL_0272: ldloc.s 9
-		IL_0274: ldc.r8 0.0
-		IL_027d: box [System.Runtime]System.Double
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0287: stloc.s 4
-		IL_0289: ldloc.s 8
-		IL_028b: ldloc.s 4
-		IL_028d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0292: pop
-		IL_0293: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0298: stloc.s 8
-		IL_029a: ldstr "Iterator"
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a9: ldc.i4.3
-		IL_02aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02af: dup
-		IL_02b0: ldc.r8 1
-		IL_02b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02be: dup
-		IL_02bf: ldc.r8 2
-		IL_02c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02cd: dup
-		IL_02ce: ldc.r8 3
-		IL_02d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02dc: stloc.3
-		IL_02dd: ldstr "from"
-		IL_02e2: ldloc.3
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e8: stloc.s 4
-		IL_02ea: ldloc.s 4
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f1: stloc.s 4
-		IL_02f3: ldc.i4.1
-		IL_02f4: newarr [System.Runtime]System.Object
-		IL_02f9: dup
-		IL_02fa: ldc.i4.0
-		IL_02fb: ldloc.0
-		IL_02fc: stelem.ref
-		IL_02fd: stloc.s 5
-		IL_02ff: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L15C44/FunctionObject::.ctor()
-		IL_0304: ldc.i4.1
-		IL_0305: conv.r8
-		IL_0306: ldstr ""
-		IL_030b: ldc.i4.0
-		IL_030c: ldc.i4.0
-		IL_030d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L15C44/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L15C44/FunctionObject>(!!0)
-		IL_0317: stloc.s 10
-		IL_0319: ldloc.s 4
-		IL_031b: ldstr "every"
-		IL_0320: ldloc.s 10
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0327: stloc.s 4
-		IL_0329: ldloc.s 8
-		IL_032b: ldloc.s 4
-		IL_032d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0332: pop
-		IL_0333: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0338: stloc.s 8
-		IL_033a: ldstr "Iterator"
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0349: ldc.i4.3
-		IL_034a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00f2: stloc.s 4
+		IL_00f4: ldloc.s 4
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fb: stloc.s 4
+		IL_00fd: ldc.i4.1
+		IL_00fe: newarr [System.Runtime]System.Object
+		IL_0103: dup
+		IL_0104: ldc.i4.0
+		IL_0105: ldloc.0
+		IL_0106: stelem.ref
+		IL_0107: stloc.s 5
+		IL_0109: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L5C13/FunctionObject::.ctor()
+		IL_010e: ldc.i4.1
+		IL_010f: conv.r8
+		IL_0110: ldstr ""
+		IL_0115: ldc.i4.0
+		IL_0116: ldc.i4.0
+		IL_0117: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L5C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_011c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L5C13/FunctionObject>(!!0)
+		IL_0121: stloc.s 7
+		IL_0123: volatile.
+		IL_0125: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_012a: brfalse IL_0142
+
+		IL_012f: ldloc.s 4
+		IL_0131: ldstr "filter"
+		IL_0136: ldloc.s 7
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013d: br IL_015a
+
+		IL_0142: ldloc.s 4
+		IL_0144: ldstr "filter"
+		IL_0149: ldloc.s 7
+		IL_014b: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:20"
+		IL_0150: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_015a: stloc.s 4
+		IL_015c: ldloc.s 4
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0163: volatile.
+		IL_0165: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_016a: brfalse IL_018c
+
+		IL_016f: ldstr "drop"
+		IL_0174: ldc.r8 1
+		IL_017d: box [System.Runtime]System.Double
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0187: br IL_01ae
+
+		IL_018c: ldstr "drop"
+		IL_0191: ldc.r8 1
+		IL_019a: box [System.Runtime]System.Double
+		IL_019f: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:24"
+		IL_01a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01ae: stloc.s 4
+		IL_01b0: ldloc.s 4
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b7: volatile.
+		IL_01b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01be: brfalse IL_01e0
+
+		IL_01c3: ldstr "take"
+		IL_01c8: ldc.r8 2
+		IL_01d1: box [System.Runtime]System.Double
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01db: br IL_0202
+
+		IL_01e0: ldstr "take"
+		IL_01e5: ldc.r8 2
+		IL_01ee: box [System.Runtime]System.Double
+		IL_01f3: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:28"
+		IL_01f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0202: stloc.s 4
+		IL_0204: ldloc.s 4
+		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020b: volatile.
+		IL_020d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0212: brfalse IL_0226
+
+		IL_0217: ldstr "toArray"
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0221: br IL_023a
+
+		IL_0226: ldstr "toArray"
+		IL_022b: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:30"
+		IL_0230: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_023a: stloc.1
+		IL_023b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0240: stloc.s 8
+		IL_0242: volatile.
+		IL_0244: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0249: brfalse IL_025e
+
+		IL_024e: ldloc.1
+		IL_024f: ldstr "length"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0259: br IL_0273
+
+		IL_025e: ldloc.1
+		IL_025f: ldstr "length"
+		IL_0264: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:35"
+		IL_0269: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0273: stloc.s 4
+		IL_0275: ldloc.s 8
+		IL_0277: ldloc.s 4
+		IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_027e: pop
+		IL_027f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0284: stloc.s 8
+		IL_0286: ldloc.1
+		IL_0287: ldc.r8 0.0
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0295: stloc.s 4
+		IL_0297: ldloc.s 8
+		IL_0299: ldloc.s 4
+		IL_029b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a0: pop
+		IL_02a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a6: stloc.s 8
+		IL_02a8: ldloc.1
+		IL_02a9: ldc.r8 1
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02b7: stloc.s 4
+		IL_02b9: ldloc.s 8
+		IL_02bb: ldloc.s 4
+		IL_02bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c2: pop
+		IL_02c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c8: stloc.s 8
+		IL_02ca: ldstr "Iterator"
+		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d9: ldc.i4.3
+		IL_02da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02df: dup
+		IL_02e0: ldc.r8 1
+		IL_02e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02ee: dup
+		IL_02ef: ldc.r8 2
+		IL_02f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02fd: dup
+		IL_02fe: ldc.r8 3
+		IL_0307: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_030c: stloc.3
+		IL_030d: volatile.
+		IL_030f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0314: brfalse IL_0329
+
+		IL_0319: ldstr "from"
+		IL_031e: ldloc.3
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0324: br IL_033e
+
+		IL_0329: ldstr "from"
+		IL_032e: ldloc.3
+		IL_032f: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:56"
+		IL_0334: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_033e: stloc.s 4
+		IL_0340: ldloc.s 4
+		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0347: stloc.s 4
+		IL_0349: ldc.i4.1
+		IL_034a: newarr [System.Runtime]System.Object
 		IL_034f: dup
-		IL_0350: ldc.r8 1
-		IL_0359: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_035e: dup
-		IL_035f: ldc.r8 2
-		IL_0368: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_036d: dup
-		IL_036e: ldc.r8 3
-		IL_0377: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_037c: stloc.3
-		IL_037d: ldstr "from"
-		IL_0382: ldloc.3
-		IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0388: stloc.s 4
-		IL_038a: ldloc.s 4
-		IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0391: stloc.s 4
-		IL_0393: ldc.i4.1
-		IL_0394: newarr [System.Runtime]System.Object
-		IL_0399: dup
-		IL_039a: ldc.i4.0
-		IL_039b: ldloc.0
-		IL_039c: stelem.ref
-		IL_039d: stloc.s 5
-		IL_039f: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L16C43/FunctionObject::.ctor()
-		IL_03a4: ldc.i4.1
-		IL_03a5: conv.r8
-		IL_03a6: ldstr ""
-		IL_03ab: ldc.i4.0
-		IL_03ac: ldc.i4.0
-		IL_03ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L16C43/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L16C43/FunctionObject>(!!0)
-		IL_03b7: stloc.s 11
-		IL_03b9: ldloc.s 4
-		IL_03bb: ldstr "some"
-		IL_03c0: ldloc.s 11
-		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03c7: stloc.s 4
-		IL_03c9: ldloc.s 8
-		IL_03cb: ldloc.s 4
-		IL_03cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03d2: pop
-		IL_03d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03d8: stloc.s 8
-		IL_03da: ldstr "Iterator"
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e9: ldc.i4.3
-		IL_03ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_03ef: dup
-		IL_03f0: ldc.r8 1
-		IL_03f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_03fe: dup
-		IL_03ff: ldc.r8 2
-		IL_0408: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_040d: dup
-		IL_040e: ldc.r8 3
-		IL_0417: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_041c: stloc.3
-		IL_041d: ldstr "from"
-		IL_0422: ldloc.3
-		IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0428: stloc.s 4
-		IL_042a: ldloc.s 4
-		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0431: stloc.s 4
-		IL_0433: ldc.i4.1
-		IL_0434: newarr [System.Runtime]System.Object
-		IL_0439: dup
-		IL_043a: ldc.i4.0
-		IL_043b: ldloc.0
-		IL_043c: stelem.ref
-		IL_043d: stloc.s 5
-		IL_043f: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L17C43/FunctionObject::.ctor()
-		IL_0444: ldc.i4.1
-		IL_0445: conv.r8
-		IL_0446: ldstr ""
-		IL_044b: ldc.i4.0
-		IL_044c: ldc.i4.0
-		IL_044d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L17C43/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0452: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L17C43/FunctionObject>(!!0)
-		IL_0457: stloc.s 12
-		IL_0459: ldloc.s 4
-		IL_045b: ldstr "find"
-		IL_0460: ldloc.s 12
-		IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0467: stloc.s 4
-		IL_0469: ldloc.s 8
-		IL_046b: ldloc.s 4
-		IL_046d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0472: pop
-		IL_0473: ldloc.0
-		IL_0474: ldc.r8 0.0
-		IL_047d: box [System.Runtime]System.Double
-		IL_0482: stfld object Modules.Iterator_From_HelperChain/Scope::total
-		IL_0487: ldstr "Iterator"
-		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0496: ldc.i4.3
-		IL_0497: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_049c: dup
-		IL_049d: ldc.r8 1
-		IL_04a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_04ab: dup
-		IL_04ac: ldc.r8 2
-		IL_04b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_04ba: dup
-		IL_04bb: ldc.r8 3
-		IL_04c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_04c9: stloc.3
-		IL_04ca: ldstr "from"
-		IL_04cf: ldloc.3
-		IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04d5: stloc.s 4
-		IL_04d7: ldloc.s 4
-		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04de: stloc.s 4
-		IL_04e0: ldc.i4.1
-		IL_04e1: newarr [System.Runtime]System.Object
-		IL_04e6: dup
-		IL_04e7: ldc.i4.0
-		IL_04e8: ldloc.0
-		IL_04e9: stelem.ref
-		IL_04ea: stloc.s 5
-		IL_04ec: ldloc.s 5
-		IL_04ee: ldc.i4.0
-		IL_04ef: ldelem.ref
-		IL_04f0: castclass Modules.Iterator_From_HelperChain/Scope
-		IL_04f5: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L20C34/FunctionObject::.ctor(class Modules.Iterator_From_HelperChain/Scope)
-		IL_04fa: ldc.i4.1
-		IL_04fb: conv.r8
-		IL_04fc: ldstr ""
-		IL_0501: ldc.i4.0
-		IL_0502: ldc.i4.0
-		IL_0503: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L20C34/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0508: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L20C34/FunctionObject>(!!0)
-		IL_050d: stloc.s 13
-		IL_050f: ldloc.s 4
-		IL_0511: ldstr "forEach"
-		IL_0516: ldloc.s 13
-		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_051d: pop
-		IL_051e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0523: stloc.s 8
-		IL_0525: ldloc.0
-		IL_0526: ldfld object Modules.Iterator_From_HelperChain/Scope::total
-		IL_052b: stloc.s 4
-		IL_052d: ldloc.s 8
-		IL_052f: ldloc.s 4
-		IL_0531: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0536: pop
-		IL_0537: ldstr "Iterator"
-		IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0546: ldc.i4.2
-		IL_0547: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_054c: dup
-		IL_054d: ldc.r8 1
-		IL_0556: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_055b: dup
-		IL_055c: ldc.r8 2
-		IL_0565: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_056a: stloc.3
-		IL_056b: ldstr "from"
-		IL_0570: ldloc.3
-		IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0576: stloc.s 4
-		IL_0578: ldloc.s 4
-		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_057f: stloc.s 4
-		IL_0581: ldc.i4.1
-		IL_0582: newarr [System.Runtime]System.Object
-		IL_0587: dup
-		IL_0588: ldc.i4.0
-		IL_0589: ldloc.0
-		IL_058a: stelem.ref
-		IL_058b: stloc.s 5
-		IL_058d: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L24C14/FunctionObject::.ctor()
-		IL_0592: ldc.i4.1
-		IL_0593: conv.r8
-		IL_0594: ldstr ""
-		IL_0599: ldc.i4.0
-		IL_059a: ldc.i4.0
-		IL_059b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L24C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L24C14/FunctionObject>(!!0)
-		IL_05a5: stloc.s 14
-		IL_05a7: ldloc.s 4
-		IL_05a9: ldstr "flatMap"
-		IL_05ae: ldloc.s 14
-		IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05b5: stloc.s 4
-		IL_05b7: ldloc.s 4
-		IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05be: volatile.
-		IL_05c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_05c5: brfalse IL_05d9
+		IL_0350: ldc.i4.0
+		IL_0351: ldloc.0
+		IL_0352: stelem.ref
+		IL_0353: stloc.s 5
+		IL_0355: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L14C45/FunctionObject::.ctor()
+		IL_035a: ldc.i4.2
+		IL_035b: conv.r8
+		IL_035c: ldstr ""
+		IL_0361: ldc.i4.0
+		IL_0362: ldc.i4.0
+		IL_0363: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L14C45/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0368: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L14C45/FunctionObject>(!!0)
+		IL_036d: stloc.s 9
+		IL_036f: ldloc.s 4
+		IL_0371: ldstr "reduce"
+		IL_0376: ldloc.s 9
+		IL_0378: ldc.r8 0.0
+		IL_0381: box [System.Runtime]System.Double
+		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_038b: stloc.s 4
+		IL_038d: ldloc.s 8
+		IL_038f: ldloc.s 4
+		IL_0391: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0396: pop
+		IL_0397: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_039c: stloc.s 8
+		IL_039e: ldstr "Iterator"
+		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ad: ldc.i4.3
+		IL_03ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_03b3: dup
+		IL_03b4: ldc.r8 1
+		IL_03bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_03c2: dup
+		IL_03c3: ldc.r8 2
+		IL_03cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_03d1: dup
+		IL_03d2: ldc.r8 3
+		IL_03db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_03e0: stloc.3
+		IL_03e1: volatile.
+		IL_03e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_03e8: brfalse IL_03fd
 
-		IL_05ca: ldstr "toArray"
-		IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_05d4: br IL_05ed
+		IL_03ed: ldstr "from"
+		IL_03f2: ldloc.3
+		IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03f8: br IL_0412
 
-		IL_05d9: ldstr "toArray"
-		IL_05de: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:143"
-		IL_05e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_05e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_03fd: ldstr "from"
+		IL_0402: ldloc.3
+		IL_0403: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:73"
+		IL_0408: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_05ed: stloc.2
-		IL_05ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05f3: stloc.s 8
-		IL_05f5: volatile.
-		IL_05f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_05fc: brfalse IL_0611
+		IL_0412: stloc.s 4
+		IL_0414: ldloc.s 4
+		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_041b: stloc.s 4
+		IL_041d: ldc.i4.1
+		IL_041e: newarr [System.Runtime]System.Object
+		IL_0423: dup
+		IL_0424: ldc.i4.0
+		IL_0425: ldloc.0
+		IL_0426: stelem.ref
+		IL_0427: stloc.s 5
+		IL_0429: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L15C44/FunctionObject::.ctor()
+		IL_042e: ldc.i4.1
+		IL_042f: conv.r8
+		IL_0430: ldstr ""
+		IL_0435: ldc.i4.0
+		IL_0436: ldc.i4.0
+		IL_0437: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L15C44/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_043c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L15C44/FunctionObject>(!!0)
+		IL_0441: stloc.s 10
+		IL_0443: volatile.
+		IL_0445: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_044a: brfalse IL_0462
 
-		IL_0601: ldloc.2
-		IL_0602: ldstr "length"
-		IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_060c: br IL_0626
+		IL_044f: ldloc.s 4
+		IL_0451: ldstr "every"
+		IL_0456: ldloc.s 10
+		IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_045d: br IL_047a
 
-		IL_0611: ldloc.2
-		IL_0612: ldstr "length"
-		IL_0617: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:148"
-		IL_061c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0462: ldloc.s 4
+		IL_0464: ldstr "every"
+		IL_0469: ldloc.s 10
+		IL_046b: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:77"
+		IL_0470: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0626: stloc.s 4
-		IL_0628: ldloc.s 8
-		IL_062a: ldloc.s 4
-		IL_062c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0631: pop
-		IL_0632: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0637: stloc.s 8
-		IL_0639: ldloc.2
-		IL_063a: ldc.r8 0.0
-		IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0648: stloc.s 4
-		IL_064a: ldloc.s 8
-		IL_064c: ldloc.s 4
-		IL_064e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0653: pop
-		IL_0654: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0659: stloc.s 8
-		IL_065b: ldloc.2
-		IL_065c: ldc.r8 1
-		IL_0665: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_066a: stloc.s 4
-		IL_066c: ldloc.s 8
-		IL_066e: ldloc.s 4
-		IL_0670: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0675: pop
-		IL_0676: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_067b: stloc.s 8
-		IL_067d: ldloc.2
-		IL_067e: ldc.r8 2
-		IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_068c: stloc.s 4
-		IL_068e: ldloc.s 8
-		IL_0690: ldloc.s 4
-		IL_0692: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0697: pop
-		IL_0698: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_069d: stloc.s 8
-		IL_069f: ldloc.2
-		IL_06a0: ldc.r8 3
-		IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_06ae: stloc.s 4
-		IL_06b0: ldloc.s 8
-		IL_06b2: ldloc.s 4
-		IL_06b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06b9: pop
-		IL_06ba: ret
+		IL_047a: stloc.s 4
+		IL_047c: ldloc.s 8
+		IL_047e: ldloc.s 4
+		IL_0480: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0485: pop
+		IL_0486: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_048b: stloc.s 8
+		IL_048d: ldstr "Iterator"
+		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_049c: ldc.i4.3
+		IL_049d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_04a2: dup
+		IL_04a3: ldc.r8 1
+		IL_04ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_04b1: dup
+		IL_04b2: ldc.r8 2
+		IL_04bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_04c0: dup
+		IL_04c1: ldc.r8 3
+		IL_04ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_04cf: stloc.3
+		IL_04d0: volatile.
+		IL_04d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_04d7: brfalse IL_04ec
+
+		IL_04dc: ldstr "from"
+		IL_04e1: ldloc.3
+		IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04e7: br IL_0501
+
+		IL_04ec: ldstr "from"
+		IL_04f1: ldloc.3
+		IL_04f2: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:88"
+		IL_04f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_04fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0501: stloc.s 4
+		IL_0503: ldloc.s 4
+		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_050a: stloc.s 4
+		IL_050c: ldc.i4.1
+		IL_050d: newarr [System.Runtime]System.Object
+		IL_0512: dup
+		IL_0513: ldc.i4.0
+		IL_0514: ldloc.0
+		IL_0515: stelem.ref
+		IL_0516: stloc.s 5
+		IL_0518: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L16C43/FunctionObject::.ctor()
+		IL_051d: ldc.i4.1
+		IL_051e: conv.r8
+		IL_051f: ldstr ""
+		IL_0524: ldc.i4.0
+		IL_0525: ldc.i4.0
+		IL_0526: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L16C43/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_052b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L16C43/FunctionObject>(!!0)
+		IL_0530: stloc.s 11
+		IL_0532: volatile.
+		IL_0534: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0539: brfalse IL_0551
+
+		IL_053e: ldloc.s 4
+		IL_0540: ldstr "some"
+		IL_0545: ldloc.s 11
+		IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_054c: br IL_0569
+
+		IL_0551: ldloc.s 4
+		IL_0553: ldstr "some"
+		IL_0558: ldloc.s 11
+		IL_055a: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:92"
+		IL_055f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0569: stloc.s 4
+		IL_056b: ldloc.s 8
+		IL_056d: ldloc.s 4
+		IL_056f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0574: pop
+		IL_0575: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_057a: stloc.s 8
+		IL_057c: ldstr "Iterator"
+		IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_058b: ldc.i4.3
+		IL_058c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0591: dup
+		IL_0592: ldc.r8 1
+		IL_059b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_05a0: dup
+		IL_05a1: ldc.r8 2
+		IL_05aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_05af: dup
+		IL_05b0: ldc.r8 3
+		IL_05b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_05be: stloc.3
+		IL_05bf: volatile.
+		IL_05c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_05c6: brfalse IL_05db
+
+		IL_05cb: ldstr "from"
+		IL_05d0: ldloc.3
+		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05d6: br IL_05f0
+
+		IL_05db: ldstr "from"
+		IL_05e0: ldloc.3
+		IL_05e1: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:103"
+		IL_05e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_05f0: stloc.s 4
+		IL_05f2: ldloc.s 4
+		IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05f9: stloc.s 4
+		IL_05fb: ldc.i4.1
+		IL_05fc: newarr [System.Runtime]System.Object
+		IL_0601: dup
+		IL_0602: ldc.i4.0
+		IL_0603: ldloc.0
+		IL_0604: stelem.ref
+		IL_0605: stloc.s 5
+		IL_0607: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L17C43/FunctionObject::.ctor()
+		IL_060c: ldc.i4.1
+		IL_060d: conv.r8
+		IL_060e: ldstr ""
+		IL_0613: ldc.i4.0
+		IL_0614: ldc.i4.0
+		IL_0615: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L17C43/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_061a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L17C43/FunctionObject>(!!0)
+		IL_061f: stloc.s 12
+		IL_0621: volatile.
+		IL_0623: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0628: brfalse IL_0640
+
+		IL_062d: ldloc.s 4
+		IL_062f: ldstr "find"
+		IL_0634: ldloc.s 12
+		IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_063b: br IL_0658
+
+		IL_0640: ldloc.s 4
+		IL_0642: ldstr "find"
+		IL_0647: ldloc.s 12
+		IL_0649: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:107"
+		IL_064e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0658: stloc.s 4
+		IL_065a: ldloc.s 8
+		IL_065c: ldloc.s 4
+		IL_065e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0663: pop
+		IL_0664: ldloc.0
+		IL_0665: ldc.r8 0.0
+		IL_066e: box [System.Runtime]System.Double
+		IL_0673: stfld object Modules.Iterator_From_HelperChain/Scope::total
+		IL_0678: ldstr "Iterator"
+		IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0687: ldc.i4.3
+		IL_0688: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_068d: dup
+		IL_068e: ldc.r8 1
+		IL_0697: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_069c: dup
+		IL_069d: ldc.r8 2
+		IL_06a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_06ab: dup
+		IL_06ac: ldc.r8 3
+		IL_06b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_06ba: stloc.3
+		IL_06bb: volatile.
+		IL_06bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_06c2: brfalse IL_06d7
+
+		IL_06c7: ldstr "from"
+		IL_06cc: ldloc.3
+		IL_06cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06d2: br IL_06ec
+
+		IL_06d7: ldstr "from"
+		IL_06dc: ldloc.3
+		IL_06dd: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:121"
+		IL_06e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_06ec: stloc.s 4
+		IL_06ee: ldloc.s 4
+		IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06f5: stloc.s 4
+		IL_06f7: ldc.i4.1
+		IL_06f8: newarr [System.Runtime]System.Object
+		IL_06fd: dup
+		IL_06fe: ldc.i4.0
+		IL_06ff: ldloc.0
+		IL_0700: stelem.ref
+		IL_0701: stloc.s 5
+		IL_0703: ldloc.s 5
+		IL_0705: ldc.i4.0
+		IL_0706: ldelem.ref
+		IL_0707: castclass Modules.Iterator_From_HelperChain/Scope
+		IL_070c: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L20C34/FunctionObject::.ctor(class Modules.Iterator_From_HelperChain/Scope)
+		IL_0711: ldc.i4.1
+		IL_0712: conv.r8
+		IL_0713: ldstr ""
+		IL_0718: ldc.i4.0
+		IL_0719: ldc.i4.0
+		IL_071a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L20C34/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_071f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L20C34/FunctionObject>(!!0)
+		IL_0724: stloc.s 13
+		IL_0726: volatile.
+		IL_0728: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_072d: brfalse IL_0745
+
+		IL_0732: ldloc.s 4
+		IL_0734: ldstr "forEach"
+		IL_0739: ldloc.s 13
+		IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0740: br IL_075d
+
+		IL_0745: ldloc.s 4
+		IL_0747: ldstr "forEach"
+		IL_074c: ldloc.s 13
+		IL_074e: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:125"
+		IL_0753: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0758: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_075d: pop
+		IL_075e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0763: stloc.s 8
+		IL_0765: ldloc.0
+		IL_0766: ldfld object Modules.Iterator_From_HelperChain/Scope::total
+		IL_076b: stloc.s 4
+		IL_076d: ldloc.s 8
+		IL_076f: ldloc.s 4
+		IL_0771: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0776: pop
+		IL_0777: ldstr "Iterator"
+		IL_077c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0781: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0786: ldc.i4.2
+		IL_0787: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_078c: dup
+		IL_078d: ldc.r8 1
+		IL_0796: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_079b: dup
+		IL_079c: ldc.r8 2
+		IL_07a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_07aa: stloc.3
+		IL_07ab: volatile.
+		IL_07ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_07b2: brfalse IL_07c7
+
+		IL_07b7: ldstr "from"
+		IL_07bc: ldloc.3
+		IL_07bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07c2: br IL_07dc
+
+		IL_07c7: ldstr "from"
+		IL_07cc: ldloc.3
+		IL_07cd: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:137"
+		IL_07d2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_07d7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_07dc: stloc.s 4
+		IL_07de: ldloc.s 4
+		IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07e5: stloc.s 4
+		IL_07e7: ldc.i4.1
+		IL_07e8: newarr [System.Runtime]System.Object
+		IL_07ed: dup
+		IL_07ee: ldc.i4.0
+		IL_07ef: ldloc.0
+		IL_07f0: stelem.ref
+		IL_07f1: stloc.s 5
+		IL_07f3: newobj instance void Modules.Iterator_From_HelperChain/ArrowFunction_L24C14/FunctionObject::.ctor()
+		IL_07f8: ldc.i4.1
+		IL_07f9: conv.r8
+		IL_07fa: ldstr ""
+		IL_07ff: ldc.i4.0
+		IL_0800: ldc.i4.0
+		IL_0801: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_From_HelperChain/ArrowFunction_L24C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0806: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_From_HelperChain/ArrowFunction_L24C14/FunctionObject>(!!0)
+		IL_080b: stloc.s 14
+		IL_080d: volatile.
+		IL_080f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0814: brfalse IL_082c
+
+		IL_0819: ldloc.s 4
+		IL_081b: ldstr "flatMap"
+		IL_0820: ldloc.s 14
+		IL_0822: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0827: br IL_0844
+
+		IL_082c: ldloc.s 4
+		IL_082e: ldstr "flatMap"
+		IL_0833: ldloc.s 14
+		IL_0835: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:141"
+		IL_083a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_083f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0844: stloc.s 4
+		IL_0846: ldloc.s 4
+		IL_0848: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_084d: volatile.
+		IL_084f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0854: brfalse IL_0868
+
+		IL_0859: ldstr "toArray"
+		IL_085e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0863: br IL_087c
+
+		IL_0868: ldstr "toArray"
+		IL_086d: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:143"
+		IL_0872: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0877: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_087c: stloc.2
+		IL_087d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0882: stloc.s 8
+		IL_0884: volatile.
+		IL_0886: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_088b: brfalse IL_08a0
+
+		IL_0890: ldloc.2
+		IL_0891: ldstr "length"
+		IL_0896: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_089b: br IL_08b5
+
+		IL_08a0: ldloc.2
+		IL_08a1: ldstr "length"
+		IL_08a6: ldstr "Iterator_From_HelperChain:Modules.Iterator_From_HelperChain:__js_module_init__:148"
+		IL_08ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_08b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_08b5: stloc.s 4
+		IL_08b7: ldloc.s 8
+		IL_08b9: ldloc.s 4
+		IL_08bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08c0: pop
+		IL_08c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08c6: stloc.s 8
+		IL_08c8: ldloc.2
+		IL_08c9: ldc.r8 0.0
+		IL_08d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_08d7: stloc.s 4
+		IL_08d9: ldloc.s 8
+		IL_08db: ldloc.s 4
+		IL_08dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08e2: pop
+		IL_08e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08e8: stloc.s 8
+		IL_08ea: ldloc.2
+		IL_08eb: ldc.r8 1
+		IL_08f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_08f9: stloc.s 4
+		IL_08fb: ldloc.s 8
+		IL_08fd: ldloc.s 4
+		IL_08ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0904: pop
+		IL_0905: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_090a: stloc.s 8
+		IL_090c: ldloc.2
+		IL_090d: ldc.r8 2
+		IL_0916: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_091b: stloc.s 4
+		IL_091d: ldloc.s 8
+		IL_091f: ldloc.s 4
+		IL_0921: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0926: pop
+		IL_0927: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_092c: stloc.s 8
+		IL_092e: ldloc.2
+		IL_092f: ldc.r8 3
+		IL_0938: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_093d: stloc.s 4
+		IL_093f: ldloc.s 8
+		IL_0941: ldloc.s 4
+		IL_0943: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0948: pop
+		IL_0949: ret
 	} // end of method Iterator_From_HelperChain::__js_module_init__
 
 } // end of class Modules.Iterator_From_HelperChain
@@ -1639,6 +1840,22 @@
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -3589,7 +3589,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2780 (0xadc)
+		// Code size: 3362 (0xd22)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_Helper_Cleanup/Scope,
@@ -3684,878 +3684,1059 @@
 		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0091: stloc.s 29
-		IL_0093: ldloc.s 28
-		IL_0095: ldstr "from"
-		IL_009a: ldloc.s 29
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a1: stloc.s 29
-		IL_00a3: ldloc.s 29
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00aa: stloc.s 29
-		IL_00ac: ldc.i4.1
-		IL_00ad: newarr [System.Runtime]System.Object
-		IL_00b2: dup
-		IL_00b3: ldc.i4.0
-		IL_00b4: ldloc.0
-		IL_00b5: stelem.ref
-		IL_00b6: stloc.s 27
-		IL_00b8: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject::.ctor()
-		IL_00bd: ldc.i4.1
-		IL_00be: conv.r8
-		IL_00bf: ldstr ""
-		IL_00c4: ldc.i4.0
-		IL_00c5: ldc.i4.0
-		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject>(!!0)
-		IL_00d0: stloc.s 30
-		IL_00d2: ldloc.s 29
-		IL_00d4: ldstr "map"
-		IL_00d9: ldloc.s 30
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e0: stloc.3
-		IL_00e1: ldloc.3
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e7: volatile.
-		IL_00e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-		IL_00ee: brfalse IL_0102
+		IL_0093: volatile.
+		IL_0095: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_009a: brfalse IL_00b2
 
-		IL_00f3: ldstr "next"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00fd: br IL_0116
+		IL_009f: ldloc.s 28
+		IL_00a1: ldstr "from"
+		IL_00a6: ldloc.s 29
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ad: br IL_00ca
 
-		IL_0102: ldstr "next"
-		IL_0107: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:27"
-		IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_00b2: ldloc.s 28
+		IL_00b4: ldstr "from"
+		IL_00b9: ldloc.s 29
+		IL_00bb: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:19"
+		IL_00c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0116: pop
-		IL_0117: ldloc.3
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011d: volatile.
-		IL_011f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-		IL_0124: brfalse IL_0138
+		IL_00ca: stloc.s 29
+		IL_00cc: ldloc.s 29
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d3: stloc.s 29
+		IL_00d5: ldc.i4.1
+		IL_00d6: newarr [System.Runtime]System.Object
+		IL_00db: dup
+		IL_00dc: ldc.i4.0
+		IL_00dd: ldloc.0
+		IL_00de: stelem.ref
+		IL_00df: stloc.s 27
+		IL_00e1: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject::.ctor()
+		IL_00e6: ldc.i4.1
+		IL_00e7: conv.r8
+		IL_00e8: ldstr ""
+		IL_00ed: ldc.i4.0
+		IL_00ee: ldc.i4.0
+		IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject>(!!0)
+		IL_00f9: stloc.s 30
+		IL_00fb: volatile.
+		IL_00fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+		IL_0102: brfalse IL_011a
 
-		IL_0129: ldstr "next"
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0133: br IL_014c
+		IL_0107: ldloc.s 29
+		IL_0109: ldstr "map"
+		IL_010e: ldloc.s 30
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0115: br IL_0132
 
-		IL_0138: ldstr "next"
-		IL_013d: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:30"
-		IL_0142: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_011a: ldloc.s 29
+		IL_011c: ldstr "map"
+		IL_0121: ldloc.s 30
+		IL_0123: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:23"
+		IL_0128: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_014c: pop
-		IL_014d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0152: stloc.s 31
-		IL_0154: ldloc.3
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015a: volatile.
-		IL_015c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-		IL_0161: brfalse IL_0175
+		IL_0132: stloc.3
+		IL_0133: ldloc.3
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0139: volatile.
+		IL_013b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+		IL_0140: brfalse IL_0154
 
-		IL_0166: ldstr "next"
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0170: br IL_0189
+		IL_0145: ldstr "next"
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_014f: br IL_0168
 
-		IL_0175: ldstr "next"
-		IL_017a: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:34"
-		IL_017f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0154: ldstr "next"
+		IL_0159: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:27"
+		IL_015e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0189: stloc.s 29
-		IL_018b: volatile.
-		IL_018d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-		IL_0192: brfalse IL_01a8
+		IL_0168: pop
+		IL_0169: ldloc.3
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016f: volatile.
+		IL_0171: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+		IL_0176: brfalse IL_018a
 
-		IL_0197: ldloc.s 29
-		IL_0199: ldstr "done"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a3: br IL_01be
+		IL_017b: ldstr "next"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0185: br IL_019e
 
-		IL_01a8: ldloc.s 29
-		IL_01aa: ldstr "done"
-		IL_01af: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:36"
-		IL_01b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_018a: ldstr "next"
+		IL_018f: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:30"
+		IL_0194: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_01be: stloc.s 29
-		IL_01c0: ldloc.s 31
-		IL_01c2: ldloc.s 29
-		IL_01c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01c9: pop
-		IL_01ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01cf: stloc.s 31
-		IL_01d1: ldloc.2
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d7: volatile.
-		IL_01d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-		IL_01de: brfalse IL_01f2
+		IL_019e: pop
+		IL_019f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a4: stloc.s 31
+		IL_01a6: ldloc.3
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ac: volatile.
+		IL_01ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+		IL_01b3: brfalse IL_01c7
 
-		IL_01e3: ldstr "getClosed"
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01ed: br IL_0206
+		IL_01b8: ldstr "next"
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01c2: br IL_01db
 
-		IL_01f2: ldstr "getClosed"
-		IL_01f7: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:41"
-		IL_01fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01c7: ldstr "next"
+		IL_01cc: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:34"
+		IL_01d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0206: stloc.s 29
-		IL_0208: ldloc.s 31
-		IL_020a: ldloc.s 29
-		IL_020c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0211: pop
-		IL_0212: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0217: stloc.s 27
-		IL_0219: ldloc.1
-		IL_021a: ldloc.s 27
-		IL_021c: ldc.r8 2
-		IL_0225: box [System.Runtime]System.Double
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_022f: stloc.s 4
-		IL_0231: ldstr "Iterator"
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0240: stloc.s 29
-		IL_0242: volatile.
-		IL_0244: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-		IL_0249: brfalse IL_025f
+		IL_01db: stloc.s 29
+		IL_01dd: volatile.
+		IL_01df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+		IL_01e4: brfalse IL_01fa
 
-		IL_024e: ldloc.s 4
-		IL_0250: ldstr "iterable"
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_025a: br IL_0275
+		IL_01e9: ldloc.s 29
+		IL_01eb: ldstr "done"
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f5: br IL_0210
 
-		IL_025f: ldloc.s 4
-		IL_0261: ldstr "iterable"
-		IL_0266: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:54"
-		IL_026b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01fa: ldloc.s 29
+		IL_01fc: ldstr "done"
+		IL_0201: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:36"
+		IL_0206: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0275: stloc.s 28
-		IL_0277: ldloc.s 29
-		IL_0279: ldstr "from"
-		IL_027e: ldloc.s 28
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0285: stloc.s 28
-		IL_0287: ldloc.s 28
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028e: stloc.s 28
-		IL_0290: ldc.i4.1
-		IL_0291: newarr [System.Runtime]System.Object
-		IL_0296: dup
-		IL_0297: ldc.i4.0
-		IL_0298: ldloc.0
-		IL_0299: stelem.ref
-		IL_029a: stloc.s 27
-		IL_029c: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject::.ctor()
-		IL_02a1: ldc.i4.1
-		IL_02a2: conv.r8
-		IL_02a3: ldstr ""
-		IL_02a8: ldc.i4.0
-		IL_02a9: ldc.i4.0
-		IL_02aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject>(!!0)
-		IL_02b4: stloc.s 32
-		IL_02b6: ldloc.s 28
-		IL_02b8: ldstr "map"
-		IL_02bd: ldloc.s 32
-		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c4: stloc.s 5
+		IL_0210: stloc.s 29
+		IL_0212: ldloc.s 31
+		IL_0214: ldloc.s 29
+		IL_0216: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_021b: pop
+		IL_021c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0221: stloc.s 31
+		IL_0223: ldloc.2
+		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0229: volatile.
+		IL_022b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+		IL_0230: brfalse IL_0244
+
+		IL_0235: ldstr "getClosed"
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_023f: br IL_0258
+
+		IL_0244: ldstr "getClosed"
+		IL_0249: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:41"
+		IL_024e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0258: stloc.s 29
+		IL_025a: ldloc.s 31
+		IL_025c: ldloc.s 29
+		IL_025e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0263: pop
+		IL_0264: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0269: stloc.s 27
+		IL_026b: ldloc.1
+		IL_026c: ldloc.s 27
+		IL_026e: ldc.r8 2
+		IL_0277: box [System.Runtime]System.Double
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0281: stloc.s 4
+		IL_0283: ldstr "Iterator"
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0292: stloc.s 29
+		IL_0294: volatile.
+		IL_0296: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_029b: brfalse IL_02b1
+
+		IL_02a0: ldloc.s 4
+		IL_02a2: ldstr "iterable"
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02ac: br IL_02c7
+
+		IL_02b1: ldloc.s 4
+		IL_02b3: ldstr "iterable"
+		IL_02b8: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:54"
+		IL_02bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02c7: stloc.s 28
+		IL_02c9: volatile.
+		IL_02cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_02d0: brfalse IL_02e8
+
+		IL_02d5: ldloc.s 29
+		IL_02d7: ldstr "from"
+		IL_02dc: ldloc.s 28
+		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e3: br IL_0300
+
+		IL_02e8: ldloc.s 29
+		IL_02ea: ldstr "from"
+		IL_02ef: ldloc.s 28
+		IL_02f1: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:55"
+		IL_02f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0300: stloc.s 28
+		IL_0302: ldloc.s 28
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0309: stloc.s 28
+		IL_030b: ldc.i4.1
+		IL_030c: newarr [System.Runtime]System.Object
+		IL_0311: dup
+		IL_0312: ldc.i4.0
+		IL_0313: ldloc.0
+		IL_0314: stelem.ref
+		IL_0315: stloc.s 27
+		IL_0317: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject::.ctor()
+		IL_031c: ldc.i4.1
+		IL_031d: conv.r8
+		IL_031e: ldstr ""
+		IL_0323: ldc.i4.0
+		IL_0324: ldc.i4.0
+		IL_0325: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_032a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject>(!!0)
+		IL_032f: stloc.s 32
+		IL_0331: volatile.
+		IL_0333: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_0338: brfalse IL_0350
+
+		IL_033d: ldloc.s 28
+		IL_033f: ldstr "map"
+		IL_0344: ldloc.s 32
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_034b: br IL_0368
+
+		IL_0350: ldloc.s 28
+		IL_0352: ldstr "map"
+		IL_0357: ldloc.s 32
+		IL_0359: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:59"
+		IL_035e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0368: stloc.s 5
 		.try
 		{
-			IL_02c6: nop
-			IL_02c7: ldloc.s 5
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ce: volatile.
-			IL_02d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_02d5: brfalse IL_02e9
+			IL_036a: nop
+			IL_036b: ldloc.s 5
+			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0372: volatile.
+			IL_0374: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0379: brfalse IL_038d
 
-			IL_02da: ldstr "next"
-			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_02e4: br IL_02fd
+			IL_037e: ldstr "next"
+			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0388: br IL_03a1
 
-			IL_02e9: ldstr "next"
-			IL_02ee: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:66"
-			IL_02f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_038d: ldstr "next"
+			IL_0392: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:66"
+			IL_0397: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_02fd: pop
-			IL_02fe: leave IL_033a
+			IL_03a1: pop
+			IL_03a2: leave IL_03de
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0303: stloc.s 6
-			IL_0305: ldloc.s 6
-			IL_0307: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_030c: dup
-			IL_030d: brtrue IL_0323
+			IL_03a7: stloc.s 6
+			IL_03a9: ldloc.s 6
+			IL_03ab: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03b0: dup
+			IL_03b1: brtrue IL_03c7
 
-			IL_0312: pop
-			IL_0313: ldloc.s 6
-			IL_0315: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_031a: dup
-			IL_031b: brtrue IL_032f
+			IL_03b6: pop
+			IL_03b7: ldloc.s 6
+			IL_03b9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03be: dup
+			IL_03bf: brtrue IL_03d3
 
-			IL_0320: pop
-			IL_0321: rethrow
+			IL_03c4: pop
+			IL_03c5: rethrow
 
-			IL_0323: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0328: stloc.s 7
-			IL_032a: br IL_0331
+			IL_03c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03cc: stloc.s 7
+			IL_03ce: br IL_03d5
 
-			IL_032f: stloc.s 7
+			IL_03d3: stloc.s 7
 
-			IL_0331: ldloc.s 7
-			IL_0333: stloc.s 8
-			IL_0335: leave IL_033a
+			IL_03d5: ldloc.s 7
+			IL_03d7: stloc.s 8
+			IL_03d9: leave IL_03de
 		} // end handler
 
-		IL_033a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_033f: stloc.s 31
-		IL_0341: ldloc.s 4
-		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0348: volatile.
-		IL_034a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-		IL_034f: brfalse IL_0363
+		IL_03de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03e3: stloc.s 31
+		IL_03e5: ldloc.s 4
+		IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ec: volatile.
+		IL_03ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+		IL_03f3: brfalse IL_0407
 
-		IL_0354: ldstr "getClosed"
-		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_035e: br IL_0377
+		IL_03f8: ldstr "getClosed"
+		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0402: br IL_041b
 
-		IL_0363: ldstr "getClosed"
-		IL_0368: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:81"
-		IL_036d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0407: ldstr "getClosed"
+		IL_040c: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:81"
+		IL_0411: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0377: stloc.s 28
-		IL_0379: ldloc.s 31
-		IL_037b: ldloc.s 28
-		IL_037d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0382: pop
-		IL_0383: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0388: stloc.s 27
-		IL_038a: ldloc.1
-		IL_038b: ldloc.s 27
-		IL_038d: ldc.r8 2
-		IL_0396: box [System.Runtime]System.Double
-		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03a0: stloc.s 9
-		IL_03a2: ldstr "Iterator"
-		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b1: stloc.s 28
-		IL_03b3: volatile.
-		IL_03b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_03ba: brfalse IL_03d0
+		IL_041b: stloc.s 28
+		IL_041d: ldloc.s 31
+		IL_041f: ldloc.s 28
+		IL_0421: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0426: pop
+		IL_0427: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_042c: stloc.s 27
+		IL_042e: ldloc.1
+		IL_042f: ldloc.s 27
+		IL_0431: ldc.r8 2
+		IL_043a: box [System.Runtime]System.Double
+		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0444: stloc.s 9
+		IL_0446: ldstr "Iterator"
+		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0455: stloc.s 28
+		IL_0457: volatile.
+		IL_0459: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+		IL_045e: brfalse IL_0474
 
-		IL_03bf: ldloc.s 9
-		IL_03c1: ldstr "iterable"
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03cb: br IL_03e6
+		IL_0463: ldloc.s 9
+		IL_0465: ldstr "iterable"
+		IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_046f: br IL_048a
 
-		IL_03d0: ldloc.s 9
-		IL_03d2: ldstr "iterable"
-		IL_03d7: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:94"
-		IL_03dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0474: ldloc.s 9
+		IL_0476: ldstr "iterable"
+		IL_047b: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:94"
+		IL_0480: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03e6: stloc.s 29
-		IL_03e8: ldloc.s 28
-		IL_03ea: ldstr "from"
-		IL_03ef: ldloc.s 29
-		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03f6: stloc.s 29
-		IL_03f8: ldloc.s 29
-		IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03ff: stloc.s 29
-		IL_0401: ldc.i4.1
-		IL_0402: newarr [System.Runtime]System.Object
-		IL_0407: dup
-		IL_0408: ldc.i4.0
-		IL_0409: ldloc.0
-		IL_040a: stelem.ref
-		IL_040b: stloc.s 27
-		IL_040d: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject::.ctor()
-		IL_0412: ldc.i4.1
-		IL_0413: conv.r8
-		IL_0414: ldstr ""
-		IL_0419: ldc.i4.0
-		IL_041a: ldc.i4.0
-		IL_041b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0420: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject>(!!0)
-		IL_0425: stloc.s 33
-		IL_0427: ldloc.s 29
-		IL_0429: ldstr "filter"
-		IL_042e: ldloc.s 33
-		IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0435: stloc.s 10
+		IL_048a: stloc.s 29
+		IL_048c: volatile.
+		IL_048e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_0493: brfalse IL_04ab
+
+		IL_0498: ldloc.s 28
+		IL_049a: ldstr "from"
+		IL_049f: ldloc.s 29
+		IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04a6: br IL_04c3
+
+		IL_04ab: ldloc.s 28
+		IL_04ad: ldstr "from"
+		IL_04b2: ldloc.s 29
+		IL_04b4: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:95"
+		IL_04b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_04c3: stloc.s 29
+		IL_04c5: ldloc.s 29
+		IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04cc: stloc.s 29
+		IL_04ce: ldc.i4.1
+		IL_04cf: newarr [System.Runtime]System.Object
+		IL_04d4: dup
+		IL_04d5: ldc.i4.0
+		IL_04d6: ldloc.0
+		IL_04d7: stelem.ref
+		IL_04d8: stloc.s 27
+		IL_04da: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject::.ctor()
+		IL_04df: ldc.i4.1
+		IL_04e0: conv.r8
+		IL_04e1: ldstr ""
+		IL_04e6: ldc.i4.0
+		IL_04e7: ldc.i4.0
+		IL_04e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject>(!!0)
+		IL_04f2: stloc.s 33
+		IL_04f4: volatile.
+		IL_04f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_04fb: brfalse IL_0513
+
+		IL_0500: ldloc.s 29
+		IL_0502: ldstr "filter"
+		IL_0507: ldloc.s 33
+		IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_050e: br IL_052b
+
+		IL_0513: ldloc.s 29
+		IL_0515: ldstr "filter"
+		IL_051a: ldloc.s 33
+		IL_051c: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:99"
+		IL_0521: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_052b: stloc.s 10
 		.try
 		{
-			IL_0437: nop
-			IL_0438: ldloc.s 10
-			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_043f: volatile.
-			IL_0441: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_0446: brfalse IL_045a
+			IL_052d: nop
+			IL_052e: ldloc.s 10
+			IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0535: volatile.
+			IL_0537: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_053c: brfalse IL_0550
 
-			IL_044b: ldstr "next"
-			IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0455: br IL_046e
+			IL_0541: ldstr "next"
+			IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_054b: br IL_0564
 
-			IL_045a: ldstr "next"
-			IL_045f: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:106"
-			IL_0464: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0550: ldstr "next"
+			IL_0555: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:106"
+			IL_055a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_046e: pop
-			IL_046f: leave IL_04ab
+			IL_0564: pop
+			IL_0565: leave IL_05a1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0474: stloc.s 11
-			IL_0476: ldloc.s 11
-			IL_0478: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_047d: dup
-			IL_047e: brtrue IL_0494
+			IL_056a: stloc.s 11
+			IL_056c: ldloc.s 11
+			IL_056e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0573: dup
+			IL_0574: brtrue IL_058a
 
-			IL_0483: pop
-			IL_0484: ldloc.s 11
-			IL_0486: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_048b: dup
-			IL_048c: brtrue IL_04a0
+			IL_0579: pop
+			IL_057a: ldloc.s 11
+			IL_057c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0581: dup
+			IL_0582: brtrue IL_0596
 
-			IL_0491: pop
-			IL_0492: rethrow
+			IL_0587: pop
+			IL_0588: rethrow
 
-			IL_0494: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0499: stloc.s 12
-			IL_049b: br IL_04a2
+			IL_058a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_058f: stloc.s 12
+			IL_0591: br IL_0598
 
-			IL_04a0: stloc.s 12
+			IL_0596: stloc.s 12
 
-			IL_04a2: ldloc.s 12
-			IL_04a4: stloc.s 13
-			IL_04a6: leave IL_04ab
+			IL_0598: ldloc.s 12
+			IL_059a: stloc.s 13
+			IL_059c: leave IL_05a1
 		} // end handler
 
-		IL_04ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04b0: stloc.s 31
-		IL_04b2: ldloc.s 9
-		IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b9: volatile.
-		IL_04bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-		IL_04c0: brfalse IL_04d4
+		IL_05a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05a6: stloc.s 31
+		IL_05a8: ldloc.s 9
+		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05af: volatile.
+		IL_05b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+		IL_05b6: brfalse IL_05ca
 
-		IL_04c5: ldstr "getClosed"
-		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_04cf: br IL_04e8
+		IL_05bb: ldstr "getClosed"
+		IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05c5: br IL_05de
 
-		IL_04d4: ldstr "getClosed"
-		IL_04d9: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:121"
-		IL_04de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-		IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_05ca: ldstr "getClosed"
+		IL_05cf: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:121"
+		IL_05d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+		IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_04e8: stloc.s 29
-		IL_04ea: ldloc.s 31
-		IL_04ec: ldloc.s 29
-		IL_04ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04f3: pop
-		IL_04f4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04f9: stloc.s 27
-		IL_04fb: ldloc.1
-		IL_04fc: ldloc.s 27
-		IL_04fe: ldc.r8 3
-		IL_0507: box [System.Runtime]System.Double
-		IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0511: stloc.s 14
-		IL_0513: ldstr "Iterator"
-		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0522: stloc.s 29
-		IL_0524: volatile.
-		IL_0526: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-		IL_052b: brfalse IL_0541
+		IL_05de: stloc.s 29
+		IL_05e0: ldloc.s 31
+		IL_05e2: ldloc.s 29
+		IL_05e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05e9: pop
+		IL_05ea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05ef: stloc.s 27
+		IL_05f1: ldloc.1
+		IL_05f2: ldloc.s 27
+		IL_05f4: ldc.r8 3
+		IL_05fd: box [System.Runtime]System.Double
+		IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0607: stloc.s 14
+		IL_0609: ldstr "Iterator"
+		IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0618: stloc.s 29
+		IL_061a: volatile.
+		IL_061c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_0621: brfalse IL_0637
 
-		IL_0530: ldloc.s 14
-		IL_0532: ldstr "iterable"
-		IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_053c: br IL_0557
+		IL_0626: ldloc.s 14
+		IL_0628: ldstr "iterable"
+		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0632: br IL_064d
 
-		IL_0541: ldloc.s 14
-		IL_0543: ldstr "iterable"
-		IL_0548: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:134"
-		IL_054d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-		IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0637: ldloc.s 14
+		IL_0639: ldstr "iterable"
+		IL_063e: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:134"
+		IL_0643: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0557: stloc.s 28
-		IL_0559: ldloc.s 29
-		IL_055b: ldstr "from"
-		IL_0560: ldloc.s 28
-		IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0567: stloc.s 28
-		IL_0569: ldloc.s 28
-		IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0570: ldstr "take"
-		IL_0575: ldc.r8 0.0
-		IL_057e: box [System.Runtime]System.Double
-		IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0588: stloc.s 15
-		IL_058a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_058f: stloc.s 31
-		IL_0591: ldloc.s 15
-		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0598: volatile.
-		IL_059a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-		IL_059f: brfalse IL_05b3
+		IL_064d: stloc.s 28
+		IL_064f: volatile.
+		IL_0651: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_0656: brfalse IL_066e
 
-		IL_05a4: ldstr "next"
-		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_05ae: br IL_05c7
+		IL_065b: ldloc.s 29
+		IL_065d: ldstr "from"
+		IL_0662: ldloc.s 28
+		IL_0664: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0669: br IL_0686
 
-		IL_05b3: ldstr "next"
-		IL_05b8: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:144"
-		IL_05bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_066e: ldloc.s 29
+		IL_0670: ldstr "from"
+		IL_0675: ldloc.s 28
+		IL_0677: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:135"
+		IL_067c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_05c7: stloc.s 28
-		IL_05c9: volatile.
-		IL_05cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_05d0: brfalse IL_05e6
+		IL_0686: stloc.s 28
+		IL_0688: ldloc.s 28
+		IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_068f: volatile.
+		IL_0691: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_0696: brfalse IL_06b8
 
-		IL_05d5: ldloc.s 28
-		IL_05d7: ldstr "done"
-		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05e1: br IL_05fc
+		IL_069b: ldstr "take"
+		IL_06a0: ldc.r8 0.0
+		IL_06a9: box [System.Runtime]System.Double
+		IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06b3: br IL_06da
 
-		IL_05e6: ldloc.s 28
-		IL_05e8: ldstr "done"
-		IL_05ed: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:146"
-		IL_05f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06b8: ldstr "take"
+		IL_06bd: ldc.r8 0.0
+		IL_06c6: box [System.Runtime]System.Double
+		IL_06cb: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:139"
+		IL_06d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_05fc: stloc.s 28
-		IL_05fe: ldloc.s 31
-		IL_0600: ldloc.s 28
-		IL_0602: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0607: pop
-		IL_0608: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_060d: stloc.s 31
-		IL_060f: ldloc.s 14
-		IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0616: volatile.
-		IL_0618: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-		IL_061d: brfalse IL_0631
+		IL_06da: stloc.s 15
+		IL_06dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06e1: stloc.s 31
+		IL_06e3: ldloc.s 15
+		IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06ea: volatile.
+		IL_06ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+		IL_06f1: brfalse IL_0705
 
-		IL_0622: ldstr "getClosed"
-		IL_0627: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_062c: br IL_0645
+		IL_06f6: ldstr "next"
+		IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0700: br IL_0719
 
-		IL_0631: ldstr "getClosed"
-		IL_0636: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:151"
-		IL_063b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-		IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0705: ldstr "next"
+		IL_070a: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:144"
+		IL_070f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+		IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0645: stloc.s 28
-		IL_0647: ldloc.s 31
-		IL_0649: ldloc.s 28
-		IL_064b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0650: pop
-		IL_0651: ldloc.0
-		IL_0652: ldc.r8 0.0
-		IL_065b: box [System.Runtime]System.Double
-		IL_0660: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_0665: ldstr "Iterator"
-		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_066f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0674: ldc.i4.1
-		IL_0675: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_067a: dup
-		IL_067b: ldc.r8 1
-		IL_0684: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0689: stloc.s 34
-		IL_068b: ldstr "from"
-		IL_0690: ldloc.s 34
-		IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0697: stloc.s 28
-		IL_0699: ldloc.s 28
-		IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06a0: stloc.s 28
-		IL_06a2: ldc.i4.1
-		IL_06a3: newarr [System.Runtime]System.Object
-		IL_06a8: dup
-		IL_06a9: ldc.i4.0
-		IL_06aa: ldloc.0
-		IL_06ab: stelem.ref
-		IL_06ac: stloc.s 27
-		IL_06ae: ldloc.s 27
-		IL_06b0: ldc.i4.0
-		IL_06b1: ldelem.ref
-		IL_06b2: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_06b7: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
-		IL_06bc: ldc.i4.1
-		IL_06bd: conv.r8
-		IL_06be: ldstr ""
-		IL_06c3: ldc.i4.0
-		IL_06c4: ldc.i4.0
-		IL_06c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject>(!!0)
-		IL_06cf: stloc.s 35
-		IL_06d1: ldloc.s 28
-		IL_06d3: ldstr "flatMap"
-		IL_06d8: ldloc.s 35
-		IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06df: stloc.s 16
-		IL_06e1: ldloc.s 16
-		IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06e8: volatile.
-		IL_06ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-		IL_06ef: brfalse IL_0703
+		IL_0719: stloc.s 28
+		IL_071b: volatile.
+		IL_071d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+		IL_0722: brfalse IL_0738
 
-		IL_06f4: ldstr "next"
-		IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_06fe: br IL_0717
+		IL_0727: ldloc.s 28
+		IL_0729: ldstr "done"
+		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0733: br IL_074e
 
-		IL_0703: ldstr "next"
-		IL_0708: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:171"
-		IL_070d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-		IL_0712: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0738: ldloc.s 28
+		IL_073a: ldstr "done"
+		IL_073f: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:146"
+		IL_0744: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+		IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0717: pop
-		IL_0718: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_071d: stloc.s 31
-		IL_071f: ldloc.s 16
-		IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0726: volatile.
-		IL_0728: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-		IL_072d: brfalse IL_0741
+		IL_074e: stloc.s 28
+		IL_0750: ldloc.s 31
+		IL_0752: ldloc.s 28
+		IL_0754: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0759: pop
+		IL_075a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_075f: stloc.s 31
+		IL_0761: ldloc.s 14
+		IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0768: volatile.
+		IL_076a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+		IL_076f: brfalse IL_0783
 
-		IL_0732: ldstr "next"
-		IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_073c: br IL_0755
+		IL_0774: ldstr "getClosed"
+		IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_077e: br IL_0797
 
-		IL_0741: ldstr "next"
-		IL_0746: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:175"
-		IL_074b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-		IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0783: ldstr "getClosed"
+		IL_0788: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:151"
+		IL_078d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+		IL_0792: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0755: stloc.s 28
-		IL_0757: volatile.
-		IL_0759: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_075e: brfalse IL_0774
+		IL_0797: stloc.s 28
+		IL_0799: ldloc.s 31
+		IL_079b: ldloc.s 28
+		IL_079d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07a2: pop
+		IL_07a3: ldloc.0
+		IL_07a4: ldc.r8 0.0
+		IL_07ad: box [System.Runtime]System.Double
+		IL_07b2: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_07b7: ldstr "Iterator"
+		IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07c6: ldc.i4.1
+		IL_07c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_07cc: dup
+		IL_07cd: ldc.r8 1
+		IL_07d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_07db: stloc.s 34
+		IL_07dd: volatile.
+		IL_07df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+		IL_07e4: brfalse IL_07fa
 
-		IL_0763: ldloc.s 28
-		IL_0765: ldstr "done"
-		IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_076f: br IL_078a
+		IL_07e9: ldstr "from"
+		IL_07ee: ldloc.s 34
+		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07f5: br IL_0810
 
-		IL_0774: ldloc.s 28
-		IL_0776: ldstr "done"
-		IL_077b: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:177"
-		IL_0780: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_0785: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07fa: ldstr "from"
+		IL_07ff: ldloc.s 34
+		IL_0801: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:163"
+		IL_0806: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+		IL_080b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_078a: stloc.s 28
-		IL_078c: ldloc.s 31
-		IL_078e: ldloc.s 28
-		IL_0790: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0795: pop
-		IL_0796: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_079b: stloc.s 31
-		IL_079d: ldloc.0
-		IL_079e: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_07a3: stloc.s 28
-		IL_07a5: ldloc.s 31
-		IL_07a7: ldloc.s 28
-		IL_07a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07ae: pop
-		IL_07af: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_07b4: stloc.s 27
-		IL_07b6: ldloc.1
-		IL_07b7: ldloc.s 27
-		IL_07b9: ldc.r8 2
-		IL_07c2: box [System.Runtime]System.Double
-		IL_07c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_07cc: stloc.s 17
-		IL_07ce: ldstr "Iterator"
-		IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07dd: stloc.s 28
-		IL_07df: volatile.
-		IL_07e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_07e6: brfalse IL_07fc
+		IL_0810: stloc.s 28
+		IL_0812: ldloc.s 28
+		IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0819: stloc.s 28
+		IL_081b: ldc.i4.1
+		IL_081c: newarr [System.Runtime]System.Object
+		IL_0821: dup
+		IL_0822: ldc.i4.0
+		IL_0823: ldloc.0
+		IL_0824: stelem.ref
+		IL_0825: stloc.s 27
+		IL_0827: ldloc.s 27
+		IL_0829: ldc.i4.0
+		IL_082a: ldelem.ref
+		IL_082b: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0830: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_0835: ldc.i4.1
+		IL_0836: conv.r8
+		IL_0837: ldstr ""
+		IL_083c: ldc.i4.0
+		IL_083d: ldc.i4.0
+		IL_083e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0843: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject>(!!0)
+		IL_0848: stloc.s 35
+		IL_084a: volatile.
+		IL_084c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+		IL_0851: brfalse IL_0869
 
-		IL_07eb: ldloc.s 17
-		IL_07ed: ldstr "iterable"
-		IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07f7: br IL_0812
+		IL_0856: ldloc.s 28
+		IL_0858: ldstr "flatMap"
+		IL_085d: ldloc.s 35
+		IL_085f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0864: br IL_0881
 
-		IL_07fc: ldloc.s 17
-		IL_07fe: ldstr "iterable"
-		IL_0803: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:194"
-		IL_0808: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_080d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0869: ldloc.s 28
+		IL_086b: ldstr "flatMap"
+		IL_0870: ldloc.s 35
+		IL_0872: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:167"
+		IL_0877: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+		IL_087c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0812: stloc.s 29
-		IL_0814: ldloc.s 28
-		IL_0816: ldstr "from"
-		IL_081b: ldloc.s 29
-		IL_081d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0822: stloc.s 29
-		IL_0824: ldloc.s 29
-		IL_0826: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_082b: stloc.s 29
-		IL_082d: ldc.i4.1
-		IL_082e: newarr [System.Runtime]System.Object
-		IL_0833: dup
-		IL_0834: ldc.i4.0
-		IL_0835: ldloc.0
-		IL_0836: stelem.ref
-		IL_0837: stloc.s 27
-		IL_0839: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject::.ctor()
-		IL_083e: ldc.i4.1
-		IL_083f: conv.r8
-		IL_0840: ldstr ""
-		IL_0845: ldc.i4.0
-		IL_0846: ldc.i4.0
-		IL_0847: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_084c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject>(!!0)
-		IL_0851: stloc.s 36
-		IL_0853: ldloc.s 29
-		IL_0855: ldstr "flatMap"
-		IL_085a: ldloc.s 36
-		IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0861: stloc.s 18
+		IL_0881: stloc.s 16
+		IL_0883: ldloc.s 16
+		IL_0885: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_088a: volatile.
+		IL_088c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_0891: brfalse IL_08a5
+
+		IL_0896: ldstr "next"
+		IL_089b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_08a0: br IL_08b9
+
+		IL_08a5: ldstr "next"
+		IL_08aa: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:171"
+		IL_08af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_08b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_08b9: pop
+		IL_08ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08bf: stloc.s 31
+		IL_08c1: ldloc.s 16
+		IL_08c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08c8: volatile.
+		IL_08ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+		IL_08cf: brfalse IL_08e3
+
+		IL_08d4: ldstr "next"
+		IL_08d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_08de: br IL_08f7
+
+		IL_08e3: ldstr "next"
+		IL_08e8: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:175"
+		IL_08ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+		IL_08f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_08f7: stloc.s 28
+		IL_08f9: volatile.
+		IL_08fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+		IL_0900: brfalse IL_0916
+
+		IL_0905: ldloc.s 28
+		IL_0907: ldstr "done"
+		IL_090c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0911: br IL_092c
+
+		IL_0916: ldloc.s 28
+		IL_0918: ldstr "done"
+		IL_091d: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:177"
+		IL_0922: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+		IL_0927: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_092c: stloc.s 28
+		IL_092e: ldloc.s 31
+		IL_0930: ldloc.s 28
+		IL_0932: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0937: pop
+		IL_0938: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_093d: stloc.s 31
+		IL_093f: ldloc.0
+		IL_0940: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_0945: stloc.s 28
+		IL_0947: ldloc.s 31
+		IL_0949: ldloc.s 28
+		IL_094b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0950: pop
+		IL_0951: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0956: stloc.s 27
+		IL_0958: ldloc.1
+		IL_0959: ldloc.s 27
+		IL_095b: ldc.r8 2
+		IL_0964: box [System.Runtime]System.Double
+		IL_0969: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_096e: stloc.s 17
+		IL_0970: ldstr "Iterator"
+		IL_0975: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_097a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_097f: stloc.s 28
+		IL_0981: volatile.
+		IL_0983: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+		IL_0988: brfalse IL_099e
+
+		IL_098d: ldloc.s 17
+		IL_098f: ldstr "iterable"
+		IL_0994: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0999: br IL_09b4
+
+		IL_099e: ldloc.s 17
+		IL_09a0: ldstr "iterable"
+		IL_09a5: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:194"
+		IL_09aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+		IL_09af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_09b4: stloc.s 29
+		IL_09b6: volatile.
+		IL_09b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+		IL_09bd: brfalse IL_09d5
+
+		IL_09c2: ldloc.s 28
+		IL_09c4: ldstr "from"
+		IL_09c9: ldloc.s 29
+		IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_09d0: br IL_09ed
+
+		IL_09d5: ldloc.s 28
+		IL_09d7: ldstr "from"
+		IL_09dc: ldloc.s 29
+		IL_09de: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:195"
+		IL_09e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+		IL_09e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_09ed: stloc.s 29
+		IL_09ef: ldloc.s 29
+		IL_09f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_09f6: stloc.s 29
+		IL_09f8: ldc.i4.1
+		IL_09f9: newarr [System.Runtime]System.Object
+		IL_09fe: dup
+		IL_09ff: ldc.i4.0
+		IL_0a00: ldloc.0
+		IL_0a01: stelem.ref
+		IL_0a02: stloc.s 27
+		IL_0a04: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject::.ctor()
+		IL_0a09: ldc.i4.1
+		IL_0a0a: conv.r8
+		IL_0a0b: ldstr ""
+		IL_0a10: ldc.i4.0
+		IL_0a11: ldc.i4.0
+		IL_0a12: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a17: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject>(!!0)
+		IL_0a1c: stloc.s 36
+		IL_0a1e: volatile.
+		IL_0a20: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+		IL_0a25: brfalse IL_0a3d
+
+		IL_0a2a: ldloc.s 29
+		IL_0a2c: ldstr "flatMap"
+		IL_0a31: ldloc.s 36
+		IL_0a33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a38: br IL_0a55
+
+		IL_0a3d: ldloc.s 29
+		IL_0a3f: ldstr "flatMap"
+		IL_0a44: ldloc.s 36
+		IL_0a46: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:199"
+		IL_0a4b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+		IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0a55: stloc.s 18
 		.try
 		{
-			IL_0863: nop
-			IL_0864: ldloc.s 18
-			IL_0866: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_086b: volatile.
-			IL_086d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_0872: brfalse IL_0886
+			IL_0a57: nop
+			IL_0a58: ldloc.s 18
+			IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a5f: volatile.
+			IL_0a61: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0a66: brfalse IL_0a7a
 
-			IL_0877: ldstr "next"
-			IL_087c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0881: br IL_089a
+			IL_0a6b: ldstr "next"
+			IL_0a70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0a75: br IL_0a8e
 
-			IL_0886: ldstr "next"
-			IL_088b: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:206"
-			IL_0890: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_0895: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0a7a: ldstr "next"
+			IL_0a7f: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:206"
+			IL_0a84: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0a89: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_089a: pop
-			IL_089b: leave IL_08d7
+			IL_0a8e: pop
+			IL_0a8f: leave IL_0acb
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_08a0: stloc.s 19
-			IL_08a2: ldloc.s 19
-			IL_08a4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_08a9: dup
-			IL_08aa: brtrue IL_08c0
+			IL_0a94: stloc.s 19
+			IL_0a96: ldloc.s 19
+			IL_0a98: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0a9d: dup
+			IL_0a9e: brtrue IL_0ab4
 
-			IL_08af: pop
-			IL_08b0: ldloc.s 19
-			IL_08b2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_08b7: dup
-			IL_08b8: brtrue IL_08cc
+			IL_0aa3: pop
+			IL_0aa4: ldloc.s 19
+			IL_0aa6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0aab: dup
+			IL_0aac: brtrue IL_0ac0
 
-			IL_08bd: pop
-			IL_08be: rethrow
+			IL_0ab1: pop
+			IL_0ab2: rethrow
 
-			IL_08c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_08c5: stloc.s 20
-			IL_08c7: br IL_08ce
+			IL_0ab4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0ab9: stloc.s 20
+			IL_0abb: br IL_0ac2
 
-			IL_08cc: stloc.s 20
+			IL_0ac0: stloc.s 20
 
-			IL_08ce: ldloc.s 20
-			IL_08d0: stloc.s 21
-			IL_08d2: leave IL_08d7
+			IL_0ac2: ldloc.s 20
+			IL_0ac4: stloc.s 21
+			IL_0ac6: leave IL_0acb
 		} // end handler
 
-		IL_08d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08dc: stloc.s 31
-		IL_08de: ldloc.s 17
-		IL_08e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08e5: volatile.
-		IL_08e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-		IL_08ec: brfalse IL_0900
+		IL_0acb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ad0: stloc.s 31
+		IL_0ad2: ldloc.s 17
+		IL_0ad4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0ad9: volatile.
+		IL_0adb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+		IL_0ae0: brfalse IL_0af4
 
-		IL_08f1: ldstr "getClosed"
-		IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_08fb: br IL_0914
+		IL_0ae5: ldstr "getClosed"
+		IL_0aea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0aef: br IL_0b08
 
-		IL_0900: ldstr "getClosed"
-		IL_0905: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:221"
-		IL_090a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-		IL_090f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0af4: ldstr "getClosed"
+		IL_0af9: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:221"
+		IL_0afe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+		IL_0b03: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0914: stloc.s 29
-		IL_0916: ldloc.s 31
-		IL_0918: ldloc.s 29
-		IL_091a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_091f: pop
-		IL_0920: ldloc.0
-		IL_0921: ldc.r8 0.0
-		IL_092a: box [System.Runtime]System.Double
-		IL_092f: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_0934: ldloc.0
-		IL_0935: ldc.r8 0.0
-		IL_093e: box [System.Runtime]System.Double
-		IL_0943: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_0948: ldstr "Iterator"
-		IL_094d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0952: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0957: stloc.s 29
-		IL_0959: ldstr "iterator"
-		IL_095e: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0963: stloc.s 28
-		IL_0965: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_096a: stloc.s 37
-		IL_096c: ldc.i4.1
-		IL_096d: newarr [System.Runtime]System.Object
-		IL_0972: dup
-		IL_0973: ldc.i4.0
-		IL_0974: ldloc.0
-		IL_0975: stelem.ref
-		IL_0976: stloc.s 27
-		IL_0978: ldloc.s 37
-		IL_097a: ldloc.s 28
-		IL_097c: ldloc.s 27
-		IL_097e: ldc.i4.0
-		IL_097f: ldelem.ref
-		IL_0980: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0985: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
-		IL_098a: ldc.i4.0
-		IL_098b: conv.r8
-		IL_098c: ldstr ""
-		IL_0991: ldc.i4.0
-		IL_0992: ldc.i4.1
-		IL_0993: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0998: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0)
-		IL_099d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_09a2: pop
-		IL_09a3: ldloc.s 29
-		IL_09a5: ldstr "from"
-		IL_09aa: ldloc.s 37
-		IL_09ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_09b1: stloc.s 29
-		IL_09b3: ldloc.s 29
-		IL_09b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_09ba: stloc.s 29
-		IL_09bc: ldc.i4.1
-		IL_09bd: newarr [System.Runtime]System.Object
-		IL_09c2: dup
-		IL_09c3: ldc.i4.0
-		IL_09c4: ldloc.0
-		IL_09c5: stelem.ref
-		IL_09c6: stloc.s 27
-		IL_09c8: ldloc.s 27
-		IL_09ca: ldc.i4.0
-		IL_09cb: ldelem.ref
-		IL_09cc: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_09d1: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
-		IL_09d6: ldc.i4.1
-		IL_09d7: conv.r8
-		IL_09d8: ldstr ""
-		IL_09dd: ldc.i4.0
-		IL_09de: ldc.i4.0
-		IL_09df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_09e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0)
-		IL_09e9: stloc.s 38
-		IL_09eb: ldloc.s 29
-		IL_09ed: ldstr "flatMap"
-		IL_09f2: ldloc.s 38
-		IL_09f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_09f9: stloc.s 22
+		IL_0b08: stloc.s 29
+		IL_0b0a: ldloc.s 31
+		IL_0b0c: ldloc.s 29
+		IL_0b0e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b13: pop
+		IL_0b14: ldloc.0
+		IL_0b15: ldc.r8 0.0
+		IL_0b1e: box [System.Runtime]System.Double
+		IL_0b23: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_0b28: ldloc.0
+		IL_0b29: ldc.r8 0.0
+		IL_0b32: box [System.Runtime]System.Double
+		IL_0b37: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_0b3c: ldstr "Iterator"
+		IL_0b41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b4b: stloc.s 29
+		IL_0b4d: ldstr "iterator"
+		IL_0b52: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0b57: stloc.s 28
+		IL_0b59: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0b5e: stloc.s 37
+		IL_0b60: ldc.i4.1
+		IL_0b61: newarr [System.Runtime]System.Object
+		IL_0b66: dup
+		IL_0b67: ldc.i4.0
+		IL_0b68: ldloc.0
+		IL_0b69: stelem.ref
+		IL_0b6a: stloc.s 27
+		IL_0b6c: ldloc.s 37
+		IL_0b6e: ldloc.s 28
+		IL_0b70: ldloc.s 27
+		IL_0b72: ldc.i4.0
+		IL_0b73: ldelem.ref
+		IL_0b74: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0b79: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_0b7e: ldc.i4.0
+		IL_0b7f: conv.r8
+		IL_0b80: ldstr ""
+		IL_0b85: ldc.i4.0
+		IL_0b86: ldc.i4.1
+		IL_0b87: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b8c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0)
+		IL_0b91: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0b96: pop
+		IL_0b97: volatile.
+		IL_0b99: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+		IL_0b9e: brfalse IL_0bb6
+
+		IL_0ba3: ldloc.s 29
+		IL_0ba5: ldstr "from"
+		IL_0baa: ldloc.s 37
+		IL_0bac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0bb1: br IL_0bce
+
+		IL_0bb6: ldloc.s 29
+		IL_0bb8: ldstr "from"
+		IL_0bbd: ldloc.s 37
+		IL_0bbf: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:241"
+		IL_0bc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+		IL_0bc9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0bce: stloc.s 29
+		IL_0bd0: ldloc.s 29
+		IL_0bd2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0bd7: stloc.s 29
+		IL_0bd9: ldc.i4.1
+		IL_0bda: newarr [System.Runtime]System.Object
+		IL_0bdf: dup
+		IL_0be0: ldc.i4.0
+		IL_0be1: ldloc.0
+		IL_0be2: stelem.ref
+		IL_0be3: stloc.s 27
+		IL_0be5: ldloc.s 27
+		IL_0be7: ldc.i4.0
+		IL_0be8: ldelem.ref
+		IL_0be9: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0bee: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_0bf3: ldc.i4.1
+		IL_0bf4: conv.r8
+		IL_0bf5: ldstr ""
+		IL_0bfa: ldc.i4.0
+		IL_0bfb: ldc.i4.0
+		IL_0bfc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c01: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0)
+		IL_0c06: stloc.s 38
+		IL_0c08: volatile.
+		IL_0c0a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+		IL_0c0f: brfalse IL_0c27
+
+		IL_0c14: ldloc.s 29
+		IL_0c16: ldstr "flatMap"
+		IL_0c1b: ldloc.s 38
+		IL_0c1d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0c22: br IL_0c3f
+
+		IL_0c27: ldloc.s 29
+		IL_0c29: ldstr "flatMap"
+		IL_0c2e: ldloc.s 38
+		IL_0c30: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:245"
+		IL_0c35: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+		IL_0c3a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0c3f: stloc.s 22
 		.try
 		{
-			IL_09fb: nop
-			IL_09fc: ldloc.s 22
-			IL_09fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a03: volatile.
-			IL_0a05: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_0a0a: brfalse IL_0a1e
+			IL_0c41: nop
+			IL_0c42: ldloc.s 22
+			IL_0c44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c49: volatile.
+			IL_0c4b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0c50: brfalse IL_0c64
 
-			IL_0a0f: ldstr "next"
-			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0a19: br IL_0a32
+			IL_0c55: ldstr "next"
+			IL_0c5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0c5f: br IL_0c78
 
-			IL_0a1e: ldstr "next"
-			IL_0a23: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:252"
-			IL_0a28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_0a2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0c64: ldstr "next"
+			IL_0c69: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:252"
+			IL_0c6e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0c73: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0a32: pop
-			IL_0a33: ldloc.s 22
-			IL_0a35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a3a: volatile.
-			IL_0a3c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_0a41: brfalse IL_0a55
+			IL_0c78: pop
+			IL_0c79: ldloc.s 22
+			IL_0c7b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c80: volatile.
+			IL_0c82: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_0c87: brfalse IL_0c9b
 
-			IL_0a46: ldstr "next"
-			IL_0a4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0a50: br IL_0a69
+			IL_0c8c: ldstr "next"
+			IL_0c91: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0c96: br IL_0caf
 
-			IL_0a55: ldstr "next"
-			IL_0a5a: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:255"
-			IL_0a5f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_0a64: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0c9b: ldstr "next"
+			IL_0ca0: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:255"
+			IL_0ca5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_0caa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0a69: pop
-			IL_0a6a: leave IL_0aa6
+			IL_0caf: pop
+			IL_0cb0: leave IL_0cec
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0a6f: stloc.s 23
-			IL_0a71: ldloc.s 23
-			IL_0a73: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0a78: dup
-			IL_0a79: brtrue IL_0a8f
+			IL_0cb5: stloc.s 23
+			IL_0cb7: ldloc.s 23
+			IL_0cb9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0cbe: dup
+			IL_0cbf: brtrue IL_0cd5
 
-			IL_0a7e: pop
-			IL_0a7f: ldloc.s 23
-			IL_0a81: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0a86: dup
-			IL_0a87: brtrue IL_0a9b
+			IL_0cc4: pop
+			IL_0cc5: ldloc.s 23
+			IL_0cc7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0ccc: dup
+			IL_0ccd: brtrue IL_0ce1
 
-			IL_0a8c: pop
-			IL_0a8d: rethrow
+			IL_0cd2: pop
+			IL_0cd3: rethrow
 
-			IL_0a8f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0a94: stloc.s 24
-			IL_0a96: br IL_0a9d
+			IL_0cd5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0cda: stloc.s 24
+			IL_0cdc: br IL_0ce3
 
-			IL_0a9b: stloc.s 24
+			IL_0ce1: stloc.s 24
 
-			IL_0a9d: ldloc.s 24
-			IL_0a9f: stloc.s 25
-			IL_0aa1: leave IL_0aa6
+			IL_0ce3: ldloc.s 24
+			IL_0ce5: stloc.s 25
+			IL_0ce7: leave IL_0cec
 		} // end handler
 
-		IL_0aa6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0aab: stloc.s 31
-		IL_0aad: ldloc.0
-		IL_0aae: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_0ab3: stloc.s 29
-		IL_0ab5: ldloc.s 31
-		IL_0ab7: ldloc.s 29
-		IL_0ab9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0abe: pop
-		IL_0abf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0ac4: stloc.s 31
-		IL_0ac6: ldloc.0
-		IL_0ac7: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_0acc: stloc.s 29
-		IL_0ace: ldloc.s 31
-		IL_0ad0: ldloc.s 29
-		IL_0ad2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0ad7: pop
-		IL_0ad8: ldnull
-		IL_0ad9: stloc.s 26
-		IL_0adb: ret
+		IL_0cec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0cf1: stloc.s 31
+		IL_0cf3: ldloc.0
+		IL_0cf4: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_0cf9: stloc.s 29
+		IL_0cfb: ldloc.s 31
+		IL_0cfd: ldloc.s 29
+		IL_0cff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0d04: pop
+		IL_0d05: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0d0a: stloc.s 31
+		IL_0d0c: ldloc.0
+		IL_0d0d: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_0d12: stloc.s 29
+		IL_0d14: ldloc.s 31
+		IL_0d16: ldloc.s 29
+		IL_0d18: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0d1d: pop
+		IL_0d1e: ldnull
+		IL_0d1f: stloc.s 26
+		IL_0d21: ret
 	} // end of method Iterator_Helper_Cleanup::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Cleanup
@@ -4609,6 +4790,20 @@
 	.field assembly static int32 __jroc_dynamicLookup_76
 	.field assembly static int32 __jroc_dynamicLookup_77
 	.field assembly static int32 __jroc_dynamicLookup_78
+	.field assembly static int32 __jroc_dynamicLookup_79
+	.field assembly static int32 __jroc_dynamicLookup_80
+	.field assembly static int32 __jroc_dynamicLookup_81
+	.field assembly static int32 __jroc_dynamicLookup_82
+	.field assembly static int32 __jroc_dynamicLookup_83
+	.field assembly static int32 __jroc_dynamicLookup_84
+	.field assembly static int32 __jroc_dynamicLookup_85
+	.field assembly static int32 __jroc_dynamicLookup_86
+	.field assembly static int32 __jroc_dynamicLookup_87
+	.field assembly static int32 __jroc_dynamicLookup_88
+	.field assembly static int32 __jroc_dynamicLookup_89
+	.field assembly static int32 __jroc_dynamicLookup_90
+	.field assembly static int32 __jroc_dynamicLookup_91
+	.field assembly static int32 __jroc_dynamicLookup_92
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
@@ -742,7 +742,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1658 (0x67a)
+		// Code size: 1776 (0x6f0)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Iterator_Helper_Next_Return/Scope,
@@ -804,482 +804,519 @@
 		IL_0068: ldstr "Iterator"
 		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0077: ldstr "from"
-		IL_007c: ldloc.1
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: stloc.s 7
-		IL_0084: ldloc.s 7
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008b: stloc.s 7
-		IL_008d: ldc.i4.1
-		IL_008e: newarr [System.Runtime]System.Object
-		IL_0093: dup
-		IL_0094: ldc.i4.0
-		IL_0095: ldloc.0
-		IL_0096: stelem.ref
-		IL_0097: stloc.s 9
-		IL_0099: newobj instance void Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject::.ctor()
-		IL_009e: ldc.i4.1
-		IL_009f: conv.r8
-		IL_00a0: ldstr ""
-		IL_00a5: ldc.i4.0
-		IL_00a6: ldc.i4.0
-		IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0)
-		IL_00b1: stloc.s 10
-		IL_00b3: ldloc.s 7
-		IL_00b5: ldstr "map"
-		IL_00ba: ldloc.s 10
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c1: stloc.2
-		IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c7: stloc.s 11
-		IL_00c9: ldloc.2
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cf: ldstr "iterator"
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_00d9: stloc.s 7
-		IL_00db: ldloc.s 7
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
-		IL_00e2: stloc.s 7
-		IL_00e4: ldloc.s 7
-		IL_00e6: ldloc.2
-		IL_00e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00ec: stloc.s 12
-		IL_00ee: ldloc.s 12
-		IL_00f0: box [System.Runtime]System.Boolean
-		IL_00f5: stloc.s 13
-		IL_00f7: ldloc.s 11
-		IL_00f9: ldloc.s 13
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0100: pop
-		IL_0101: ldloc.2
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0107: volatile.
-		IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_010e: brfalse IL_0122
+		IL_0077: volatile.
+		IL_0079: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_007e: brfalse IL_0093
 
-		IL_0113: ldstr "next"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_011d: br IL_0136
+		IL_0083: ldstr "from"
+		IL_0088: ldloc.1
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008e: br IL_00a8
 
-		IL_0122: ldstr "next"
-		IL_0127: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:36"
-		IL_012c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0093: ldstr "from"
+		IL_0098: ldloc.1
+		IL_0099: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:19"
+		IL_009e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0136: stloc.3
-		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013c: stloc.s 11
-		IL_013e: volatile.
-		IL_0140: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0145: brfalse IL_015a
+		IL_00a8: stloc.s 7
+		IL_00aa: ldloc.s 7
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b1: stloc.s 7
+		IL_00b3: ldc.i4.1
+		IL_00b4: newarr [System.Runtime]System.Object
+		IL_00b9: dup
+		IL_00ba: ldc.i4.0
+		IL_00bb: ldloc.0
+		IL_00bc: stelem.ref
+		IL_00bd: stloc.s 9
+		IL_00bf: newobj instance void Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject::.ctor()
+		IL_00c4: ldc.i4.1
+		IL_00c5: conv.r8
+		IL_00c6: ldstr ""
+		IL_00cb: ldc.i4.0
+		IL_00cc: ldc.i4.0
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/ArrowFunction_L20C44/FunctionObject>(!!0)
+		IL_00d7: stloc.s 10
+		IL_00d9: volatile.
+		IL_00db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_00e0: brfalse IL_00f8
 
-		IL_014a: ldloc.3
-		IL_014b: ldstr "value"
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0155: br IL_016f
+		IL_00e5: ldloc.s 7
+		IL_00e7: ldstr "map"
+		IL_00ec: ldloc.s 10
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f3: br IL_0110
 
-		IL_015a: ldloc.3
-		IL_015b: ldstr "value"
-		IL_0160: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:41"
-		IL_0165: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00f8: ldloc.s 7
+		IL_00fa: ldstr "map"
+		IL_00ff: ldloc.s 10
+		IL_0101: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:23"
+		IL_0106: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_016f: stloc.s 7
-		IL_0171: ldloc.s 11
-		IL_0173: ldloc.s 7
-		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017a: pop
-		IL_017b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0180: stloc.s 11
-		IL_0182: volatile.
-		IL_0184: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0189: brfalse IL_019e
+		IL_0110: stloc.2
+		IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0116: stloc.s 11
+		IL_0118: ldloc.2
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011e: ldstr "iterator"
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0128: stloc.s 7
+		IL_012a: ldloc.s 7
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
+		IL_0131: stloc.s 7
+		IL_0133: ldloc.s 7
+		IL_0135: ldloc.2
+		IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_013b: stloc.s 12
+		IL_013d: ldloc.s 12
+		IL_013f: box [System.Runtime]System.Boolean
+		IL_0144: stloc.s 13
+		IL_0146: ldloc.s 11
+		IL_0148: ldloc.s 13
+		IL_014a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014f: pop
+		IL_0150: ldloc.2
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0156: volatile.
+		IL_0158: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_015d: brfalse IL_0171
 
-		IL_018e: ldloc.3
-		IL_018f: ldstr "done"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0199: br IL_01b3
+		IL_0162: ldstr "next"
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_016c: br IL_0185
 
-		IL_019e: ldloc.3
-		IL_019f: ldstr "done"
-		IL_01a4: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:46"
-		IL_01a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0171: ldstr "next"
+		IL_0176: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:36"
+		IL_017b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_01b3: stloc.s 7
-		IL_01b5: ldloc.s 11
-		IL_01b7: ldloc.s 7
-		IL_01b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01be: pop
-		IL_01bf: ldloc.2
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c5: volatile.
-		IL_01c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_01cc: brfalse IL_01e0
+		IL_0185: stloc.3
+		IL_0186: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_018b: stloc.s 11
+		IL_018d: volatile.
+		IL_018f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0194: brfalse IL_01a9
 
-		IL_01d1: ldstr "return"
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01db: br IL_01f4
+		IL_0199: ldloc.3
+		IL_019a: ldstr "value"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a4: br IL_01be
 
-		IL_01e0: ldstr "return"
-		IL_01e5: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:50"
-		IL_01ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01a9: ldloc.3
+		IL_01aa: ldstr "value"
+		IL_01af: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:41"
+		IL_01b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01f4: stloc.s 4
-		IL_01f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fb: stloc.s 11
-		IL_01fd: volatile.
-		IL_01ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0204: brfalse IL_021a
+		IL_01be: stloc.s 7
+		IL_01c0: ldloc.s 11
+		IL_01c2: ldloc.s 7
+		IL_01c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c9: pop
+		IL_01ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cf: stloc.s 11
+		IL_01d1: volatile.
+		IL_01d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_01d8: brfalse IL_01ed
 
-		IL_0209: ldloc.s 4
-		IL_020b: ldstr "done"
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0215: br IL_0230
+		IL_01dd: ldloc.3
+		IL_01de: ldstr "done"
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e8: br IL_0202
 
-		IL_021a: ldloc.s 4
-		IL_021c: ldstr "done"
-		IL_0221: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:55"
-		IL_0226: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01ed: ldloc.3
+		IL_01ee: ldstr "done"
+		IL_01f3: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:46"
+		IL_01f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0230: stloc.s 7
-		IL_0232: ldloc.s 11
-		IL_0234: ldloc.s 7
-		IL_0236: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023b: pop
-		IL_023c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0241: stloc.s 11
-		IL_0243: ldloc.0
-		IL_0244: ldfld object Modules.Iterator_Helper_Next_Return/Scope::closed
-		IL_0249: stloc.s 7
-		IL_024b: ldloc.s 11
-		IL_024d: ldloc.s 7
-		IL_024f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0254: pop
-		IL_0255: ldloc.2
-		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025b: volatile.
-		IL_025d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0262: brfalse IL_0276
+		IL_0202: stloc.s 7
+		IL_0204: ldloc.s 11
+		IL_0206: ldloc.s 7
+		IL_0208: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_020d: pop
+		IL_020e: ldloc.2
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0214: volatile.
+		IL_0216: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_021b: brfalse IL_022f
 
-		IL_0267: ldstr "next"
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0271: br IL_028a
+		IL_0220: ldstr "return"
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_022a: br IL_0243
 
-		IL_0276: ldstr "next"
-		IL_027b: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:63"
-		IL_0280: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_022f: ldstr "return"
+		IL_0234: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:50"
+		IL_0239: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_028a: stloc.s 7
-		IL_028c: ldloc.s 7
-		IL_028e: stloc.3
-		IL_028f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0294: stloc.s 11
-		IL_0296: volatile.
-		IL_0298: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_029d: brfalse IL_02b2
+		IL_0243: stloc.s 4
+		IL_0245: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_024a: stloc.s 11
+		IL_024c: volatile.
+		IL_024e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0253: brfalse IL_0269
 
-		IL_02a2: ldloc.3
-		IL_02a3: ldstr "done"
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ad: br IL_02c7
+		IL_0258: ldloc.s 4
+		IL_025a: ldstr "done"
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0264: br IL_027f
 
-		IL_02b2: ldloc.3
-		IL_02b3: ldstr "done"
-		IL_02b8: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:69"
-		IL_02bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0269: ldloc.s 4
+		IL_026b: ldstr "done"
+		IL_0270: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:55"
+		IL_0275: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02c7: stloc.s 7
-		IL_02c9: ldloc.s 11
-		IL_02cb: ldloc.s 7
-		IL_02cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d2: pop
-		IL_02d3: ldc.i4.2
-		IL_02d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02d9: dup
-		IL_02da: ldc.r8 7
-		IL_02e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02e8: dup
-		IL_02e9: ldc.r8 8
-		IL_02f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02f7: stloc.s 14
-		IL_02f9: ldloc.s 14
-		IL_02fb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Array::values()
-		IL_0300: stloc.s 5
-		IL_0302: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0307: stloc.s 11
-		IL_0309: ldstr "Iterator"
-		IL_030e: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
-		IL_0313: stloc.s 15
-		IL_0315: ldloc.s 11
-		IL_0317: ldloc.s 15
-		IL_0319: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_031e: pop
-		IL_031f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0324: stloc.s 11
-		IL_0326: ldstr "Iterator"
-		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0330: volatile.
-		IL_0332: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0337: brfalse IL_034b
+		IL_027f: stloc.s 7
+		IL_0281: ldloc.s 11
+		IL_0283: ldloc.s 7
+		IL_0285: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_028a: pop
+		IL_028b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0290: stloc.s 11
+		IL_0292: ldloc.0
+		IL_0293: ldfld object Modules.Iterator_Helper_Next_Return/Scope::closed
+		IL_0298: stloc.s 7
+		IL_029a: ldloc.s 11
+		IL_029c: ldloc.s 7
+		IL_029e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a3: pop
+		IL_02a4: ldloc.2
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02aa: volatile.
+		IL_02ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_02b1: brfalse IL_02c5
 
-		IL_033c: ldstr "from"
-		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0346: br IL_035f
+		IL_02b6: ldstr "next"
+		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02c0: br IL_02d9
 
-		IL_034b: ldstr "from"
-		IL_0350: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:87"
-		IL_0355: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02c5: ldstr "next"
+		IL_02ca: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:63"
+		IL_02cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_035f: stloc.s 7
-		IL_0361: ldloc.s 7
-		IL_0363: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0368: stloc.s 15
-		IL_036a: ldloc.s 11
-		IL_036c: ldloc.s 15
-		IL_036e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0373: pop
-		IL_0374: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0379: stloc.s 11
-		IL_037b: ldstr "Iterator"
-		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0385: volatile.
-		IL_0387: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_038c: brfalse IL_03a0
+		IL_02d9: stloc.s 7
+		IL_02db: ldloc.s 7
+		IL_02dd: stloc.3
+		IL_02de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02e3: stloc.s 11
+		IL_02e5: volatile.
+		IL_02e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_02ec: brfalse IL_0301
 
-		IL_0391: ldstr "prototype"
-		IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_039b: br IL_03b4
+		IL_02f1: ldloc.3
+		IL_02f2: ldstr "done"
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02fc: br IL_0316
 
-		IL_03a0: ldstr "prototype"
-		IL_03a5: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:95"
-		IL_03aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0301: ldloc.3
+		IL_0302: ldstr "done"
+		IL_0307: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:69"
+		IL_030c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03b4: stloc.s 7
-		IL_03b6: volatile.
-		IL_03b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_03bd: brfalse IL_03d3
+		IL_0316: stloc.s 7
+		IL_0318: ldloc.s 11
+		IL_031a: ldloc.s 7
+		IL_031c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0321: pop
+		IL_0322: ldc.i4.2
+		IL_0323: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0328: dup
+		IL_0329: ldc.r8 7
+		IL_0332: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0337: dup
+		IL_0338: ldc.r8 8
+		IL_0341: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0346: stloc.s 14
+		IL_0348: ldloc.s 14
+		IL_034a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Array::values()
+		IL_034f: stloc.s 5
+		IL_0351: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0356: stloc.s 11
+		IL_0358: ldstr "Iterator"
+		IL_035d: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
+		IL_0362: stloc.s 15
+		IL_0364: ldloc.s 11
+		IL_0366: ldloc.s 15
+		IL_0368: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_036d: pop
+		IL_036e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0373: stloc.s 11
+		IL_0375: ldstr "Iterator"
+		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_037f: volatile.
+		IL_0381: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0386: brfalse IL_039a
 
-		IL_03c2: ldloc.s 7
-		IL_03c4: ldstr "map"
-		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03ce: br IL_03e9
+		IL_038b: ldstr "from"
+		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0395: br IL_03ae
 
-		IL_03d3: ldloc.s 7
-		IL_03d5: ldstr "map"
-		IL_03da: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:97"
-		IL_03df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_039a: ldstr "from"
+		IL_039f: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:87"
+		IL_03a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03e9: stloc.s 7
-		IL_03eb: ldloc.s 7
-		IL_03ed: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_03f2: stloc.s 15
-		IL_03f4: ldloc.s 11
-		IL_03f6: ldloc.s 15
-		IL_03f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03fd: pop
-		IL_03fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0403: stloc.s 11
-		IL_0405: ldloc.s 5
-		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040c: ldstr "iterator"
-		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0416: stloc.s 7
-		IL_0418: ldloc.s 7
-		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
-		IL_041f: stloc.s 7
-		IL_0421: ldloc.s 7
-		IL_0423: ldloc.s 5
-		IL_0425: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_042a: stloc.s 12
-		IL_042c: ldloc.s 12
-		IL_042e: box [System.Runtime]System.Boolean
-		IL_0433: stloc.s 13
-		IL_0435: ldloc.s 11
-		IL_0437: ldloc.s 13
-		IL_0439: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_043e: pop
-		IL_043f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0444: stloc.s 11
-		IL_0446: ldloc.s 5
-		IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_044d: volatile.
-		IL_044f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0454: brfalse IL_0468
+		IL_03ae: stloc.s 7
+		IL_03b0: ldloc.s 7
+		IL_03b2: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_03b7: stloc.s 15
+		IL_03b9: ldloc.s 11
+		IL_03bb: ldloc.s 15
+		IL_03bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03c2: pop
+		IL_03c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03c8: stloc.s 11
+		IL_03ca: ldstr "Iterator"
+		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03d4: volatile.
+		IL_03d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_03db: brfalse IL_03ef
 
-		IL_0459: ldstr "next"
-		IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0463: br IL_047c
+		IL_03e0: ldstr "prototype"
+		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ea: br IL_0403
 
-		IL_0468: ldstr "next"
-		IL_046d: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:112"
-		IL_0472: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_03ef: ldstr "prototype"
+		IL_03f4: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:95"
+		IL_03f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_047c: stloc.s 7
-		IL_047e: volatile.
-		IL_0480: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0485: brfalse IL_049b
+		IL_0403: stloc.s 7
+		IL_0405: volatile.
+		IL_0407: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_040c: brfalse IL_0422
 
-		IL_048a: ldloc.s 7
-		IL_048c: ldstr "value"
-		IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0496: br IL_04b1
+		IL_0411: ldloc.s 7
+		IL_0413: ldstr "map"
+		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_041d: br IL_0438
 
-		IL_049b: ldloc.s 7
-		IL_049d: ldstr "value"
-		IL_04a2: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:114"
-		IL_04a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0422: ldloc.s 7
+		IL_0424: ldstr "map"
+		IL_0429: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:97"
+		IL_042e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04b1: stloc.s 7
-		IL_04b3: ldloc.s 11
-		IL_04b5: ldloc.s 7
-		IL_04b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04bc: pop
-		IL_04bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04c2: stloc.s 11
-		IL_04c4: ldloc.s 5
-		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04cb: volatile.
-		IL_04cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_04d2: brfalse IL_04e6
+		IL_0438: stloc.s 7
+		IL_043a: ldloc.s 7
+		IL_043c: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0441: stloc.s 15
+		IL_0443: ldloc.s 11
+		IL_0445: ldloc.s 15
+		IL_0447: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_044c: pop
+		IL_044d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0452: stloc.s 11
+		IL_0454: ldloc.s 5
+		IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_045b: ldstr "iterator"
+		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0465: stloc.s 7
+		IL_0467: ldloc.s 7
+		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
+		IL_046e: stloc.s 7
+		IL_0470: ldloc.s 7
+		IL_0472: ldloc.s 5
+		IL_0474: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0479: stloc.s 12
+		IL_047b: ldloc.s 12
+		IL_047d: box [System.Runtime]System.Boolean
+		IL_0482: stloc.s 13
+		IL_0484: ldloc.s 11
+		IL_0486: ldloc.s 13
+		IL_0488: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_048d: pop
+		IL_048e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0493: stloc.s 11
+		IL_0495: ldloc.s 5
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_049c: volatile.
+		IL_049e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_04a3: brfalse IL_04b7
 
-		IL_04d7: ldstr "next"
-		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_04e1: br IL_04fa
+		IL_04a8: ldstr "next"
+		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_04b2: br IL_04cb
 
-		IL_04e6: ldstr "next"
-		IL_04eb: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:119"
-		IL_04f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_04b7: ldstr "next"
+		IL_04bc: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:112"
+		IL_04c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_04fa: stloc.s 7
-		IL_04fc: volatile.
-		IL_04fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0503: brfalse IL_0519
+		IL_04cb: stloc.s 7
+		IL_04cd: volatile.
+		IL_04cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_04d4: brfalse IL_04ea
 
-		IL_0508: ldloc.s 7
-		IL_050a: ldstr "value"
-		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0514: br IL_052f
+		IL_04d9: ldloc.s 7
+		IL_04db: ldstr "value"
+		IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04e5: br IL_0500
 
-		IL_0519: ldloc.s 7
-		IL_051b: ldstr "value"
-		IL_0520: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:121"
-		IL_0525: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04ea: ldloc.s 7
+		IL_04ec: ldstr "value"
+		IL_04f1: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:114"
+		IL_04f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_052f: stloc.s 7
-		IL_0531: ldloc.s 11
-		IL_0533: ldloc.s 7
-		IL_0535: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_053a: pop
-		IL_053b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0540: stloc.s 11
-		IL_0542: ldloc.s 5
-		IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0549: volatile.
-		IL_054b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0550: brfalse IL_0564
+		IL_0500: stloc.s 7
+		IL_0502: ldloc.s 11
+		IL_0504: ldloc.s 7
+		IL_0506: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_050b: pop
+		IL_050c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0511: stloc.s 11
+		IL_0513: ldloc.s 5
+		IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_051a: volatile.
+		IL_051c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0521: brfalse IL_0535
 
-		IL_0555: ldstr "next"
-		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_055f: br IL_0578
+		IL_0526: ldstr "next"
+		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0530: br IL_0549
 
-		IL_0564: ldstr "next"
-		IL_0569: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:126"
-		IL_056e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0535: ldstr "next"
+		IL_053a: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:119"
+		IL_053f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0578: stloc.s 7
-		IL_057a: volatile.
-		IL_057c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0581: brfalse IL_0597
+		IL_0549: stloc.s 7
+		IL_054b: volatile.
+		IL_054d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0552: brfalse IL_0568
 
-		IL_0586: ldloc.s 7
-		IL_0588: ldstr "done"
-		IL_058d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0592: br IL_05ad
+		IL_0557: ldloc.s 7
+		IL_0559: ldstr "value"
+		IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0563: br IL_057e
 
-		IL_0597: ldloc.s 7
-		IL_0599: ldstr "done"
-		IL_059e: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:128"
-		IL_05a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0568: ldloc.s 7
+		IL_056a: ldstr "value"
+		IL_056f: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:121"
+		IL_0574: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05ad: stloc.s 7
-		IL_05af: ldloc.s 11
-		IL_05b1: ldloc.s 7
-		IL_05b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05b8: pop
-		IL_05b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_05be: dup
-		IL_05bf: ldstr "kind"
-		IL_05c4: ldstr "async"
-		IL_05c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_05ce: stloc.s 6
-		IL_05d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05d5: stloc.s 11
-		IL_05d7: ldstr "AsyncIterator"
-		IL_05dc: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
-		IL_05e1: stloc.s 15
-		IL_05e3: ldloc.s 11
-		IL_05e5: ldloc.s 15
-		IL_05e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05ec: pop
-		IL_05ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05f2: stloc.s 11
-		IL_05f4: ldstr "AsyncIterator"
-		IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05fe: volatile.
-		IL_0600: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0605: brfalse IL_0619
+		IL_057e: stloc.s 7
+		IL_0580: ldloc.s 11
+		IL_0582: ldloc.s 7
+		IL_0584: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0589: pop
+		IL_058a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_058f: stloc.s 11
+		IL_0591: ldloc.s 5
+		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0598: volatile.
+		IL_059a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_059f: brfalse IL_05b3
 
-		IL_060a: ldstr "prototype"
-		IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0614: br IL_062d
+		IL_05a4: ldstr "next"
+		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05ae: br IL_05c7
 
-		IL_0619: ldstr "prototype"
-		IL_061e: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:144"
-		IL_0623: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05b3: ldstr "next"
+		IL_05b8: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:126"
+		IL_05bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_062d: stloc.s 7
-		IL_062f: ldstr "asyncIterator"
-		IL_0634: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0639: stloc.s 16
-		IL_063b: ldloc.s 7
-		IL_063d: ldloc.s 16
-		IL_063f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0644: stloc.s 16
-		IL_0646: ldloc.s 16
-		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_064d: ldstr "call"
-		IL_0652: ldloc.s 6
-		IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0659: stloc.s 16
-		IL_065b: ldloc.s 16
-		IL_065d: ldloc.s 6
-		IL_065f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0664: stloc.s 12
-		IL_0666: ldloc.s 12
-		IL_0668: box [System.Runtime]System.Boolean
-		IL_066d: stloc.s 13
-		IL_066f: ldloc.s 11
-		IL_0671: ldloc.s 13
-		IL_0673: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0678: pop
-		IL_0679: ret
+		IL_05c7: stloc.s 7
+		IL_05c9: volatile.
+		IL_05cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_05d0: brfalse IL_05e6
+
+		IL_05d5: ldloc.s 7
+		IL_05d7: ldstr "done"
+		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05e1: br IL_05fc
+
+		IL_05e6: ldloc.s 7
+		IL_05e8: ldstr "done"
+		IL_05ed: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:128"
+		IL_05f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05fc: stloc.s 7
+		IL_05fe: ldloc.s 11
+		IL_0600: ldloc.s 7
+		IL_0602: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0607: pop
+		IL_0608: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_060d: dup
+		IL_060e: ldstr "kind"
+		IL_0613: ldstr "async"
+		IL_0618: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_061d: stloc.s 6
+		IL_061f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0624: stloc.s 11
+		IL_0626: ldstr "AsyncIterator"
+		IL_062b: call string [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::TypeOfGlobalBinding(string)
+		IL_0630: stloc.s 15
+		IL_0632: ldloc.s 11
+		IL_0634: ldloc.s 15
+		IL_0636: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_063b: pop
+		IL_063c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0641: stloc.s 11
+		IL_0643: ldstr "AsyncIterator"
+		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_064d: volatile.
+		IL_064f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0654: brfalse IL_0668
+
+		IL_0659: ldstr "prototype"
+		IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0663: br IL_067c
+
+		IL_0668: ldstr "prototype"
+		IL_066d: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:144"
+		IL_0672: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_067c: stloc.s 7
+		IL_067e: ldstr "asyncIterator"
+		IL_0683: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0688: stloc.s 16
+		IL_068a: ldloc.s 7
+		IL_068c: ldloc.s 16
+		IL_068e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0693: stloc.s 16
+		IL_0695: ldloc.s 16
+		IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_069c: volatile.
+		IL_069e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_06a3: brfalse IL_06b9
+
+		IL_06a8: ldstr "call"
+		IL_06ad: ldloc.s 6
+		IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06b4: br IL_06cf
+
+		IL_06b9: ldstr "call"
+		IL_06be: ldloc.s 6
+		IL_06c0: ldstr "Iterator_Helper_Next_Return:Modules.Iterator_Helper_Next_Return:__js_module_init__:149"
+		IL_06c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_06cf: stloc.s 16
+		IL_06d1: ldloc.s 16
+		IL_06d3: ldloc.s 6
+		IL_06d5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06da: stloc.s 12
+		IL_06dc: ldloc.s 12
+		IL_06de: box [System.Runtime]System.Boolean
+		IL_06e3: stloc.s 13
+		IL_06e5: ldloc.s 11
+		IL_06e7: ldloc.s 13
+		IL_06e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06ee: pop
+		IL_06ef: ret
 	} // end of method Iterator_Helper_Next_Return::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Next_Return
@@ -1326,6 +1363,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_25
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Literals/Snapshots/GeneratorTests.NewExpression_Boolean_Sugar.verified.txt
+++ b/tests/Jroc.Tests/Literals/Snapshots/GeneratorTests.NewExpression_Boolean_Sugar.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 976 (0x3d0)
+		// Code size: 1062 (0x426)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.NewExpression_Boolean_Sugar/Scope,
@@ -364,61 +364,87 @@
 		IL_0310: stloc.s 9
 		IL_0312: ldloc.s 9
 		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0319: ldstr "call"
-		IL_031e: ldc.i4.0
-		IL_031f: box [System.Runtime]System.Boolean
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0329: stloc.s 9
-		IL_032b: ldloc.s 6
-		IL_032d: ldloc.s 9
-		IL_032f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0334: pop
-		IL_0335: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_033a: stloc.s 6
-		IL_033c: ldstr "Boolean"
-		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0346: volatile.
-		IL_0348: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_034d: brfalse IL_0361
+		IL_0319: volatile.
+		IL_031b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0320: brfalse IL_033a
 
-		IL_0352: ldstr "prototype"
-		IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_035c: br IL_0375
+		IL_0325: ldstr "call"
+		IL_032a: ldc.i4.0
+		IL_032b: box [System.Runtime]System.Boolean
+		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0335: br IL_0354
 
-		IL_0361: ldstr "prototype"
-		IL_0366: ldstr "NewExpression_Boolean_Sugar:Modules.NewExpression_Boolean_Sugar:__js_module_init__:83"
-		IL_036b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_033a: ldstr "call"
+		IL_033f: ldc.i4.0
+		IL_0340: box [System.Runtime]System.Boolean
+		IL_0345: ldstr "NewExpression_Boolean_Sugar:Modules.NewExpression_Boolean_Sugar:__js_module_init__:76"
+		IL_034a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0375: stloc.s 9
-		IL_0377: volatile.
-		IL_0379: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_037e: brfalse IL_0394
+		IL_0354: stloc.s 9
+		IL_0356: ldloc.s 6
+		IL_0358: ldloc.s 9
+		IL_035a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_035f: pop
+		IL_0360: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0365: stloc.s 6
+		IL_0367: ldstr "Boolean"
+		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0371: volatile.
+		IL_0373: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0378: brfalse IL_038c
 
-		IL_0383: ldloc.s 9
-		IL_0385: ldstr "valueOf"
-		IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_038f: br IL_03aa
+		IL_037d: ldstr "prototype"
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0387: br IL_03a0
 
-		IL_0394: ldloc.s 9
-		IL_0396: ldstr "valueOf"
-		IL_039b: ldstr "NewExpression_Boolean_Sugar:Modules.NewExpression_Boolean_Sugar:__js_module_init__:85"
-		IL_03a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_038c: ldstr "prototype"
+		IL_0391: ldstr "NewExpression_Boolean_Sugar:Modules.NewExpression_Boolean_Sugar:__js_module_init__:83"
+		IL_0396: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03aa: stloc.s 9
-		IL_03ac: ldloc.s 9
-		IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b3: ldstr "call"
-		IL_03b8: ldc.i4.1
-		IL_03b9: box [System.Runtime]System.Boolean
-		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03c3: stloc.s 9
-		IL_03c5: ldloc.s 6
-		IL_03c7: ldloc.s 9
-		IL_03c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03ce: pop
-		IL_03cf: ret
+		IL_03a0: stloc.s 9
+		IL_03a2: volatile.
+		IL_03a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_03a9: brfalse IL_03bf
+
+		IL_03ae: ldloc.s 9
+		IL_03b0: ldstr "valueOf"
+		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ba: br IL_03d5
+
+		IL_03bf: ldloc.s 9
+		IL_03c1: ldstr "valueOf"
+		IL_03c6: ldstr "NewExpression_Boolean_Sugar:Modules.NewExpression_Boolean_Sugar:__js_module_init__:85"
+		IL_03cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_03d5: stloc.s 9
+		IL_03d7: ldloc.s 9
+		IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03de: volatile.
+		IL_03e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_03e5: brfalse IL_03ff
+
+		IL_03ea: ldstr "call"
+		IL_03ef: ldc.i4.1
+		IL_03f0: box [System.Runtime]System.Boolean
+		IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03fa: br IL_0419
+
+		IL_03ff: ldstr "call"
+		IL_0404: ldc.i4.1
+		IL_0405: box [System.Runtime]System.Boolean
+		IL_040a: ldstr "NewExpression_Boolean_Sugar:Modules.NewExpression_Boolean_Sugar:__js_module_init__:89"
+		IL_040f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0419: stloc.s 9
+		IL_041b: ldloc.s 6
+		IL_041d: ldloc.s 9
+		IL_041f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0424: pop
+		IL_0425: ret
 	} // end of method NewExpression_Boolean_Sugar::__js_module_init__
 
 } // end of class Modules.NewExpression_Boolean_Sugar
@@ -460,6 +486,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
@@ -1683,7 +1683,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 830 (0x33e)
+		// Code size: 1004 (0x3ec)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Constructor_Iterable/Scope,
@@ -1766,246 +1766,298 @@
 		IL_009e: pop
 		IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00a4: stloc.s 14
-		IL_00a6: ldloc.2
-		IL_00a7: ldstr "get"
-		IL_00ac: ldstr "alpha"
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b6: stloc.s 11
-		IL_00b8: ldloc.s 14
-		IL_00ba: ldloc.s 11
-		IL_00bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c1: pop
-		IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c7: stloc.s 14
-		IL_00c9: ldloc.2
-		IL_00ca: ldstr "get"
-		IL_00cf: ldstr "beta"
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d9: stloc.s 11
-		IL_00db: ldloc.s 14
-		IL_00dd: ldloc.s 11
-		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e4: pop
-		IL_00e5: ldloc.0
-		IL_00e6: ldc.i4.0
-		IL_00e7: box [System.Runtime]System.Boolean
-		IL_00ec: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_00f1: ldstr "iterator"
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_00fb: stloc.s 11
-		IL_00fd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0102: stloc.s 12
-		IL_0104: ldc.i4.1
-		IL_0105: newarr [System.Runtime]System.Object
-		IL_010a: dup
-		IL_010b: ldc.i4.0
-		IL_010c: ldloc.0
-		IL_010d: stelem.ref
-		IL_010e: stloc.s 13
-		IL_0110: ldloc.s 12
-		IL_0112: ldloc.s 11
-		IL_0114: ldloc.s 13
-		IL_0116: ldc.i4.0
-		IL_0117: ldelem.ref
-		IL_0118: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_011d: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope)
-		IL_0122: ldc.i4.0
-		IL_0123: conv.r8
-		IL_0124: ldstr ""
-		IL_0129: ldc.i4.0
-		IL_012a: ldc.i4.1
-		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0130: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0)
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_00a6: volatile.
+		IL_00a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_00ad: brfalse IL_00c7
+
+		IL_00b2: ldloc.2
+		IL_00b3: ldstr "get"
+		IL_00b8: ldstr "alpha"
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c2: br IL_00e1
+
+		IL_00c7: ldloc.2
+		IL_00c8: ldstr "get"
+		IL_00cd: ldstr "alpha"
+		IL_00d2: ldstr "Map_Constructor_Iterable:Modules.Map_Constructor_Iterable:__js_module_init__:22"
+		IL_00d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00e1: stloc.s 11
+		IL_00e3: ldloc.s 14
+		IL_00e5: ldloc.s 11
+		IL_00e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ec: pop
+		IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f2: stloc.s 14
+		IL_00f4: volatile.
+		IL_00f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_00fb: brfalse IL_0115
+
+		IL_0100: ldloc.2
+		IL_0101: ldstr "get"
+		IL_0106: ldstr "beta"
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0110: br IL_012f
+
+		IL_0115: ldloc.2
+		IL_0116: ldstr "get"
+		IL_011b: ldstr "beta"
+		IL_0120: ldstr "Map_Constructor_Iterable:Modules.Map_Constructor_Iterable:__js_module_init__:27"
+		IL_0125: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_012f: stloc.s 11
+		IL_0131: ldloc.s 14
+		IL_0133: ldloc.s 11
+		IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_013a: pop
-		IL_013b: ldloc.s 12
-		IL_013d: stloc.3
-		IL_013e: ldloc.3
-		IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_0144: stloc.s 4
-		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014b: stloc.s 14
-		IL_014d: ldloc.0
-		IL_014e: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0153: stloc.s 11
-		IL_0155: ldloc.s 14
-		IL_0157: ldloc.s 11
-		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015e: pop
-		IL_015f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0164: stloc.s 14
-		IL_0166: volatile.
-		IL_0168: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_016d: brfalse IL_0183
+		IL_013b: ldloc.0
+		IL_013c: ldc.i4.0
+		IL_013d: box [System.Runtime]System.Boolean
+		IL_0142: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_0147: ldstr "iterator"
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0151: stloc.s 11
+		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0158: stloc.s 12
+		IL_015a: ldc.i4.1
+		IL_015b: newarr [System.Runtime]System.Object
+		IL_0160: dup
+		IL_0161: ldc.i4.0
+		IL_0162: ldloc.0
+		IL_0163: stelem.ref
+		IL_0164: stloc.s 13
+		IL_0166: ldloc.s 12
+		IL_0168: ldloc.s 11
+		IL_016a: ldloc.s 13
+		IL_016c: ldc.i4.0
+		IL_016d: ldelem.ref
+		IL_016e: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_0173: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope)
+		IL_0178: ldc.i4.0
+		IL_0179: conv.r8
+		IL_017a: ldstr ""
+		IL_017f: ldc.i4.0
+		IL_0180: ldc.i4.1
+		IL_0181: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0186: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0)
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0190: pop
+		IL_0191: ldloc.s 12
+		IL_0193: stloc.3
+		IL_0194: ldloc.3
+		IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_019a: stloc.s 4
+		IL_019c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a1: stloc.s 14
+		IL_01a3: ldloc.0
+		IL_01a4: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_01a9: stloc.s 11
+		IL_01ab: ldloc.s 14
+		IL_01ad: ldloc.s 11
+		IL_01af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b4: pop
+		IL_01b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ba: stloc.s 14
+		IL_01bc: volatile.
+		IL_01be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_01c3: brfalse IL_01d9
 
-		IL_0172: ldloc.s 4
-		IL_0174: ldstr "size"
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017e: br IL_0199
+		IL_01c8: ldloc.s 4
+		IL_01ca: ldstr "size"
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d4: br IL_01ef
 
-		IL_0183: ldloc.s 4
-		IL_0185: ldstr "size"
-		IL_018a: ldstr "Map_Constructor_Iterable:Modules.Map_Constructor_Iterable:__js_module_init__:51"
-		IL_018f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01d9: ldloc.s 4
+		IL_01db: ldstr "size"
+		IL_01e0: ldstr "Map_Constructor_Iterable:Modules.Map_Constructor_Iterable:__js_module_init__:51"
+		IL_01e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0199: stloc.s 11
-		IL_019b: ldloc.s 14
-		IL_019d: ldloc.s 11
-		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a4: pop
-		IL_01a5: ldc.i4.1
-		IL_01a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01ab: dup
-		IL_01ac: ldc.i4.1
-		IL_01ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01b2: dup
-		IL_01b3: ldstr "short"
-		IL_01b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_01bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_01c2: stloc.s 15
-		IL_01c4: ldloc.s 15
-		IL_01c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-		IL_01cb: stloc.s 5
-		IL_01cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d2: stloc.s 14
-		IL_01d4: ldloc.s 5
-		IL_01d6: ldstr "has"
-		IL_01db: ldstr "short"
-		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e5: stloc.s 11
-		IL_01e7: ldloc.s 14
-		IL_01e9: ldloc.s 11
-		IL_01eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01f0: pop
-		IL_01f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f6: stloc.s 14
-		IL_01f8: ldloc.s 5
-		IL_01fa: ldstr "get"
-		IL_01ff: ldstr "short"
-		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0209: stloc.s 11
-		IL_020b: ldloc.s 11
-		IL_020d: ldnull
-		IL_020e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0213: stloc.s 16
-		IL_0215: ldloc.s 16
-		IL_0217: box [System.Runtime]System.Boolean
-		IL_021c: stloc.s 17
-		IL_021e: ldloc.s 14
-		IL_0220: ldloc.s 17
-		IL_0222: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0227: pop
-		IL_0228: ldloc.0
-		IL_0229: ldc.i4.0
-		IL_022a: box [System.Runtime]System.Boolean
-		IL_022f: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_0234: ldstr "iterator"
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_023e: stloc.s 11
-		IL_0240: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0245: stloc.s 12
-		IL_0247: ldc.i4.1
-		IL_0248: newarr [System.Runtime]System.Object
-		IL_024d: dup
-		IL_024e: ldc.i4.0
-		IL_024f: ldloc.0
-		IL_0250: stelem.ref
-		IL_0251: stloc.s 13
-		IL_0253: ldloc.s 12
-		IL_0255: ldloc.s 11
-		IL_0257: ldloc.s 13
-		IL_0259: ldc.i4.0
-		IL_025a: ldelem.ref
-		IL_025b: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_0260: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope)
-		IL_0265: ldc.i4.0
-		IL_0266: conv.r8
-		IL_0267: ldstr ""
-		IL_026c: ldc.i4.0
-		IL_026d: ldc.i4.1
-		IL_026e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0273: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject>(!!0)
-		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_027d: pop
-		IL_027e: ldloc.s 12
-		IL_0280: stloc.s 6
+		IL_01ef: stloc.s 11
+		IL_01f1: ldloc.s 14
+		IL_01f3: ldloc.s 11
+		IL_01f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01fa: pop
+		IL_01fb: ldc.i4.1
+		IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0201: dup
+		IL_0202: ldc.i4.1
+		IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0208: dup
+		IL_0209: ldstr "short"
+		IL_020e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0213: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0218: stloc.s 15
+		IL_021a: ldloc.s 15
+		IL_021c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+		IL_0221: stloc.s 5
+		IL_0223: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0228: stloc.s 14
+		IL_022a: volatile.
+		IL_022c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0231: brfalse IL_024c
+
+		IL_0236: ldloc.s 5
+		IL_0238: ldstr "has"
+		IL_023d: ldstr "short"
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0247: br IL_0267
+
+		IL_024c: ldloc.s 5
+		IL_024e: ldstr "has"
+		IL_0253: ldstr "short"
+		IL_0258: ldstr "Map_Constructor_Iterable:Modules.Map_Constructor_Iterable:__js_module_init__:62"
+		IL_025d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0267: stloc.s 11
+		IL_0269: ldloc.s 14
+		IL_026b: ldloc.s 11
+		IL_026d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0272: pop
+		IL_0273: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0278: stloc.s 14
+		IL_027a: volatile.
+		IL_027c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0281: brfalse IL_029c
+
+		IL_0286: ldloc.s 5
+		IL_0288: ldstr "get"
+		IL_028d: ldstr "short"
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0297: br IL_02b7
+
+		IL_029c: ldloc.s 5
+		IL_029e: ldstr "get"
+		IL_02a3: ldstr "short"
+		IL_02a8: ldstr "Map_Constructor_Iterable:Modules.Map_Constructor_Iterable:__js_module_init__:67"
+		IL_02ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02b7: stloc.s 11
+		IL_02b9: ldloc.s 11
+		IL_02bb: ldnull
+		IL_02bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02c1: stloc.s 16
+		IL_02c3: ldloc.s 16
+		IL_02c5: box [System.Runtime]System.Boolean
+		IL_02ca: stloc.s 17
+		IL_02cc: ldloc.s 14
+		IL_02ce: ldloc.s 17
+		IL_02d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d5: pop
+		IL_02d6: ldloc.0
+		IL_02d7: ldc.i4.0
+		IL_02d8: box [System.Runtime]System.Boolean
+		IL_02dd: stfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_02e2: ldstr "iterator"
+		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_02ec: stloc.s 11
+		IL_02ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02f3: stloc.s 12
+		IL_02f5: ldc.i4.1
+		IL_02f6: newarr [System.Runtime]System.Object
+		IL_02fb: dup
+		IL_02fc: ldc.i4.0
+		IL_02fd: ldloc.0
+		IL_02fe: stelem.ref
+		IL_02ff: stloc.s 13
+		IL_0301: ldloc.s 12
+		IL_0303: ldloc.s 11
+		IL_0305: ldloc.s 13
+		IL_0307: ldc.i4.0
+		IL_0308: ldelem.ref
+		IL_0309: castclass Modules.Map_Constructor_Iterable/Scope
+		IL_030e: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope)
+		IL_0313: ldc.i4.0
+		IL_0314: conv.r8
+		IL_0315: ldstr ""
+		IL_031a: ldc.i4.0
+		IL_031b: ldc.i4.1
+		IL_031c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0321: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject>(!!0)
+		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_032b: pop
+		IL_032c: ldloc.s 12
+		IL_032e: stloc.s 6
 		.try
 		{
-			IL_0282: nop
-			IL_0283: ldloc.s 6
-			IL_0285: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
-			IL_028a: pop
-			IL_028b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0290: stloc.s 14
-			IL_0292: ldloc.s 14
-			IL_0294: ldstr "no error"
-			IL_0299: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_029e: pop
-			IL_029f: leave IL_0321
+			IL_0330: nop
+			IL_0331: ldloc.s 6
+			IL_0333: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor(object)
+			IL_0338: pop
+			IL_0339: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_033e: stloc.s 14
+			IL_0340: ldloc.s 14
+			IL_0342: ldstr "no error"
+			IL_0347: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_034c: pop
+			IL_034d: leave IL_03cf
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02a4: stloc.s 7
-			IL_02a6: ldloc.s 7
-			IL_02a8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02ad: dup
-			IL_02ae: brtrue IL_02c4
+			IL_0352: stloc.s 7
+			IL_0354: ldloc.s 7
+			IL_0356: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_035b: dup
+			IL_035c: brtrue IL_0372
 
-			IL_02b3: pop
-			IL_02b4: ldloc.s 7
-			IL_02b6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02bb: dup
-			IL_02bc: brtrue IL_02d0
+			IL_0361: pop
+			IL_0362: ldloc.s 7
+			IL_0364: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0369: dup
+			IL_036a: brtrue IL_037e
 
-			IL_02c1: pop
-			IL_02c2: rethrow
+			IL_036f: pop
+			IL_0370: rethrow
 
-			IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02c9: stloc.s 8
-			IL_02cb: br IL_02d2
+			IL_0372: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0377: stloc.s 8
+			IL_0379: br IL_0380
 
-			IL_02d0: stloc.s 8
+			IL_037e: stloc.s 8
 
-			IL_02d2: ldloc.s 8
-			IL_02d4: stloc.s 9
-			IL_02d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02db: stloc.s 14
-			IL_02dd: volatile.
-			IL_02df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_02e4: brfalse IL_02fa
+			IL_0380: ldloc.s 8
+			IL_0382: stloc.s 9
+			IL_0384: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0389: stloc.s 14
+			IL_038b: volatile.
+			IL_038d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0392: brfalse IL_03a8
 
-			IL_02e9: ldloc.s 9
-			IL_02eb: ldstr "name"
-			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f5: br IL_0310
+			IL_0397: ldloc.s 9
+			IL_0399: ldstr "name"
+			IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a3: br IL_03be
 
-			IL_02fa: ldloc.s 9
-			IL_02fc: ldstr "name"
-			IL_0301: ldstr "Map_Constructor_Iterable:Modules.Map_Constructor_Iterable:__js_module_init__:103"
-			IL_0306: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03a8: ldloc.s 9
+			IL_03aa: ldstr "name"
+			IL_03af: ldstr "Map_Constructor_Iterable:Modules.Map_Constructor_Iterable:__js_module_init__:103"
+			IL_03b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0310: stloc.s 11
-			IL_0312: ldloc.s 14
-			IL_0314: ldloc.s 11
-			IL_0316: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_031b: pop
-			IL_031c: leave IL_0321
+			IL_03be: stloc.s 11
+			IL_03c0: ldloc.s 14
+			IL_03c2: ldloc.s 11
+			IL_03c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03c9: pop
+			IL_03ca: leave IL_03cf
 		} // end handler
 
-		IL_0321: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0326: stloc.s 14
-		IL_0328: ldloc.0
-		IL_0329: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
-		IL_032e: stloc.s 11
-		IL_0330: ldloc.s 14
-		IL_0332: ldloc.s 11
-		IL_0334: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0339: pop
-		IL_033a: ldnull
-		IL_033b: stloc.s 10
-		IL_033d: ret
+		IL_03cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03d4: stloc.s 14
+		IL_03d6: ldloc.0
+		IL_03d7: ldfld object Modules.Map_Constructor_Iterable/Scope::closedOnAbruptCompletion
+		IL_03dc: stloc.s 11
+		IL_03de: ldloc.s 14
+		IL_03e0: ldloc.s 11
+		IL_03e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03e7: pop
+		IL_03e8: ldnull
+		IL_03e9: stloc.s 10
+		IL_03eb: ret
 	} // end of method Map_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Iterable
@@ -2038,6 +2090,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
 	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Prototype_Surface.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Prototype_Surface.verified.txt
@@ -143,7 +143,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1998 (0x7ce)
+		// Code size: 2573 (0xa0d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Constructor_Prototype_Surface/Scope,
@@ -209,556 +209,737 @@
 		IL_00ab: ldloc.s 11
 		IL_00ad: box [System.Runtime]System.Boolean
 		IL_00b2: stloc.s 12
-		IL_00b4: ldloc.s 8
-		IL_00b6: ldstr "log"
-		IL_00bb: ldloc.s 12
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c2: pop
-		IL_00c3: ldstr "console"
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d2: stloc.s 8
-		IL_00d4: ldstr "Map"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00de: volatile.
-		IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00e5: brfalse IL_00f9
+		IL_00b4: volatile.
+		IL_00b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00bb: brfalse IL_00d3
 
-		IL_00ea: ldstr "prototype"
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f4: br IL_010d
+		IL_00c0: ldloc.s 8
+		IL_00c2: ldstr "log"
+		IL_00c7: ldloc.s 12
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ce: br IL_00eb
 
-		IL_00f9: ldstr "prototype"
-		IL_00fe: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:35"
-		IL_0103: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00d3: ldloc.s 8
+		IL_00d5: ldstr "log"
+		IL_00da: ldloc.s 12
+		IL_00dc: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:27"
+		IL_00e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_010d: stloc.s 10
-		IL_010f: volatile.
-		IL_0111: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0116: brfalse IL_012c
+		IL_00eb: pop
+		IL_00ec: ldstr "console"
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fb: stloc.s 8
+		IL_00fd: ldstr "Map"
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0107: volatile.
+		IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_010e: brfalse IL_0122
 
-		IL_011b: ldloc.s 10
-		IL_011d: ldstr "constructor"
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0127: br IL_0142
+		IL_0113: ldstr "prototype"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011d: br IL_0136
 
-		IL_012c: ldloc.s 10
-		IL_012e: ldstr "constructor"
-		IL_0133: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:37"
-		IL_0138: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0122: ldstr "prototype"
+		IL_0127: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:35"
+		IL_012c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0142: stloc.s 10
-		IL_0144: ldstr "Map"
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014e: stloc.s 9
-		IL_0150: ldloc.s 10
-		IL_0152: ldloc.s 9
-		IL_0154: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0159: stloc.s 11
-		IL_015b: ldloc.s 11
-		IL_015d: box [System.Runtime]System.Boolean
-		IL_0162: stloc.s 12
-		IL_0164: ldloc.s 8
-		IL_0166: ldstr "log"
-		IL_016b: ldloc.s 12
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0172: pop
-		IL_0173: ldstr "console"
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0182: stloc.s 8
-		IL_0184: ldstr "Map"
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018e: stloc.s 9
-		IL_0190: ldstr "Function"
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_019a: stloc.s 10
-		IL_019c: ldloc.s 9
-		IL_019e: ldloc.s 10
-		IL_01a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_01a5: stloc.s 11
-		IL_01a7: ldloc.s 11
-		IL_01a9: box [System.Runtime]System.Boolean
-		IL_01ae: stloc.s 12
-		IL_01b0: ldloc.s 8
-		IL_01b2: ldstr "log"
-		IL_01b7: ldloc.s 12
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01be: pop
-		IL_01bf: ldstr "console"
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ce: stloc.s 8
-		IL_01d0: ldstr "Map"
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_01df: stloc.s 10
-		IL_01e1: ldstr "Function"
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01eb: volatile.
-		IL_01ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_01f2: brfalse IL_0206
+		IL_0136: stloc.s 10
+		IL_0138: volatile.
+		IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_013f: brfalse IL_0155
 
-		IL_01f7: ldstr "prototype"
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0201: br IL_021a
+		IL_0144: ldloc.s 10
+		IL_0146: ldstr "constructor"
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0150: br IL_016b
 
-		IL_0206: ldstr "prototype"
-		IL_020b: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:64"
-		IL_0210: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0155: ldloc.s 10
+		IL_0157: ldstr "constructor"
+		IL_015c: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:37"
+		IL_0161: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_021a: stloc.s 9
-		IL_021c: ldloc.s 10
-		IL_021e: ldloc.s 9
-		IL_0220: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0225: stloc.s 11
-		IL_0227: ldloc.s 11
-		IL_0229: box [System.Runtime]System.Boolean
-		IL_022e: stloc.s 12
-		IL_0230: ldloc.s 8
-		IL_0232: ldstr "log"
-		IL_0237: ldloc.s 12
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023e: pop
-		IL_023f: ldstr "console"
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024e: stloc.s 8
-		IL_0250: ldstr "Map"
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_025a: volatile.
-		IL_025c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0261: brfalse IL_0275
+		IL_016b: stloc.s 10
+		IL_016d: ldstr "Map"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0177: stloc.s 9
+		IL_0179: ldloc.s 10
+		IL_017b: ldloc.s 9
+		IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0182: stloc.s 11
+		IL_0184: ldloc.s 11
+		IL_0186: box [System.Runtime]System.Boolean
+		IL_018b: stloc.s 12
+		IL_018d: volatile.
+		IL_018f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0194: brfalse IL_01ac
 
-		IL_0266: ldstr "prototype"
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0270: br IL_0289
+		IL_0199: ldloc.s 8
+		IL_019b: ldstr "log"
+		IL_01a0: ldloc.s 12
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a7: br IL_01c4
 
-		IL_0275: ldstr "prototype"
-		IL_027a: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:75"
-		IL_027f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01ac: ldloc.s 8
+		IL_01ae: ldstr "log"
+		IL_01b3: ldloc.s 12
+		IL_01b5: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:42"
+		IL_01ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0289: stloc.s 9
-		IL_028b: ldloc.s 9
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0292: stloc.s 9
-		IL_0294: ldstr "Object"
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_029e: volatile.
-		IL_02a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02a5: brfalse IL_02b9
+		IL_01c4: pop
+		IL_01c5: ldstr "console"
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d4: stloc.s 8
+		IL_01d6: ldstr "Map"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e0: stloc.s 9
+		IL_01e2: ldstr "Function"
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ec: stloc.s 10
+		IL_01ee: ldloc.s 9
+		IL_01f0: ldloc.s 10
+		IL_01f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_01f7: stloc.s 11
+		IL_01f9: ldloc.s 11
+		IL_01fb: box [System.Runtime]System.Boolean
+		IL_0200: stloc.s 12
+		IL_0202: volatile.
+		IL_0204: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0209: brfalse IL_0221
 
-		IL_02aa: ldstr "prototype"
-		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b4: br IL_02cd
+		IL_020e: ldloc.s 8
+		IL_0210: ldstr "log"
+		IL_0215: ldloc.s 12
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021c: br IL_0239
 
-		IL_02b9: ldstr "prototype"
-		IL_02be: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:80"
-		IL_02c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0221: ldloc.s 8
+		IL_0223: ldstr "log"
+		IL_0228: ldloc.s 12
+		IL_022a: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:53"
+		IL_022f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02cd: stloc.s 10
-		IL_02cf: ldloc.s 9
-		IL_02d1: ldloc.s 10
-		IL_02d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02d8: stloc.s 11
-		IL_02da: ldloc.s 11
-		IL_02dc: box [System.Runtime]System.Boolean
-		IL_02e1: stloc.s 12
-		IL_02e3: ldloc.s 8
-		IL_02e5: ldstr "log"
-		IL_02ea: ldloc.s 12
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f1: pop
-		IL_02f2: ldstr "Map"
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02fc: ldstr "prototype"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0306: stloc.1
-		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_030c: stloc.s 8
-		IL_030e: ldloc.s 8
-		IL_0310: ldstr "descriptor"
-		IL_0315: ldloc.1
-		IL_0316: ldc.i4.0
-		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_031c: pop
-		IL_031d: ldstr "console"
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_032c: stloc.s 8
-		IL_032e: volatile.
-		IL_0330: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0335: brfalse IL_034a
+		IL_0239: pop
+		IL_023a: ldstr "console"
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0249: stloc.s 8
+		IL_024b: ldstr "Map"
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_025a: stloc.s 10
+		IL_025c: ldstr "Function"
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0266: volatile.
+		IL_0268: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_026d: brfalse IL_0281
 
-		IL_033a: ldloc.1
-		IL_033b: ldstr "writable"
-		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0345: br IL_035f
+		IL_0272: ldstr "prototype"
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_027c: br IL_0295
 
-		IL_034a: ldloc.1
-		IL_034b: ldstr "writable"
-		IL_0350: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:99"
-		IL_0355: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0281: ldstr "prototype"
+		IL_0286: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:64"
+		IL_028b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_035f: stloc.s 10
-		IL_0361: ldloc.s 8
-		IL_0363: ldstr "log"
-		IL_0368: ldloc.s 10
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_036f: pop
-		IL_0370: ldstr "console"
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037f: stloc.s 10
-		IL_0381: volatile.
-		IL_0383: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0388: brfalse IL_039d
+		IL_0295: stloc.s 9
+		IL_0297: ldloc.s 10
+		IL_0299: ldloc.s 9
+		IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02a0: stloc.s 11
+		IL_02a2: ldloc.s 11
+		IL_02a4: box [System.Runtime]System.Boolean
+		IL_02a9: stloc.s 12
+		IL_02ab: volatile.
+		IL_02ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02b2: brfalse IL_02ca
 
-		IL_038d: ldloc.1
-		IL_038e: ldstr "enumerable"
-		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0398: br IL_03b2
+		IL_02b7: ldloc.s 8
+		IL_02b9: ldstr "log"
+		IL_02be: ldloc.s 12
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c5: br IL_02e2
 
-		IL_039d: ldloc.1
-		IL_039e: ldstr "enumerable"
-		IL_03a3: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:106"
-		IL_03a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02ca: ldloc.s 8
+		IL_02cc: ldstr "log"
+		IL_02d1: ldloc.s 12
+		IL_02d3: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:67"
+		IL_02d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03b2: stloc.s 8
-		IL_03b4: ldloc.s 10
-		IL_03b6: ldstr "log"
-		IL_03bb: ldloc.s 8
-		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03c2: pop
-		IL_03c3: ldstr "console"
-		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d2: stloc.s 8
-		IL_03d4: volatile.
-		IL_03d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_03db: brfalse IL_03f0
+		IL_02e2: pop
+		IL_02e3: ldstr "console"
+		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f2: stloc.s 8
+		IL_02f4: ldstr "Map"
+		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02fe: volatile.
+		IL_0300: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0305: brfalse IL_0319
 
-		IL_03e0: ldloc.1
-		IL_03e1: ldstr "configurable"
-		IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03eb: br IL_0405
+		IL_030a: ldstr "prototype"
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0314: br IL_032d
 
-		IL_03f0: ldloc.1
-		IL_03f1: ldstr "configurable"
-		IL_03f6: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:113"
-		IL_03fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0319: ldstr "prototype"
+		IL_031e: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:75"
+		IL_0323: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0405: stloc.s 10
-		IL_0407: ldloc.s 8
-		IL_0409: ldstr "log"
-		IL_040e: ldloc.s 10
-		IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0415: pop
-		IL_0416: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
-		IL_041b: stloc.2
-		IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0421: stloc.s 10
-		IL_0423: ldloc.s 10
-		IL_0425: ldstr "map"
-		IL_042a: ldloc.2
-		IL_042b: ldc.i4.0
-		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_0431: pop
-		IL_0432: ldstr "console"
-		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0441: stloc.s 10
-		IL_0443: ldloc.2
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0449: stloc.s 8
-		IL_044b: ldstr "Map"
-		IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0455: volatile.
-		IL_0457: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_045c: brfalse IL_0470
+		IL_032d: stloc.s 9
+		IL_032f: ldloc.s 9
+		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0336: stloc.s 9
+		IL_0338: ldstr "Object"
+		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0342: volatile.
+		IL_0344: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0349: brfalse IL_035d
 
-		IL_0461: ldstr "prototype"
-		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_046b: br IL_0484
+		IL_034e: ldstr "prototype"
+		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0358: br IL_0371
 
-		IL_0470: ldstr "prototype"
-		IL_0475: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:130"
-		IL_047a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_035d: ldstr "prototype"
+		IL_0362: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:80"
+		IL_0367: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0484: stloc.s 9
-		IL_0486: ldloc.s 8
-		IL_0488: ldloc.s 9
-		IL_048a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_048f: stloc.s 11
-		IL_0491: ldloc.s 11
-		IL_0493: box [System.Runtime]System.Boolean
-		IL_0498: stloc.s 12
-		IL_049a: ldloc.s 10
-		IL_049c: ldstr "log"
-		IL_04a1: ldloc.s 12
-		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04a8: pop
-		IL_04a9: ldstr "console"
-		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b8: stloc.s 10
-		IL_04ba: ldloc.2
-		IL_04bb: stloc.s 13
-		IL_04bd: ldstr "Map"
-		IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04c7: stloc.s 9
-		IL_04c9: ldloc.s 13
-		IL_04cb: ldloc.s 9
-		IL_04cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_04d2: stloc.s 11
-		IL_04d4: ldloc.s 11
-		IL_04d6: box [System.Runtime]System.Boolean
-		IL_04db: stloc.s 12
-		IL_04dd: ldloc.s 10
-		IL_04df: ldstr "log"
-		IL_04e4: ldloc.s 12
-		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04eb: pop
-		IL_04ec: ldstr "console"
-		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04fb: stloc.s 10
-		IL_04fd: volatile.
-		IL_04ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0504: brfalse IL_0519
+		IL_0371: stloc.s 10
+		IL_0373: ldloc.s 9
+		IL_0375: ldloc.s 10
+		IL_0377: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_037c: stloc.s 11
+		IL_037e: ldloc.s 11
+		IL_0380: box [System.Runtime]System.Boolean
+		IL_0385: stloc.s 12
+		IL_0387: volatile.
+		IL_0389: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_038e: brfalse IL_03a6
 
-		IL_0509: ldloc.2
-		IL_050a: ldstr "constructor"
-		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0514: br IL_052e
+		IL_0393: ldloc.s 8
+		IL_0395: ldstr "log"
+		IL_039a: ldloc.s 12
+		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a1: br IL_03be
 
-		IL_0519: ldloc.2
-		IL_051a: ldstr "constructor"
-		IL_051f: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:149"
-		IL_0524: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03a6: ldloc.s 8
+		IL_03a8: ldstr "log"
+		IL_03ad: ldloc.s 12
+		IL_03af: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:83"
+		IL_03b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_052e: stloc.s 9
-		IL_0530: ldstr "Map"
-		IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_053a: stloc.s 8
-		IL_053c: ldloc.s 9
-		IL_053e: ldloc.s 8
-		IL_0540: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0545: stloc.s 11
-		IL_0547: ldloc.s 11
-		IL_0549: box [System.Runtime]System.Boolean
-		IL_054e: stloc.s 12
-		IL_0550: ldloc.s 10
-		IL_0552: ldstr "log"
-		IL_0557: ldloc.s 12
-		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_055e: pop
-		IL_055f: ldstr "Map"
-		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0569: volatile.
-		IL_056b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0570: brfalse IL_0584
+		IL_03be: pop
+		IL_03bf: ldstr "Map"
+		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c9: ldstr "prototype"
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_03d3: stloc.1
+		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_03d9: stloc.s 8
+		IL_03db: ldloc.s 8
+		IL_03dd: ldstr "descriptor"
+		IL_03e2: ldloc.1
+		IL_03e3: ldc.i4.0
+		IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_03e9: pop
+		IL_03ea: ldstr "console"
+		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03f9: stloc.s 8
+		IL_03fb: volatile.
+		IL_03fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0402: brfalse IL_0417
 
-		IL_0575: ldstr "prototype"
-		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_057f: br IL_0598
+		IL_0407: ldloc.1
+		IL_0408: ldstr "writable"
+		IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0412: br IL_042c
 
-		IL_0584: ldstr "prototype"
-		IL_0589: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:159"
-		IL_058e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0417: ldloc.1
+		IL_0418: ldstr "writable"
+		IL_041d: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:99"
+		IL_0422: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0598: stloc.s 10
-		IL_059a: volatile.
-		IL_059c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_05a1: brfalse IL_05b7
+		IL_042c: stloc.s 10
+		IL_042e: volatile.
+		IL_0430: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0435: brfalse IL_044d
 
-		IL_05a6: ldloc.s 10
-		IL_05a8: ldstr "set"
-		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05b2: br IL_05cd
+		IL_043a: ldloc.s 8
+		IL_043c: ldstr "log"
+		IL_0441: ldloc.s 10
+		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0448: br IL_0465
 
-		IL_05b7: ldloc.s 10
-		IL_05b9: ldstr "set"
-		IL_05be: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:161"
-		IL_05c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_044d: ldloc.s 8
+		IL_044f: ldstr "log"
+		IL_0454: ldloc.s 10
+		IL_0456: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:100"
+		IL_045b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_05cd: stloc.s 10
-		IL_05cf: ldloc.s 10
-		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05d6: ldstr "call"
-		IL_05db: ldloc.2
-		IL_05dc: ldstr "answer"
-		IL_05e1: ldc.r8 42
-		IL_05ea: box [System.Runtime]System.Double
-		IL_05ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_05f4: pop
-		IL_05f5: ldstr "console"
-		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0604: stloc.s 10
-		IL_0606: ldstr "Map"
-		IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0610: volatile.
-		IL_0612: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0617: brfalse IL_062b
+		IL_0465: pop
+		IL_0466: ldstr "console"
+		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0475: stloc.s 10
+		IL_0477: volatile.
+		IL_0479: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_047e: brfalse IL_0493
 
-		IL_061c: ldstr "prototype"
-		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0626: br IL_063f
+		IL_0483: ldloc.1
+		IL_0484: ldstr "enumerable"
+		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_048e: br IL_04a8
 
-		IL_062b: ldstr "prototype"
-		IL_0630: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:174"
-		IL_0635: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_063a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0493: ldloc.1
+		IL_0494: ldstr "enumerable"
+		IL_0499: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:106"
+		IL_049e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_063f: stloc.s 8
-		IL_0641: volatile.
-		IL_0643: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0648: brfalse IL_065e
+		IL_04a8: stloc.s 8
+		IL_04aa: volatile.
+		IL_04ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04b1: brfalse IL_04c9
 
-		IL_064d: ldloc.s 8
-		IL_064f: ldstr "get"
-		IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0659: br IL_0674
+		IL_04b6: ldloc.s 10
+		IL_04b8: ldstr "log"
+		IL_04bd: ldloc.s 8
+		IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04c4: br IL_04e1
 
-		IL_065e: ldloc.s 8
-		IL_0660: ldstr "get"
-		IL_0665: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:176"
-		IL_066a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_066f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04c9: ldloc.s 10
+		IL_04cb: ldstr "log"
+		IL_04d0: ldloc.s 8
+		IL_04d2: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:107"
+		IL_04d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0674: stloc.s 8
-		IL_0676: ldloc.s 8
-		IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_067d: ldstr "call"
-		IL_0682: ldloc.2
-		IL_0683: ldstr "answer"
-		IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_068d: stloc.s 8
-		IL_068f: ldloc.s 10
-		IL_0691: ldstr "log"
-		IL_0696: ldloc.s 8
-		IL_0698: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_069d: pop
+		IL_04e1: pop
+		IL_04e2: ldstr "console"
+		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04f1: stloc.s 8
+		IL_04f3: volatile.
+		IL_04f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_04fa: brfalse IL_050f
+
+		IL_04ff: ldloc.1
+		IL_0500: ldstr "configurable"
+		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050a: br IL_0524
+
+		IL_050f: ldloc.1
+		IL_0510: ldstr "configurable"
+		IL_0515: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:113"
+		IL_051a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0524: stloc.s 10
+		IL_0526: volatile.
+		IL_0528: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_052d: brfalse IL_0545
+
+		IL_0532: ldloc.s 8
+		IL_0534: ldstr "log"
+		IL_0539: ldloc.s 10
+		IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0540: br IL_055d
+
+		IL_0545: ldloc.s 8
+		IL_0547: ldstr "log"
+		IL_054c: ldloc.s 10
+		IL_054e: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:114"
+		IL_0553: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_055d: pop
+		IL_055e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
+		IL_0563: stloc.2
+		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_0569: stloc.s 10
+		IL_056b: ldloc.s 10
+		IL_056d: ldstr "map"
+		IL_0572: ldloc.2
+		IL_0573: ldc.i4.0
+		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_0579: pop
+		IL_057a: ldstr "console"
+		IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0589: stloc.s 10
+		IL_058b: ldloc.2
+		IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0591: stloc.s 8
+		IL_0593: ldstr "Map"
+		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_059d: volatile.
+		IL_059f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05a4: brfalse IL_05b8
+
+		IL_05a9: ldstr "prototype"
+		IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05b3: br IL_05cc
+
+		IL_05b8: ldstr "prototype"
+		IL_05bd: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:130"
+		IL_05c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05cc: stloc.s 9
+		IL_05ce: ldloc.s 8
+		IL_05d0: ldloc.s 9
+		IL_05d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05d7: stloc.s 11
+		IL_05d9: ldloc.s 11
+		IL_05db: box [System.Runtime]System.Boolean
+		IL_05e0: stloc.s 12
+		IL_05e2: volatile.
+		IL_05e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_05e9: brfalse IL_0601
+
+		IL_05ee: ldloc.s 10
+		IL_05f0: ldstr "log"
+		IL_05f5: ldloc.s 12
+		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05fc: br IL_0619
+
+		IL_0601: ldloc.s 10
+		IL_0603: ldstr "log"
+		IL_0608: ldloc.s 12
+		IL_060a: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:133"
+		IL_060f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0619: pop
+		IL_061a: ldstr "console"
+		IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0624: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0629: stloc.s 10
+		IL_062b: ldloc.2
+		IL_062c: stloc.s 13
+		IL_062e: ldstr "Map"
+		IL_0633: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0638: stloc.s 9
+		IL_063a: ldloc.s 13
+		IL_063c: ldloc.s 9
+		IL_063e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0643: stloc.s 11
+		IL_0645: ldloc.s 11
+		IL_0647: box [System.Runtime]System.Boolean
+		IL_064c: stloc.s 12
+		IL_064e: volatile.
+		IL_0650: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0655: brfalse IL_066d
+
+		IL_065a: ldloc.s 10
+		IL_065c: ldstr "log"
+		IL_0661: ldloc.s 12
+		IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0668: br IL_0685
+
+		IL_066d: ldloc.s 10
+		IL_066f: ldstr "log"
+		IL_0674: ldloc.s 12
+		IL_0676: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:143"
+		IL_067b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0685: pop
+		IL_0686: ldstr "console"
+		IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0695: stloc.s 10
+		IL_0697: volatile.
+		IL_0699: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_069e: brfalse IL_06b3
+
+		IL_06a3: ldloc.2
+		IL_06a4: ldstr "constructor"
+		IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06ae: br IL_06c8
+
+		IL_06b3: ldloc.2
+		IL_06b4: ldstr "constructor"
+		IL_06b9: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:149"
+		IL_06be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06c8: stloc.s 9
+		IL_06ca: ldstr "Map"
+		IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06d4: stloc.s 8
+		IL_06d6: ldloc.s 9
+		IL_06d8: ldloc.s 8
+		IL_06da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06df: stloc.s 11
+		IL_06e1: ldloc.s 11
+		IL_06e3: box [System.Runtime]System.Boolean
+		IL_06e8: stloc.s 12
+		IL_06ea: volatile.
+		IL_06ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_06f1: brfalse IL_0709
+
+		IL_06f6: ldloc.s 10
+		IL_06f8: ldstr "log"
+		IL_06fd: ldloc.s 12
+		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0704: br IL_0721
+
+		IL_0709: ldloc.s 10
+		IL_070b: ldstr "log"
+		IL_0710: ldloc.s 12
+		IL_0712: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:154"
+		IL_0717: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_071c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0721: pop
+		IL_0722: ldstr "Map"
+		IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_072c: volatile.
+		IL_072e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0733: brfalse IL_0747
+
+		IL_0738: ldstr "prototype"
+		IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0742: br IL_075b
+
+		IL_0747: ldstr "prototype"
+		IL_074c: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:159"
+		IL_0751: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_075b: stloc.s 10
+		IL_075d: volatile.
+		IL_075f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0764: brfalse IL_077a
+
+		IL_0769: ldloc.s 10
+		IL_076b: ldstr "set"
+		IL_0770: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0775: br IL_0790
+
+		IL_077a: ldloc.s 10
+		IL_077c: ldstr "set"
+		IL_0781: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:161"
+		IL_0786: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_078b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0790: stloc.s 10
+		IL_0792: ldloc.s 10
+		IL_0794: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0799: ldstr "call"
+		IL_079e: ldloc.2
+		IL_079f: ldstr "answer"
+		IL_07a4: ldc.r8 42
+		IL_07ad: box [System.Runtime]System.Double
+		IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_07b7: pop
+		IL_07b8: ldstr "console"
+		IL_07bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07c7: stloc.s 10
+		IL_07c9: ldstr "Map"
+		IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07d3: volatile.
+		IL_07d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_07da: brfalse IL_07ee
+
+		IL_07df: ldstr "prototype"
+		IL_07e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07e9: br IL_0802
+
+		IL_07ee: ldstr "prototype"
+		IL_07f3: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:174"
+		IL_07f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_07fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0802: stloc.s 8
+		IL_0804: volatile.
+		IL_0806: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_080b: brfalse IL_0821
+
+		IL_0810: ldloc.s 8
+		IL_0812: ldstr "get"
+		IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_081c: br IL_0837
+
+		IL_0821: ldloc.s 8
+		IL_0823: ldstr "get"
+		IL_0828: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:176"
+		IL_082d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0837: stloc.s 8
+		IL_0839: ldloc.s 8
+		IL_083b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0840: ldstr "call"
+		IL_0845: ldloc.2
+		IL_0846: ldstr "answer"
+		IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0850: stloc.s 8
+		IL_0852: volatile.
+		IL_0854: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0859: brfalse IL_0871
+
+		IL_085e: ldloc.s 10
+		IL_0860: ldstr "log"
+		IL_0865: ldloc.s 8
+		IL_0867: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_086c: br IL_0889
+
+		IL_0871: ldloc.s 10
+		IL_0873: ldstr "log"
+		IL_0878: ldloc.s 8
+		IL_087a: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:180"
+		IL_087f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0884: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0889: pop
 		.try
 		{
-			IL_069e: nop
-			IL_069f: ldstr "Map"
-			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06a9: stloc.3
-			IL_06aa: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_06af: stloc.s 8
-			IL_06b1: ldloc.s 8
-			IL_06b3: ldstr "mapCtor"
-			IL_06b8: ldloc.3
-			IL_06b9: ldc.i4.0
-			IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-			IL_06bf: pop
-			IL_06c0: ldloc.3
-			IL_06c1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_06cb: pop
-			IL_06cc: ldstr "console"
-			IL_06d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06db: ldstr "log"
-			IL_06e0: ldstr "no-throw"
-			IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06ea: pop
-			IL_06eb: leave IL_07ca
+			IL_088a: nop
+			IL_088b: ldstr "Map"
+			IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0895: stloc.3
+			IL_0896: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+			IL_089b: stloc.s 8
+			IL_089d: ldloc.s 8
+			IL_089f: ldstr "mapCtor"
+			IL_08a4: ldloc.3
+			IL_08a5: ldc.i4.0
+			IL_08a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+			IL_08ab: pop
+			IL_08ac: ldloc.3
+			IL_08ad: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_08b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_08b7: pop
+			IL_08b8: ldstr "console"
+			IL_08bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08c7: volatile.
+			IL_08c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_08ce: brfalse IL_08e7
+
+			IL_08d3: ldstr "log"
+			IL_08d8: ldstr "no-throw"
+			IL_08dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_08e2: br IL_0900
+
+			IL_08e7: ldstr "log"
+			IL_08ec: ldstr "no-throw"
+			IL_08f1: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:200"
+			IL_08f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_08fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0900: pop
+			IL_0901: leave IL_0a09
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06f0: stloc.s 4
-			IL_06f2: ldloc.s 4
-			IL_06f4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_06f9: dup
-			IL_06fa: brtrue IL_0710
+			IL_0906: stloc.s 4
+			IL_0908: ldloc.s 4
+			IL_090a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_090f: dup
+			IL_0910: brtrue IL_0926
 
-			IL_06ff: pop
-			IL_0700: ldloc.s 4
-			IL_0702: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0707: dup
-			IL_0708: brtrue IL_071c
+			IL_0915: pop
+			IL_0916: ldloc.s 4
+			IL_0918: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_091d: dup
+			IL_091e: brtrue IL_0932
 
-			IL_070d: pop
-			IL_070e: rethrow
+			IL_0923: pop
+			IL_0924: rethrow
 
-			IL_0710: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0715: stloc.s 5
-			IL_0717: br IL_071e
+			IL_0926: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_092b: stloc.s 5
+			IL_092d: br IL_0934
 
-			IL_071c: stloc.s 5
+			IL_0932: stloc.s 5
 
-			IL_071e: ldloc.s 5
-			IL_0720: stloc.s 6
-			IL_0722: ldstr "console"
-			IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_072c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0731: stloc.s 8
-			IL_0733: volatile.
-			IL_0735: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_073a: brfalse IL_0750
+			IL_0934: ldloc.s 5
+			IL_0936: stloc.s 6
+			IL_0938: ldstr "console"
+			IL_093d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0942: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0947: stloc.s 8
+			IL_0949: volatile.
+			IL_094b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0950: brfalse IL_0966
 
-			IL_073f: ldloc.s 6
-			IL_0741: ldstr "name"
-			IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_074b: br IL_0766
+			IL_0955: ldloc.s 6
+			IL_0957: ldstr "name"
+			IL_095c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0961: br IL_097c
 
-			IL_0750: ldloc.s 6
-			IL_0752: ldstr "name"
-			IL_0757: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:213"
-			IL_075c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0966: ldloc.s 6
+			IL_0968: ldstr "name"
+			IL_096d: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:213"
+			IL_0972: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0977: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0766: stloc.s 10
-			IL_0768: ldloc.s 10
-			IL_076a: ldstr ": "
-			IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0774: stloc.s 14
-			IL_0776: volatile.
-			IL_0778: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_077d: brfalse IL_0793
+			IL_097c: stloc.s 10
+			IL_097e: ldloc.s 10
+			IL_0980: ldstr ": "
+			IL_0985: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_098a: stloc.s 14
+			IL_098c: volatile.
+			IL_098e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0993: brfalse IL_09a9
 
-			IL_0782: ldloc.s 6
-			IL_0784: ldstr "message"
-			IL_0789: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_078e: br IL_07a9
+			IL_0998: ldloc.s 6
+			IL_099a: ldstr "message"
+			IL_099f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09a4: br IL_09bf
 
-			IL_0793: ldloc.s 6
-			IL_0795: ldstr "message"
-			IL_079a: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:217"
-			IL_079f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_07a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_09a9: ldloc.s 6
+			IL_09ab: ldstr "message"
+			IL_09b0: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:217"
+			IL_09b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_09ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07a9: stloc.s 10
-			IL_07ab: ldloc.s 14
-			IL_07ad: ldloc.s 10
-			IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_07b4: stloc.s 14
-			IL_07b6: ldloc.s 8
-			IL_07b8: ldstr "log"
-			IL_07bd: ldloc.s 14
-			IL_07bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07c4: pop
-			IL_07c5: leave IL_07ca
+			IL_09bf: stloc.s 10
+			IL_09c1: ldloc.s 14
+			IL_09c3: ldloc.s 10
+			IL_09c5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09ca: stloc.s 14
+			IL_09cc: volatile.
+			IL_09ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_09d3: brfalse IL_09eb
+
+			IL_09d8: ldloc.s 8
+			IL_09da: ldstr "log"
+			IL_09df: ldloc.s 14
+			IL_09e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09e6: br IL_0a03
+
+			IL_09eb: ldloc.s 8
+			IL_09ed: ldstr "log"
+			IL_09f2: ldloc.s 14
+			IL_09f4: ldstr "Map_Constructor_Prototype_Surface:Modules.Map_Constructor_Prototype_Surface:__js_module_init__:219"
+			IL_09f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_09fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0a03: pop
+			IL_0a04: leave IL_0a09
 		} // end handler
 
-		IL_07ca: ldnull
-		IL_07cb: stloc.s 7
-		IL_07cd: ret
+		IL_0a09: ldnull
+		IL_0a0a: stloc.s 7
+		IL_0a0c: ret
 	} // end of method Map_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Prototype_Surface
@@ -805,6 +986,20 @@
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Delete_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Delete_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 129 (0x81)
+		// Code size: 258 (0x102)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Delete_Basic/Scope,
@@ -125,38 +125,77 @@
 		IL_0022: pop
 		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0028: stloc.2
-		IL_0029: ldloc.1
-		IL_002a: ldstr "delete"
-		IL_002f: ldstr "key1"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.2
-		IL_003b: ldloc.3
-		IL_003c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0041: pop
-		IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0047: stloc.2
-		IL_0048: ldloc.1
-		IL_0049: ldstr "has"
-		IL_004e: ldstr "key1"
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0058: stloc.3
-		IL_0059: ldloc.2
-		IL_005a: ldloc.3
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0060: pop
-		IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0066: stloc.2
-		IL_0067: ldloc.1
-		IL_0068: ldstr "delete"
-		IL_006d: ldstr "key2"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldloc.3
-		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007f: pop
-		IL_0080: ret
+		IL_0029: volatile.
+		IL_002b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0030: brfalse IL_004a
+
+		IL_0035: ldloc.1
+		IL_0036: ldstr "delete"
+		IL_003b: ldstr "key1"
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0045: br IL_0064
+
+		IL_004a: ldloc.1
+		IL_004b: ldstr "delete"
+		IL_0050: ldstr "key1"
+		IL_0055: ldstr "Map_Delete_Basic:Modules.Map_Delete_Basic:__js_module_init__:13"
+		IL_005a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0064: stloc.3
+		IL_0065: ldloc.2
+		IL_0066: ldloc.3
+		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006c: pop
+		IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0072: stloc.2
+		IL_0073: volatile.
+		IL_0075: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007a: brfalse IL_0094
+
+		IL_007f: ldloc.1
+		IL_0080: ldstr "has"
+		IL_0085: ldstr "key1"
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008f: br IL_00ae
+
+		IL_0094: ldloc.1
+		IL_0095: ldstr "has"
+		IL_009a: ldstr "key1"
+		IL_009f: ldstr "Map_Delete_Basic:Modules.Map_Delete_Basic:__js_module_init__:18"
+		IL_00a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ae: stloc.3
+		IL_00af: ldloc.2
+		IL_00b0: ldloc.3
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b6: pop
+		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bc: stloc.2
+		IL_00bd: volatile.
+		IL_00bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00c4: brfalse IL_00de
+
+		IL_00c9: ldloc.1
+		IL_00ca: ldstr "delete"
+		IL_00cf: ldstr "key2"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d9: br IL_00f8
+
+		IL_00de: ldloc.1
+		IL_00df: ldstr "delete"
+		IL_00e4: ldstr "key2"
+		IL_00e9: ldstr "Map_Delete_Basic:Modules.Map_Delete_Basic:__js_module_init__:23"
+		IL_00ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f8: stloc.3
+		IL_00f9: ldloc.2
+		IL_00fa: ldloc.3
+		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0100: pop
+		IL_0101: ret
 	} // end of method Map_Delete_Basic::__js_module_init__
 
 } // end of class Modules.Map_Delete_Basic
@@ -181,4 +220,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Has_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Has_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 98 (0x62)
+		// Code size: 184 (0xb8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Has_Basic/Scope,
@@ -125,27 +125,53 @@
 		IL_0022: pop
 		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0028: stloc.2
-		IL_0029: ldloc.1
-		IL_002a: ldstr "has"
-		IL_002f: ldstr "key1"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.2
-		IL_003b: ldloc.3
-		IL_003c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0041: pop
-		IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0047: stloc.2
-		IL_0048: ldloc.1
-		IL_0049: ldstr "has"
-		IL_004e: ldstr "key2"
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0058: stloc.3
-		IL_0059: ldloc.2
-		IL_005a: ldloc.3
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0060: pop
-		IL_0061: ret
+		IL_0029: volatile.
+		IL_002b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0030: brfalse IL_004a
+
+		IL_0035: ldloc.1
+		IL_0036: ldstr "has"
+		IL_003b: ldstr "key1"
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0045: br IL_0064
+
+		IL_004a: ldloc.1
+		IL_004b: ldstr "has"
+		IL_0050: ldstr "key1"
+		IL_0055: ldstr "Map_Has_Basic:Modules.Map_Has_Basic:__js_module_init__:13"
+		IL_005a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0064: stloc.3
+		IL_0065: ldloc.2
+		IL_0066: ldloc.3
+		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006c: pop
+		IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0072: stloc.2
+		IL_0073: volatile.
+		IL_0075: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007a: brfalse IL_0094
+
+		IL_007f: ldloc.1
+		IL_0080: ldstr "has"
+		IL_0085: ldstr "key2"
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008f: br IL_00ae
+
+		IL_0094: ldloc.1
+		IL_0095: ldstr "has"
+		IL_009a: ldstr "key2"
+		IL_009f: ldstr "Map_Has_Basic:Modules.Map_Has_Basic:__js_module_init__:18"
+		IL_00a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ae: stloc.3
+		IL_00af: ldloc.2
+		IL_00b0: ldloc.3
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b6: pop
+		IL_00b7: ret
 	} // end of method Map_Has_Basic::__js_module_init__
 
 } // end of class Modules.Map_Has_Basic
@@ -170,4 +196,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Multiple_Keys.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Multiple_Keys.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 237 (0xed)
+		// Code size: 366 (0x16e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Multiple_Keys/Scope,
@@ -159,38 +159,77 @@
 		IL_008e: pop
 		IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0094: stloc.2
-		IL_0095: ldloc.1
-		IL_0096: ldstr "get"
-		IL_009b: ldstr "key1"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a5: stloc.3
-		IL_00a6: ldloc.2
-		IL_00a7: ldloc.3
-		IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ad: pop
-		IL_00ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b3: stloc.2
-		IL_00b4: ldloc.1
-		IL_00b5: ldstr "get"
-		IL_00ba: ldstr "key2"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c4: stloc.3
-		IL_00c5: ldloc.2
-		IL_00c6: ldloc.3
-		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cc: pop
-		IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d2: stloc.2
-		IL_00d3: ldloc.1
-		IL_00d4: ldstr "get"
-		IL_00d9: ldstr "key3"
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e3: stloc.3
-		IL_00e4: ldloc.2
-		IL_00e5: ldloc.3
-		IL_00e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00eb: pop
-		IL_00ec: ret
+		IL_0095: volatile.
+		IL_0097: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_009c: brfalse IL_00b6
+
+		IL_00a1: ldloc.1
+		IL_00a2: ldstr "get"
+		IL_00a7: ldstr "key1"
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b1: br IL_00d0
+
+		IL_00b6: ldloc.1
+		IL_00b7: ldstr "get"
+		IL_00bc: ldstr "key1"
+		IL_00c1: ldstr "Map_Multiple_Keys:Modules.Map_Multiple_Keys:__js_module_init__:26"
+		IL_00c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d0: stloc.3
+		IL_00d1: ldloc.2
+		IL_00d2: ldloc.3
+		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d8: pop
+		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00de: stloc.2
+		IL_00df: volatile.
+		IL_00e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00e6: brfalse IL_0100
+
+		IL_00eb: ldloc.1
+		IL_00ec: ldstr "get"
+		IL_00f1: ldstr "key2"
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fb: br IL_011a
+
+		IL_0100: ldloc.1
+		IL_0101: ldstr "get"
+		IL_0106: ldstr "key2"
+		IL_010b: ldstr "Map_Multiple_Keys:Modules.Map_Multiple_Keys:__js_module_init__:31"
+		IL_0110: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_011a: stloc.3
+		IL_011b: ldloc.2
+		IL_011c: ldloc.3
+		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0122: pop
+		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0128: stloc.2
+		IL_0129: volatile.
+		IL_012b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0130: brfalse IL_014a
+
+		IL_0135: ldloc.1
+		IL_0136: ldstr "get"
+		IL_013b: ldstr "key3"
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0145: br IL_0164
+
+		IL_014a: ldloc.1
+		IL_014b: ldstr "get"
+		IL_0150: ldstr "key3"
+		IL_0155: ldstr "Map_Multiple_Keys:Modules.Map_Multiple_Keys:__js_module_init__:36"
+		IL_015a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0164: stloc.3
+		IL_0165: ldloc.2
+		IL_0166: ldloc.3
+		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_016c: pop
+		IL_016d: ret
 	} // end of method Map_Multiple_Keys::__js_module_init__
 
 } // end of class Modules.Map_Multiple_Keys
@@ -221,6 +260,9 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Null_Key.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Null_Key.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 101 (0x65)
+		// Code size: 189 (0xbd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Null_Key/Scope,
@@ -126,29 +126,57 @@
 		IL_0023: pop
 		IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0029: stloc.2
-		IL_002a: ldloc.1
-		IL_002b: ldstr "has"
-		IL_0030: ldc.i4.0
-		IL_0031: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_003b: stloc.3
-		IL_003c: ldloc.2
-		IL_003d: ldloc.3
-		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0043: pop
-		IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0049: stloc.2
-		IL_004a: ldloc.1
-		IL_004b: ldstr "get"
-		IL_0050: ldc.i4.0
-		IL_0051: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005b: stloc.3
-		IL_005c: ldloc.2
-		IL_005d: ldloc.3
-		IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0063: pop
-		IL_0064: ret
+		IL_002a: volatile.
+		IL_002c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0031: brfalse IL_004c
+
+		IL_0036: ldloc.1
+		IL_0037: ldstr "has"
+		IL_003c: ldc.i4.0
+		IL_003d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0047: br IL_0067
+
+		IL_004c: ldloc.1
+		IL_004d: ldstr "has"
+		IL_0052: ldc.i4.0
+		IL_0053: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0058: ldstr "Map_Null_Key:Modules.Map_Null_Key:__js_module_init__:15"
+		IL_005d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0067: stloc.3
+		IL_0068: ldloc.2
+		IL_0069: ldloc.3
+		IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006f: pop
+		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0075: stloc.2
+		IL_0076: volatile.
+		IL_0078: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007d: brfalse IL_0098
+
+		IL_0082: ldloc.1
+		IL_0083: ldstr "get"
+		IL_0088: ldc.i4.0
+		IL_0089: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0093: br IL_00b3
+
+		IL_0098: ldloc.1
+		IL_0099: ldstr "get"
+		IL_009e: ldc.i4.0
+		IL_009f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00a4: ldstr "Map_Null_Key:Modules.Map_Null_Key:__js_module_init__:21"
+		IL_00a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00b3: stloc.3
+		IL_00b4: ldloc.2
+		IL_00b5: ldloc.3
+		IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00bb: pop
+		IL_00bc: ret
 	} // end of method Map_Null_Key::__js_module_init__
 
 } // end of class Modules.Map_Null_Key
@@ -173,4 +201,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Get_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Set_Get_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 67 (0x43)
+		// Code size: 110 (0x6e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Set_Get_Basic/Scope,
@@ -125,16 +125,29 @@
 		IL_0022: pop
 		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0028: stloc.2
-		IL_0029: ldloc.1
-		IL_002a: ldstr "get"
-		IL_002f: ldstr "key1"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.2
-		IL_003b: ldloc.3
-		IL_003c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0041: pop
-		IL_0042: ret
+		IL_0029: volatile.
+		IL_002b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0030: brfalse IL_004a
+
+		IL_0035: ldloc.1
+		IL_0036: ldstr "get"
+		IL_003b: ldstr "key1"
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0045: br IL_0064
+
+		IL_004a: ldloc.1
+		IL_004b: ldstr "get"
+		IL_0050: ldstr "key1"
+		IL_0055: ldstr "Map_Set_Get_Basic:Modules.Map_Set_Get_Basic:__js_module_init__:13"
+		IL_005a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0064: stloc.3
+		IL_0065: ldloc.2
+		IL_0066: ldloc.3
+		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006c: pop
+		IL_006d: ret
 	} // end of method Map_Set_Get_Basic::__js_module_init__
 
 } // end of class Modules.Map_Set_Get_Basic
@@ -159,4 +172,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Update_Existing_Key.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Update_Existing_Key.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 184 (0xb8)
+		// Code size: 270 (0x10e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Map_Update_Existing_Key/Scope,
@@ -125,55 +125,81 @@
 		IL_0022: pop
 		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0028: stloc.2
-		IL_0029: ldloc.1
-		IL_002a: ldstr "get"
-		IL_002f: ldstr "key1"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.2
-		IL_003b: ldloc.3
-		IL_003c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0041: pop
-		IL_0042: ldloc.1
-		IL_0043: ldstr "set"
-		IL_0048: ldstr "key1"
-		IL_004d: ldstr "value2"
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0057: pop
-		IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005d: stloc.2
-		IL_005e: ldloc.1
-		IL_005f: ldstr "get"
-		IL_0064: ldstr "key1"
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006e: stloc.3
-		IL_006f: ldloc.2
-		IL_0070: ldloc.3
-		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0076: pop
-		IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007c: stloc.2
-		IL_007d: volatile.
-		IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0084: brfalse IL_0099
+		IL_0029: volatile.
+		IL_002b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0030: brfalse IL_004a
 
-		IL_0089: ldloc.1
-		IL_008a: ldstr "size"
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0094: br IL_00ae
+		IL_0035: ldloc.1
+		IL_0036: ldstr "get"
+		IL_003b: ldstr "key1"
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0045: br IL_0064
 
-		IL_0099: ldloc.1
-		IL_009a: ldstr "size"
-		IL_009f: ldstr "Map_Update_Existing_Key:Modules.Map_Update_Existing_Key:__js_module_init__:27"
-		IL_00a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_004a: ldloc.1
+		IL_004b: ldstr "get"
+		IL_0050: ldstr "key1"
+		IL_0055: ldstr "Map_Update_Existing_Key:Modules.Map_Update_Existing_Key:__js_module_init__:13"
+		IL_005a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00ae: stloc.3
-		IL_00af: ldloc.2
-		IL_00b0: ldloc.3
-		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b6: pop
-		IL_00b7: ret
+		IL_0064: stloc.3
+		IL_0065: ldloc.2
+		IL_0066: ldloc.3
+		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006c: pop
+		IL_006d: ldloc.1
+		IL_006e: ldstr "set"
+		IL_0073: ldstr "key1"
+		IL_0078: ldstr "value2"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0082: pop
+		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0088: stloc.2
+		IL_0089: volatile.
+		IL_008b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0090: brfalse IL_00aa
+
+		IL_0095: ldloc.1
+		IL_0096: ldstr "get"
+		IL_009b: ldstr "key1"
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a5: br IL_00c4
+
+		IL_00aa: ldloc.1
+		IL_00ab: ldstr "get"
+		IL_00b0: ldstr "key1"
+		IL_00b5: ldstr "Map_Update_Existing_Key:Modules.Map_Update_Existing_Key:__js_module_init__:22"
+		IL_00ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00c4: stloc.3
+		IL_00c5: ldloc.2
+		IL_00c6: ldloc.3
+		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00cc: pop
+		IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d2: stloc.2
+		IL_00d3: volatile.
+		IL_00d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00da: brfalse IL_00ef
+
+		IL_00df: ldloc.1
+		IL_00e0: ldstr "size"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ea: br IL_0104
+
+		IL_00ef: ldloc.1
+		IL_00f0: ldstr "size"
+		IL_00f5: ldstr "Map_Update_Existing_Key:Modules.Map_Update_Existing_Key:__js_module_init__:27"
+		IL_00fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0104: stloc.3
+		IL_0105: ldloc.2
+		IL_0106: ldloc.3
+		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010c: pop
+		IL_010d: ret
 	} // end of method Map_Update_Existing_Key::__js_module_init__
 
 } // end of class Modules.Map_Update_Existing_Key
@@ -204,6 +230,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_AliasReplacement_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_AliasReplacement_Dispatch.verified.txt
@@ -251,7 +251,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 135 (0x87)
+		// Code size: 174 (0xae)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_AliasReplacement_Dispatch/Scope,
@@ -302,15 +302,27 @@
 		IL_0065: ldloc.s 5
 		IL_0067: box [System.Runtime]System.Double
 		IL_006c: stloc.s 6
-		IL_006e: ldstr "abs"
-		IL_0073: ldloc.s 6
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007a: stloc.s 7
-		IL_007c: ldloc.s 4
-		IL_007e: ldloc.s 7
-		IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0085: pop
-		IL_0086: ret
+		IL_006e: volatile.
+		IL_0070: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0075: brfalse IL_008b
+
+		IL_007a: ldstr "abs"
+		IL_007f: ldloc.s 6
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0086: br IL_00a1
+
+		IL_008b: ldstr "abs"
+		IL_0090: ldloc.s 6
+		IL_0092: ldstr "Math_AliasReplacement_Dispatch:Modules.Math_AliasReplacement_Dispatch:__js_module_init__:18"
+		IL_0097: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a1: stloc.s 7
+		IL_00a3: ldloc.s 4
+		IL_00a5: ldloc.s 7
+		IL_00a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ac: pop
+		IL_00ad: ret
 	} // end of method Math_AliasReplacement_Dispatch::__js_module_init__
 
 } // end of class Modules.Math_AliasReplacement_Dispatch
@@ -335,4 +347,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_DefinePropertyReplacement_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_DefinePropertyReplacement_Dispatch.verified.txt
@@ -251,7 +251,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 167 (0xa7)
+		// Code size: 218 (0xda)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_DefinePropertyReplacement_Dispatch/Scope,
@@ -307,16 +307,29 @@
 		IL_0075: ldstr "Math"
 		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0084: ldstr "sqrt"
-		IL_0089: ldc.r8 9
-		IL_0092: box [System.Runtime]System.Double
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009c: stloc.1
-		IL_009d: ldloc.s 5
-		IL_009f: ldloc.1
-		IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a5: pop
-		IL_00a6: ret
+		IL_0084: volatile.
+		IL_0086: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_008b: brfalse IL_00ad
+
+		IL_0090: ldstr "sqrt"
+		IL_0095: ldc.r8 9
+		IL_009e: box [System.Runtime]System.Double
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a8: br IL_00cf
+
+		IL_00ad: ldstr "sqrt"
+		IL_00b2: ldc.r8 9
+		IL_00bb: box [System.Runtime]System.Double
+		IL_00c0: ldstr "Math_DefinePropertyReplacement_Dispatch:Modules.Math_DefinePropertyReplacement_Dispatch:__js_module_init__:18"
+		IL_00c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00cf: stloc.1
+		IL_00d0: ldloc.s 5
+		IL_00d2: ldloc.1
+		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d8: pop
+		IL_00d9: ret
 	} // end of method Math_DefinePropertyReplacement_Dispatch::__js_module_init__
 
 } // end of class Modules.Math_DefinePropertyReplacement_Dispatch
@@ -341,4 +354,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_GlobalThisReplacement_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_GlobalThisReplacement_Dispatch.verified.txt
@@ -251,7 +251,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 216 (0xd8)
+		// Code size: 307 (0x133)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_GlobalThisReplacement_Dispatch/Scope,
@@ -314,17 +314,43 @@
 		IL_00a0: ldstr "Math"
 		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00af: ldstr "round"
-		IL_00b4: ldc.r8 1.2
-		IL_00bd: box [System.Runtime]System.Double
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c7: stloc.s 4
-		IL_00c9: ldloc.1
-		IL_00ca: ldstr "log"
-		IL_00cf: ldloc.s 4
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d6: pop
-		IL_00d7: ret
+		IL_00af: volatile.
+		IL_00b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00b6: brfalse IL_00d8
+
+		IL_00bb: ldstr "round"
+		IL_00c0: ldc.r8 1.2
+		IL_00c9: box [System.Runtime]System.Double
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d3: br IL_00fa
+
+		IL_00d8: ldstr "round"
+		IL_00dd: ldc.r8 1.2
+		IL_00e6: box [System.Runtime]System.Double
+		IL_00eb: ldstr "Math_GlobalThisReplacement_Dispatch:Modules.Math_GlobalThisReplacement_Dispatch:__js_module_init__:25"
+		IL_00f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00fa: stloc.s 4
+		IL_00fc: volatile.
+		IL_00fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0103: brfalse IL_011a
+
+		IL_0108: ldloc.1
+		IL_0109: ldstr "log"
+		IL_010e: ldloc.s 4
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0115: br IL_0131
+
+		IL_011a: ldloc.1
+		IL_011b: ldstr "log"
+		IL_0120: ldloc.s 4
+		IL_0122: ldstr "Math_GlobalThisReplacement_Dispatch:Modules.Math_GlobalThisReplacement_Dispatch:__js_module_init__:26"
+		IL_0127: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0131: pop
+		IL_0132: ret
 	} // end of method Math_GlobalThisReplacement_Dispatch::__js_module_init__
 
 } // end of class Modules.Math_GlobalThisReplacement_Dispatch
@@ -355,6 +381,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -456,7 +456,7 @@
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 516 (0x204)
+			// Code size: 558 (0x22e)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -497,7 +497,7 @@
 			IL_0033: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 			IL_0038: stloc.1
 			IL_0039: volatile.
-			IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0040: brfalse IL_0055
 
 			IL_0045: ldarg.2
@@ -508,12 +508,12 @@
 			IL_0055: ldarg.2
 			IL_0056: ldstr "verbose"
 			IL_005b: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:<TwoPhaseDummy_M5>:__js_call__:14"
-			IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_006a: stloc.2
 			IL_006b: volatile.
-			IL_006d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_006d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_0072: brfalse IL_0087
 
 			IL_0077: ldarg.2
@@ -524,7 +524,7 @@
 			IL_0087: ldarg.2
 			IL_0088: ldstr "runtime"
 			IL_008d: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:<TwoPhaseDummy_M5>:__js_call__:16"
-			IL_0092: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0092: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_009c: stloc.3
@@ -611,7 +611,7 @@
 			IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve>(!!0)
 			IL_0197: stloc.s 9
 			IL_0199: volatile.
-			IL_019b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_019b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_01a0: brfalse IL_01b6
 
 			IL_01a5: ldloc.s 4
@@ -622,7 +622,7 @@
 			IL_01b6: ldloc.s 4
 			IL_01b8: ldstr "sieveSizeInBits"
 			IL_01bd: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:<TwoPhaseDummy_M5>:__js_call__:49"
-			IL_01c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_01c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01cc: stloc.s 14
@@ -634,16 +634,28 @@
 			IL_01de: stloc.s 11
 			IL_01e0: ldloc.s 6
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e7: ldstr "join"
-			IL_01ec: ldstr ","
-			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01f6: stloc.s 14
-			IL_01f8: ldloc.s 11
-			IL_01fa: ldloc.s 14
-			IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0201: pop
-			IL_0202: ldnull
-			IL_0203: ret
+			IL_01e7: volatile.
+			IL_01e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_01ee: brfalse IL_0207
+
+			IL_01f3: ldstr "join"
+			IL_01f8: ldstr ","
+			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0202: br IL_0220
+
+			IL_0207: ldstr "join"
+			IL_020c: ldstr ","
+			IL_0211: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:<TwoPhaseDummy_M5>:__js_call__:56"
+			IL_0216: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0220: stloc.s 14
+			IL_0222: ldloc.s 11
+			IL_0224: ldloc.s 14
+			IL_0226: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_022b: pop
+			IL_022c: ldnull
+			IL_022d: ret
 		} // end of method ArrowFunction_L232C14::__js_call__
 
 	} // end of class ArrowFunction_L232C14
@@ -3192,7 +3204,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1159 (0x487)
+		// Code size: 1200 (0x4b0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -3276,330 +3288,343 @@
 		IL_00da: ldstr ""
 		IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_00e4: stloc.s 6
-		IL_00e6: ldloc.s 5
-		IL_00e8: ldstr "split"
-		IL_00ed: ldloc.s 6
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f4: stloc.2
-		IL_00f5: volatile.
-		IL_00f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_00fc: brfalse IL_0111
+		IL_00e6: volatile.
+		IL_00e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_00ed: brfalse IL_0105
 
-		IL_0101: ldloc.2
-		IL_0102: ldstr "length"
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010c: br IL_0126
+		IL_00f2: ldloc.s 5
+		IL_00f4: ldstr "split"
+		IL_00f9: ldloc.s 6
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0100: br IL_011d
 
-		IL_0111: ldloc.2
-		IL_0112: ldstr "length"
-		IL_0117: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:__js_module_init__:42"
-		IL_011c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0105: ldloc.s 5
+		IL_0107: ldstr "split"
+		IL_010c: ldloc.s 6
+		IL_010e: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:__js_module_init__:38"
+		IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0126: stloc.s 5
-		IL_0128: ldloc.s 5
-		IL_012a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_012f: ldc.r8 1
-		IL_0138: sub
-		IL_0139: stloc.s 7
-		IL_013b: ldloc.2
-		IL_013c: ldloc.s 7
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0143: stloc.s 5
-		IL_0145: ldloc.1
-		IL_0146: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_014b: ldloc.s 5
-		IL_014d: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
-		IL_0152: ldstr "process"
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_015c: volatile.
-		IL_015e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0163: brfalse IL_0177
+		IL_011d: stloc.2
+		IL_011e: volatile.
+		IL_0120: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0125: brfalse IL_013a
 
-		IL_0168: ldstr "argv"
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0172: br IL_018b
+		IL_012a: ldloc.2
+		IL_012b: ldstr "length"
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0135: br IL_014f
 
-		IL_0177: ldstr "argv"
-		IL_017c: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:__js_module_init__:52"
-		IL_0181: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_013a: ldloc.2
+		IL_013b: ldstr "length"
+		IL_0140: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:__js_module_init__:42"
+		IL_0145: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_018b: stloc.s 5
-		IL_018d: ldloc.s 5
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0194: stloc.s 5
-		IL_0196: ldc.i4.0
-		IL_0197: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_019c: brfalse IL_01d8
+		IL_014f: stloc.s 5
+		IL_0151: ldloc.s 5
+		IL_0153: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0158: ldc.r8 1
+		IL_0161: sub
+		IL_0162: stloc.s 7
+		IL_0164: ldloc.2
+		IL_0165: ldloc.s 7
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_016c: stloc.s 5
+		IL_016e: ldloc.1
+		IL_016f: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_0174: ldloc.s 5
+		IL_0176: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_runtime(object)
+		IL_017b: ldstr "process"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0185: volatile.
+		IL_0187: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_018c: brfalse IL_01a0
 
-		IL_01a1: ldloc.s 5
-		IL_01a3: isinst [System.Runtime]System.String
-		IL_01a8: dup
-		IL_01a9: brtrue IL_01c1
+		IL_0191: ldstr "argv"
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019b: br IL_01b4
 
-		IL_01ae: pop
-		IL_01af: ldloc.s 5
-		IL_01b1: ldstr "includes"
-		IL_01b6: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_01bb: dup
-		IL_01bc: brfalse IL_01d7
+		IL_01a0: ldstr "argv"
+		IL_01a5: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:__js_module_init__:52"
+		IL_01aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01c1: ldstr "verbose"
-		IL_01c6: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_01cb: box [System.Runtime]System.Boolean
-		IL_01d0: stloc.s 5
-		IL_01d2: br IL_01eb
+		IL_01b4: stloc.s 5
+		IL_01b6: ldloc.s 5
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bd: stloc.s 5
+		IL_01bf: ldc.i4.0
+		IL_01c0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01c5: brfalse IL_0201
+
+		IL_01ca: ldloc.s 5
+		IL_01cc: isinst [System.Runtime]System.String
+		IL_01d1: dup
+		IL_01d2: brtrue IL_01ea
 
 		IL_01d7: pop
-
 		IL_01d8: ldloc.s 5
 		IL_01da: ldstr "includes"
-		IL_01df: ldstr "verbose"
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e9: stloc.s 5
+		IL_01df: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_01e4: dup
+		IL_01e5: brfalse IL_0200
 
-		IL_01eb: ldloc.1
-		IL_01ec: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_01f1: ldloc.s 5
-		IL_01f3: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
-		IL_01f8: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_01fd: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0202: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0207: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_020c: stloc.s 8
-		IL_020e: volatile.
-		IL_0210: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0215: brfalse IL_022b
+		IL_01ea: ldstr "verbose"
+		IL_01ef: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_01f4: box [System.Runtime]System.Boolean
+		IL_01f9: stloc.s 5
+		IL_01fb: br IL_0214
 
-		IL_021a: ldloc.s 8
-		IL_021c: ldstr "prototype"
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0226: br IL_0241
+		IL_0200: pop
 
-		IL_022b: ldloc.s 8
-		IL_022d: ldstr "prototype"
-		IL_0232: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:__js_module_init__:60"
-		IL_0237: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0201: ldloc.s 5
+		IL_0203: ldstr "includes"
+		IL_0208: ldstr "verbose"
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0212: stloc.s 5
 
-		IL_0241: stloc.s 5
-		IL_0243: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0248: stloc.s 9
-		IL_024a: ldloc.s 5
-		IL_024c: ldstr "setBitTrue"
-		IL_0251: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
-		IL_0256: ldc.i4.1
-		IL_0257: conv.r8
-		IL_0258: ldstr "setBitTrue"
-		IL_025d: ldc.i4.1
-		IL_025e: ldc.i4.1
-		IL_025f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0264: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_026e: pop
-		IL_026f: ldc.i4.1
-		IL_0270: newarr [System.Runtime]System.Object
-		IL_0275: dup
-		IL_0276: ldc.i4.0
-		IL_0277: ldloc.0
-		IL_0278: stelem.ref
-		IL_0279: stloc.s 9
-		IL_027b: ldloc.s 5
-		IL_027d: ldstr "setBitsTrue"
-		IL_0282: ldloc.s 9
-		IL_0284: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
-		IL_0289: ldc.i4.3
-		IL_028a: conv.r8
-		IL_028b: ldstr "setBitsTrue"
-		IL_0290: ldc.i4.1
-		IL_0291: ldc.i4.1
-		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02a1: pop
-		IL_02a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02a7: stloc.s 9
-		IL_02a9: ldloc.s 5
-		IL_02ab: ldstr "testBitTrue"
-		IL_02b0: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
-		IL_02b5: ldc.i4.1
-		IL_02b6: conv.r8
-		IL_02b7: ldstr "testBitTrue"
-		IL_02bc: ldc.i4.1
-		IL_02bd: ldc.i4.1
-		IL_02be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02cd: pop
-		IL_02ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02d3: stloc.s 9
-		IL_02d5: ldloc.s 5
-		IL_02d7: ldstr "searchBitFalse"
-		IL_02dc: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
-		IL_02e1: ldc.i4.1
-		IL_02e2: conv.r8
-		IL_02e3: ldstr "searchBitFalse"
-		IL_02e8: ldc.i4.1
-		IL_02e9: ldc.i4.1
-		IL_02ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
-		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02f9: pop
-		IL_02fa: ldc.i4.1
-		IL_02fb: newarr [System.Runtime]System.Object
-		IL_0300: dup
-		IL_0301: ldc.i4.0
-		IL_0302: ldloc.0
-		IL_0303: stelem.ref
-		IL_0304: stloc.s 9
-		IL_0306: ldloc.s 9
-		IL_0308: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
-		IL_030d: ldloc.s 8
-		IL_030f: ldloc.s 9
+		IL_0214: ldloc.1
+		IL_0215: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_021a: ldloc.s 5
+		IL_021c: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
+		IL_0221: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_0226: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_022b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_0230: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0235: stloc.s 8
+		IL_0237: volatile.
+		IL_0239: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_023e: brfalse IL_0254
+
+		IL_0243: ldloc.s 8
+		IL_0245: ldstr "prototype"
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024f: br IL_026a
+
+		IL_0254: ldloc.s 8
+		IL_0256: ldstr "prototype"
+		IL_025b: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:__js_module_init__:60"
+		IL_0260: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_026a: stloc.s 5
+		IL_026c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0271: stloc.s 9
+		IL_0273: ldloc.s 5
+		IL_0275: ldstr "setBitTrue"
+		IL_027a: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
+		IL_027f: ldc.i4.1
+		IL_0280: conv.r8
+		IL_0281: ldstr "setBitTrue"
+		IL_0286: ldc.i4.1
+		IL_0287: ldc.i4.1
+		IL_0288: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_028d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0297: pop
+		IL_0298: ldc.i4.1
+		IL_0299: newarr [System.Runtime]System.Object
+		IL_029e: dup
+		IL_029f: ldc.i4.0
+		IL_02a0: ldloc.0
+		IL_02a1: stelem.ref
+		IL_02a2: stloc.s 9
+		IL_02a4: ldloc.s 5
+		IL_02a6: ldstr "setBitsTrue"
+		IL_02ab: ldloc.s 9
+		IL_02ad: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
+		IL_02b2: ldc.i4.3
+		IL_02b3: conv.r8
+		IL_02b4: ldstr "setBitsTrue"
+		IL_02b9: ldc.i4.1
+		IL_02ba: ldc.i4.1
+		IL_02bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02ca: pop
+		IL_02cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02d0: stloc.s 9
+		IL_02d2: ldloc.s 5
+		IL_02d4: ldstr "testBitTrue"
+		IL_02d9: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
+		IL_02de: ldc.i4.1
+		IL_02df: conv.r8
+		IL_02e0: ldstr "testBitTrue"
+		IL_02e5: ldc.i4.1
+		IL_02e6: ldc.i4.1
+		IL_02e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02f6: pop
+		IL_02f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02fc: stloc.s 9
+		IL_02fe: ldloc.s 5
+		IL_0300: ldstr "searchBitFalse"
+		IL_0305: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
+		IL_030a: ldc.i4.1
+		IL_030b: conv.r8
+		IL_030c: ldstr "searchBitFalse"
 		IL_0311: ldc.i4.1
-		IL_0312: conv.r8
-		IL_0313: ldc.i4.0
-		IL_0314: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0319: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject
-		IL_031e: stloc.s 10
-		IL_0320: ldloc.0
-		IL_0321: ldloc.s 10
-		IL_0323: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
-		IL_0328: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_032d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0332: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0337: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_033c: stloc.s 8
-		IL_033e: volatile.
-		IL_0340: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0345: brfalse IL_035b
+		IL_0312: ldc.i4.1
+		IL_0313: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0318: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0322: pop
+		IL_0323: ldc.i4.1
+		IL_0324: newarr [System.Runtime]System.Object
+		IL_0329: dup
+		IL_032a: ldc.i4.0
+		IL_032b: ldloc.0
+		IL_032c: stelem.ref
+		IL_032d: stloc.s 9
+		IL_032f: ldloc.s 9
+		IL_0331: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
+		IL_0336: ldloc.s 8
+		IL_0338: ldloc.s 9
+		IL_033a: ldc.i4.1
+		IL_033b: conv.r8
+		IL_033c: ldc.i4.0
+		IL_033d: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0342: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject
+		IL_0347: stloc.s 10
+		IL_0349: ldloc.0
+		IL_034a: ldloc.s 10
+		IL_034c: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_0351: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0356: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_035b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0360: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0365: stloc.s 8
+		IL_0367: volatile.
+		IL_0369: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_036e: brfalse IL_0384
 
-		IL_034a: ldloc.s 8
-		IL_034c: ldstr "prototype"
-		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0356: br IL_0371
+		IL_0373: ldloc.s 8
+		IL_0375: ldstr "prototype"
+		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_037f: br IL_039a
 
-		IL_035b: ldloc.s 8
-		IL_035d: ldstr "prototype"
-		IL_0362: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:__js_module_init__:83"
-		IL_0367: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0384: ldloc.s 8
+		IL_0386: ldstr "prototype"
+		IL_038b: ldstr "Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes:__js_module_init__:83"
+		IL_0390: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0371: stloc.s 5
-		IL_0373: ldc.i4.1
-		IL_0374: newarr [System.Runtime]System.Object
-		IL_0379: dup
-		IL_037a: ldc.i4.0
-		IL_037b: ldloc.0
-		IL_037c: stelem.ref
-		IL_037d: stloc.s 9
-		IL_037f: ldloc.s 5
-		IL_0381: ldstr "runSieve"
-		IL_0386: ldloc.s 9
-		IL_0388: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject::.ctor(object[])
-		IL_038d: ldc.i4.0
-		IL_038e: conv.r8
-		IL_038f: ldstr "runSieve"
-		IL_0394: ldc.i4.1
-		IL_0395: ldc.i4.1
-		IL_0396: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_039b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0)
-		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_03a5: pop
-		IL_03a6: ldc.i4.1
-		IL_03a7: newarr [System.Runtime]System.Object
-		IL_03ac: dup
-		IL_03ad: ldc.i4.0
-		IL_03ae: ldloc.0
-		IL_03af: stelem.ref
-		IL_03b0: stloc.s 9
-		IL_03b2: ldloc.s 5
-		IL_03b4: ldstr "countPrimes"
-		IL_03b9: ldloc.s 9
-		IL_03bb: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject::.ctor(object[])
-		IL_03c0: ldc.i4.0
-		IL_03c1: conv.r8
-		IL_03c2: ldstr "countPrimes"
-		IL_03c7: ldc.i4.1
-		IL_03c8: ldc.i4.1
-		IL_03c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0)
-		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_03d8: pop
-		IL_03d9: ldc.i4.1
-		IL_03da: newarr [System.Runtime]System.Object
-		IL_03df: dup
-		IL_03e0: ldc.i4.0
-		IL_03e1: ldloc.0
-		IL_03e2: stelem.ref
-		IL_03e3: stloc.s 9
-		IL_03e5: ldloc.s 5
-		IL_03e7: ldstr "getPrimes"
-		IL_03ec: ldloc.s 9
-		IL_03ee: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject::.ctor(object[])
-		IL_03f3: ldc.i4.0
-		IL_03f4: conv.r8
-		IL_03f5: ldstr "getPrimes"
-		IL_03fa: ldc.i4.1
-		IL_03fb: ldc.i4.1
-		IL_03fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0401: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0)
-		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_040b: pop
-		IL_040c: ldc.i4.1
-		IL_040d: newarr [System.Runtime]System.Object
-		IL_0412: dup
-		IL_0413: ldc.i4.0
-		IL_0414: ldloc.0
-		IL_0415: stelem.ref
-		IL_0416: stloc.s 9
-		IL_0418: ldloc.s 5
-		IL_041a: ldstr "validatePrimeCount"
-		IL_041f: ldloc.s 9
-		IL_0421: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject::.ctor(object[])
-		IL_0426: ldc.i4.1
-		IL_0427: conv.r8
-		IL_0428: ldstr "validatePrimeCount"
-		IL_042d: ldc.i4.1
-		IL_042e: ldc.i4.1
-		IL_042f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0434: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0)
-		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_043e: pop
-		IL_043f: ldc.i4.1
-		IL_0440: newarr [System.Runtime]System.Object
-		IL_0445: dup
-		IL_0446: ldc.i4.0
-		IL_0447: ldloc.0
-		IL_0448: stelem.ref
-		IL_0449: stloc.s 9
-		IL_044b: ldloc.s 9
-		IL_044d: ldc.i4.0
-		IL_044e: ldelem.ref
-		IL_044f: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0454: ldloc.s 9
-		IL_0456: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object[])
-		IL_045b: ldloc.s 8
-		IL_045d: ldloc.s 9
-		IL_045f: ldc.i4.1
-		IL_0460: conv.r8
-		IL_0461: ldc.i4.0
-		IL_0462: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0467: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject
-		IL_046c: stloc.s 11
-		IL_046e: ldloc.0
-		IL_046f: ldloc.s 11
-		IL_0471: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_0476: nop
-		IL_0477: nop
-		IL_0478: ldloc.0
-		IL_0479: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_047e: ldnull
-		IL_047f: ldloc.1
-		IL_0480: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_0485: pop
-		IL_0486: ret
+		IL_039a: stloc.s 5
+		IL_039c: ldc.i4.1
+		IL_039d: newarr [System.Runtime]System.Object
+		IL_03a2: dup
+		IL_03a3: ldc.i4.0
+		IL_03a4: ldloc.0
+		IL_03a5: stelem.ref
+		IL_03a6: stloc.s 9
+		IL_03a8: ldloc.s 5
+		IL_03aa: ldstr "runSieve"
+		IL_03af: ldloc.s 9
+		IL_03b1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject::.ctor(object[])
+		IL_03b6: ldc.i4.0
+		IL_03b7: conv.r8
+		IL_03b8: ldstr "runSieve"
+		IL_03bd: ldc.i4.1
+		IL_03be: ldc.i4.1
+		IL_03bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0)
+		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_03ce: pop
+		IL_03cf: ldc.i4.1
+		IL_03d0: newarr [System.Runtime]System.Object
+		IL_03d5: dup
+		IL_03d6: ldc.i4.0
+		IL_03d7: ldloc.0
+		IL_03d8: stelem.ref
+		IL_03d9: stloc.s 9
+		IL_03db: ldloc.s 5
+		IL_03dd: ldstr "countPrimes"
+		IL_03e2: ldloc.s 9
+		IL_03e4: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject::.ctor(object[])
+		IL_03e9: ldc.i4.0
+		IL_03ea: conv.r8
+		IL_03eb: ldstr "countPrimes"
+		IL_03f0: ldc.i4.1
+		IL_03f1: ldc.i4.1
+		IL_03f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0)
+		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0401: pop
+		IL_0402: ldc.i4.1
+		IL_0403: newarr [System.Runtime]System.Object
+		IL_0408: dup
+		IL_0409: ldc.i4.0
+		IL_040a: ldloc.0
+		IL_040b: stelem.ref
+		IL_040c: stloc.s 9
+		IL_040e: ldloc.s 5
+		IL_0410: ldstr "getPrimes"
+		IL_0415: ldloc.s 9
+		IL_0417: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject::.ctor(object[])
+		IL_041c: ldc.i4.0
+		IL_041d: conv.r8
+		IL_041e: ldstr "getPrimes"
+		IL_0423: ldc.i4.1
+		IL_0424: ldc.i4.1
+		IL_0425: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_042a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0)
+		IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0434: pop
+		IL_0435: ldc.i4.1
+		IL_0436: newarr [System.Runtime]System.Object
+		IL_043b: dup
+		IL_043c: ldc.i4.0
+		IL_043d: ldloc.0
+		IL_043e: stelem.ref
+		IL_043f: stloc.s 9
+		IL_0441: ldloc.s 5
+		IL_0443: ldstr "validatePrimeCount"
+		IL_0448: ldloc.s 9
+		IL_044a: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject::.ctor(object[])
+		IL_044f: ldc.i4.1
+		IL_0450: conv.r8
+		IL_0451: ldstr "validatePrimeCount"
+		IL_0456: ldc.i4.1
+		IL_0457: ldc.i4.1
+		IL_0458: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_045d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0)
+		IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0467: pop
+		IL_0468: ldc.i4.1
+		IL_0469: newarr [System.Runtime]System.Object
+		IL_046e: dup
+		IL_046f: ldc.i4.0
+		IL_0470: ldloc.0
+		IL_0471: stelem.ref
+		IL_0472: stloc.s 9
+		IL_0474: ldloc.s 9
+		IL_0476: ldc.i4.0
+		IL_0477: ldelem.ref
+		IL_0478: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_047d: ldloc.s 9
+		IL_047f: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object[])
+		IL_0484: ldloc.s 8
+		IL_0486: ldloc.s 9
+		IL_0488: ldc.i4.1
+		IL_0489: conv.r8
+		IL_048a: ldc.i4.0
+		IL_048b: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0490: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject
+		IL_0495: stloc.s 11
+		IL_0497: ldloc.0
+		IL_0498: ldloc.s 11
+		IL_049a: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_049f: nop
+		IL_04a0: nop
+		IL_04a1: ldloc.0
+		IL_04a2: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_04a7: ldnull
+		IL_04a8: ldloc.1
+		IL_04a9: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_04ae: pop
+		IL_04af: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
@@ -3637,6 +3662,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_35
 	.field assembly static int32 __jroc_dynamicLookup_36
 	.field assembly static int32 __jroc_dynamicLookup_37
+	.field assembly static int32 __jroc_dynamicLookup_38
+	.field assembly static int32 __jroc_dynamicLookup_39
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_ShadowedAndReplaced_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_ShadowedAndReplaced_Dispatch.verified.txt
@@ -520,7 +520,7 @@
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 223 (0xdf)
+			// Code size: 315 (0x13b)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/Scope,
@@ -588,32 +588,59 @@
 			IL_0086: ldloc.s 6
 			IL_0088: box [System.Runtime]System.Double
 			IL_008d: stloc.s 7
-			IL_008f: ldloc.1
-			IL_0090: ldstr "abs"
-			IL_0095: ldloc.s 7
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_009c: stloc.s 8
-			IL_009e: ldloc.1
-			IL_009f: ldstr "round"
-			IL_00a4: ldc.r8 0.0
-			IL_00ad: box [System.Runtime]System.Double
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00b7: stloc.s 9
-			IL_00b9: ldloc.1
-			IL_00ba: castclass Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math
-			IL_00bf: callvirt instance float64 Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math::get_PI()
-			IL_00c4: stloc.s 6
-			IL_00c6: ldloc.s 6
-			IL_00c8: box [System.Runtime]System.Double
-			IL_00cd: stloc.s 7
-			IL_00cf: ldloc.s 5
-			IL_00d1: ldloc.s 8
-			IL_00d3: ldloc.s 9
-			IL_00d5: ldloc.s 7
-			IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-			IL_00dc: pop
-			IL_00dd: ldnull
-			IL_00de: ret
+			IL_008f: volatile.
+			IL_0091: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0096: brfalse IL_00ad
+
+			IL_009b: ldloc.1
+			IL_009c: ldstr "abs"
+			IL_00a1: ldloc.s 7
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00a8: br IL_00c4
+
+			IL_00ad: ldloc.1
+			IL_00ae: ldstr "abs"
+			IL_00b3: ldloc.s 7
+			IL_00b5: ldstr "Math_ShadowedAndReplaced_Dispatch:<TwoPhaseDummy_M4>:__js_call__:14"
+			IL_00ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00c4: stloc.s 8
+			IL_00c6: volatile.
+			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_00cd: brfalse IL_00f0
+
+			IL_00d2: ldloc.1
+			IL_00d3: ldstr "round"
+			IL_00d8: ldc.r8 0.0
+			IL_00e1: box [System.Runtime]System.Double
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00eb: br IL_0113
+
+			IL_00f0: ldloc.1
+			IL_00f1: ldstr "round"
+			IL_00f6: ldc.r8 0.0
+			IL_00ff: box [System.Runtime]System.Double
+			IL_0104: ldstr "Math_ShadowedAndReplaced_Dispatch:<TwoPhaseDummy_M4>:__js_call__:17"
+			IL_0109: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0113: stloc.s 9
+			IL_0115: ldloc.1
+			IL_0116: castclass Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math
+			IL_011b: callvirt instance float64 Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math::get_PI()
+			IL_0120: stloc.s 6
+			IL_0122: ldloc.s 6
+			IL_0124: box [System.Runtime]System.Double
+			IL_0129: stloc.s 7
+			IL_012b: ldloc.s 5
+			IL_012d: ldloc.s 8
+			IL_012f: ldloc.s 9
+			IL_0131: ldloc.s 7
+			IL_0133: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+			IL_0138: pop
+			IL_0139: ldnull
+			IL_013a: ret
 		} // end of method FunctionExpression_L1C1::__js_call__
 
 	} // end of class FunctionExpression_L1C1
@@ -920,7 +947,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 191 (0xbf)
+		// Code size: 230 (0xe6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_ShadowedAndReplaced_Dispatch/Scope,
@@ -995,15 +1022,27 @@
 		IL_009f: ldloc.s 6
 		IL_00a1: box [System.Runtime]System.Double
 		IL_00a6: stloc.s 7
-		IL_00a8: ldstr "abs"
-		IL_00ad: ldloc.s 7
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b4: stloc.3
-		IL_00b5: ldloc.s 5
-		IL_00b7: ldloc.3
-		IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bd: pop
-		IL_00be: ret
+		IL_00a8: volatile.
+		IL_00aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00af: brfalse IL_00c5
+
+		IL_00b4: ldstr "abs"
+		IL_00b9: ldloc.s 7
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c0: br IL_00db
+
+		IL_00c5: ldstr "abs"
+		IL_00ca: ldloc.s 7
+		IL_00cc: ldstr "Math_ShadowedAndReplaced_Dispatch:Modules.Math_ShadowedAndReplaced_Dispatch:__js_module_init__:21"
+		IL_00d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00db: stloc.3
+		IL_00dc: ldloc.s 5
+		IL_00de: ldloc.3
+		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e4: pop
+		IL_00e5: ret
 	} // end of method Math_ShadowedAndReplaced_Dispatch::__js_module_init__
 
 } // end of class Modules.Math_ShadowedAndReplaced_Dispatch
@@ -1028,4 +1067,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/AssertModule/Snapshots/GeneratorTests.Require_Assert_Callable_And_Core_Methods.verified.txt
+++ b/tests/Jroc.Tests/Node/AssertModule/Snapshots/GeneratorTests.Require_Assert_Callable_And_Core_Methods.verified.txt
@@ -705,7 +705,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1259 (0x4eb)
+		// Code size: 1299 (0x513)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Assert_Callable_And_Core_Methods/Scope,
@@ -1076,103 +1076,116 @@
 		IL_03c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Assert_Callable_And_Core_Methods/ArrowFunction_L24C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Assert_Callable_And_Core_Methods/ArrowFunction_L24C21/FunctionObject>(!!0)
 		IL_03cf: stloc.s 12
-		IL_03d1: ldloc.2
-		IL_03d2: ldstr "doesNotThrow"
-		IL_03d7: ldloc.s 12
-		IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03de: pop
-		IL_03df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03e4: stloc.s 13
-		IL_03e6: ldloc.0
-		IL_03e7: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
-		IL_03ec: stloc.2
-		IL_03ed: ldloc.2
-		IL_03ee: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_03f3: stloc.s 14
-		IL_03f5: ldloc.s 13
-		IL_03f7: ldstr "callable:"
-		IL_03fc: ldloc.s 14
-		IL_03fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0403: pop
-		IL_0404: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0409: stloc.s 13
-		IL_040b: ldloc.0
-		IL_040c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
-		IL_0411: stloc.2
-		IL_0412: ldloc.2
-		IL_0413: ldloc.1
-		IL_0414: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0419: stloc.s 15
-		IL_041b: ldloc.s 15
-		IL_041d: box [System.Runtime]System.Boolean
-		IL_0422: stloc.s 16
-		IL_0424: ldloc.s 13
-		IL_0426: ldstr "same module:"
-		IL_042b: ldloc.s 16
-		IL_042d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0432: pop
-		IL_0433: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0438: stloc.s 13
-		IL_043a: ldloc.0
-		IL_043b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
-		IL_0440: volatile.
-		IL_0442: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0447: brfalse IL_045b
+		IL_03d1: volatile.
+		IL_03d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_03d8: brfalse IL_03ef
 
-		IL_044c: ldstr "ok"
-		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0456: br IL_046f
+		IL_03dd: ldloc.2
+		IL_03de: ldstr "doesNotThrow"
+		IL_03e3: ldloc.s 12
+		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03ea: br IL_0406
 
-		IL_045b: ldstr "ok"
-		IL_0460: ldstr "Require_Assert_Callable_And_Core_Methods:Modules.Require_Assert_Callable_And_Core_Methods:__js_module_init__:104"
-		IL_0465: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03ef: ldloc.2
+		IL_03f0: ldstr "doesNotThrow"
+		IL_03f5: ldloc.s 12
+		IL_03f7: ldstr "Require_Assert_Callable_And_Core_Methods:Modules.Require_Assert_Callable_And_Core_Methods:__js_module_init__:85"
+		IL_03fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_046f: stloc.s 9
-		IL_0471: ldloc.0
-		IL_0472: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
-		IL_0477: stloc.2
-		IL_0478: ldloc.s 9
-		IL_047a: ldloc.2
-		IL_047b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0480: stloc.s 15
-		IL_0482: ldloc.s 15
-		IL_0484: box [System.Runtime]System.Boolean
-		IL_0489: stloc.s 16
-		IL_048b: ldloc.s 13
-		IL_048d: ldstr "ok identity:"
-		IL_0492: ldloc.s 16
-		IL_0494: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0499: pop
-		IL_049a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_049f: stloc.s 13
-		IL_04a1: ldloc.0
-		IL_04a2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
-		IL_04a7: stloc.2
-		IL_04a8: ldloc.2
-		IL_04a9: ldstr "strict"
-		IL_04ae: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_04b3: brtrue IL_04c5
+		IL_0406: pop
+		IL_0407: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_040c: stloc.s 13
+		IL_040e: ldloc.0
+		IL_040f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
+		IL_0414: stloc.2
+		IL_0415: ldloc.2
+		IL_0416: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_041b: stloc.s 14
+		IL_041d: ldloc.s 13
+		IL_041f: ldstr "callable:"
+		IL_0424: ldloc.s 14
+		IL_0426: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_042b: pop
+		IL_042c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0431: stloc.s 13
+		IL_0433: ldloc.0
+		IL_0434: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
+		IL_0439: stloc.2
+		IL_043a: ldloc.2
+		IL_043b: ldloc.1
+		IL_043c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0441: stloc.s 15
+		IL_0443: ldloc.s 15
+		IL_0445: box [System.Runtime]System.Boolean
+		IL_044a: stloc.s 16
+		IL_044c: ldloc.s 13
+		IL_044e: ldstr "same module:"
+		IL_0453: ldloc.s 16
+		IL_0455: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_045a: pop
+		IL_045b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0460: stloc.s 13
+		IL_0462: ldloc.0
+		IL_0463: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
+		IL_0468: volatile.
+		IL_046a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_046f: brfalse IL_0483
 
-		IL_04b8: ldloc.2
-		IL_04b9: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule::get_strict()
-		IL_04be: stloc.s 9
-		IL_04c0: br IL_04d2
+		IL_0474: ldstr "ok"
+		IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_047e: br IL_0497
 
-		IL_04c5: ldloc.2
-		IL_04c6: ldstr "strict"
-		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_04d0: stloc.s 9
+		IL_0483: ldstr "ok"
+		IL_0488: ldstr "Require_Assert_Callable_And_Core_Methods:Modules.Require_Assert_Callable_And_Core_Methods:__js_module_init__:104"
+		IL_048d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04d2: ldloc.s 9
-		IL_04d4: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_04d9: stloc.s 14
-		IL_04db: ldloc.s 13
-		IL_04dd: ldstr "strict callable:"
-		IL_04e2: ldloc.s 14
-		IL_04e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_04e9: pop
-		IL_04ea: ret
+		IL_0497: stloc.s 9
+		IL_0499: ldloc.0
+		IL_049a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
+		IL_049f: stloc.2
+		IL_04a0: ldloc.s 9
+		IL_04a2: ldloc.2
+		IL_04a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04a8: stloc.s 15
+		IL_04aa: ldloc.s 15
+		IL_04ac: box [System.Runtime]System.Boolean
+		IL_04b1: stloc.s 16
+		IL_04b3: ldloc.s 13
+		IL_04b5: ldstr "ok identity:"
+		IL_04ba: ldloc.s 16
+		IL_04bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_04c1: pop
+		IL_04c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04c7: stloc.s 13
+		IL_04c9: ldloc.0
+		IL_04ca: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule Modules.Require_Assert_Callable_And_Core_Methods/Scope::'assert'
+		IL_04cf: stloc.2
+		IL_04d0: ldloc.2
+		IL_04d1: ldstr "strict"
+		IL_04d6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_04db: brtrue IL_04ed
+
+		IL_04e0: ldloc.2
+		IL_04e1: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAssertModule::get_strict()
+		IL_04e6: stloc.s 9
+		IL_04e8: br IL_04fa
+
+		IL_04ed: ldloc.2
+		IL_04ee: ldstr "strict"
+		IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_04f8: stloc.s 9
+
+		IL_04fa: ldloc.s 9
+		IL_04fc: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0501: stloc.s 14
+		IL_0503: ldloc.s 13
+		IL_0505: ldstr "strict callable:"
+		IL_050a: ldloc.s 14
+		IL_050c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0511: pop
+		IL_0512: ret
 	} // end of method Require_Assert_Callable_And_Core_Methods::__js_module_init__
 
 } // end of class Modules.Require_Assert_Callable_And_Core_Methods
@@ -1203,6 +1216,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncLocalStorage.verified.txt
+++ b/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncLocalStorage.verified.txt
@@ -187,7 +187,7 @@
 			IL_0007: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "getStore"
@@ -196,7 +196,7 @@
 
 			IL_002c: ldstr "getStore"
 			IL_0031: ldstr "Require_AsyncHooks_AsyncLocalStorage:<TwoPhaseDummy_M4>:__js_call__:5"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
@@ -341,7 +341,7 @@
 				IL_000e: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
 				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0018: volatile.
-				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_001f: brfalse IL_0033
 
 				IL_0024: ldstr "getStore"
@@ -350,7 +350,7 @@
 
 				IL_0033: ldstr "getStore"
 				IL_0038: ldstr "Require_AsyncHooks_AsyncLocalStorage:<TwoPhaseDummy_M12>:__js_call__:5"
-				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0047: stloc.1
@@ -538,7 +538,7 @@
 			IL_0014: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
 			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_001e: volatile.
-			IL_0020: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0020: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 			IL_0025: brfalse IL_0039
 
 			IL_002a: ldstr "getStore"
@@ -547,7 +547,7 @@
 
 			IL_0039: ldstr "getStore"
 			IL_003e: ldstr "Require_AsyncHooks_AsyncLocalStorage:<TwoPhaseDummy_M5>:__js_call__:8"
-			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_004d: stloc.2
@@ -724,7 +724,7 @@
 			IL_0001: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000b: volatile.
-			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 			IL_0012: brfalse IL_0026
 
 			IL_0017: ldstr "getStore"
@@ -733,7 +733,7 @@
 
 			IL_0026: ldstr "getStore"
 			IL_002b: ldstr "Require_AsyncHooks_AsyncLocalStorage:<TwoPhaseDummy_M6>:__js_call__:2"
-			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_003a: stloc.0
@@ -855,7 +855,7 @@
 			IL_0001: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000b: volatile.
-			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 			IL_0012: brfalse IL_0026
 
 			IL_0017: ldstr "getStore"
@@ -864,7 +864,7 @@
 
 			IL_0026: ldstr "getStore"
 			IL_002b: ldstr "Require_AsyncHooks_AsyncLocalStorage:<TwoPhaseDummy_M7>:__js_call__:2"
-			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_003a: stloc.0
@@ -986,7 +986,7 @@
 			IL_0001: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::AsyncLocalStorage
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000b: volatile.
-			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_0012: brfalse IL_0026
 
 			IL_0017: ldstr "snapshot"
@@ -995,7 +995,7 @@
 
 			IL_0026: ldstr "snapshot"
 			IL_002b: ldstr "Require_AsyncHooks_AsyncLocalStorage:<TwoPhaseDummy_M8>:__js_call__:3"
-			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_003a: stloc.0
@@ -1120,7 +1120,7 @@
 			IL_0001: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000b: volatile.
-			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0012: brfalse IL_0026
 
 			IL_0017: ldstr "getStore"
@@ -1129,7 +1129,7 @@
 
 			IL_0026: ldstr "getStore"
 			IL_002b: ldstr "Require_AsyncHooks_AsyncLocalStorage:<TwoPhaseDummy_M9>:__js_call__:2"
-			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_003a: stloc.0
@@ -1251,7 +1251,7 @@
 			IL_0001: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000b: volatile.
-			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_0012: brfalse IL_0026
 
 			IL_0017: ldstr "getStore"
@@ -1260,7 +1260,7 @@
 
 			IL_0026: ldstr "getStore"
 			IL_002b: ldstr "Require_AsyncHooks_AsyncLocalStorage:<TwoPhaseDummy_M10>:__js_call__:2"
-			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_003a: stloc.0
@@ -1382,7 +1382,7 @@
 			IL_0001: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000b: volatile.
-			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_0012: brfalse IL_0026
 
 			IL_0017: ldstr "getStore"
@@ -1391,7 +1391,7 @@
 
 			IL_0026: ldstr "getStore"
 			IL_002b: ldstr "Require_AsyncHooks_AsyncLocalStorage:<TwoPhaseDummy_M11>:__js_call__:2"
-			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_003a: stloc.0
@@ -1450,7 +1450,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1506 (0x5e2)
+		// Code size: 1712 (0x6b0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope,
@@ -1721,266 +1721,330 @@
 		IL_02dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L25C51/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L25C51/FunctionObject>(!!0)
 		IL_02e7: stloc.s 10
-		IL_02e9: ldloc.s 4
-		IL_02eb: ldstr "runInAsyncScope"
-		IL_02f0: ldloc.s 10
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f7: stloc.s 4
-		IL_02f9: ldloc.s 6
-		IL_02fb: ldstr "captured:"
-		IL_0300: ldloc.s 4
-		IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0307: pop
-		IL_0308: ldloc.0
-		IL_0309: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::AsyncLocalStorage
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0313: stloc.s 4
-		IL_0315: ldc.i4.1
-		IL_0316: newarr [System.Runtime]System.Object
-		IL_031b: dup
-		IL_031c: ldc.i4.0
-		IL_031d: ldloc.0
-		IL_031e: stelem.ref
-		IL_031f: stloc.s 7
-		IL_0321: ldloc.s 7
-		IL_0323: ldc.i4.0
-		IL_0324: ldelem.ref
-		IL_0325: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
-		IL_032a: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L27C38/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
-		IL_032f: ldc.i4.0
-		IL_0330: conv.r8
-		IL_0331: ldstr ""
-		IL_0336: ldc.i4.0
-		IL_0337: ldc.i4.0
-		IL_0338: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L27C38/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_033d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L27C38/FunctionObject>(!!0)
-		IL_0342: stloc.s 11
-		IL_0344: ldloc.s 4
-		IL_0346: ldstr "bind"
-		IL_034b: ldloc.s 11
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0352: stloc.2
-		IL_0353: ldloc.0
-		IL_0354: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
-		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035e: stloc.s 4
-		IL_0360: ldc.i4.1
-		IL_0361: newarr [System.Runtime]System.Object
-		IL_0366: dup
-		IL_0367: ldc.i4.0
-		IL_0368: ldloc.0
-		IL_0369: stelem.ref
-		IL_036a: stloc.s 7
-		IL_036c: ldloc.s 7
-		IL_036e: ldc.i4.0
-		IL_036f: ldelem.ref
-		IL_0370: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
-		IL_0375: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L28C25/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
-		IL_037a: ldc.i4.0
-		IL_037b: conv.r8
-		IL_037c: ldstr ""
-		IL_0381: ldc.i4.0
-		IL_0382: ldc.i4.0
-		IL_0383: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L28C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0388: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L28C25/FunctionObject>(!!0)
-		IL_038d: stloc.s 12
-		IL_038f: ldloc.s 4
-		IL_0391: ldstr "run"
-		IL_0396: ldstr "snapshot"
-		IL_039b: ldloc.s 12
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03a2: pop
-		IL_03a3: ldloc.0
-		IL_03a4: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
-		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03ae: ldstr "enterWith"
-		IL_03b3: ldstr "entered"
-		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03bd: pop
-		IL_03be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03c3: stloc.s 6
-		IL_03c5: ldloc.2
-		IL_03c6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_03d0: stloc.s 4
-		IL_03d2: ldloc.s 6
-		IL_03d4: ldstr "bound:"
-		IL_03d9: ldloc.s 4
-		IL_03db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03e0: pop
-		IL_03e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03e6: stloc.s 6
-		IL_03e8: ldloc.0
-		IL_03e9: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::snapshot
-		IL_03ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03f3: stloc.s 7
-		IL_03f5: ldc.i4.1
-		IL_03f6: newarr [System.Runtime]System.Object
-		IL_03fb: dup
-		IL_03fc: ldc.i4.0
-		IL_03fd: ldloc.0
-		IL_03fe: stelem.ref
-		IL_03ff: stloc.s 13
-		IL_0401: ldloc.s 13
-		IL_0403: ldc.i4.0
-		IL_0404: ldelem.ref
-		IL_0405: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
-		IL_040a: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L33C35/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
-		IL_040f: ldc.i4.0
-		IL_0410: conv.r8
-		IL_0411: ldstr ""
-		IL_0416: ldc.i4.0
-		IL_0417: ldc.i4.0
-		IL_0418: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L33C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_041d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L33C35/FunctionObject>(!!0)
-		IL_0422: stloc.s 14
-		IL_0424: ldloc.s 7
-		IL_0426: ldloc.s 14
-		IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_042d: stloc.s 4
-		IL_042f: ldloc.s 6
-		IL_0431: ldstr "snapshot:"
-		IL_0436: ldloc.s 4
-		IL_0438: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_043d: pop
-		IL_043e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0443: stloc.s 6
-		IL_0445: ldloc.0
-		IL_0446: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
-		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0450: stloc.s 4
-		IL_0452: ldc.i4.1
-		IL_0453: newarr [System.Runtime]System.Object
-		IL_0458: dup
-		IL_0459: ldc.i4.0
-		IL_045a: ldloc.0
-		IL_045b: stelem.ref
-		IL_045c: stloc.s 7
-		IL_045e: ldloc.s 7
-		IL_0460: ldc.i4.0
-		IL_0461: ldelem.ref
-		IL_0462: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
-		IL_0467: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L34C35/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
-		IL_046c: ldc.i4.0
-		IL_046d: conv.r8
-		IL_046e: ldstr ""
-		IL_0473: ldc.i4.0
-		IL_0474: ldc.i4.0
-		IL_0475: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L34C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_047a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L34C35/FunctionObject>(!!0)
-		IL_047f: stloc.s 15
-		IL_0481: ldloc.s 4
-		IL_0483: ldstr "exit"
-		IL_0488: ldloc.s 15
-		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_048f: stloc.s 4
-		IL_0491: ldloc.s 6
-		IL_0493: ldstr "exit:"
-		IL_0498: ldloc.s 4
-		IL_049a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_049f: pop
-		IL_04a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04a5: stloc.s 6
-		IL_04a7: ldloc.0
-		IL_04a8: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
-		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b2: volatile.
-		IL_04b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_04b9: brfalse IL_04cd
+		IL_02e9: volatile.
+		IL_02eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_02f0: brfalse IL_0308
 
-		IL_04be: ldstr "getStore"
-		IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_04c8: br IL_04e1
+		IL_02f5: ldloc.s 4
+		IL_02f7: ldstr "runInAsyncScope"
+		IL_02fc: ldloc.s 10
+		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0303: br IL_0320
 
-		IL_04cd: ldstr "getStore"
-		IL_04d2: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:133"
-		IL_04d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0308: ldloc.s 4
+		IL_030a: ldstr "runInAsyncScope"
+		IL_030f: ldloc.s 10
+		IL_0311: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:83"
+		IL_0316: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_04e1: stloc.s 4
-		IL_04e3: ldloc.s 6
-		IL_04e5: ldstr "entered:"
-		IL_04ea: ldloc.s 4
-		IL_04ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_04f1: pop
-		IL_04f2: ldloc.0
-		IL_04f3: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
-		IL_04f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0320: stloc.s 4
+		IL_0322: ldloc.s 6
+		IL_0324: ldstr "captured:"
+		IL_0329: ldloc.s 4
+		IL_032b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0330: pop
+		IL_0331: ldloc.0
+		IL_0332: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::AsyncLocalStorage
+		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033c: stloc.s 4
+		IL_033e: ldc.i4.1
+		IL_033f: newarr [System.Runtime]System.Object
+		IL_0344: dup
+		IL_0345: ldc.i4.0
+		IL_0346: ldloc.0
+		IL_0347: stelem.ref
+		IL_0348: stloc.s 7
+		IL_034a: ldloc.s 7
+		IL_034c: ldc.i4.0
+		IL_034d: ldelem.ref
+		IL_034e: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
+		IL_0353: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L27C38/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
+		IL_0358: ldc.i4.0
+		IL_0359: conv.r8
+		IL_035a: ldstr ""
+		IL_035f: ldc.i4.0
+		IL_0360: ldc.i4.0
+		IL_0361: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L27C38/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0366: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L27C38/FunctionObject>(!!0)
+		IL_036b: stloc.s 11
+		IL_036d: volatile.
+		IL_036f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0374: brfalse IL_038c
+
+		IL_0379: ldloc.s 4
+		IL_037b: ldstr "bind"
+		IL_0380: ldloc.s 11
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0387: br IL_03a4
+
+		IL_038c: ldloc.s 4
+		IL_038e: ldstr "bind"
+		IL_0393: ldloc.s 11
+		IL_0395: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:90"
+		IL_039a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03a4: stloc.2
+		IL_03a5: ldloc.0
+		IL_03a6: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
+		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03b0: stloc.s 4
+		IL_03b2: ldc.i4.1
+		IL_03b3: newarr [System.Runtime]System.Object
+		IL_03b8: dup
+		IL_03b9: ldc.i4.0
+		IL_03ba: ldloc.0
+		IL_03bb: stelem.ref
+		IL_03bc: stloc.s 7
+		IL_03be: ldloc.s 7
+		IL_03c0: ldc.i4.0
+		IL_03c1: ldelem.ref
+		IL_03c2: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
+		IL_03c7: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L28C25/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
+		IL_03cc: ldc.i4.0
+		IL_03cd: conv.r8
+		IL_03ce: ldstr ""
+		IL_03d3: ldc.i4.0
+		IL_03d4: ldc.i4.0
+		IL_03d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L28C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L28C25/FunctionObject>(!!0)
+		IL_03df: stloc.s 12
+		IL_03e1: ldloc.s 4
+		IL_03e3: ldstr "run"
+		IL_03e8: ldstr "snapshot"
+		IL_03ed: ldloc.s 12
+		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03f4: pop
+		IL_03f5: ldloc.0
+		IL_03f6: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
+		IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0400: volatile.
+		IL_0402: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0407: brfalse IL_0420
+
+		IL_040c: ldstr "enterWith"
+		IL_0411: ldstr "entered"
+		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_041b: br IL_0439
+
+		IL_0420: ldstr "enterWith"
+		IL_0425: ldstr "entered"
+		IL_042a: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:103"
+		IL_042f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0439: pop
+		IL_043a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_043f: stloc.s 6
+		IL_0441: ldloc.2
+		IL_0442: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_044c: stloc.s 4
+		IL_044e: ldloc.s 6
+		IL_0450: ldstr "bound:"
+		IL_0455: ldloc.s 4
+		IL_0457: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_045c: pop
+		IL_045d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0462: stloc.s 6
+		IL_0464: ldloc.0
+		IL_0465: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::snapshot
+		IL_046a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_046f: stloc.s 7
+		IL_0471: ldc.i4.1
+		IL_0472: newarr [System.Runtime]System.Object
+		IL_0477: dup
+		IL_0478: ldc.i4.0
+		IL_0479: ldloc.0
+		IL_047a: stelem.ref
+		IL_047b: stloc.s 13
+		IL_047d: ldloc.s 13
+		IL_047f: ldc.i4.0
+		IL_0480: ldelem.ref
+		IL_0481: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
+		IL_0486: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L33C35/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
+		IL_048b: ldc.i4.0
+		IL_048c: conv.r8
+		IL_048d: ldstr ""
+		IL_0492: ldc.i4.0
+		IL_0493: ldc.i4.0
+		IL_0494: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L33C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0499: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L33C35/FunctionObject>(!!0)
+		IL_049e: stloc.s 14
+		IL_04a0: ldloc.s 7
+		IL_04a2: ldloc.s 14
+		IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_04a9: stloc.s 4
+		IL_04ab: ldloc.s 6
+		IL_04ad: ldstr "snapshot:"
+		IL_04b2: ldloc.s 4
+		IL_04b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_04b9: pop
+		IL_04ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04bf: stloc.s 6
+		IL_04c1: ldloc.0
+		IL_04c2: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
+		IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04cc: stloc.s 4
+		IL_04ce: ldc.i4.1
+		IL_04cf: newarr [System.Runtime]System.Object
+		IL_04d4: dup
+		IL_04d5: ldc.i4.0
+		IL_04d6: ldloc.0
+		IL_04d7: stelem.ref
+		IL_04d8: stloc.s 7
+		IL_04da: ldloc.s 7
+		IL_04dc: ldc.i4.0
+		IL_04dd: ldelem.ref
+		IL_04de: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
+		IL_04e3: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L34C35/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
+		IL_04e8: ldc.i4.0
+		IL_04e9: conv.r8
+		IL_04ea: ldstr ""
+		IL_04ef: ldc.i4.0
+		IL_04f0: ldc.i4.0
+		IL_04f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L34C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L34C35/FunctionObject>(!!0)
+		IL_04fb: stloc.s 15
 		IL_04fd: volatile.
-		IL_04ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0504: brfalse IL_0518
+		IL_04ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0504: brfalse IL_051c
 
-		IL_0509: ldstr "disable"
-		IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0513: br IL_052c
+		IL_0509: ldloc.s 4
+		IL_050b: ldstr "exit"
+		IL_0510: ldloc.s 15
+		IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0517: br IL_0534
 
-		IL_0518: ldstr "disable"
-		IL_051d: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:138"
-		IL_0522: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_051c: ldloc.s 4
+		IL_051e: ldstr "exit"
+		IL_0523: ldloc.s 15
+		IL_0525: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:126"
+		IL_052a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_052c: pop
-		IL_052d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0532: stloc.s 6
-		IL_0534: ldloc.0
-		IL_0535: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
-		IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_053f: volatile.
-		IL_0541: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0546: brfalse IL_055a
+		IL_0534: stloc.s 4
+		IL_0536: ldloc.s 6
+		IL_0538: ldstr "exit:"
+		IL_053d: ldloc.s 4
+		IL_053f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0544: pop
+		IL_0545: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_054a: stloc.s 6
+		IL_054c: ldloc.0
+		IL_054d: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
+		IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0557: volatile.
+		IL_0559: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_055e: brfalse IL_0572
 
-		IL_054b: ldstr "getStore"
-		IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0555: br IL_056e
+		IL_0563: ldstr "getStore"
+		IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_056d: br IL_0586
 
-		IL_055a: ldstr "getStore"
-		IL_055f: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:144"
-		IL_0564: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0569: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0572: ldstr "getStore"
+		IL_0577: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:133"
+		IL_057c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_056e: stloc.s 4
-		IL_0570: ldloc.s 6
-		IL_0572: ldstr "disabled:"
-		IL_0577: ldloc.s 4
-		IL_0579: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_057e: pop
-		IL_057f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0584: stloc.s 6
-		IL_0586: ldloc.0
-		IL_0587: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::captured
-		IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0591: stloc.s 4
-		IL_0593: ldc.i4.1
-		IL_0594: newarr [System.Runtime]System.Object
-		IL_0599: dup
-		IL_059a: ldc.i4.0
-		IL_059b: ldloc.0
-		IL_059c: stelem.ref
-		IL_059d: stloc.s 7
-		IL_059f: ldloc.s 7
-		IL_05a1: ldc.i4.0
-		IL_05a2: ldelem.ref
-		IL_05a3: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
-		IL_05a8: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L38C60/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
-		IL_05ad: ldc.i4.0
-		IL_05ae: conv.r8
-		IL_05af: ldstr ""
-		IL_05b4: ldc.i4.0
-		IL_05b5: ldc.i4.0
-		IL_05b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L38C60/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L38C60/FunctionObject>(!!0)
-		IL_05c0: stloc.s 16
-		IL_05c2: ldloc.s 4
-		IL_05c4: ldstr "runInAsyncScope"
-		IL_05c9: ldloc.s 16
-		IL_05cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05d0: stloc.s 4
-		IL_05d2: ldloc.s 6
-		IL_05d4: ldstr "captured disabled:"
-		IL_05d9: ldloc.s 4
-		IL_05db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_05e0: pop
-		IL_05e1: ret
+		IL_0586: stloc.s 4
+		IL_0588: ldloc.s 6
+		IL_058a: ldstr "entered:"
+		IL_058f: ldloc.s 4
+		IL_0591: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0596: pop
+		IL_0597: ldloc.0
+		IL_0598: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
+		IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05a2: volatile.
+		IL_05a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_05a9: brfalse IL_05bd
+
+		IL_05ae: ldstr "disable"
+		IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05b8: br IL_05d1
+
+		IL_05bd: ldstr "disable"
+		IL_05c2: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:138"
+		IL_05c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_05d1: pop
+		IL_05d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05d7: stloc.s 6
+		IL_05d9: ldloc.0
+		IL_05da: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::'storage'
+		IL_05df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05e4: volatile.
+		IL_05e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_05eb: brfalse IL_05ff
+
+		IL_05f0: ldstr "getStore"
+		IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05fa: br IL_0613
+
+		IL_05ff: ldstr "getStore"
+		IL_0604: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:144"
+		IL_0609: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0613: stloc.s 4
+		IL_0615: ldloc.s 6
+		IL_0617: ldstr "disabled:"
+		IL_061c: ldloc.s 4
+		IL_061e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0623: pop
+		IL_0624: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0629: stloc.s 6
+		IL_062b: ldloc.0
+		IL_062c: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage/Scope::captured
+		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0636: stloc.s 4
+		IL_0638: ldc.i4.1
+		IL_0639: newarr [System.Runtime]System.Object
+		IL_063e: dup
+		IL_063f: ldc.i4.0
+		IL_0640: ldloc.0
+		IL_0641: stelem.ref
+		IL_0642: stloc.s 7
+		IL_0644: ldloc.s 7
+		IL_0646: ldc.i4.0
+		IL_0647: ldelem.ref
+		IL_0648: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
+		IL_064d: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L38C60/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
+		IL_0652: ldc.i4.0
+		IL_0653: conv.r8
+		IL_0654: ldstr ""
+		IL_0659: ldc.i4.0
+		IL_065a: ldc.i4.0
+		IL_065b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L38C60/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0660: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L38C60/FunctionObject>(!!0)
+		IL_0665: stloc.s 16
+		IL_0667: volatile.
+		IL_0669: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_066e: brfalse IL_0686
+
+		IL_0673: ldloc.s 4
+		IL_0675: ldstr "runInAsyncScope"
+		IL_067a: ldloc.s 16
+		IL_067c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0681: br IL_069e
+
+		IL_0686: ldloc.s 4
+		IL_0688: ldstr "runInAsyncScope"
+		IL_068d: ldloc.s 16
+		IL_068f: ldstr "Require_AsyncHooks_AsyncLocalStorage:Modules.Require_AsyncHooks_AsyncLocalStorage:__js_module_init__:153"
+		IL_0694: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0699: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_069e: stloc.s 4
+		IL_06a0: ldloc.s 6
+		IL_06a2: ldstr "captured disabled:"
+		IL_06a7: ldloc.s 4
+		IL_06a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_06ae: pop
+		IL_06af: ret
 	} // end of method Require_AsyncHooks_AsyncLocalStorage::__js_module_init__
 
 } // end of class Modules.Require_AsyncHooks_AsyncLocalStorage
@@ -2027,6 +2091,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_32
 	.field assembly static int32 __jroc_dynamicLookup_33
 	.field assembly static int32 __jroc_dynamicLookup_34
+	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
+	.field assembly static int32 __jroc_dynamicLookup_37
+	.field assembly static int32 __jroc_dynamicLookup_38
+	.field assembly static int32 __jroc_dynamicLookup_39
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncLocalStorage_Propagation.verified.txt
+++ b/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncLocalStorage_Propagation.verified.txt
@@ -197,7 +197,7 @@
 				IL_000e: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::'storage'
 				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0018: volatile.
-				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 				IL_001f: brfalse IL_0033
 
 				IL_0024: ldstr "getStore"
@@ -206,7 +206,7 @@
 
 				IL_0033: ldstr "getStore"
 				IL_0038: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M11>:__js_call__:4"
-				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0047: stloc.1
@@ -342,7 +342,7 @@
 				IL_000e: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::'storage'
 				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0018: volatile.
-				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_001f: brfalse IL_0033
 
 				IL_0024: ldstr "getStore"
@@ -351,7 +351,7 @@
 
 				IL_0033: ldstr "getStore"
 				IL_0038: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M12>:__js_call__:4"
-				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0047: stloc.1
@@ -487,7 +487,7 @@
 				IL_000e: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::'storage'
 				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0018: volatile.
-				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
 				IL_001f: brfalse IL_0033
 
 				IL_0024: ldstr "getStore"
@@ -496,7 +496,7 @@
 
 				IL_0033: ldstr "getStore"
 				IL_0038: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M13>:__js_call__:4"
-				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
 				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0047: stloc.1
@@ -632,7 +632,7 @@
 				IL_000e: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::'storage'
 				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0018: volatile.
-				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 				IL_001f: brfalse IL_0033
 
 				IL_0024: ldstr "getStore"
@@ -641,7 +641,7 @@
 
 				IL_0033: ldstr "getStore"
 				IL_0038: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M14>:__js_call__:4"
-				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0047: stloc.1
@@ -777,7 +777,7 @@
 				IL_000e: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::'storage'
 				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0018: volatile.
-				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 				IL_001f: brfalse IL_0033
 
 				IL_0024: ldstr "getStore"
@@ -786,7 +786,7 @@
 
 				IL_0033: ldstr "getStore"
 				IL_0038: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M15>:__js_call__:4"
-				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0047: stloc.1
@@ -899,7 +899,7 @@
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
 			// Header size: 12
-			// Code size: 448 (0x1c0)
+			// Code size: 527 (0x20f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/Scope,
@@ -944,129 +944,119 @@
 			IL_003c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L8C22/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L8C22/FunctionObject>(!!0)
 			IL_0046: stloc.3
-			IL_0047: ldloc.1
-			IL_0048: ldstr "nextTick"
-			IL_004d: ldloc.3
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0053: pop
-			IL_0054: ldstr "Promise"
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0063: volatile.
-			IL_0065: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-			IL_006a: brfalse IL_007e
+			IL_0047: volatile.
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_004e: brfalse IL_0064
 
-			IL_006f: ldstr "resolve"
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0079: br IL_0092
+			IL_0053: ldloc.1
+			IL_0054: ldstr "nextTick"
+			IL_0059: ldloc.3
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_005f: br IL_007a
 
-			IL_007e: ldstr "resolve"
-			IL_0083: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M4>:__js_call__:12"
-			IL_0088: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0064: ldloc.1
+			IL_0065: ldstr "nextTick"
+			IL_006a: ldloc.3
+			IL_006b: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M4>:__js_call__:7"
+			IL_0070: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0092: stloc.1
-			IL_0093: ldloc.1
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0099: stloc.1
-			IL_009a: ldc.i4.2
-			IL_009b: newarr [System.Runtime]System.Object
-			IL_00a0: dup
-			IL_00a1: ldc.i4.0
-			IL_00a2: ldarg.0
-			IL_00a3: stelem.ref
-			IL_00a4: dup
-			IL_00a5: ldc.i4.1
-			IL_00a6: ldloc.0
-			IL_00a7: stelem.ref
-			IL_00a8: stloc.2
-			IL_00a9: ldloc.2
-			IL_00aa: ldc.i4.0
-			IL_00ab: ldelem.ref
-			IL_00ac: castclass Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope
-			IL_00b1: ldloc.2
-			IL_00b2: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L9C28/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope, object[])
-			IL_00b7: ldc.i4.0
-			IL_00b8: conv.r8
-			IL_00b9: ldstr ""
-			IL_00be: ldc.i4.0
-			IL_00bf: ldc.i4.0
-			IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L9C28/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_00c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L9C28/FunctionObject>(!!0)
-			IL_00ca: stloc.s 4
-			IL_00cc: ldloc.1
-			IL_00cd: ldstr "then"
-			IL_00d2: ldloc.s 4
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d9: pop
-			IL_00da: ldc.i4.2
-			IL_00db: newarr [System.Runtime]System.Object
-			IL_00e0: dup
-			IL_00e1: ldc.i4.0
-			IL_00e2: ldarg.0
-			IL_00e3: stelem.ref
-			IL_00e4: dup
-			IL_00e5: ldc.i4.1
-			IL_00e6: ldloc.0
-			IL_00e7: stelem.ref
-			IL_00e8: stloc.2
-			IL_00e9: ldloc.2
-			IL_00ea: ldc.i4.0
-			IL_00eb: ldelem.ref
-			IL_00ec: castclass Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope
-			IL_00f1: ldloc.2
-			IL_00f2: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L10C16/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope, object[])
-			IL_00f7: ldc.i4.0
-			IL_00f8: conv.r8
-			IL_00f9: ldstr ""
-			IL_00fe: ldc.i4.0
-			IL_00ff: ldc.i4.0
-			IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L10C16/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L10C16/FunctionObject>(!!0)
-			IL_010a: stloc.s 5
-			IL_010c: ldloc.s 5
-			IL_010e: ldc.r8 0.0
-			IL_0117: box [System.Runtime]System.Double
-			IL_011c: ldc.i4.0
-			IL_011d: newarr [System.Runtime]System.Object
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
-			IL_0127: pop
-			IL_0128: ldc.i4.2
-			IL_0129: newarr [System.Runtime]System.Object
-			IL_012e: dup
-			IL_012f: ldc.i4.0
-			IL_0130: ldarg.0
-			IL_0131: stelem.ref
-			IL_0132: dup
-			IL_0133: ldc.i4.1
-			IL_0134: ldloc.0
-			IL_0135: stelem.ref
-			IL_0136: stloc.2
-			IL_0137: ldloc.2
-			IL_0138: ldc.i4.0
-			IL_0139: ldelem.ref
-			IL_013a: castclass Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope
-			IL_013f: ldloc.2
-			IL_0140: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L11C18/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope, object[])
-			IL_0145: ldc.i4.0
-			IL_0146: conv.r8
-			IL_0147: ldstr ""
-			IL_014c: ldc.i4.0
+			IL_007a: pop
+			IL_007b: ldstr "Promise"
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008a: volatile.
+			IL_008c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0091: brfalse IL_00a5
+
+			IL_0096: ldstr "resolve"
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00a0: br IL_00b9
+
+			IL_00a5: ldstr "resolve"
+			IL_00aa: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M4>:__js_call__:12"
+			IL_00af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+			IL_00b9: stloc.1
+			IL_00ba: ldloc.1
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c0: stloc.1
+			IL_00c1: ldc.i4.2
+			IL_00c2: newarr [System.Runtime]System.Object
+			IL_00c7: dup
+			IL_00c8: ldc.i4.0
+			IL_00c9: ldarg.0
+			IL_00ca: stelem.ref
+			IL_00cb: dup
+			IL_00cc: ldc.i4.1
+			IL_00cd: ldloc.0
+			IL_00ce: stelem.ref
+			IL_00cf: stloc.2
+			IL_00d0: ldloc.2
+			IL_00d1: ldc.i4.0
+			IL_00d2: ldelem.ref
+			IL_00d3: castclass Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope
+			IL_00d8: ldloc.2
+			IL_00d9: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L9C28/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope, object[])
+			IL_00de: ldc.i4.0
+			IL_00df: conv.r8
+			IL_00e0: ldstr ""
+			IL_00e5: ldc.i4.0
+			IL_00e6: ldc.i4.0
+			IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L9C28/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L9C28/FunctionObject>(!!0)
+			IL_00f1: stloc.s 4
+			IL_00f3: volatile.
+			IL_00f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_00fa: brfalse IL_0111
+
+			IL_00ff: ldloc.1
+			IL_0100: ldstr "then"
+			IL_0105: ldloc.s 4
+			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_010c: br IL_0128
+
+			IL_0111: ldloc.1
+			IL_0112: ldstr "then"
+			IL_0117: ldloc.s 4
+			IL_0119: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M4>:__js_call__:16"
+			IL_011e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0128: pop
+			IL_0129: ldc.i4.2
+			IL_012a: newarr [System.Runtime]System.Object
+			IL_012f: dup
+			IL_0130: ldc.i4.0
+			IL_0131: ldarg.0
+			IL_0132: stelem.ref
+			IL_0133: dup
+			IL_0134: ldc.i4.1
+			IL_0135: ldloc.0
+			IL_0136: stelem.ref
+			IL_0137: stloc.2
+			IL_0138: ldloc.2
+			IL_0139: ldc.i4.0
+			IL_013a: ldelem.ref
+			IL_013b: castclass Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope
+			IL_0140: ldloc.2
+			IL_0141: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L10C16/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope, object[])
+			IL_0146: ldc.i4.0
+			IL_0147: conv.r8
+			IL_0148: ldstr ""
 			IL_014d: ldc.i4.0
-			IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L11C18/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0153: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L11C18/FunctionObject>(!!0)
-			IL_0158: stloc.s 6
-			IL_015a: ldloc.s 6
-			IL_015c: ldc.i4.0
-			IL_015d: newarr [System.Runtime]System.Object
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-			IL_0167: pop
-			IL_0168: ldarg.0
-			IL_0169: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::fs
-			IL_016e: stloc.s 7
-			IL_0170: ldarg.0
-			IL_0171: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::__filename
-			IL_0176: stloc.1
+			IL_014e: ldc.i4.0
+			IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L10C16/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L10C16/FunctionObject>(!!0)
+			IL_0159: stloc.s 5
+			IL_015b: ldloc.s 5
+			IL_015d: ldc.r8 0.0
+			IL_0166: box [System.Runtime]System.Double
+			IL_016b: ldc.i4.0
+			IL_016c: newarr [System.Runtime]System.Object
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
+			IL_0176: pop
 			IL_0177: ldc.i4.2
 			IL_0178: newarr [System.Runtime]System.Object
 			IL_017d: dup
@@ -1083,24 +1073,60 @@
 			IL_0188: ldelem.ref
 			IL_0189: castclass Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope
 			IL_018e: ldloc.2
-			IL_018f: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L12C37/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope, object[])
+			IL_018f: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L11C18/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope, object[])
 			IL_0194: ldc.i4.0
 			IL_0195: conv.r8
 			IL_0196: ldstr ""
 			IL_019b: ldc.i4.0
 			IL_019c: ldc.i4.0
-			IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L12C37/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L12C37/FunctionObject>(!!0)
-			IL_01a7: stloc.s 8
-			IL_01a9: ldloc.s 7
-			IL_01ab: ldstr "readFile"
-			IL_01b0: ldloc.1
-			IL_01b1: ldstr "utf8"
-			IL_01b6: ldloc.s 8
-			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_01bd: pop
-			IL_01be: ldnull
-			IL_01bf: ret
+			IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L11C18/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L11C18/FunctionObject>(!!0)
+			IL_01a7: stloc.s 6
+			IL_01a9: ldloc.s 6
+			IL_01ab: ldc.i4.0
+			IL_01ac: newarr [System.Runtime]System.Object
+			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+			IL_01b6: pop
+			IL_01b7: ldarg.0
+			IL_01b8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::fs
+			IL_01bd: stloc.s 7
+			IL_01bf: ldarg.0
+			IL_01c0: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::__filename
+			IL_01c5: stloc.1
+			IL_01c6: ldc.i4.2
+			IL_01c7: newarr [System.Runtime]System.Object
+			IL_01cc: dup
+			IL_01cd: ldc.i4.0
+			IL_01ce: ldarg.0
+			IL_01cf: stelem.ref
+			IL_01d0: dup
+			IL_01d1: ldc.i4.1
+			IL_01d2: ldloc.0
+			IL_01d3: stelem.ref
+			IL_01d4: stloc.2
+			IL_01d5: ldloc.2
+			IL_01d6: ldc.i4.0
+			IL_01d7: ldelem.ref
+			IL_01d8: castclass Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope
+			IL_01dd: ldloc.2
+			IL_01de: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L12C37/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope, object[])
+			IL_01e3: ldc.i4.0
+			IL_01e4: conv.r8
+			IL_01e5: ldstr ""
+			IL_01ea: ldc.i4.0
+			IL_01eb: ldc.i4.0
+			IL_01ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L12C37/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L7C22/ArrowFunction_L12C37/FunctionObject>(!!0)
+			IL_01f6: stloc.s 8
+			IL_01f8: ldloc.s 7
+			IL_01fa: ldstr "readFile"
+			IL_01ff: ldloc.1
+			IL_0200: ldstr "utf8"
+			IL_0205: ldloc.s 8
+			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_020c: pop
+			IL_020d: ldnull
+			IL_020e: ret
 		} // end of method ArrowFunction_L7C22::__js_call__
 
 	} // end of class ArrowFunction_L7C22
@@ -1230,7 +1256,7 @@
 				IL_000e: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::'storage'
 				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0018: volatile.
-				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 				IL_001f: brfalse IL_0033
 
 				IL_0024: ldstr "getStore"
@@ -1239,7 +1265,7 @@
 
 				IL_0033: ldstr "getStore"
 				IL_0038: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M16>:__js_call__:4"
-				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0047: stloc.1
@@ -1352,7 +1378,7 @@
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
 			// Header size: 12
-			// Code size: 140 (0x8c)
+			// Code size: 179 (0xb3)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L15C24/Scope,
@@ -1367,7 +1393,7 @@
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0015: volatile.
-			IL_0017: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0017: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_001c: brfalse IL_0030
 
 			IL_0021: ldstr "resolve"
@@ -1376,7 +1402,7 @@
 
 			IL_0030: ldstr "resolve"
 			IL_0035: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0044: stloc.1
@@ -1408,13 +1434,26 @@
 			IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L15C24/ArrowFunction_L16C28/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/ArrowFunction_L15C24/ArrowFunction_L16C28/FunctionObject>(!!0)
 			IL_007c: stloc.3
-			IL_007d: ldloc.1
-			IL_007e: ldstr "then"
-			IL_0083: ldloc.3
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0089: pop
-			IL_008a: ldnull
-			IL_008b: ret
+			IL_007d: volatile.
+			IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0084: brfalse IL_009a
+
+			IL_0089: ldloc.1
+			IL_008a: ldstr "then"
+			IL_008f: ldloc.3
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0095: br IL_00b0
+
+			IL_009a: ldloc.1
+			IL_009b: ldstr "then"
+			IL_00a0: ldloc.3
+			IL_00a1: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M5>:__js_call__:9"
+			IL_00a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00b0: pop
+			IL_00b1: ldnull
+			IL_00b2: ret
 		} // end of method ArrowFunction_L15C24::__js_call__
 
 	} // end of class ArrowFunction_L15C24
@@ -1659,7 +1698,7 @@
 			IL_0007: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::'storage'
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "getStore"
@@ -1668,7 +1707,7 @@
 
 			IL_002c: ldstr "getStore"
 			IL_0031: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M7>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
@@ -2057,7 +2096,7 @@
 				IL_000e: ldfld object Modules.Require_AsyncHooks_AsyncLocalStorage_Propagation/Scope::'storage'
 				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0018: volatile.
-				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+				IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 				IL_001f: brfalse IL_0033
 
 				IL_0024: ldstr "getStore"
@@ -2066,7 +2105,7 @@
 
 				IL_0033: ldstr "getStore"
 				IL_0038: ldstr "Require_AsyncHooks_AsyncLocalStorage_Propagation:<TwoPhaseDummy_M17>:__js_call__:4"
-				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0047: stloc.1
@@ -2670,6 +2709,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_39
 	.field assembly static int32 __jroc_dynamicLookup_40
 	.field assembly static int32 __jroc_dynamicLookup_41
+	.field assembly static int32 __jroc_dynamicLookup_42
+	.field assembly static int32 __jroc_dynamicLookup_43
+	.field assembly static int32 __jroc_dynamicLookup_44
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncResource.verified.txt
+++ b/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncResource.verified.txt
@@ -301,7 +301,7 @@
 			IL_0078: ldfld object Modules.Require_AsyncHooks_AsyncResource/Scope::resource
 			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0082: volatile.
-			IL_0084: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0084: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_0089: brfalse IL_009d
 
 			IL_008e: ldstr "asyncId"
@@ -310,7 +310,7 @@
 
 			IL_009d: ldstr "asyncId"
 			IL_00a2: ldstr "Require_AsyncHooks_AsyncResource:<TwoPhaseDummy_M4>:__js_call__:15"
-			IL_00a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_00a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_00b1: stloc.s 5
@@ -353,7 +353,7 @@
 			IL_0117: ldfld object Modules.Require_AsyncHooks_AsyncResource/Scope::resource
 			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0121: volatile.
-			IL_0123: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0123: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0128: brfalse IL_013c
 
 			IL_012d: ldstr "triggerAsyncId"
@@ -362,7 +362,7 @@
 
 			IL_013c: ldstr "triggerAsyncId"
 			IL_0141: ldstr "Require_AsyncHooks_AsyncResource:<TwoPhaseDummy_M4>:__js_call__:26"
-			IL_0146: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0146: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0150: stloc.1
@@ -379,7 +379,7 @@
 			IL_0168: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_016d: pop
 			IL_016e: volatile.
-			IL_0170: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0170: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0175: brfalse IL_0194
 
 			IL_017a: ldarg.2
@@ -394,7 +394,7 @@
 			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_019f: ldstr "value"
 			IL_01a4: ldstr "Require_AsyncHooks_AsyncResource:<TwoPhaseDummy_M4>:__js_call__:33"
-			IL_01a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_01a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01b3: stloc.1
@@ -569,7 +569,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -584,7 +584,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "value"
 			IL_0036: ldstr "Require_AsyncHooks_AsyncResource:<TwoPhaseDummy_M5>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -747,7 +747,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -762,7 +762,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "value"
 			IL_0036: ldstr "Require_AsyncHooks_AsyncResource:<TwoPhaseDummy_M6>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -971,7 +971,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1074 (0x432)
+		// Code size: 1115 (0x45b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_AsyncHooks_AsyncResource/Scope,
@@ -1280,102 +1280,115 @@
 			IL_0323: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource/ArrowFunction_L28C30/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0328: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncResource/ArrowFunction_L28C30/FunctionObject>(!!0)
 			IL_032d: stloc.s 22
-			IL_032f: ldloc.s 15
-			IL_0331: ldstr "runInAsyncScope"
-			IL_0336: ldloc.s 22
-			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_033d: pop
-			IL_033e: leave IL_03c5
+			IL_032f: volatile.
+			IL_0331: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0336: brfalse IL_034e
+
+			IL_033b: ldloc.s 15
+			IL_033d: ldstr "runInAsyncScope"
+			IL_0342: ldloc.s 22
+			IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0349: br IL_0366
+
+			IL_034e: ldloc.s 15
+			IL_0350: ldstr "runInAsyncScope"
+			IL_0355: ldloc.s 22
+			IL_0357: ldstr "Require_AsyncHooks_AsyncResource:Modules.Require_AsyncHooks_AsyncResource:__js_module_init__:97"
+			IL_035c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0366: pop
+			IL_0367: leave IL_03ee
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0343: stloc.s 6
-			IL_0345: ldloc.s 6
-			IL_0347: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_034c: dup
-			IL_034d: brtrue IL_0363
+			IL_036c: stloc.s 6
+			IL_036e: ldloc.s 6
+			IL_0370: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0375: dup
+			IL_0376: brtrue IL_038c
 
-			IL_0352: pop
-			IL_0353: ldloc.s 6
-			IL_0355: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_035a: dup
-			IL_035b: brtrue IL_036f
+			IL_037b: pop
+			IL_037c: ldloc.s 6
+			IL_037e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0383: dup
+			IL_0384: brtrue IL_0398
 
-			IL_0360: pop
-			IL_0361: rethrow
+			IL_0389: pop
+			IL_038a: rethrow
 
-			IL_0363: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0368: stloc.s 7
-			IL_036a: br IL_0371
+			IL_038c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0391: stloc.s 7
+			IL_0393: br IL_039a
 
-			IL_036f: stloc.s 7
+			IL_0398: stloc.s 7
 
-			IL_0371: ldloc.s 7
-			IL_0373: stloc.s 8
-			IL_0375: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_037a: stloc.s 16
-			IL_037c: volatile.
-			IL_037e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-			IL_0383: brfalse IL_0399
+			IL_039a: ldloc.s 7
+			IL_039c: stloc.s 8
+			IL_039e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03a3: stloc.s 16
+			IL_03a5: volatile.
+			IL_03a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_03ac: brfalse IL_03c2
 
-			IL_0388: ldloc.s 8
-			IL_038a: ldstr "message"
-			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0394: br IL_03af
+			IL_03b1: ldloc.s 8
+			IL_03b3: ldstr "message"
+			IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03bd: br IL_03d8
 
-			IL_0399: ldloc.s 8
-			IL_039b: ldstr "message"
-			IL_03a0: ldstr "Require_AsyncHooks_AsyncResource:Modules.Require_AsyncHooks_AsyncResource:__js_module_init__:109"
-			IL_03a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-			IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03c2: ldloc.s 8
+			IL_03c4: ldstr "message"
+			IL_03c9: ldstr "Require_AsyncHooks_AsyncResource:Modules.Require_AsyncHooks_AsyncResource:__js_module_init__:109"
+			IL_03ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03af: stloc.s 15
-			IL_03b1: ldloc.s 16
-			IL_03b3: ldstr "error:"
-			IL_03b8: ldloc.s 15
-			IL_03ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_03bf: pop
-			IL_03c0: leave IL_03c5
+			IL_03d8: stloc.s 15
+			IL_03da: ldloc.s 16
+			IL_03dc: ldstr "error:"
+			IL_03e1: ldloc.s 15
+			IL_03e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_03e8: pop
+			IL_03e9: leave IL_03ee
 		} // end handler
 
-		IL_03c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03ca: stloc.s 16
-		IL_03cc: ldloc.0
-		IL_03cd: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAsyncHooksModule Modules.Require_AsyncHooks_AsyncResource/Scope::asyncHooks
-		IL_03d2: stloc.s 10
-		IL_03d4: ldloc.s 10
-		IL_03d6: ldstr "executionAsyncId"
-		IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_03e0: brtrue IL_03f8
+		IL_03ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03f3: stloc.s 16
+		IL_03f5: ldloc.0
+		IL_03f6: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAsyncHooksModule Modules.Require_AsyncHooks_AsyncResource/Scope::asyncHooks
+		IL_03fb: stloc.s 10
+		IL_03fd: ldloc.s 10
+		IL_03ff: ldstr "executionAsyncId"
+		IL_0404: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_0409: brtrue IL_0421
 
-		IL_03e5: ldloc.s 10
-		IL_03e7: callvirt instance float64 [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAsyncHooksModule::executionAsyncId()
-		IL_03ec: box [System.Runtime]System.Double
-		IL_03f1: stloc.s 15
-		IL_03f3: br IL_040c
+		IL_040e: ldloc.s 10
+		IL_0410: callvirt instance float64 [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IAsyncHooksModule::executionAsyncId()
+		IL_0415: box [System.Runtime]System.Double
+		IL_041a: stloc.s 15
+		IL_041c: br IL_0435
 
-		IL_03f8: ldloc.s 10
-		IL_03fa: ldstr "executionAsyncId"
-		IL_03ff: ldc.i4.0
-		IL_0400: newarr [System.Runtime]System.Object
-		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-		IL_040a: stloc.s 15
+		IL_0421: ldloc.s 10
+		IL_0423: ldstr "executionAsyncId"
+		IL_0428: ldc.i4.0
+		IL_0429: newarr [System.Runtime]System.Object
+		IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_0433: stloc.s 15
 
-		IL_040c: ldloc.s 15
-		IL_040e: ldloc.2
-		IL_040f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0414: stloc.s 17
-		IL_0416: ldloc.s 17
-		IL_0418: box [System.Runtime]System.Boolean
-		IL_041d: stloc.s 18
-		IL_041f: ldloc.s 16
-		IL_0421: ldstr "restored:"
-		IL_0426: ldloc.s 18
-		IL_0428: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_042d: pop
-		IL_042e: ldnull
-		IL_042f: stloc.s 9
-		IL_0431: ret
+		IL_0435: ldloc.s 15
+		IL_0437: ldloc.2
+		IL_0438: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_043d: stloc.s 17
+		IL_043f: ldloc.s 17
+		IL_0441: box [System.Runtime]System.Boolean
+		IL_0446: stloc.s 18
+		IL_0448: ldloc.s 16
+		IL_044a: ldstr "restored:"
+		IL_044f: ldloc.s 18
+		IL_0451: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0456: pop
+		IL_0457: ldnull
+		IL_0458: stloc.s 9
+		IL_045a: ret
 	} // end of method Require_AsyncHooks_AsyncResource::__js_module_init__
 
 } // end of class Modules.Require_AsyncHooks_AsyncResource
@@ -1411,6 +1424,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_CreateHook.verified.txt
+++ b/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_CreateHook.verified.txt
@@ -1109,7 +1109,7 @@
 			IL_0007: ldfld object Modules.Require_AsyncHooks_CreateHook/Scope::hook
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "disable"
@@ -1118,7 +1118,7 @@
 
 			IL_002c: ldstr "disable"
 			IL_0031: ldstr "Require_AsyncHooks_CreateHook:<TwoPhaseDummy_M11>:__js_call__:5"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
@@ -1216,7 +1216,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1009 (0x3f1)
+		// Code size: 1091 (0x443)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_AsyncHooks_CreateHook/Scope,
@@ -1533,83 +1533,109 @@
 		IL_030e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L30C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0313: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L30C26/FunctionObject>(!!0)
 		IL_0318: stloc.s 17
-		IL_031a: ldloc.s 14
-		IL_031c: ldstr "runInAsyncScope"
-		IL_0321: ldloc.s 17
-		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0328: pop
-		IL_0329: ldloc.0
-		IL_032a: ldfld object Modules.Require_AsyncHooks_CreateHook/Scope::resource
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0334: volatile.
-		IL_0336: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_033b: brfalse IL_034f
+		IL_031a: volatile.
+		IL_031c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0321: brfalse IL_0339
 
-		IL_0340: ldstr "emitDestroy"
-		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_034a: br IL_0363
+		IL_0326: ldloc.s 14
+		IL_0328: ldstr "runInAsyncScope"
+		IL_032d: ldloc.s 17
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0334: br IL_0351
 
-		IL_034f: ldstr "emitDestroy"
-		IL_0354: ldstr "Require_AsyncHooks_CreateHook:Modules.Require_AsyncHooks_CreateHook:__js_module_init__:77"
-		IL_0359: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0339: ldloc.s 14
+		IL_033b: ldstr "runInAsyncScope"
+		IL_0340: ldloc.s 17
+		IL_0342: ldstr "Require_AsyncHooks_CreateHook:Modules.Require_AsyncHooks_CreateHook:__js_module_init__:73"
+		IL_0347: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0363: pop
-		IL_0364: ldstr "done"
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0373: stloc.s 14
-		IL_0375: ldc.i4.1
-		IL_0376: newarr [System.Runtime]System.Object
-		IL_037b: dup
-		IL_037c: ldc.i4.0
-		IL_037d: ldloc.0
-		IL_037e: stelem.ref
-		IL_037f: stloc.s 5
-		IL_0381: ldloc.s 5
-		IL_0383: ldc.i4.0
-		IL_0384: ldelem.ref
-		IL_0385: castclass Modules.Require_AsyncHooks_CreateHook/Scope
-		IL_038a: newobj instance void Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L34C30/FunctionObject::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
-		IL_038f: ldc.i4.0
-		IL_0390: conv.r8
-		IL_0391: ldstr ""
-		IL_0396: ldc.i4.0
-		IL_0397: ldc.i4.0
-		IL_0398: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L34C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_039d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L34C30/FunctionObject>(!!0)
-		IL_03a2: stloc.s 18
-		IL_03a4: ldloc.s 14
-		IL_03a6: ldstr "then"
-		IL_03ab: ldloc.s 18
-		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03b2: pop
-		IL_03b3: ldc.i4.1
-		IL_03b4: newarr [System.Runtime]System.Object
-		IL_03b9: dup
-		IL_03ba: ldc.i4.0
-		IL_03bb: ldloc.0
-		IL_03bc: stelem.ref
-		IL_03bd: stloc.s 5
-		IL_03bf: ldloc.s 5
-		IL_03c1: ldc.i4.0
-		IL_03c2: ldelem.ref
-		IL_03c3: castclass Modules.Require_AsyncHooks_CreateHook/Scope
-		IL_03c8: newobj instance void Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L37C14/FunctionObject::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
-		IL_03cd: ldc.i4.0
-		IL_03ce: conv.r8
-		IL_03cf: ldstr ""
-		IL_03d4: ldc.i4.0
-		IL_03d5: ldc.i4.0
-		IL_03d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L37C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L37C14/FunctionObject>(!!0)
-		IL_03e0: stloc.s 19
-		IL_03e2: ldloc.s 19
-		IL_03e4: ldc.i4.0
-		IL_03e5: newarr [System.Runtime]System.Object
-		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_03ef: pop
-		IL_03f0: ret
+		IL_0351: pop
+		IL_0352: ldloc.0
+		IL_0353: ldfld object Modules.Require_AsyncHooks_CreateHook/Scope::resource
+		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_035d: volatile.
+		IL_035f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0364: brfalse IL_0378
+
+		IL_0369: ldstr "emitDestroy"
+		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0373: br IL_038c
+
+		IL_0378: ldstr "emitDestroy"
+		IL_037d: ldstr "Require_AsyncHooks_CreateHook:Modules.Require_AsyncHooks_CreateHook:__js_module_init__:77"
+		IL_0382: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_038c: pop
+		IL_038d: ldstr "done"
+		IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_039c: stloc.s 14
+		IL_039e: ldc.i4.1
+		IL_039f: newarr [System.Runtime]System.Object
+		IL_03a4: dup
+		IL_03a5: ldc.i4.0
+		IL_03a6: ldloc.0
+		IL_03a7: stelem.ref
+		IL_03a8: stloc.s 5
+		IL_03aa: ldloc.s 5
+		IL_03ac: ldc.i4.0
+		IL_03ad: ldelem.ref
+		IL_03ae: castclass Modules.Require_AsyncHooks_CreateHook/Scope
+		IL_03b3: newobj instance void Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L34C30/FunctionObject::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
+		IL_03b8: ldc.i4.0
+		IL_03b9: conv.r8
+		IL_03ba: ldstr ""
+		IL_03bf: ldc.i4.0
+		IL_03c0: ldc.i4.0
+		IL_03c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L34C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L34C30/FunctionObject>(!!0)
+		IL_03cb: stloc.s 18
+		IL_03cd: volatile.
+		IL_03cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_03d4: brfalse IL_03ec
+
+		IL_03d9: ldloc.s 14
+		IL_03db: ldstr "then"
+		IL_03e0: ldloc.s 18
+		IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03e7: br IL_0404
+
+		IL_03ec: ldloc.s 14
+		IL_03ee: ldstr "then"
+		IL_03f3: ldloc.s 18
+		IL_03f5: ldstr "Require_AsyncHooks_CreateHook:Modules.Require_AsyncHooks_CreateHook:__js_module_init__:84"
+		IL_03fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0404: pop
+		IL_0405: ldc.i4.1
+		IL_0406: newarr [System.Runtime]System.Object
+		IL_040b: dup
+		IL_040c: ldc.i4.0
+		IL_040d: ldloc.0
+		IL_040e: stelem.ref
+		IL_040f: stloc.s 5
+		IL_0411: ldloc.s 5
+		IL_0413: ldc.i4.0
+		IL_0414: ldelem.ref
+		IL_0415: castclass Modules.Require_AsyncHooks_CreateHook/Scope
+		IL_041a: newobj instance void Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L37C14/FunctionObject::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
+		IL_041f: ldc.i4.0
+		IL_0420: conv.r8
+		IL_0421: ldstr ""
+		IL_0426: ldc.i4.0
+		IL_0427: ldc.i4.0
+		IL_0428: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L37C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_042d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/ArrowFunction_L37C14/FunctionObject>(!!0)
+		IL_0432: stloc.s 19
+		IL_0434: ldloc.s 19
+		IL_0436: ldc.i4.0
+		IL_0437: newarr [System.Runtime]System.Object
+		IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0441: pop
+		IL_0442: ret
 	} // end of method Require_AsyncHooks_CreateHook::__js_module_init__
 
 } // end of class Modules.Require_AsyncHooks_CreateHook
@@ -1645,6 +1671,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
 	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Advanced_CoreApis.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Advanced_CoreApis.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1643 (0x66b)
+		// Code size: 2210 (0x8a2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_Advanced_CoreApis/Scope,
@@ -219,337 +219,498 @@
 		IL_0191: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0196: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 		IL_019b: stloc.s 10
-		IL_019d: ldloc.s 7
-		IL_019f: ldstr "equals"
-		IL_01a4: ldloc.s 10
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ab: stloc.s 9
-		IL_01ad: ldloc.s 8
-		IL_01af: ldloc.s 9
-		IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b6: pop
-		IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01bc: stloc.s 8
-		IL_01be: ldloc.1
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_01c4: stloc.s 10
-		IL_01c6: ldloc.s 10
-		IL_01c8: ldstr "indexOf"
-		IL_01cd: ldc.r8 77
-		IL_01d6: box [System.Runtime]System.Double
-		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e0: stloc.s 9
-		IL_01e2: ldloc.s 8
-		IL_01e4: ldloc.s 9
-		IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01eb: pop
-		IL_01ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f1: stloc.s 8
-		IL_01f3: ldloc.1
-		IL_01f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_01f9: stloc.s 10
-		IL_01fb: ldc.i4.2
-		IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0201: dup
+		IL_019d: volatile.
+		IL_019f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_01a4: brfalse IL_01bc
+
+		IL_01a9: ldloc.s 7
+		IL_01ab: ldstr "equals"
+		IL_01b0: ldloc.s 10
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b7: br IL_01d4
+
+		IL_01bc: ldloc.s 7
+		IL_01be: ldstr "equals"
+		IL_01c3: ldloc.s 10
+		IL_01c5: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:56"
+		IL_01ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01d4: stloc.s 9
+		IL_01d6: ldloc.s 8
+		IL_01d8: ldloc.s 9
+		IL_01da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01df: pop
+		IL_01e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e5: stloc.s 8
+		IL_01e7: ldloc.1
+		IL_01e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_01ed: stloc.s 10
+		IL_01ef: volatile.
+		IL_01f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_01f6: brfalse IL_021a
+
+		IL_01fb: ldloc.s 10
+		IL_01fd: ldstr "indexOf"
 		IL_0202: ldc.r8 77
-		IL_020b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0210: dup
-		IL_0211: ldc.r8 5
-		IL_021a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_021f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0224: stloc.s 7
-		IL_0226: ldloc.s 10
-		IL_0228: ldstr "lastIndexOf"
-		IL_022d: ldloc.s 7
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0234: stloc.s 9
-		IL_0236: ldloc.s 8
-		IL_0238: ldloc.s 9
-		IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023f: pop
-		IL_0240: ldc.r8 6
-		IL_0249: box [System.Runtime]System.Double
-		IL_024e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_0253: stloc.s 4
-		IL_0255: ldloc.s 4
-		IL_0257: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_025c: stloc.s 7
-		IL_025e: ldloc.s 7
-		IL_0260: ldstr "fill"
-		IL_0265: ldstr "ab"
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026f: pop
-		IL_0270: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0275: stloc.s 8
-		IL_0277: ldloc.s 4
-		IL_0279: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_027e: stloc.s 7
-		IL_0280: volatile.
-		IL_0282: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0287: brfalse IL_029d
+		IL_020b: box [System.Runtime]System.Double
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0215: br IL_023e
 
-		IL_028c: ldloc.s 7
-		IL_028e: ldstr "toString"
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0298: br IL_02b3
+		IL_021a: ldloc.s 10
+		IL_021c: ldstr "indexOf"
+		IL_0221: ldc.r8 77
+		IL_022a: box [System.Runtime]System.Double
+		IL_022f: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:63"
+		IL_0234: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_029d: ldloc.s 7
-		IL_029f: ldstr "toString"
-		IL_02a4: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:86"
-		IL_02a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_023e: stloc.s 9
+		IL_0240: ldloc.s 8
+		IL_0242: ldloc.s 9
+		IL_0244: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0249: pop
+		IL_024a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_024f: stloc.s 8
+		IL_0251: ldloc.1
+		IL_0252: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0257: stloc.s 10
+		IL_0259: ldc.i4.2
+		IL_025a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_025f: dup
+		IL_0260: ldc.r8 77
+		IL_0269: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_026e: dup
+		IL_026f: ldc.r8 5
+		IL_0278: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_027d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0282: stloc.s 7
+		IL_0284: volatile.
+		IL_0286: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_028b: brfalse IL_02a3
 
-		IL_02b3: stloc.s 9
-		IL_02b5: ldloc.s 8
-		IL_02b7: ldloc.s 9
-		IL_02b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02be: pop
-		IL_02bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c4: stloc.s 8
-		IL_02c6: ldloc.s 4
-		IL_02c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_02cd: stloc.s 7
-		IL_02cf: ldloc.s 7
-		IL_02d1: ldstr "indexOf"
-		IL_02d6: ldstr "ba"
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e0: stloc.s 9
-		IL_02e2: ldloc.s 8
-		IL_02e4: ldloc.s 9
-		IL_02e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02eb: pop
-		IL_02ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f1: stloc.s 8
-		IL_02f3: ldloc.s 4
-		IL_02f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_02fa: stloc.s 7
-		IL_02fc: ldloc.s 7
-		IL_02fe: ldstr "lastIndexOf"
-		IL_0303: ldstr "ab"
-		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030d: stloc.s 9
-		IL_030f: ldloc.s 8
-		IL_0311: ldloc.s 9
-		IL_0313: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0318: pop
-		IL_0319: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_031e: stloc.s 8
-		IL_0320: ldloc.s 4
-		IL_0322: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0327: stloc.s 7
-		IL_0329: ldloc.s 7
-		IL_032b: ldstr "includes"
-		IL_0330: ldstr "zz"
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_033a: stloc.s 9
-		IL_033c: ldloc.s 8
-		IL_033e: ldloc.s 9
-		IL_0340: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0345: pop
-		IL_0346: ldc.r8 16
-		IL_034f: box [System.Runtime]System.Double
-		IL_0354: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_0359: stloc.s 5
-		IL_035b: ldloc.s 5
-		IL_035d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0362: stloc.s 7
-		IL_0364: ldloc.s 7
-		IL_0366: ldstr "writeFloatLE"
-		IL_036b: ldc.r8 3.5
-		IL_0374: box [System.Runtime]System.Double
-		IL_0379: ldc.r8 0.0
-		IL_0382: box [System.Runtime]System.Double
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_038c: pop
-		IL_038d: ldloc.s 5
-		IL_038f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0394: stloc.s 7
-		IL_0396: ldloc.s 7
-		IL_0398: ldstr "writeFloatBE"
-		IL_039d: ldc.r8 3.5
-		IL_03a6: box [System.Runtime]System.Double
-		IL_03ab: ldc.r8 4
-		IL_03b4: box [System.Runtime]System.Double
-		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03be: pop
-		IL_03bf: ldloc.s 5
-		IL_03c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_03c6: stloc.s 7
-		IL_03c8: ldloc.s 7
-		IL_03ca: ldstr "writeDoubleLE"
-		IL_03cf: ldc.r8 10.25
-		IL_03d8: box [System.Runtime]System.Double
-		IL_03dd: ldc.r8 8
-		IL_03e6: box [System.Runtime]System.Double
-		IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03f0: pop
-		IL_03f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03f6: stloc.s 8
-		IL_03f8: ldloc.s 5
-		IL_03fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_03ff: stloc.s 7
-		IL_0401: ldloc.s 7
-		IL_0403: ldstr "readFloatLE"
-		IL_0408: ldc.r8 0.0
-		IL_0411: box [System.Runtime]System.Double
-		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_041b: stloc.s 9
-		IL_041d: ldloc.s 9
-		IL_041f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0424: ldc.r8 100
-		IL_042d: mul
-		IL_042e: stloc.s 11
-		IL_0430: ldloc.s 11
-		IL_0432: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
-		IL_0437: ldc.r8 100
-		IL_0440: div
-		IL_0441: stloc.s 11
-		IL_0443: ldloc.s 11
-		IL_0445: box [System.Runtime]System.Double
-		IL_044a: stloc.s 12
-		IL_044c: ldloc.s 8
-		IL_044e: ldloc.s 12
-		IL_0450: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0455: pop
-		IL_0456: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_045b: stloc.s 8
-		IL_045d: ldloc.s 5
-		IL_045f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0464: stloc.s 7
-		IL_0466: ldloc.s 7
-		IL_0468: ldstr "readFloatBE"
-		IL_046d: ldc.r8 4
-		IL_0476: box [System.Runtime]System.Double
-		IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0480: stloc.s 9
-		IL_0482: ldloc.s 9
-		IL_0484: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0489: ldc.r8 100
-		IL_0492: mul
-		IL_0493: stloc.s 11
-		IL_0495: ldloc.s 11
-		IL_0497: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
-		IL_049c: ldc.r8 100
-		IL_04a5: div
-		IL_04a6: stloc.s 11
-		IL_04a8: ldloc.s 11
-		IL_04aa: box [System.Runtime]System.Double
-		IL_04af: stloc.s 12
-		IL_04b1: ldloc.s 8
-		IL_04b3: ldloc.s 12
-		IL_04b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ba: pop
-		IL_04bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04c0: stloc.s 8
-		IL_04c2: ldloc.s 5
-		IL_04c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_04c9: stloc.s 7
-		IL_04cb: ldloc.s 7
-		IL_04cd: ldstr "readDoubleLE"
-		IL_04d2: ldc.r8 8
-		IL_04db: box [System.Runtime]System.Double
-		IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04e5: stloc.s 9
-		IL_04e7: ldloc.s 9
-		IL_04e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_04ee: ldc.r8 100
-		IL_04f7: mul
-		IL_04f8: stloc.s 11
-		IL_04fa: ldloc.s 11
-		IL_04fc: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
-		IL_0501: ldc.r8 100
-		IL_050a: div
-		IL_050b: stloc.s 11
-		IL_050d: ldloc.s 11
+		IL_0290: ldloc.s 10
+		IL_0292: ldstr "lastIndexOf"
+		IL_0297: ldloc.s 7
+		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029e: br IL_02bb
+
+		IL_02a3: ldloc.s 10
+		IL_02a5: ldstr "lastIndexOf"
+		IL_02aa: ldloc.s 7
+		IL_02ac: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:72"
+		IL_02b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02bb: stloc.s 9
+		IL_02bd: ldloc.s 8
+		IL_02bf: ldloc.s 9
+		IL_02c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c6: pop
+		IL_02c7: ldc.r8 6
+		IL_02d0: box [System.Runtime]System.Double
+		IL_02d5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_02da: stloc.s 4
+		IL_02dc: ldloc.s 4
+		IL_02de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_02e3: stloc.s 7
+		IL_02e5: volatile.
+		IL_02e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_02ec: brfalse IL_0307
+
+		IL_02f1: ldloc.s 7
+		IL_02f3: ldstr "fill"
+		IL_02f8: ldstr "ab"
+		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0302: br IL_0322
+
+		IL_0307: ldloc.s 7
+		IL_0309: ldstr "fill"
+		IL_030e: ldstr "ab"
+		IL_0313: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:82"
+		IL_0318: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0322: pop
+		IL_0323: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0328: stloc.s 8
+		IL_032a: ldloc.s 4
+		IL_032c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0331: stloc.s 7
+		IL_0333: volatile.
+		IL_0335: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_033a: brfalse IL_0350
+
+		IL_033f: ldloc.s 7
+		IL_0341: ldstr "toString"
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_034b: br IL_0366
+
+		IL_0350: ldloc.s 7
+		IL_0352: ldstr "toString"
+		IL_0357: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:86"
+		IL_035c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0366: stloc.s 9
+		IL_0368: ldloc.s 8
+		IL_036a: ldloc.s 9
+		IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0371: pop
+		IL_0372: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0377: stloc.s 8
+		IL_0379: ldloc.s 4
+		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0380: stloc.s 7
+		IL_0382: volatile.
+		IL_0384: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0389: brfalse IL_03a4
+
+		IL_038e: ldloc.s 7
+		IL_0390: ldstr "indexOf"
+		IL_0395: ldstr "ba"
+		IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_039f: br IL_03bf
+
+		IL_03a4: ldloc.s 7
+		IL_03a6: ldstr "indexOf"
+		IL_03ab: ldstr "ba"
+		IL_03b0: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:92"
+		IL_03b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03bf: stloc.s 9
+		IL_03c1: ldloc.s 8
+		IL_03c3: ldloc.s 9
+		IL_03c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03ca: pop
+		IL_03cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03d0: stloc.s 8
+		IL_03d2: ldloc.s 4
+		IL_03d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_03d9: stloc.s 7
+		IL_03db: volatile.
+		IL_03dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_03e2: brfalse IL_03fd
+
+		IL_03e7: ldloc.s 7
+		IL_03e9: ldstr "lastIndexOf"
+		IL_03ee: ldstr "ab"
+		IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03f8: br IL_0418
+
+		IL_03fd: ldloc.s 7
+		IL_03ff: ldstr "lastIndexOf"
+		IL_0404: ldstr "ab"
+		IL_0409: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:98"
+		IL_040e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0418: stloc.s 9
+		IL_041a: ldloc.s 8
+		IL_041c: ldloc.s 9
+		IL_041e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0423: pop
+		IL_0424: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0429: stloc.s 8
+		IL_042b: ldloc.s 4
+		IL_042d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0432: stloc.s 7
+		IL_0434: volatile.
+		IL_0436: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_043b: brfalse IL_0456
+
+		IL_0440: ldloc.s 7
+		IL_0442: ldstr "includes"
+		IL_0447: ldstr "zz"
+		IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0451: br IL_0471
+
+		IL_0456: ldloc.s 7
+		IL_0458: ldstr "includes"
+		IL_045d: ldstr "zz"
+		IL_0462: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:104"
+		IL_0467: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0471: stloc.s 9
+		IL_0473: ldloc.s 8
+		IL_0475: ldloc.s 9
+		IL_0477: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_047c: pop
+		IL_047d: ldc.r8 16
+		IL_0486: box [System.Runtime]System.Double
+		IL_048b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_0490: stloc.s 5
+		IL_0492: ldloc.s 5
+		IL_0494: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0499: stloc.s 7
+		IL_049b: ldloc.s 7
+		IL_049d: ldstr "writeFloatLE"
+		IL_04a2: ldc.r8 3.5
+		IL_04ab: box [System.Runtime]System.Double
+		IL_04b0: ldc.r8 0.0
+		IL_04b9: box [System.Runtime]System.Double
+		IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04c3: pop
+		IL_04c4: ldloc.s 5
+		IL_04c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_04cb: stloc.s 7
+		IL_04cd: ldloc.s 7
+		IL_04cf: ldstr "writeFloatBE"
+		IL_04d4: ldc.r8 3.5
+		IL_04dd: box [System.Runtime]System.Double
+		IL_04e2: ldc.r8 4
+		IL_04eb: box [System.Runtime]System.Double
+		IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04f5: pop
+		IL_04f6: ldloc.s 5
+		IL_04f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_04fd: stloc.s 7
+		IL_04ff: ldloc.s 7
+		IL_0501: ldstr "writeDoubleLE"
+		IL_0506: ldc.r8 10.25
 		IL_050f: box [System.Runtime]System.Double
-		IL_0514: stloc.s 12
-		IL_0516: ldloc.s 8
-		IL_0518: ldloc.s 12
-		IL_051a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_051f: pop
-		IL_0520: ldloc.s 5
-		IL_0522: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0527: stloc.s 7
-		IL_0529: ldc.r8 2.5
-		IL_0532: neg
-		IL_0533: stloc.s 11
-		IL_0535: ldloc.s 11
-		IL_0537: box [System.Runtime]System.Double
-		IL_053c: stloc.s 12
-		IL_053e: ldloc.s 7
-		IL_0540: ldstr "writeDoubleBE"
-		IL_0545: ldloc.s 12
-		IL_0547: ldc.r8 0.0
-		IL_0550: box [System.Runtime]System.Double
-		IL_0555: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_055a: pop
-		IL_055b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0560: stloc.s 8
-		IL_0562: ldloc.s 5
-		IL_0564: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0569: stloc.s 7
-		IL_056b: ldloc.s 7
-		IL_056d: ldstr "readDoubleBE"
-		IL_0572: ldc.r8 0.0
-		IL_057b: box [System.Runtime]System.Double
-		IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0585: stloc.s 9
-		IL_0587: ldloc.s 9
-		IL_0589: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_058e: ldc.r8 10
-		IL_0597: mul
-		IL_0598: stloc.s 11
-		IL_059a: ldloc.s 11
-		IL_059c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
-		IL_05a1: ldc.r8 10
-		IL_05aa: div
-		IL_05ab: stloc.s 11
-		IL_05ad: ldloc.s 11
-		IL_05af: box [System.Runtime]System.Double
-		IL_05b4: stloc.s 12
-		IL_05b6: ldloc.s 8
-		IL_05b8: ldloc.s 12
-		IL_05ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05bf: pop
-		IL_05c0: ldc.r8 4
-		IL_05c9: box [System.Runtime]System.Double
-		IL_05ce: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::allocUnsafe(object)
-		IL_05d3: stloc.s 6
-		IL_05d5: ldloc.s 6
-		IL_05d7: ldc.r8 0.0
-		IL_05e0: ldc.r8 1
-		IL_05e9: ldc.i4.1
-		IL_05ea: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_05ef: ldloc.s 6
-		IL_05f1: ldc.r8 1
-		IL_05fa: ldc.r8 2
-		IL_0603: ldc.i4.1
-		IL_0604: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0609: ldloc.s 6
-		IL_060b: ldc.r8 2
-		IL_0614: ldc.r8 3
-		IL_061d: ldc.i4.1
-		IL_061e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_0623: ldloc.s 6
-		IL_0625: ldc.r8 3
-		IL_062e: ldc.r8 4
-		IL_0637: ldc.i4.1
-		IL_0638: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_063d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0642: stloc.s 8
-		IL_0644: ldloc.s 6
-		IL_0646: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_064b: stloc.s 7
-		IL_064d: ldloc.s 7
-		IL_064f: ldstr "toString"
-		IL_0654: ldstr "hex"
-		IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_065e: stloc.s 9
-		IL_0660: ldloc.s 8
-		IL_0662: ldloc.s 9
-		IL_0664: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0669: pop
-		IL_066a: ret
+		IL_0514: ldc.r8 8
+		IL_051d: box [System.Runtime]System.Double
+		IL_0522: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0527: pop
+		IL_0528: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_052d: stloc.s 8
+		IL_052f: ldloc.s 5
+		IL_0531: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0536: stloc.s 7
+		IL_0538: volatile.
+		IL_053a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_053f: brfalse IL_0563
+
+		IL_0544: ldloc.s 7
+		IL_0546: ldstr "readFloatLE"
+		IL_054b: ldc.r8 0.0
+		IL_0554: box [System.Runtime]System.Double
+		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_055e: br IL_0587
+
+		IL_0563: ldloc.s 7
+		IL_0565: ldstr "readFloatLE"
+		IL_056a: ldc.r8 0.0
+		IL_0573: box [System.Runtime]System.Double
+		IL_0578: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:137"
+		IL_057d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0587: stloc.s 9
+		IL_0589: ldloc.s 9
+		IL_058b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0590: ldc.r8 100
+		IL_0599: mul
+		IL_059a: stloc.s 11
+		IL_059c: ldloc.s 11
+		IL_059e: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
+		IL_05a3: ldc.r8 100
+		IL_05ac: div
+		IL_05ad: stloc.s 11
+		IL_05af: ldloc.s 11
+		IL_05b1: box [System.Runtime]System.Double
+		IL_05b6: stloc.s 12
+		IL_05b8: ldloc.s 8
+		IL_05ba: ldloc.s 12
+		IL_05bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05c1: pop
+		IL_05c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05c7: stloc.s 8
+		IL_05c9: ldloc.s 5
+		IL_05cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_05d0: stloc.s 7
+		IL_05d2: volatile.
+		IL_05d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_05d9: brfalse IL_05fd
+
+		IL_05de: ldloc.s 7
+		IL_05e0: ldstr "readFloatBE"
+		IL_05e5: ldc.r8 4
+		IL_05ee: box [System.Runtime]System.Double
+		IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05f8: br IL_0621
+
+		IL_05fd: ldloc.s 7
+		IL_05ff: ldstr "readFloatBE"
+		IL_0604: ldc.r8 4
+		IL_060d: box [System.Runtime]System.Double
+		IL_0612: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:151"
+		IL_0617: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0621: stloc.s 9
+		IL_0623: ldloc.s 9
+		IL_0625: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_062a: ldc.r8 100
+		IL_0633: mul
+		IL_0634: stloc.s 11
+		IL_0636: ldloc.s 11
+		IL_0638: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
+		IL_063d: ldc.r8 100
+		IL_0646: div
+		IL_0647: stloc.s 11
+		IL_0649: ldloc.s 11
+		IL_064b: box [System.Runtime]System.Double
+		IL_0650: stloc.s 12
+		IL_0652: ldloc.s 8
+		IL_0654: ldloc.s 12
+		IL_0656: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_065b: pop
+		IL_065c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0661: stloc.s 8
+		IL_0663: ldloc.s 5
+		IL_0665: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_066a: stloc.s 7
+		IL_066c: volatile.
+		IL_066e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0673: brfalse IL_0697
+
+		IL_0678: ldloc.s 7
+		IL_067a: ldstr "readDoubleLE"
+		IL_067f: ldc.r8 8
+		IL_0688: box [System.Runtime]System.Double
+		IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0692: br IL_06bb
+
+		IL_0697: ldloc.s 7
+		IL_0699: ldstr "readDoubleLE"
+		IL_069e: ldc.r8 8
+		IL_06a7: box [System.Runtime]System.Double
+		IL_06ac: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:165"
+		IL_06b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_06bb: stloc.s 9
+		IL_06bd: ldloc.s 9
+		IL_06bf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_06c4: ldc.r8 100
+		IL_06cd: mul
+		IL_06ce: stloc.s 11
+		IL_06d0: ldloc.s 11
+		IL_06d2: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
+		IL_06d7: ldc.r8 100
+		IL_06e0: div
+		IL_06e1: stloc.s 11
+		IL_06e3: ldloc.s 11
+		IL_06e5: box [System.Runtime]System.Double
+		IL_06ea: stloc.s 12
+		IL_06ec: ldloc.s 8
+		IL_06ee: ldloc.s 12
+		IL_06f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06f5: pop
+		IL_06f6: ldloc.s 5
+		IL_06f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_06fd: stloc.s 7
+		IL_06ff: ldc.r8 2.5
+		IL_0708: neg
+		IL_0709: stloc.s 11
+		IL_070b: ldloc.s 11
+		IL_070d: box [System.Runtime]System.Double
+		IL_0712: stloc.s 12
+		IL_0714: ldloc.s 7
+		IL_0716: ldstr "writeDoubleBE"
+		IL_071b: ldloc.s 12
+		IL_071d: ldc.r8 0.0
+		IL_0726: box [System.Runtime]System.Double
+		IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0730: pop
+		IL_0731: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0736: stloc.s 8
+		IL_0738: ldloc.s 5
+		IL_073a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_073f: stloc.s 7
+		IL_0741: volatile.
+		IL_0743: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0748: brfalse IL_076c
+
+		IL_074d: ldloc.s 7
+		IL_074f: ldstr "readDoubleBE"
+		IL_0754: ldc.r8 0.0
+		IL_075d: box [System.Runtime]System.Double
+		IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0767: br IL_0790
+
+		IL_076c: ldloc.s 7
+		IL_076e: ldstr "readDoubleBE"
+		IL_0773: ldc.r8 0.0
+		IL_077c: box [System.Runtime]System.Double
+		IL_0781: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:187"
+		IL_0786: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_078b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0790: stloc.s 9
+		IL_0792: ldloc.s 9
+		IL_0794: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0799: ldc.r8 10
+		IL_07a2: mul
+		IL_07a3: stloc.s 11
+		IL_07a5: ldloc.s 11
+		IL_07a7: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(float64)
+		IL_07ac: ldc.r8 10
+		IL_07b5: div
+		IL_07b6: stloc.s 11
+		IL_07b8: ldloc.s 11
+		IL_07ba: box [System.Runtime]System.Double
+		IL_07bf: stloc.s 12
+		IL_07c1: ldloc.s 8
+		IL_07c3: ldloc.s 12
+		IL_07c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07ca: pop
+		IL_07cb: ldc.r8 4
+		IL_07d4: box [System.Runtime]System.Double
+		IL_07d9: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::allocUnsafe(object)
+		IL_07de: stloc.s 6
+		IL_07e0: ldloc.s 6
+		IL_07e2: ldc.r8 0.0
+		IL_07eb: ldc.r8 1
+		IL_07f4: ldc.i4.1
+		IL_07f5: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_07fa: ldloc.s 6
+		IL_07fc: ldc.r8 1
+		IL_0805: ldc.r8 2
+		IL_080e: ldc.i4.1
+		IL_080f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0814: ldloc.s 6
+		IL_0816: ldc.r8 2
+		IL_081f: ldc.r8 3
+		IL_0828: ldc.i4.1
+		IL_0829: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_082e: ldloc.s 6
+		IL_0830: ldc.r8 3
+		IL_0839: ldc.r8 4
+		IL_0842: ldc.i4.1
+		IL_0843: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0848: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_084d: stloc.s 8
+		IL_084f: ldloc.s 6
+		IL_0851: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0856: stloc.s 7
+		IL_0858: volatile.
+		IL_085a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_085f: brfalse IL_087a
+
+		IL_0864: ldloc.s 7
+		IL_0866: ldstr "toString"
+		IL_086b: ldstr "hex"
+		IL_0870: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0875: br IL_0895
+
+		IL_087a: ldloc.s 7
+		IL_087c: ldstr "toString"
+		IL_0881: ldstr "hex"
+		IL_0886: ldstr "Buffer_Advanced_CoreApis:Modules.Buffer_Advanced_CoreApis:__js_module_init__:221"
+		IL_088b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0895: stloc.s 9
+		IL_0897: ldloc.s 8
+		IL_0899: ldloc.s 9
+		IL_089b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08a0: pop
+		IL_08a1: ret
 	} // end of method Buffer_Advanced_CoreApis::__js_module_init__
 
 } // end of class Modules.Buffer_Advanced_CoreApis
@@ -580,6 +741,18 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Alloc_ByteLength_Concat.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Alloc_ByteLength_Concat.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 887 (0x377)
+		// Code size: 931 (0x3a3)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Buffer_Alloc_ByteLength_Concat/Scope,
@@ -145,245 +145,258 @@
 		IL_0044: ldloc.1
 		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_004a: stloc.s 11
-		IL_004c: ldloc.s 11
-		IL_004e: ldstr "toString"
-		IL_0053: ldstr "hex"
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005d: stloc.s 12
-		IL_005f: ldloc.s 8
-		IL_0061: ldloc.s 12
-		IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0068: pop
-		IL_0069: ldc.r8 5
-		IL_0072: box [System.Runtime]System.Double
-		IL_0077: ldstr "ab"
-		IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object, object)
-		IL_0081: stloc.2
-		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0087: stloc.s 8
-		IL_0089: ldloc.2
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_008f: stloc.s 11
-		IL_0091: volatile.
-		IL_0093: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0098: brfalse IL_00ae
+		IL_004c: volatile.
+		IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0053: brfalse IL_006e
 
-		IL_009d: ldloc.s 11
-		IL_009f: ldstr "toString"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00a9: br IL_00c4
+		IL_0058: ldloc.s 11
+		IL_005a: ldstr "toString"
+		IL_005f: ldstr "hex"
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0069: br IL_0089
 
-		IL_00ae: ldloc.s 11
-		IL_00b0: ldstr "toString"
-		IL_00b5: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:28"
-		IL_00ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_006e: ldloc.s 11
+		IL_0070: ldstr "toString"
+		IL_0075: ldstr "hex"
+		IL_007a: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:17"
+		IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00c4: stloc.s 12
-		IL_00c6: ldloc.s 8
-		IL_00c8: ldloc.s 12
-		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cf: pop
-		IL_00d0: ldc.r8 3
-		IL_00d9: box [System.Runtime]System.Double
-		IL_00de: ldc.r8 65
-		IL_00e7: box [System.Runtime]System.Double
-		IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object, object)
-		IL_00f1: stloc.3
-		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f7: stloc.s 8
-		IL_00f9: ldloc.3
-		IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_00ff: stloc.s 11
-		IL_0101: volatile.
-		IL_0103: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0108: brfalse IL_011e
+		IL_0089: stloc.s 12
+		IL_008b: ldloc.s 8
+		IL_008d: ldloc.s 12
+		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0094: pop
+		IL_0095: ldc.r8 5
+		IL_009e: box [System.Runtime]System.Double
+		IL_00a3: ldstr "ab"
+		IL_00a8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object, object)
+		IL_00ad: stloc.2
+		IL_00ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b3: stloc.s 8
+		IL_00b5: ldloc.2
+		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_00bb: stloc.s 11
+		IL_00bd: volatile.
+		IL_00bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c4: brfalse IL_00da
 
-		IL_010d: ldloc.s 11
-		IL_010f: ldstr "toString"
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0119: br IL_0134
+		IL_00c9: ldloc.s 11
+		IL_00cb: ldstr "toString"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00d5: br IL_00f0
 
-		IL_011e: ldloc.s 11
-		IL_0120: ldstr "toString"
-		IL_0125: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:40"
-		IL_012a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_00da: ldloc.s 11
+		IL_00dc: ldstr "toString"
+		IL_00e1: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:28"
+		IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0134: stloc.s 12
-		IL_0136: ldloc.s 8
-		IL_0138: ldloc.s 12
-		IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013f: pop
-		IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0145: stloc.s 8
-		IL_0147: ldstr "hello"
-		IL_014c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object)
-		IL_0151: box [System.Runtime]System.Double
-		IL_0156: stloc.s 10
-		IL_0158: ldloc.s 8
-		IL_015a: ldloc.s 10
-		IL_015c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0161: pop
-		IL_0162: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0167: stloc.s 8
-		IL_0169: ldstr "6869"
-		IL_016e: ldstr "hex"
-		IL_0173: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object, object)
-		IL_0178: box [System.Runtime]System.Double
-		IL_017d: stloc.s 10
-		IL_017f: ldloc.s 8
-		IL_0181: ldloc.s 10
-		IL_0183: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0188: pop
-		IL_0189: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018e: stloc.s 8
-		IL_0190: ldstr "aGk="
-		IL_0195: ldstr "base64"
-		IL_019a: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object, object)
-		IL_019f: box [System.Runtime]System.Double
-		IL_01a4: stloc.s 10
-		IL_01a6: ldloc.s 8
-		IL_01a8: ldloc.s 10
-		IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01af: pop
-		IL_01b0: ldstr "6869"
-		IL_01b5: ldstr "hex"
-		IL_01ba: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object, object)
-		IL_01bf: stloc.s 4
-		IL_01c1: ldstr "aGk="
-		IL_01c6: ldstr "base64"
-		IL_01cb: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object, object)
-		IL_01d0: stloc.s 5
-		IL_01d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d7: stloc.s 8
-		IL_01d9: ldloc.s 4
-		IL_01db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_01e0: stloc.s 11
-		IL_01e2: volatile.
-		IL_01e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_01e9: brfalse IL_01ff
+		IL_00f0: stloc.s 12
+		IL_00f2: ldloc.s 8
+		IL_00f4: ldloc.s 12
+		IL_00f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fb: pop
+		IL_00fc: ldc.r8 3
+		IL_0105: box [System.Runtime]System.Double
+		IL_010a: ldc.r8 65
+		IL_0113: box [System.Runtime]System.Double
+		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object, object)
+		IL_011d: stloc.3
+		IL_011e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0123: stloc.s 8
+		IL_0125: ldloc.3
+		IL_0126: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_012b: stloc.s 11
+		IL_012d: volatile.
+		IL_012f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0134: brfalse IL_014a
 
-		IL_01ee: ldloc.s 11
-		IL_01f0: ldstr "toString"
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01fa: br IL_0215
+		IL_0139: ldloc.s 11
+		IL_013b: ldstr "toString"
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0145: br IL_0160
 
-		IL_01ff: ldloc.s 11
-		IL_0201: ldstr "toString"
-		IL_0206: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:75"
-		IL_020b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_014a: ldloc.s 11
+		IL_014c: ldstr "toString"
+		IL_0151: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:40"
+		IL_0156: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0215: stloc.s 12
-		IL_0217: ldloc.s 8
-		IL_0219: ldloc.s 12
-		IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0220: pop
-		IL_0221: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0226: stloc.s 8
-		IL_0228: ldloc.s 5
-		IL_022a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_022f: stloc.s 11
-		IL_0231: volatile.
-		IL_0233: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0238: brfalse IL_024e
+		IL_0160: stloc.s 12
+		IL_0162: ldloc.s 8
+		IL_0164: ldloc.s 12
+		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_016b: pop
+		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0171: stloc.s 8
+		IL_0173: ldstr "hello"
+		IL_0178: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object)
+		IL_017d: box [System.Runtime]System.Double
+		IL_0182: stloc.s 10
+		IL_0184: ldloc.s 8
+		IL_0186: ldloc.s 10
+		IL_0188: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_018d: pop
+		IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0193: stloc.s 8
+		IL_0195: ldstr "6869"
+		IL_019a: ldstr "hex"
+		IL_019f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object, object)
+		IL_01a4: box [System.Runtime]System.Double
+		IL_01a9: stloc.s 10
+		IL_01ab: ldloc.s 8
+		IL_01ad: ldloc.s 10
+		IL_01af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b4: pop
+		IL_01b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ba: stloc.s 8
+		IL_01bc: ldstr "aGk="
+		IL_01c1: ldstr "base64"
+		IL_01c6: call float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::byteLength(object, object)
+		IL_01cb: box [System.Runtime]System.Double
+		IL_01d0: stloc.s 10
+		IL_01d2: ldloc.s 8
+		IL_01d4: ldloc.s 10
+		IL_01d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01db: pop
+		IL_01dc: ldstr "6869"
+		IL_01e1: ldstr "hex"
+		IL_01e6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object, object)
+		IL_01eb: stloc.s 4
+		IL_01ed: ldstr "aGk="
+		IL_01f2: ldstr "base64"
+		IL_01f7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object, object)
+		IL_01fc: stloc.s 5
+		IL_01fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0203: stloc.s 8
+		IL_0205: ldloc.s 4
+		IL_0207: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_020c: stloc.s 11
+		IL_020e: volatile.
+		IL_0210: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0215: brfalse IL_022b
 
-		IL_023d: ldloc.s 11
-		IL_023f: ldstr "toString"
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0249: br IL_0264
+		IL_021a: ldloc.s 11
+		IL_021c: ldstr "toString"
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0226: br IL_0241
 
-		IL_024e: ldloc.s 11
-		IL_0250: ldstr "toString"
-		IL_0255: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:80"
-		IL_025a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_022b: ldloc.s 11
+		IL_022d: ldstr "toString"
+		IL_0232: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:75"
+		IL_0237: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0264: stloc.s 12
-		IL_0266: ldloc.s 8
-		IL_0268: ldloc.s 12
-		IL_026a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026f: pop
-		IL_0270: ldc.i4.3
-		IL_0271: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0276: dup
-		IL_0277: ldloc.s 4
-		IL_0279: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_027e: dup
-		IL_027f: ldstr "!"
-		IL_0284: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0289: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_028e: dup
-		IL_028f: ldloc.s 5
-		IL_0291: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0296: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
-		IL_029b: stloc.s 6
-		IL_029d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02a2: stloc.s 8
-		IL_02a4: ldloc.s 6
-		IL_02a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_02ab: stloc.s 11
-		IL_02ad: volatile.
-		IL_02af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_02b4: brfalse IL_02ca
+		IL_0241: stloc.s 12
+		IL_0243: ldloc.s 8
+		IL_0245: ldloc.s 12
+		IL_0247: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_024c: pop
+		IL_024d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0252: stloc.s 8
+		IL_0254: ldloc.s 5
+		IL_0256: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_025b: stloc.s 11
+		IL_025d: volatile.
+		IL_025f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0264: brfalse IL_027a
 
-		IL_02b9: ldloc.s 11
-		IL_02bb: ldstr "toString"
-		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02c5: br IL_02e0
+		IL_0269: ldloc.s 11
+		IL_026b: ldstr "toString"
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0275: br IL_0290
 
-		IL_02ca: ldloc.s 11
-		IL_02cc: ldstr "toString"
-		IL_02d1: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:91"
-		IL_02d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_027a: ldloc.s 11
+		IL_027c: ldstr "toString"
+		IL_0281: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:80"
+		IL_0286: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_02e0: stloc.s 12
-		IL_02e2: ldloc.s 8
-		IL_02e4: ldloc.s 12
-		IL_02e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02eb: pop
-		IL_02ec: ldc.i4.2
-		IL_02ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02f2: dup
-		IL_02f3: ldstr "hello"
-		IL_02f8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_02fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0302: dup
-		IL_0303: ldstr "world"
-		IL_0308: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_030d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0312: ldc.r8 7
-		IL_031b: box [System.Runtime]System.Double
-		IL_0320: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object, object)
-		IL_0325: stloc.s 7
-		IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_032c: stloc.s 8
-		IL_032e: ldloc.s 7
-		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0335: stloc.s 11
-		IL_0337: volatile.
-		IL_0339: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_033e: brfalse IL_0354
+		IL_0290: stloc.s 12
+		IL_0292: ldloc.s 8
+		IL_0294: ldloc.s 12
+		IL_0296: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029b: pop
+		IL_029c: ldc.i4.3
+		IL_029d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02a2: dup
+		IL_02a3: ldloc.s 4
+		IL_02a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_02aa: dup
+		IL_02ab: ldstr "!"
+		IL_02b0: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_02b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_02ba: dup
+		IL_02bb: ldloc.s 5
+		IL_02bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_02c2: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object)
+		IL_02c7: stloc.s 6
+		IL_02c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ce: stloc.s 8
+		IL_02d0: ldloc.s 6
+		IL_02d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_02d7: stloc.s 11
+		IL_02d9: volatile.
+		IL_02db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_02e0: brfalse IL_02f6
 
-		IL_0343: ldloc.s 11
-		IL_0345: ldstr "toString"
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_034f: br IL_036a
+		IL_02e5: ldloc.s 11
+		IL_02e7: ldstr "toString"
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02f1: br IL_030c
 
-		IL_0354: ldloc.s 11
-		IL_0356: ldstr "toString"
-		IL_035b: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:106"
-		IL_0360: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_02f6: ldloc.s 11
+		IL_02f8: ldstr "toString"
+		IL_02fd: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:91"
+		IL_0302: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_036a: stloc.s 12
-		IL_036c: ldloc.s 8
-		IL_036e: ldloc.s 12
-		IL_0370: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0375: pop
-		IL_0376: ret
+		IL_030c: stloc.s 12
+		IL_030e: ldloc.s 8
+		IL_0310: ldloc.s 12
+		IL_0312: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0317: pop
+		IL_0318: ldc.i4.2
+		IL_0319: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_031e: dup
+		IL_031f: ldstr "hello"
+		IL_0324: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0329: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_032e: dup
+		IL_032f: ldstr "world"
+		IL_0334: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0339: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_033e: ldc.r8 7
+		IL_0347: box [System.Runtime]System.Double
+		IL_034c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::concat(object, object)
+		IL_0351: stloc.s 7
+		IL_0353: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0358: stloc.s 8
+		IL_035a: ldloc.s 7
+		IL_035c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0361: stloc.s 11
+		IL_0363: volatile.
+		IL_0365: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_036a: brfalse IL_0380
+
+		IL_036f: ldloc.s 11
+		IL_0371: ldstr "toString"
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_037b: br IL_0396
+
+		IL_0380: ldloc.s 11
+		IL_0382: ldstr "toString"
+		IL_0387: ldstr "Buffer_Alloc_ByteLength_Concat:Modules.Buffer_Alloc_ByteLength_Concat:__js_module_init__:106"
+		IL_038c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0396: stloc.s 12
+		IL_0398: ldloc.s 8
+		IL_039a: ldloc.s 12
+		IL_039c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03a1: pop
+		IL_03a2: ret
 	} // end of method Buffer_Alloc_ByteLength_Concat::__js_module_init__
 
 } // end of class Modules.Buffer_Alloc_ByteLength_Concat
@@ -419,6 +432,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Constructor_Legacy.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_Constructor_Legacy.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 203 (0xcb)
+		// Code size: 289 (0x121)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_Constructor_Legacy/Scope,
@@ -143,39 +143,65 @@
 		IL_0061: stloc.3
 		IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0067: stloc.s 5
-		IL_0069: ldloc.1
-		IL_006a: ldstr "toString"
-		IL_006f: ldstr "utf8"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0079: stloc.s 6
-		IL_007b: ldloc.s 5
-		IL_007d: ldloc.s 6
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008a: stloc.s 5
-		IL_008c: ldloc.2
-		IL_008d: ldstr "toString"
-		IL_0092: ldstr "utf8"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009c: stloc.s 6
-		IL_009e: ldloc.s 5
-		IL_00a0: ldloc.s 6
-		IL_00a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a7: pop
-		IL_00a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ad: stloc.s 5
-		IL_00af: ldloc.3
-		IL_00b0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-		IL_00b5: stloc.s 7
-		IL_00b7: ldloc.s 7
-		IL_00b9: box [System.Runtime]System.Double
-		IL_00be: stloc.s 8
-		IL_00c0: ldloc.s 5
-		IL_00c2: ldloc.s 8
-		IL_00c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c9: pop
-		IL_00ca: ret
+		IL_0069: volatile.
+		IL_006b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0070: brfalse IL_008a
+
+		IL_0075: ldloc.1
+		IL_0076: ldstr "toString"
+		IL_007b: ldstr "utf8"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0085: br IL_00a4
+
+		IL_008a: ldloc.1
+		IL_008b: ldstr "toString"
+		IL_0090: ldstr "utf8"
+		IL_0095: ldstr "Buffer_Constructor_Legacy:Modules.Buffer_Constructor_Legacy:__js_module_init__:20"
+		IL_009a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a4: stloc.s 6
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldloc.s 6
+		IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00af: pop
+		IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b5: stloc.s 5
+		IL_00b7: volatile.
+		IL_00b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00be: brfalse IL_00d8
+
+		IL_00c3: ldloc.2
+		IL_00c4: ldstr "toString"
+		IL_00c9: ldstr "utf8"
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d3: br IL_00f2
+
+		IL_00d8: ldloc.2
+		IL_00d9: ldstr "toString"
+		IL_00de: ldstr "utf8"
+		IL_00e3: ldstr "Buffer_Constructor_Legacy:Modules.Buffer_Constructor_Legacy:__js_module_init__:25"
+		IL_00e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f2: stloc.s 6
+		IL_00f4: ldloc.s 5
+		IL_00f6: ldloc.s 6
+		IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fd: pop
+		IL_00fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0103: stloc.s 5
+		IL_0105: ldloc.3
+		IL_0106: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+		IL_010b: stloc.s 7
+		IL_010d: ldloc.s 7
+		IL_010f: box [System.Runtime]System.Double
+		IL_0114: stloc.s 8
+		IL_0116: ldloc.s 5
+		IL_0118: ldloc.s 8
+		IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011f: pop
+		IL_0120: ret
 	} // end of method Buffer_Constructor_Legacy::__js_module_init__
 
 } // end of class Modules.Buffer_Constructor_Legacy
@@ -200,4 +226,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_From_And_IsBuffer.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_From_And_IsBuffer.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 475 (0x1db)
+		// Code size: 519 (0x207)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_From_And_IsBuffer/Scope,
@@ -151,124 +151,137 @@
 		IL_0059: ldloc.1
 		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_005f: stloc.s 8
-		IL_0061: ldloc.s 8
-		IL_0063: ldstr "toString"
-		IL_0068: ldstr "utf8"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: stloc.s 9
-		IL_0074: ldloc.s 4
-		IL_0076: ldloc.s 9
-		IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007d: pop
-		IL_007e: ldc.i4.3
-		IL_007f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0084: dup
-		IL_0085: ldc.r8 65
-		IL_008e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0093: dup
-		IL_0094: ldc.r8 66
-		IL_009d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00a2: dup
-		IL_00a3: ldc.r8 67
-		IL_00ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_00b6: stloc.2
-		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bc: stloc.s 4
-		IL_00be: ldloc.2
-		IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_00c4: box [System.Runtime]System.Boolean
-		IL_00c9: stloc.s 5
-		IL_00cb: ldloc.s 4
-		IL_00cd: ldloc.s 5
-		IL_00cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d4: pop
-		IL_00d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00da: stloc.s 4
-		IL_00dc: ldloc.2
-		IL_00dd: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-		IL_00e2: stloc.s 6
-		IL_00e4: ldloc.s 6
-		IL_00e6: box [System.Runtime]System.Double
-		IL_00eb: stloc.s 7
-		IL_00ed: ldloc.s 4
-		IL_00ef: ldloc.s 7
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f6: pop
-		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fc: stloc.s 4
-		IL_00fe: ldloc.2
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0104: stloc.s 8
-		IL_0106: volatile.
-		IL_0108: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_010d: brfalse IL_0123
+		IL_0061: volatile.
+		IL_0063: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0068: brfalse IL_0083
 
-		IL_0112: ldloc.s 8
-		IL_0114: ldstr "toString"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_011e: br IL_0139
+		IL_006d: ldloc.s 8
+		IL_006f: ldstr "toString"
+		IL_0074: ldstr "utf8"
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009e
 
-		IL_0123: ldloc.s 8
-		IL_0125: ldstr "toString"
-		IL_012a: ldstr "Buffer_From_And_IsBuffer:Modules.Buffer_From_And_IsBuffer:__js_module_init__:43"
-		IL_012f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0083: ldloc.s 8
+		IL_0085: ldstr "toString"
+		IL_008a: ldstr "utf8"
+		IL_008f: ldstr "Buffer_From_And_IsBuffer:Modules.Buffer_From_And_IsBuffer:__js_module_init__:21"
+		IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0139: stloc.s 9
-		IL_013b: ldloc.s 4
-		IL_013d: ldloc.s 9
-		IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0144: pop
-		IL_0145: ldloc.2
-		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_014b: stloc.3
-		IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0151: stloc.s 4
-		IL_0153: ldloc.3
-		IL_0154: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_0159: box [System.Runtime]System.Boolean
-		IL_015e: stloc.s 5
-		IL_0160: ldloc.s 4
-		IL_0162: ldloc.s 5
-		IL_0164: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0169: pop
-		IL_016a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016f: stloc.s 4
-		IL_0171: ldloc.3
-		IL_0172: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0177: stloc.s 8
-		IL_0179: volatile.
-		IL_017b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0180: brfalse IL_0196
+		IL_009e: stloc.s 9
+		IL_00a0: ldloc.s 4
+		IL_00a2: ldloc.s 9
+		IL_00a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a9: pop
+		IL_00aa: ldc.i4.3
+		IL_00ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00b0: dup
+		IL_00b1: ldc.r8 65
+		IL_00ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00bf: dup
+		IL_00c0: ldc.r8 66
+		IL_00c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00ce: dup
+		IL_00cf: ldc.r8 67
+		IL_00d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_00e2: stloc.2
+		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e8: stloc.s 4
+		IL_00ea: ldloc.2
+		IL_00eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_00f0: box [System.Runtime]System.Boolean
+		IL_00f5: stloc.s 5
+		IL_00f7: ldloc.s 4
+		IL_00f9: ldloc.s 5
+		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0100: pop
+		IL_0101: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0106: stloc.s 4
+		IL_0108: ldloc.2
+		IL_0109: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+		IL_010e: stloc.s 6
+		IL_0110: ldloc.s 6
+		IL_0112: box [System.Runtime]System.Double
+		IL_0117: stloc.s 7
+		IL_0119: ldloc.s 4
+		IL_011b: ldloc.s 7
+		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0122: pop
+		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0128: stloc.s 4
+		IL_012a: ldloc.2
+		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0130: stloc.s 8
+		IL_0132: volatile.
+		IL_0134: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0139: brfalse IL_014f
 
-		IL_0185: ldloc.s 8
-		IL_0187: ldstr "toString"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0191: br IL_01ac
+		IL_013e: ldloc.s 8
+		IL_0140: ldstr "toString"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_014a: br IL_0165
 
-		IL_0196: ldloc.s 8
-		IL_0198: ldstr "toString"
-		IL_019d: ldstr "Buffer_From_And_IsBuffer:Modules.Buffer_From_And_IsBuffer:__js_module_init__:56"
-		IL_01a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_014f: ldloc.s 8
+		IL_0151: ldstr "toString"
+		IL_0156: ldstr "Buffer_From_And_IsBuffer:Modules.Buffer_From_And_IsBuffer:__js_module_init__:43"
+		IL_015b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_01ac: stloc.s 9
-		IL_01ae: ldloc.s 4
-		IL_01b0: ldloc.s 9
-		IL_01b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b7: pop
-		IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01bd: stloc.s 4
-		IL_01bf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_01c9: box [System.Runtime]System.Boolean
-		IL_01ce: stloc.s 5
-		IL_01d0: ldloc.s 4
-		IL_01d2: ldloc.s 5
-		IL_01d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d9: pop
-		IL_01da: ret
+		IL_0165: stloc.s 9
+		IL_0167: ldloc.s 4
+		IL_0169: ldloc.s 9
+		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0170: pop
+		IL_0171: ldloc.2
+		IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0177: stloc.3
+		IL_0178: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017d: stloc.s 4
+		IL_017f: ldloc.3
+		IL_0180: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_0185: box [System.Runtime]System.Boolean
+		IL_018a: stloc.s 5
+		IL_018c: ldloc.s 4
+		IL_018e: ldloc.s 5
+		IL_0190: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0195: pop
+		IL_0196: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019b: stloc.s 4
+		IL_019d: ldloc.3
+		IL_019e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_01a3: stloc.s 8
+		IL_01a5: volatile.
+		IL_01a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_01ac: brfalse IL_01c2
+
+		IL_01b1: ldloc.s 8
+		IL_01b3: ldstr "toString"
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01bd: br IL_01d8
+
+		IL_01c2: ldloc.s 8
+		IL_01c4: ldstr "toString"
+		IL_01c9: ldstr "Buffer_From_And_IsBuffer:Modules.Buffer_From_And_IsBuffer:__js_module_init__:56"
+		IL_01ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_01d8: stloc.s 9
+		IL_01da: ldloc.s 4
+		IL_01dc: ldloc.s 9
+		IL_01de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01e3: pop
+		IL_01e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e9: stloc.s 4
+		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_01f5: box [System.Runtime]System.Boolean
+		IL_01fa: stloc.s 5
+		IL_01fc: ldloc.s 4
+		IL_01fe: ldloc.s 5
+		IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0205: pop
+		IL_0206: ret
 	} // end of method Buffer_From_And_IsBuffer::__js_module_init__
 
 } // end of class Modules.Buffer_From_And_IsBuffer
@@ -300,6 +313,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_ReadWrite_Methods.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Buffer_ReadWrite_Methods.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1624 (0x658)
+		// Code size: 2525 (0x9dd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Buffer_ReadWrite_Methods/Scope,
@@ -155,26 +155,25 @@
 		IL_0092: ldloc.1
 		IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_0098: stloc.s 7
-		IL_009a: ldloc.s 7
-		IL_009c: ldstr "readInt8"
-		IL_00a1: ldc.r8 0.0
-		IL_00aa: box [System.Runtime]System.Double
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b4: stloc.s 8
-		IL_00b6: ldloc.s 6
-		IL_00b8: ldloc.s 8
-		IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bf: pop
-		IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c5: stloc.s 6
-		IL_00c7: ldloc.1
-		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_00cd: stloc.s 7
-		IL_00cf: ldloc.s 7
-		IL_00d1: ldstr "readInt8"
-		IL_00d6: ldc.r8 1
-		IL_00df: box [System.Runtime]System.Double
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009a: volatile.
+		IL_009c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00a1: brfalse IL_00c5
+
+		IL_00a6: ldloc.s 7
+		IL_00a8: ldstr "readInt8"
+		IL_00ad: ldc.r8 0.0
+		IL_00b6: box [System.Runtime]System.Double
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c0: br IL_00e9
+
+		IL_00c5: ldloc.s 7
+		IL_00c7: ldstr "readInt8"
+		IL_00cc: ldc.r8 0.0
+		IL_00d5: box [System.Runtime]System.Double
+		IL_00da: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:20"
+		IL_00df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
 		IL_00e9: stloc.s 8
 		IL_00eb: ldloc.s 6
 		IL_00ed: ldloc.s 8
@@ -185,26 +184,25 @@
 		IL_00fc: ldloc.1
 		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_0102: stloc.s 7
-		IL_0104: ldloc.s 7
-		IL_0106: ldstr "readUInt8"
-		IL_010b: ldc.r8 0.0
-		IL_0114: box [System.Runtime]System.Double
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011e: stloc.s 8
-		IL_0120: ldloc.s 6
-		IL_0122: ldloc.s 8
-		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0129: pop
-		IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012f: stloc.s 6
-		IL_0131: ldloc.1
-		IL_0132: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0137: stloc.s 7
-		IL_0139: ldloc.s 7
-		IL_013b: ldstr "readUInt8"
-		IL_0140: ldc.r8 1
-		IL_0149: box [System.Runtime]System.Double
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0104: volatile.
+		IL_0106: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_010b: brfalse IL_012f
+
+		IL_0110: ldloc.s 7
+		IL_0112: ldstr "readInt8"
+		IL_0117: ldc.r8 1
+		IL_0120: box [System.Runtime]System.Double
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012a: br IL_0153
+
+		IL_012f: ldloc.s 7
+		IL_0131: ldstr "readInt8"
+		IL_0136: ldc.r8 1
+		IL_013f: box [System.Runtime]System.Double
+		IL_0144: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:27"
+		IL_0149: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
 		IL_0153: stloc.s 8
 		IL_0155: ldloc.s 6
 		IL_0157: ldloc.s 8
@@ -215,26 +213,25 @@
 		IL_0166: ldloc.1
 		IL_0167: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_016c: stloc.s 7
-		IL_016e: ldloc.s 7
-		IL_0170: ldstr "readInt16BE"
-		IL_0175: ldc.r8 0.0
-		IL_017e: box [System.Runtime]System.Double
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0188: stloc.s 8
-		IL_018a: ldloc.s 6
-		IL_018c: ldloc.s 8
-		IL_018e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0193: pop
-		IL_0194: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0199: stloc.s 6
-		IL_019b: ldloc.1
-		IL_019c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_01a1: stloc.s 7
-		IL_01a3: ldloc.s 7
-		IL_01a5: ldstr "readInt16LE"
-		IL_01aa: ldc.r8 0.0
-		IL_01b3: box [System.Runtime]System.Double
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016e: volatile.
+		IL_0170: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0175: brfalse IL_0199
+
+		IL_017a: ldloc.s 7
+		IL_017c: ldstr "readUInt8"
+		IL_0181: ldc.r8 0.0
+		IL_018a: box [System.Runtime]System.Double
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0194: br IL_01bd
+
+		IL_0199: ldloc.s 7
+		IL_019b: ldstr "readUInt8"
+		IL_01a0: ldc.r8 0.0
+		IL_01a9: box [System.Runtime]System.Double
+		IL_01ae: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:34"
+		IL_01b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
 		IL_01bd: stloc.s 8
 		IL_01bf: ldloc.s 6
 		IL_01c1: ldloc.s 8
@@ -245,26 +242,25 @@
 		IL_01d0: ldloc.1
 		IL_01d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_01d6: stloc.s 7
-		IL_01d8: ldloc.s 7
-		IL_01da: ldstr "readUInt16BE"
-		IL_01df: ldc.r8 0.0
-		IL_01e8: box [System.Runtime]System.Double
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f2: stloc.s 8
-		IL_01f4: ldloc.s 6
-		IL_01f6: ldloc.s 8
-		IL_01f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01fd: pop
-		IL_01fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0203: stloc.s 6
-		IL_0205: ldloc.1
-		IL_0206: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_020b: stloc.s 7
-		IL_020d: ldloc.s 7
-		IL_020f: ldstr "readUInt16LE"
-		IL_0214: ldc.r8 0.0
-		IL_021d: box [System.Runtime]System.Double
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d8: volatile.
+		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01df: brfalse IL_0203
+
+		IL_01e4: ldloc.s 7
+		IL_01e6: ldstr "readUInt8"
+		IL_01eb: ldc.r8 1
+		IL_01f4: box [System.Runtime]System.Double
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01fe: br IL_0227
+
+		IL_0203: ldloc.s 7
+		IL_0205: ldstr "readUInt8"
+		IL_020a: ldc.r8 1
+		IL_0213: box [System.Runtime]System.Double
+		IL_0218: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:41"
+		IL_021d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
 		IL_0227: stloc.s 8
 		IL_0229: ldloc.s 6
 		IL_022b: ldloc.s 8
@@ -275,26 +271,25 @@
 		IL_023a: ldloc.1
 		IL_023b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_0240: stloc.s 7
-		IL_0242: ldloc.s 7
-		IL_0244: ldstr "readInt32BE"
-		IL_0249: ldc.r8 2
-		IL_0252: box [System.Runtime]System.Double
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025c: stloc.s 8
-		IL_025e: ldloc.s 6
-		IL_0260: ldloc.s 8
-		IL_0262: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0267: pop
-		IL_0268: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_026d: stloc.s 6
-		IL_026f: ldloc.1
-		IL_0270: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0275: stloc.s 7
-		IL_0277: ldloc.s 7
-		IL_0279: ldstr "readInt32LE"
-		IL_027e: ldc.r8 2
-		IL_0287: box [System.Runtime]System.Double
-		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0242: volatile.
+		IL_0244: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0249: brfalse IL_026d
+
+		IL_024e: ldloc.s 7
+		IL_0250: ldstr "readInt16BE"
+		IL_0255: ldc.r8 0.0
+		IL_025e: box [System.Runtime]System.Double
+		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0268: br IL_0291
+
+		IL_026d: ldloc.s 7
+		IL_026f: ldstr "readInt16BE"
+		IL_0274: ldc.r8 0.0
+		IL_027d: box [System.Runtime]System.Double
+		IL_0282: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:48"
+		IL_0287: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
 		IL_0291: stloc.s 8
 		IL_0293: ldloc.s 6
 		IL_0295: ldloc.s 8
@@ -305,257 +300,500 @@
 		IL_02a4: ldloc.1
 		IL_02a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 		IL_02aa: stloc.s 7
-		IL_02ac: ldloc.s 7
-		IL_02ae: ldstr "readUInt32BE"
-		IL_02b3: ldc.r8 2
-		IL_02bc: box [System.Runtime]System.Double
-		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c6: stloc.s 8
-		IL_02c8: ldloc.s 6
-		IL_02ca: ldloc.s 8
-		IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d1: pop
-		IL_02d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02d7: stloc.s 6
-		IL_02d9: ldloc.1
-		IL_02da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_02df: stloc.s 7
-		IL_02e1: ldloc.s 7
-		IL_02e3: ldstr "readUInt32LE"
-		IL_02e8: ldc.r8 2
-		IL_02f1: box [System.Runtime]System.Double
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ac: volatile.
+		IL_02ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_02b3: brfalse IL_02d7
+
+		IL_02b8: ldloc.s 7
+		IL_02ba: ldstr "readInt16LE"
+		IL_02bf: ldc.r8 0.0
+		IL_02c8: box [System.Runtime]System.Double
+		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d2: br IL_02fb
+
+		IL_02d7: ldloc.s 7
+		IL_02d9: ldstr "readInt16LE"
+		IL_02de: ldc.r8 0.0
+		IL_02e7: box [System.Runtime]System.Double
+		IL_02ec: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:55"
+		IL_02f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
 		IL_02fb: stloc.s 8
 		IL_02fd: ldloc.s 6
 		IL_02ff: ldloc.s 8
 		IL_0301: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0306: pop
-		IL_0307: ldc.r8 8
-		IL_0310: box [System.Runtime]System.Double
-		IL_0315: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_031a: stloc.2
-		IL_031b: ldloc.2
-		IL_031c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0321: stloc.s 7
-		IL_0323: ldloc.s 7
-		IL_0325: ldstr "writeInt8"
-		IL_032a: ldc.r8 127
-		IL_0333: box [System.Runtime]System.Double
-		IL_0338: ldc.r8 0.0
-		IL_0341: box [System.Runtime]System.Double
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_034b: pop
-		IL_034c: ldloc.2
-		IL_034d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0352: stloc.s 7
-		IL_0354: ldc.r8 128
-		IL_035d: neg
-		IL_035e: stloc.s 9
-		IL_0360: ldloc.s 9
-		IL_0362: box [System.Runtime]System.Double
-		IL_0367: stloc.s 10
-		IL_0369: ldloc.s 7
-		IL_036b: ldstr "writeInt8"
-		IL_0370: ldloc.s 10
-		IL_0372: ldc.r8 1
-		IL_037b: box [System.Runtime]System.Double
-		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0385: pop
-		IL_0386: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_038b: stloc.s 6
-		IL_038d: ldloc.2
-		IL_038e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0393: stloc.s 7
-		IL_0395: ldloc.s 7
-		IL_0397: ldstr "readInt8"
-		IL_039c: ldc.r8 0.0
-		IL_03a5: box [System.Runtime]System.Double
-		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03af: stloc.s 8
-		IL_03b1: ldloc.s 6
-		IL_03b3: ldloc.s 8
-		IL_03b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03ba: pop
-		IL_03bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03c0: stloc.s 6
-		IL_03c2: ldloc.2
-		IL_03c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_03c8: stloc.s 7
-		IL_03ca: ldloc.s 7
-		IL_03cc: ldstr "readInt8"
-		IL_03d1: ldc.r8 1
-		IL_03da: box [System.Runtime]System.Double
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03e4: stloc.s 8
-		IL_03e6: ldloc.s 6
-		IL_03e8: ldloc.s 8
-		IL_03ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03ef: pop
-		IL_03f0: ldloc.2
-		IL_03f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_03f6: stloc.s 7
-		IL_03f8: ldloc.s 7
-		IL_03fa: ldstr "writeUInt8"
-		IL_03ff: ldc.r8 255
-		IL_0408: box [System.Runtime]System.Double
-		IL_040d: ldc.r8 2
-		IL_0416: box [System.Runtime]System.Double
-		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0420: pop
-		IL_0421: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0426: stloc.s 6
-		IL_0428: ldloc.2
-		IL_0429: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_042e: stloc.s 7
-		IL_0430: ldloc.s 7
-		IL_0432: ldstr "readUInt8"
-		IL_0437: ldc.r8 2
-		IL_0440: box [System.Runtime]System.Double
-		IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_044a: stloc.s 8
-		IL_044c: ldloc.s 6
-		IL_044e: ldloc.s 8
-		IL_0450: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0455: pop
-		IL_0456: ldloc.2
-		IL_0457: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_045c: stloc.s 7
-		IL_045e: ldloc.s 7
-		IL_0460: ldstr "writeInt16BE"
-		IL_0465: ldc.r8 4660
-		IL_046e: box [System.Runtime]System.Double
-		IL_0473: ldc.r8 3
-		IL_047c: box [System.Runtime]System.Double
-		IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0486: pop
-		IL_0487: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_048c: stloc.s 6
-		IL_048e: ldloc.2
-		IL_048f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0494: stloc.s 7
-		IL_0496: ldloc.s 7
-		IL_0498: ldstr "readInt16BE"
-		IL_049d: ldc.r8 3
-		IL_04a6: box [System.Runtime]System.Double
-		IL_04ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04b0: stloc.s 8
-		IL_04b2: ldloc.s 6
-		IL_04b4: ldloc.s 8
-		IL_04b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04bb: pop
-		IL_04bc: ldloc.2
-		IL_04bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_04c2: stloc.s 7
-		IL_04c4: ldc.r8 1
-		IL_04cd: neg
-		IL_04ce: stloc.s 9
-		IL_04d0: ldloc.s 9
-		IL_04d2: box [System.Runtime]System.Double
-		IL_04d7: stloc.s 10
-		IL_04d9: ldloc.s 7
-		IL_04db: ldstr "writeInt32LE"
-		IL_04e0: ldloc.s 10
-		IL_04e2: ldc.r8 0.0
-		IL_04eb: box [System.Runtime]System.Double
-		IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04f5: pop
-		IL_04f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04fb: stloc.s 6
-		IL_04fd: ldloc.2
-		IL_04fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0503: stloc.s 7
-		IL_0505: ldloc.s 7
-		IL_0507: ldstr "readInt32LE"
-		IL_050c: ldc.r8 0.0
-		IL_0515: box [System.Runtime]System.Double
-		IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_051f: stloc.s 8
-		IL_0521: ldloc.s 6
-		IL_0523: ldloc.s 8
-		IL_0525: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_052a: pop
-		IL_052b: ldc.r8 10
-		IL_0534: box [System.Runtime]System.Double
-		IL_0539: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_053e: stloc.3
-		IL_053f: ldloc.3
-		IL_0540: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0545: stloc.s 7
-		IL_0547: ldloc.s 7
-		IL_0549: ldstr "write"
-		IL_054e: ldstr "hello"
-		IL_0553: ldc.r8 0.0
-		IL_055c: box [System.Runtime]System.Double
-		IL_0561: ldc.r8 5
-		IL_056a: box [System.Runtime]System.Double
-		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0574: stloc.s 4
-		IL_0576: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_057b: stloc.s 6
-		IL_057d: ldloc.s 6
-		IL_057f: ldloc.s 4
-		IL_0581: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0586: pop
-		IL_0587: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_058c: stloc.s 6
-		IL_058e: ldloc.3
-		IL_058f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0594: stloc.s 7
-		IL_0596: ldloc.s 7
-		IL_0598: ldstr "toString"
-		IL_059d: ldstr "utf8"
-		IL_05a2: ldc.r8 0.0
-		IL_05ab: box [System.Runtime]System.Double
-		IL_05b0: ldc.r8 5
-		IL_05b9: box [System.Runtime]System.Double
-		IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_05c3: stloc.s 8
-		IL_05c5: ldloc.s 6
-		IL_05c7: ldloc.s 8
-		IL_05c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05ce: pop
-		IL_05cf: ldloc.3
-		IL_05d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_05d5: stloc.s 7
-		IL_05d7: ldloc.s 7
-		IL_05d9: ldstr "write"
-		IL_05de: ldstr "world"
-		IL_05e3: ldc.r8 5
-		IL_05ec: box [System.Runtime]System.Double
-		IL_05f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_05f6: stloc.s 5
-		IL_05f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05fd: stloc.s 6
-		IL_05ff: ldloc.s 6
-		IL_0601: ldloc.s 5
-		IL_0603: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0608: pop
-		IL_0609: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_060e: stloc.s 6
-		IL_0610: ldloc.3
-		IL_0611: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_0616: stloc.s 7
-		IL_0618: volatile.
-		IL_061a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_061f: brfalse IL_0635
+		IL_0307: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_030c: stloc.s 6
+		IL_030e: ldloc.1
+		IL_030f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0314: stloc.s 7
+		IL_0316: volatile.
+		IL_0318: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_031d: brfalse IL_0341
 
-		IL_0624: ldloc.s 7
-		IL_0626: ldstr "toString"
-		IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0630: br IL_064b
+		IL_0322: ldloc.s 7
+		IL_0324: ldstr "readUInt16BE"
+		IL_0329: ldc.r8 0.0
+		IL_0332: box [System.Runtime]System.Double
+		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_033c: br IL_0365
 
-		IL_0635: ldloc.s 7
-		IL_0637: ldstr "toString"
-		IL_063c: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:216"
-		IL_0641: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0341: ldloc.s 7
+		IL_0343: ldstr "readUInt16BE"
+		IL_0348: ldc.r8 0.0
+		IL_0351: box [System.Runtime]System.Double
+		IL_0356: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:62"
+		IL_035b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_064b: stloc.s 8
-		IL_064d: ldloc.s 6
-		IL_064f: ldloc.s 8
-		IL_0651: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0656: pop
-		IL_0657: ret
+		IL_0365: stloc.s 8
+		IL_0367: ldloc.s 6
+		IL_0369: ldloc.s 8
+		IL_036b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0370: pop
+		IL_0371: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0376: stloc.s 6
+		IL_0378: ldloc.1
+		IL_0379: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_037e: stloc.s 7
+		IL_0380: volatile.
+		IL_0382: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0387: brfalse IL_03ab
+
+		IL_038c: ldloc.s 7
+		IL_038e: ldstr "readUInt16LE"
+		IL_0393: ldc.r8 0.0
+		IL_039c: box [System.Runtime]System.Double
+		IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a6: br IL_03cf
+
+		IL_03ab: ldloc.s 7
+		IL_03ad: ldstr "readUInt16LE"
+		IL_03b2: ldc.r8 0.0
+		IL_03bb: box [System.Runtime]System.Double
+		IL_03c0: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:69"
+		IL_03c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03cf: stloc.s 8
+		IL_03d1: ldloc.s 6
+		IL_03d3: ldloc.s 8
+		IL_03d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03da: pop
+		IL_03db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03e0: stloc.s 6
+		IL_03e2: ldloc.1
+		IL_03e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_03e8: stloc.s 7
+		IL_03ea: volatile.
+		IL_03ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_03f1: brfalse IL_0415
+
+		IL_03f6: ldloc.s 7
+		IL_03f8: ldstr "readInt32BE"
+		IL_03fd: ldc.r8 2
+		IL_0406: box [System.Runtime]System.Double
+		IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0410: br IL_0439
+
+		IL_0415: ldloc.s 7
+		IL_0417: ldstr "readInt32BE"
+		IL_041c: ldc.r8 2
+		IL_0425: box [System.Runtime]System.Double
+		IL_042a: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:76"
+		IL_042f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0439: stloc.s 8
+		IL_043b: ldloc.s 6
+		IL_043d: ldloc.s 8
+		IL_043f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0444: pop
+		IL_0445: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_044a: stloc.s 6
+		IL_044c: ldloc.1
+		IL_044d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0452: stloc.s 7
+		IL_0454: volatile.
+		IL_0456: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_045b: brfalse IL_047f
+
+		IL_0460: ldloc.s 7
+		IL_0462: ldstr "readInt32LE"
+		IL_0467: ldc.r8 2
+		IL_0470: box [System.Runtime]System.Double
+		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_047a: br IL_04a3
+
+		IL_047f: ldloc.s 7
+		IL_0481: ldstr "readInt32LE"
+		IL_0486: ldc.r8 2
+		IL_048f: box [System.Runtime]System.Double
+		IL_0494: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:83"
+		IL_0499: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_04a3: stloc.s 8
+		IL_04a5: ldloc.s 6
+		IL_04a7: ldloc.s 8
+		IL_04a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04ae: pop
+		IL_04af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04b4: stloc.s 6
+		IL_04b6: ldloc.1
+		IL_04b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_04bc: stloc.s 7
+		IL_04be: volatile.
+		IL_04c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_04c5: brfalse IL_04e9
+
+		IL_04ca: ldloc.s 7
+		IL_04cc: ldstr "readUInt32BE"
+		IL_04d1: ldc.r8 2
+		IL_04da: box [System.Runtime]System.Double
+		IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04e4: br IL_050d
+
+		IL_04e9: ldloc.s 7
+		IL_04eb: ldstr "readUInt32BE"
+		IL_04f0: ldc.r8 2
+		IL_04f9: box [System.Runtime]System.Double
+		IL_04fe: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:90"
+		IL_0503: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_050d: stloc.s 8
+		IL_050f: ldloc.s 6
+		IL_0511: ldloc.s 8
+		IL_0513: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0518: pop
+		IL_0519: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_051e: stloc.s 6
+		IL_0520: ldloc.1
+		IL_0521: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0526: stloc.s 7
+		IL_0528: volatile.
+		IL_052a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_052f: brfalse IL_0553
+
+		IL_0534: ldloc.s 7
+		IL_0536: ldstr "readUInt32LE"
+		IL_053b: ldc.r8 2
+		IL_0544: box [System.Runtime]System.Double
+		IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_054e: br IL_0577
+
+		IL_0553: ldloc.s 7
+		IL_0555: ldstr "readUInt32LE"
+		IL_055a: ldc.r8 2
+		IL_0563: box [System.Runtime]System.Double
+		IL_0568: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:97"
+		IL_056d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0577: stloc.s 8
+		IL_0579: ldloc.s 6
+		IL_057b: ldloc.s 8
+		IL_057d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0582: pop
+		IL_0583: ldc.r8 8
+		IL_058c: box [System.Runtime]System.Double
+		IL_0591: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_0596: stloc.2
+		IL_0597: ldloc.2
+		IL_0598: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_059d: stloc.s 7
+		IL_059f: ldloc.s 7
+		IL_05a1: ldstr "writeInt8"
+		IL_05a6: ldc.r8 127
+		IL_05af: box [System.Runtime]System.Double
+		IL_05b4: ldc.r8 0.0
+		IL_05bd: box [System.Runtime]System.Double
+		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05c7: pop
+		IL_05c8: ldloc.2
+		IL_05c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_05ce: stloc.s 7
+		IL_05d0: ldc.r8 128
+		IL_05d9: neg
+		IL_05da: stloc.s 9
+		IL_05dc: ldloc.s 9
+		IL_05de: box [System.Runtime]System.Double
+		IL_05e3: stloc.s 10
+		IL_05e5: ldloc.s 7
+		IL_05e7: ldstr "writeInt8"
+		IL_05ec: ldloc.s 10
+		IL_05ee: ldc.r8 1
+		IL_05f7: box [System.Runtime]System.Double
+		IL_05fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0601: pop
+		IL_0602: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0607: stloc.s 6
+		IL_0609: ldloc.2
+		IL_060a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_060f: stloc.s 7
+		IL_0611: volatile.
+		IL_0613: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0618: brfalse IL_063c
+
+		IL_061d: ldloc.s 7
+		IL_061f: ldstr "readInt8"
+		IL_0624: ldc.r8 0.0
+		IL_062d: box [System.Runtime]System.Double
+		IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0637: br IL_0660
+
+		IL_063c: ldloc.s 7
+		IL_063e: ldstr "readInt8"
+		IL_0643: ldc.r8 0.0
+		IL_064c: box [System.Runtime]System.Double
+		IL_0651: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:124"
+		IL_0656: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0660: stloc.s 8
+		IL_0662: ldloc.s 6
+		IL_0664: ldloc.s 8
+		IL_0666: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_066b: pop
+		IL_066c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0671: stloc.s 6
+		IL_0673: ldloc.2
+		IL_0674: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0679: stloc.s 7
+		IL_067b: volatile.
+		IL_067d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0682: brfalse IL_06a6
+
+		IL_0687: ldloc.s 7
+		IL_0689: ldstr "readInt8"
+		IL_068e: ldc.r8 1
+		IL_0697: box [System.Runtime]System.Double
+		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06a1: br IL_06ca
+
+		IL_06a6: ldloc.s 7
+		IL_06a8: ldstr "readInt8"
+		IL_06ad: ldc.r8 1
+		IL_06b6: box [System.Runtime]System.Double
+		IL_06bb: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:131"
+		IL_06c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_06ca: stloc.s 8
+		IL_06cc: ldloc.s 6
+		IL_06ce: ldloc.s 8
+		IL_06d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06d5: pop
+		IL_06d6: ldloc.2
+		IL_06d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_06dc: stloc.s 7
+		IL_06de: ldloc.s 7
+		IL_06e0: ldstr "writeUInt8"
+		IL_06e5: ldc.r8 255
+		IL_06ee: box [System.Runtime]System.Double
+		IL_06f3: ldc.r8 2
+		IL_06fc: box [System.Runtime]System.Double
+		IL_0701: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0706: pop
+		IL_0707: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_070c: stloc.s 6
+		IL_070e: ldloc.2
+		IL_070f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0714: stloc.s 7
+		IL_0716: volatile.
+		IL_0718: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_071d: brfalse IL_0741
+
+		IL_0722: ldloc.s 7
+		IL_0724: ldstr "readUInt8"
+		IL_0729: ldc.r8 2
+		IL_0732: box [System.Runtime]System.Double
+		IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_073c: br IL_0765
+
+		IL_0741: ldloc.s 7
+		IL_0743: ldstr "readUInt8"
+		IL_0748: ldc.r8 2
+		IL_0751: box [System.Runtime]System.Double
+		IL_0756: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:145"
+		IL_075b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0765: stloc.s 8
+		IL_0767: ldloc.s 6
+		IL_0769: ldloc.s 8
+		IL_076b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0770: pop
+		IL_0771: ldloc.2
+		IL_0772: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0777: stloc.s 7
+		IL_0779: ldloc.s 7
+		IL_077b: ldstr "writeInt16BE"
+		IL_0780: ldc.r8 4660
+		IL_0789: box [System.Runtime]System.Double
+		IL_078e: ldc.r8 3
+		IL_0797: box [System.Runtime]System.Double
+		IL_079c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_07a1: pop
+		IL_07a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07a7: stloc.s 6
+		IL_07a9: ldloc.2
+		IL_07aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_07af: stloc.s 7
+		IL_07b1: volatile.
+		IL_07b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_07b8: brfalse IL_07dc
+
+		IL_07bd: ldloc.s 7
+		IL_07bf: ldstr "readInt16BE"
+		IL_07c4: ldc.r8 3
+		IL_07cd: box [System.Runtime]System.Double
+		IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07d7: br IL_0800
+
+		IL_07dc: ldloc.s 7
+		IL_07de: ldstr "readInt16BE"
+		IL_07e3: ldc.r8 3
+		IL_07ec: box [System.Runtime]System.Double
+		IL_07f1: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:159"
+		IL_07f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0800: stloc.s 8
+		IL_0802: ldloc.s 6
+		IL_0804: ldloc.s 8
+		IL_0806: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_080b: pop
+		IL_080c: ldloc.2
+		IL_080d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0812: stloc.s 7
+		IL_0814: ldc.r8 1
+		IL_081d: neg
+		IL_081e: stloc.s 9
+		IL_0820: ldloc.s 9
+		IL_0822: box [System.Runtime]System.Double
+		IL_0827: stloc.s 10
+		IL_0829: ldloc.s 7
+		IL_082b: ldstr "writeInt32LE"
+		IL_0830: ldloc.s 10
+		IL_0832: ldc.r8 0.0
+		IL_083b: box [System.Runtime]System.Double
+		IL_0840: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0845: pop
+		IL_0846: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_084b: stloc.s 6
+		IL_084d: ldloc.2
+		IL_084e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0853: stloc.s 7
+		IL_0855: volatile.
+		IL_0857: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_085c: brfalse IL_0880
+
+		IL_0861: ldloc.s 7
+		IL_0863: ldstr "readInt32LE"
+		IL_0868: ldc.r8 0.0
+		IL_0871: box [System.Runtime]System.Double
+		IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_087b: br IL_08a4
+
+		IL_0880: ldloc.s 7
+		IL_0882: ldstr "readInt32LE"
+		IL_0887: ldc.r8 0.0
+		IL_0890: box [System.Runtime]System.Double
+		IL_0895: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:174"
+		IL_089a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_089f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_08a4: stloc.s 8
+		IL_08a6: ldloc.s 6
+		IL_08a8: ldloc.s 8
+		IL_08aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08af: pop
+		IL_08b0: ldc.r8 10
+		IL_08b9: box [System.Runtime]System.Double
+		IL_08be: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_08c3: stloc.3
+		IL_08c4: ldloc.3
+		IL_08c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_08ca: stloc.s 7
+		IL_08cc: ldloc.s 7
+		IL_08ce: ldstr "write"
+		IL_08d3: ldstr "hello"
+		IL_08d8: ldc.r8 0.0
+		IL_08e1: box [System.Runtime]System.Double
+		IL_08e6: ldc.r8 5
+		IL_08ef: box [System.Runtime]System.Double
+		IL_08f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_08f9: stloc.s 4
+		IL_08fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0900: stloc.s 6
+		IL_0902: ldloc.s 6
+		IL_0904: ldloc.s 4
+		IL_0906: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_090b: pop
+		IL_090c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0911: stloc.s 6
+		IL_0913: ldloc.3
+		IL_0914: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0919: stloc.s 7
+		IL_091b: ldloc.s 7
+		IL_091d: ldstr "toString"
+		IL_0922: ldstr "utf8"
+		IL_0927: ldc.r8 0.0
+		IL_0930: box [System.Runtime]System.Double
+		IL_0935: ldc.r8 5
+		IL_093e: box [System.Runtime]System.Double
+		IL_0943: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0948: stloc.s 8
+		IL_094a: ldloc.s 6
+		IL_094c: ldloc.s 8
+		IL_094e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0953: pop
+		IL_0954: ldloc.3
+		IL_0955: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_095a: stloc.s 7
+		IL_095c: ldloc.s 7
+		IL_095e: ldstr "write"
+		IL_0963: ldstr "world"
+		IL_0968: ldc.r8 5
+		IL_0971: box [System.Runtime]System.Double
+		IL_0976: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_097b: stloc.s 5
+		IL_097d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0982: stloc.s 6
+		IL_0984: ldloc.s 6
+		IL_0986: ldloc.s 5
+		IL_0988: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_098d: pop
+		IL_098e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0993: stloc.s 6
+		IL_0995: ldloc.3
+		IL_0996: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_099b: stloc.s 7
+		IL_099d: volatile.
+		IL_099f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_09a4: brfalse IL_09ba
+
+		IL_09a9: ldloc.s 7
+		IL_09ab: ldstr "toString"
+		IL_09b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_09b5: br IL_09d0
+
+		IL_09ba: ldloc.s 7
+		IL_09bc: ldstr "toString"
+		IL_09c1: ldstr "Buffer_ReadWrite_Methods:Modules.Buffer_ReadWrite_Methods:__js_module_init__:216"
+		IL_09c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_09d0: stloc.s 8
+		IL_09d2: ldloc.s 6
+		IL_09d4: ldloc.s 8
+		IL_09d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_09db: pop
+		IL_09dc: ret
 	} // end of method Buffer_ReadWrite_Methods::__js_module_init__
 
 } // end of class Modules.Buffer_ReadWrite_Methods
@@ -586,6 +824,23 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Require_Buffer_Undici_Core.verified.txt
+++ b/tests/Jroc.Tests/Node/Buffer/Snapshots/GeneratorTests.Require_Buffer_Undici_Core.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1122 (0x462)
+		// Code size: 1469 (0x5bd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Buffer_Undici_Core/Scope,
@@ -220,250 +220,349 @@
 		IL_0121: ldc.r8 2
 		IL_012a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_012f: stloc.s 9
-		IL_0131: ldstr "from"
-		IL_0136: ldloc.s 9
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013d: stloc.s 10
-		IL_013f: ldloc.1
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0145: ldstr "alloc"
-		IL_014a: ldc.r8 2
-		IL_0153: box [System.Runtime]System.Double
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015d: stloc.s 11
-		IL_015f: ldc.i4.2
-		IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0165: dup
-		IL_0166: ldloc.s 10
-		IL_0168: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_016d: dup
-		IL_016e: ldloc.s 11
-		IL_0170: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0175: stloc.s 9
-		IL_0177: ldloc.s 8
-		IL_0179: ldstr "concat"
-		IL_017e: ldloc.s 9
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0185: stloc.s 6
-		IL_0187: ldloc.s 6
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018e: ldstr "writeUInt16BE"
-		IL_0193: ldc.r8 8080
-		IL_019c: box [System.Runtime]System.Double
-		IL_01a1: ldc.r8 2
-		IL_01aa: box [System.Runtime]System.Double
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01b4: pop
-		IL_01b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ba: stloc.s 12
-		IL_01bc: ldloc.s 4
-		IL_01be: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IBufferModule::get_Buffer()
-		IL_01c3: stloc.s 8
-		IL_01c5: ldloc.s 8
-		IL_01c7: ldloc.1
-		IL_01c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01cd: stloc.s 13
-		IL_01cf: ldloc.s 13
-		IL_01d1: box [System.Runtime]System.Boolean
-		IL_01d6: stloc.s 14
-		IL_01d8: ldloc.s 12
-		IL_01da: ldloc.s 14
-		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e1: pop
-		IL_01e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e7: stloc.s 12
-		IL_01e9: ldloc.s 5
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f0: ldstr "toString"
-		IL_01f5: ldstr "hex"
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ff: stloc.s 8
-		IL_0201: ldloc.s 12
-		IL_0203: ldloc.s 8
-		IL_0205: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_020a: pop
-		IL_020b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0210: stloc.s 12
-		IL_0212: ldloc.s 6
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0219: ldstr "readUInt16BE"
-		IL_021e: ldc.r8 2
-		IL_0227: box [System.Runtime]System.Double
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0231: stloc.s 8
-		IL_0233: ldloc.s 12
-		IL_0235: ldloc.s 8
-		IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023c: pop
-		IL_023d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0242: stloc.s 12
-		IL_0244: ldloc.s 6
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024b: ldstr "subarray"
-		IL_0250: ldc.r8 0.0
-		IL_0259: box [System.Runtime]System.Double
-		IL_025e: ldc.r8 2
-		IL_0267: box [System.Runtime]System.Double
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0271: stloc.s 8
-		IL_0273: ldloc.s 8
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027a: ldstr "toString"
-		IL_027f: ldstr "hex"
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0289: stloc.s 8
-		IL_028b: ldloc.s 12
-		IL_028d: ldloc.s 8
-		IL_028f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0294: pop
-		IL_0295: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_029a: stloc.s 12
-		IL_029c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02a1: stloc.s 15
-		IL_02a3: ldloc.1
-		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a9: ldstr "from"
-		IL_02ae: ldstr "valid"
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b8: stloc.s 8
-		IL_02ba: ldloc.2
-		IL_02bb: ldloc.s 15
-		IL_02bd: ldloc.s 8
-		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02c4: stloc.s 8
-		IL_02c6: ldloc.s 12
-		IL_02c8: ldloc.s 8
-		IL_02ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02cf: pop
-		IL_02d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02d5: stloc.s 12
-		IL_02d7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02dc: stloc.s 15
-		IL_02de: ldloc.1
-		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e4: ldc.i4.2
-		IL_02e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02ea: dup
-		IL_02eb: ldc.r8 195
-		IL_02f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02f9: dup
-		IL_02fa: ldc.r8 40
-		IL_0303: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0308: stloc.s 9
-		IL_030a: ldstr "from"
-		IL_030f: ldloc.s 9
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0316: stloc.s 8
-		IL_0318: ldloc.2
-		IL_0319: ldloc.s 15
-		IL_031b: ldloc.s 8
-		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0322: stloc.s 8
-		IL_0324: ldloc.s 12
-		IL_0326: ldloc.s 8
-		IL_0328: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_032d: pop
-		IL_032e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0333: stloc.s 12
-		IL_0335: volatile.
-		IL_0337: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_033c: brfalse IL_0352
+		IL_0131: volatile.
+		IL_0133: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0138: brfalse IL_014e
 
-		IL_0341: ldloc.s 6
-		IL_0343: ldstr "byteLength"
-		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_034d: br IL_0368
+		IL_013d: ldstr "from"
+		IL_0142: ldloc.s 9
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0149: br IL_0164
 
-		IL_0352: ldloc.s 6
-		IL_0354: ldstr "byteLength"
-		IL_0359: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:105"
-		IL_035e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_014e: ldstr "from"
+		IL_0153: ldloc.s 9
+		IL_0155: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:38"
+		IL_015a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0368: stloc.s 8
-		IL_036a: ldloc.s 12
-		IL_036c: ldloc.s 8
-		IL_036e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0373: pop
-		IL_0374: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0379: stloc.s 12
-		IL_037b: volatile.
-		IL_037d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0382: brfalse IL_0398
+		IL_0164: stloc.s 10
+		IL_0166: ldloc.1
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016c: volatile.
+		IL_016e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0173: brfalse IL_0195
 
-		IL_0387: ldloc.s 6
-		IL_0389: ldstr "buffer"
-		IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0393: br IL_03ae
+		IL_0178: ldstr "alloc"
+		IL_017d: ldc.r8 2
+		IL_0186: box [System.Runtime]System.Double
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0190: br IL_01b7
 
-		IL_0398: ldloc.s 6
-		IL_039a: ldstr "buffer"
-		IL_039f: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:110"
-		IL_03a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0195: ldstr "alloc"
+		IL_019a: ldc.r8 2
+		IL_01a3: box [System.Runtime]System.Double
+		IL_01a8: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:42"
+		IL_01ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03ae: stloc.s 8
-		IL_03b0: volatile.
-		IL_03b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_03b7: brfalse IL_03cd
+		IL_01b7: stloc.s 11
+		IL_01b9: ldc.i4.2
+		IL_01ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01bf: dup
+		IL_01c0: ldloc.s 10
+		IL_01c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01c7: dup
+		IL_01c8: ldloc.s 11
+		IL_01ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01cf: stloc.s 9
+		IL_01d1: volatile.
+		IL_01d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01d8: brfalse IL_01f0
 
-		IL_03bc: ldloc.s 8
-		IL_03be: ldstr "byteLength"
-		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03c8: br IL_03e3
+		IL_01dd: ldloc.s 8
+		IL_01df: ldstr "concat"
+		IL_01e4: ldloc.s 9
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01eb: br IL_0208
 
-		IL_03cd: ldloc.s 8
-		IL_03cf: ldstr "byteLength"
-		IL_03d4: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:112"
-		IL_03d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01f0: ldloc.s 8
+		IL_01f2: ldstr "concat"
+		IL_01f7: ldloc.s 9
+		IL_01f9: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:44"
+		IL_01fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03e3: stloc.s 8
-		IL_03e5: ldloc.s 12
-		IL_03e7: ldloc.s 8
-		IL_03e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03ee: pop
-		IL_03ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03f4: stloc.s 12
-		IL_03f6: ldloc.s 6
-		IL_03f8: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_03fd: ldc.i4.1
-		IL_03fe: newarr [System.Runtime]System.Object
-		IL_0403: dup
-		IL_0404: ldc.i4.0
-		IL_0405: ldstr ","
-		IL_040a: stelem.ref
-		IL_040b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0410: stloc.s 16
-		IL_0412: ldloc.s 12
-		IL_0414: ldloc.s 16
-		IL_0416: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_041b: pop
-		IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0421: stloc.s 12
-		IL_0423: ldloc.s 6
-		IL_0425: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_042a: stloc.s 17
-		IL_042c: ldloc.s 17
-		IL_042e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-		IL_0433: stloc.s 18
-		IL_0435: ldloc.s 18
-		IL_0437: box [System.Runtime]System.Double
-		IL_043c: stloc.s 19
-		IL_043e: ldloc.s 12
-		IL_0440: ldloc.s 19
-		IL_0442: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0447: pop
-		IL_0448: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_044d: stloc.s 12
-		IL_044f: ldloc.3
-		IL_0450: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0455: stloc.s 16
-		IL_0457: ldloc.s 12
-		IL_0459: ldloc.s 16
-		IL_045b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0460: pop
-		IL_0461: ret
+		IL_0208: stloc.s 6
+		IL_020a: ldloc.s 6
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0211: ldstr "writeUInt16BE"
+		IL_0216: ldc.r8 8080
+		IL_021f: box [System.Runtime]System.Double
+		IL_0224: ldc.r8 2
+		IL_022d: box [System.Runtime]System.Double
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0237: pop
+		IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023d: stloc.s 12
+		IL_023f: ldloc.s 4
+		IL_0241: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IBufferModule::get_Buffer()
+		IL_0246: stloc.s 8
+		IL_0248: ldloc.s 8
+		IL_024a: ldloc.1
+		IL_024b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0250: stloc.s 13
+		IL_0252: ldloc.s 13
+		IL_0254: box [System.Runtime]System.Boolean
+		IL_0259: stloc.s 14
+		IL_025b: ldloc.s 12
+		IL_025d: ldloc.s 14
+		IL_025f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0264: pop
+		IL_0265: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_026a: stloc.s 12
+		IL_026c: ldloc.s 5
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0273: volatile.
+		IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_027a: brfalse IL_0293
+
+		IL_027f: ldstr "toString"
+		IL_0284: ldstr "hex"
+		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028e: br IL_02ac
+
+		IL_0293: ldstr "toString"
+		IL_0298: ldstr "hex"
+		IL_029d: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:63"
+		IL_02a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02ac: stloc.s 8
+		IL_02ae: ldloc.s 12
+		IL_02b0: ldloc.s 8
+		IL_02b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02b7: pop
+		IL_02b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02bd: stloc.s 12
+		IL_02bf: ldloc.s 6
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c6: volatile.
+		IL_02c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02cd: brfalse IL_02ef
+
+		IL_02d2: ldstr "readUInt16BE"
+		IL_02d7: ldc.r8 2
+		IL_02e0: box [System.Runtime]System.Double
+		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ea: br IL_0311
+
+		IL_02ef: ldstr "readUInt16BE"
+		IL_02f4: ldc.r8 2
+		IL_02fd: box [System.Runtime]System.Double
+		IL_0302: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:70"
+		IL_0307: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0311: stloc.s 8
+		IL_0313: ldloc.s 12
+		IL_0315: ldloc.s 8
+		IL_0317: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_031c: pop
+		IL_031d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0322: stloc.s 12
+		IL_0324: ldloc.s 6
+		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_032b: ldstr "subarray"
+		IL_0330: ldc.r8 0.0
+		IL_0339: box [System.Runtime]System.Double
+		IL_033e: ldc.r8 2
+		IL_0347: box [System.Runtime]System.Double
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0351: stloc.s 8
+		IL_0353: ldloc.s 8
+		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_035a: volatile.
+		IL_035c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0361: brfalse IL_037a
+
+		IL_0366: ldstr "toString"
+		IL_036b: ldstr "hex"
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0375: br IL_0393
+
+		IL_037a: ldstr "toString"
+		IL_037f: ldstr "hex"
+		IL_0384: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:82"
+		IL_0389: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0393: stloc.s 8
+		IL_0395: ldloc.s 12
+		IL_0397: ldloc.s 8
+		IL_0399: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_039e: pop
+		IL_039f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a4: stloc.s 12
+		IL_03a6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03ab: stloc.s 15
+		IL_03ad: ldloc.1
+		IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03b3: volatile.
+		IL_03b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_03ba: brfalse IL_03d3
+
+		IL_03bf: ldstr "from"
+		IL_03c4: ldstr "valid"
+		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03ce: br IL_03ec
+
+		IL_03d3: ldstr "from"
+		IL_03d8: ldstr "valid"
+		IL_03dd: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:89"
+		IL_03e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03ec: stloc.s 8
+		IL_03ee: ldloc.2
+		IL_03ef: ldloc.s 15
+		IL_03f1: ldloc.s 8
+		IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_03f8: stloc.s 8
+		IL_03fa: ldloc.s 12
+		IL_03fc: ldloc.s 8
+		IL_03fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0403: pop
+		IL_0404: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0409: stloc.s 12
+		IL_040b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0410: stloc.s 15
+		IL_0412: ldloc.1
+		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0418: ldc.i4.2
+		IL_0419: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_041e: dup
+		IL_041f: ldc.r8 195
+		IL_0428: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_042d: dup
+		IL_042e: ldc.r8 40
+		IL_0437: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_043c: stloc.s 9
+		IL_043e: volatile.
+		IL_0440: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0445: brfalse IL_045b
+
+		IL_044a: ldstr "from"
+		IL_044f: ldloc.s 9
+		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0456: br IL_0471
+
+		IL_045b: ldstr "from"
+		IL_0460: ldloc.s 9
+		IL_0462: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:99"
+		IL_0467: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0471: stloc.s 8
+		IL_0473: ldloc.2
+		IL_0474: ldloc.s 15
+		IL_0476: ldloc.s 8
+		IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_047d: stloc.s 8
+		IL_047f: ldloc.s 12
+		IL_0481: ldloc.s 8
+		IL_0483: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0488: pop
+		IL_0489: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_048e: stloc.s 12
+		IL_0490: volatile.
+		IL_0492: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0497: brfalse IL_04ad
+
+		IL_049c: ldloc.s 6
+		IL_049e: ldstr "byteLength"
+		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04a8: br IL_04c3
+
+		IL_04ad: ldloc.s 6
+		IL_04af: ldstr "byteLength"
+		IL_04b4: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:105"
+		IL_04b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04c3: stloc.s 8
+		IL_04c5: ldloc.s 12
+		IL_04c7: ldloc.s 8
+		IL_04c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04ce: pop
+		IL_04cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04d4: stloc.s 12
+		IL_04d6: volatile.
+		IL_04d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_04dd: brfalse IL_04f3
+
+		IL_04e2: ldloc.s 6
+		IL_04e4: ldstr "buffer"
+		IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04ee: br IL_0509
+
+		IL_04f3: ldloc.s 6
+		IL_04f5: ldstr "buffer"
+		IL_04fa: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:110"
+		IL_04ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0509: stloc.s 8
+		IL_050b: volatile.
+		IL_050d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0512: brfalse IL_0528
+
+		IL_0517: ldloc.s 8
+		IL_0519: ldstr "byteLength"
+		IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0523: br IL_053e
+
+		IL_0528: ldloc.s 8
+		IL_052a: ldstr "byteLength"
+		IL_052f: ldstr "Require_Buffer_Undici_Core:Modules.Require_Buffer_Undici_Core:__js_module_init__:112"
+		IL_0534: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0539: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_053e: stloc.s 8
+		IL_0540: ldloc.s 12
+		IL_0542: ldloc.s 8
+		IL_0544: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0549: pop
+		IL_054a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_054f: stloc.s 12
+		IL_0551: ldloc.s 6
+		IL_0553: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0558: ldc.i4.1
+		IL_0559: newarr [System.Runtime]System.Object
+		IL_055e: dup
+		IL_055f: ldc.i4.0
+		IL_0560: ldstr ","
+		IL_0565: stelem.ref
+		IL_0566: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_056b: stloc.s 16
+		IL_056d: ldloc.s 12
+		IL_056f: ldloc.s 16
+		IL_0571: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0576: pop
+		IL_0577: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_057c: stloc.s 12
+		IL_057e: ldloc.s 6
+		IL_0580: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_0585: stloc.s 17
+		IL_0587: ldloc.s 17
+		IL_0589: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
+		IL_058e: stloc.s 18
+		IL_0590: ldloc.s 18
+		IL_0592: box [System.Runtime]System.Double
+		IL_0597: stloc.s 19
+		IL_0599: ldloc.s 12
+		IL_059b: ldloc.s 19
+		IL_059d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05a2: pop
+		IL_05a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05a8: stloc.s 12
+		IL_05aa: ldloc.3
+		IL_05ab: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_05b0: stloc.s 16
+		IL_05b2: ldloc.s 12
+		IL_05b4: ldloc.s 16
+		IL_05b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05bb: pop
+		IL_05bc: ret
 	} // end of method Require_Buffer_Undici_Core::__js_module_init__
 
 } // end of class Modules.Require_Buffer_Undici_Core
@@ -499,6 +598,14 @@
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
@@ -349,7 +349,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 186 (0xba)
+			// Code size: 228 (0xe4)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -359,7 +359,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.2
@@ -370,7 +370,7 @@
 			IL_0022: ldarg.2
 			IL_0023: ldstr "env"
 			IL_0028: ldstr "Require_ChildProcess_Fork_Kill_And_Env:<TwoPhaseDummy_M7>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -382,7 +382,7 @@
 			IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_004a: stloc.0
 			IL_004b: volatile.
-			IL_004d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_004d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_0052: brfalse IL_0067
 
 			IL_0057: ldarg.2
@@ -393,7 +393,7 @@
 			IL_0067: ldarg.2
 			IL_0068: ldstr "argv2"
 			IL_006d: ldstr "Require_ChildProcess_Fork_Kill_And_Env:<TwoPhaseDummy_M7>:__js_call__:12"
-			IL_0072: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0072: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_007c: stloc.1
@@ -407,17 +407,29 @@
 			IL_0090: ldarg.0
 			IL_0091: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
 			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009b: ldstr "kill"
-			IL_00a0: ldstr "SIGTERM"
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00aa: stloc.1
-			IL_00ab: ldloc.0
-			IL_00ac: ldstr "kill result:"
-			IL_00b1: ldloc.1
-			IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00b7: pop
-			IL_00b8: ldnull
-			IL_00b9: ret
+			IL_009b: volatile.
+			IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_00a2: brfalse IL_00bb
+
+			IL_00a7: ldstr "kill"
+			IL_00ac: ldstr "SIGTERM"
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b6: br IL_00d4
+
+			IL_00bb: ldstr "kill"
+			IL_00c0: ldstr "SIGTERM"
+			IL_00c5: ldstr "Require_ChildProcess_Fork_Kill_And_Env:<TwoPhaseDummy_M7>:__js_call__:20"
+			IL_00ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00d4: stloc.1
+			IL_00d5: ldloc.0
+			IL_00d6: ldstr "kill result:"
+			IL_00db: ldloc.1
+			IL_00dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00e1: pop
+			IL_00e2: ldnull
+			IL_00e3: ret
 		} // end of method ArrowFunction_L24C21::__js_call__
 
 	} // end of class ArrowFunction_L24C21
@@ -942,7 +954,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 777 (0x309)
+		// Code size: 819 (0x333)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope,
@@ -1060,168 +1072,180 @@
 		IL_013e: stloc.s 4
 		IL_0140: ldloc.s 4
 		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0147: ldstr "setEncoding"
-		IL_014c: ldstr "utf8"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0156: pop
-		IL_0157: ldloc.0
-		IL_0158: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_015d: volatile.
-		IL_015f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0164: brfalse IL_0178
+		IL_0147: volatile.
+		IL_0149: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_014e: brfalse IL_0167
 
-		IL_0169: ldstr "stderr"
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0173: br IL_018c
+		IL_0153: ldstr "setEncoding"
+		IL_0158: ldstr "utf8"
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0162: br IL_0180
 
-		IL_0178: ldstr "stderr"
-		IL_017d: ldstr "Require_ChildProcess_Fork_Kill_And_Env:Modules.Require_ChildProcess_Fork_Kill_And_Env:__js_module_init__:50"
-		IL_0182: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0167: ldstr "setEncoding"
+		IL_016c: ldstr "utf8"
+		IL_0171: ldstr "Require_ChildProcess_Fork_Kill_And_Env:Modules.Require_ChildProcess_Fork_Kill_And_Env:__js_module_init__:46"
+		IL_0176: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_018c: stloc.s 4
-		IL_018e: ldloc.s 4
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0195: stloc.s 4
-		IL_0197: ldc.i4.1
-		IL_0198: newarr [System.Runtime]System.Object
-		IL_019d: dup
-		IL_019e: ldc.i4.0
-		IL_019f: ldloc.0
-		IL_01a0: stelem.ref
-		IL_01a1: stloc.s 6
-		IL_01a3: ldloc.s 6
-		IL_01a5: ldc.i4.0
-		IL_01a6: ldelem.ref
-		IL_01a7: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
-		IL_01ac: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L20C25/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope)
-		IL_01b1: ldc.i4.1
-		IL_01b2: conv.r8
-		IL_01b3: ldstr ""
-		IL_01b8: ldc.i4.0
-		IL_01b9: ldc.i4.0
-		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L20C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L20C25/FunctionObject>(!!0)
-		IL_01c4: stloc.s 7
-		IL_01c6: ldloc.s 4
-		IL_01c8: ldstr "on"
-		IL_01cd: ldstr "data"
-		IL_01d2: ldloc.s 7
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01d9: pop
-		IL_01da: ldloc.0
-		IL_01db: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e5: stloc.s 4
-		IL_01e7: ldc.i4.1
-		IL_01e8: newarr [System.Runtime]System.Object
-		IL_01ed: dup
-		IL_01ee: ldc.i4.0
-		IL_01ef: ldloc.0
-		IL_01f0: stelem.ref
-		IL_01f1: stloc.s 6
-		IL_01f3: ldloc.s 6
-		IL_01f5: ldc.i4.0
-		IL_01f6: ldelem.ref
-		IL_01f7: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
-		IL_01fc: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L24C21/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope)
-		IL_0201: ldc.i4.1
-		IL_0202: conv.r8
-		IL_0203: ldstr ""
-		IL_0208: ldc.i4.0
-		IL_0209: ldc.i4.0
-		IL_020a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L24C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_020f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L24C21/FunctionObject>(!!0)
-		IL_0214: stloc.s 8
-		IL_0216: ldloc.s 4
-		IL_0218: ldstr "on"
-		IL_021d: ldstr "message"
-		IL_0222: ldloc.s 8
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0229: pop
-		IL_022a: ldloc.0
-		IL_022b: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0235: stloc.s 4
-		IL_0237: ldc.i4.1
-		IL_0238: newarr [System.Runtime]System.Object
-		IL_023d: dup
-		IL_023e: ldc.i4.0
-		IL_023f: ldloc.0
-		IL_0240: stelem.ref
-		IL_0241: stloc.s 6
-		IL_0243: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L30C24/FunctionObject::.ctor()
-		IL_0248: ldc.i4.0
-		IL_0249: conv.r8
-		IL_024a: ldstr ""
-		IL_024f: ldc.i4.0
-		IL_0250: ldc.i4.0
-		IL_0251: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L30C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0256: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L30C24/FunctionObject>(!!0)
-		IL_025b: stloc.s 9
-		IL_025d: ldloc.s 4
-		IL_025f: ldstr "on"
-		IL_0264: ldstr "disconnect"
-		IL_0269: ldloc.s 9
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0270: pop
-		IL_0271: ldloc.0
-		IL_0272: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027c: stloc.s 4
-		IL_027e: ldc.i4.1
-		IL_027f: newarr [System.Runtime]System.Object
-		IL_0284: dup
-		IL_0285: ldc.i4.0
-		IL_0286: ldloc.0
-		IL_0287: stelem.ref
-		IL_0288: stloc.s 6
-		IL_028a: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L34C18/FunctionObject::.ctor()
-		IL_028f: ldc.i4.2
-		IL_0290: conv.r8
-		IL_0291: ldstr ""
-		IL_0296: ldc.i4.0
-		IL_0297: ldc.i4.0
-		IL_0298: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L34C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_029d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L34C18/FunctionObject>(!!0)
-		IL_02a2: stloc.s 10
-		IL_02a4: ldloc.s 4
-		IL_02a6: ldstr "on"
-		IL_02ab: ldstr "exit"
-		IL_02b0: ldloc.s 10
-		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02b7: pop
-		IL_02b8: ldloc.0
-		IL_02b9: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
-		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c3: stloc.s 4
-		IL_02c5: ldc.i4.1
-		IL_02c6: newarr [System.Runtime]System.Object
-		IL_02cb: dup
-		IL_02cc: ldc.i4.0
-		IL_02cd: ldloc.0
-		IL_02ce: stelem.ref
-		IL_02cf: stloc.s 6
-		IL_02d1: ldloc.s 6
-		IL_02d3: ldc.i4.0
-		IL_02d4: ldelem.ref
-		IL_02d5: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
-		IL_02da: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L40C19/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope)
-		IL_02df: ldc.i4.2
-		IL_02e0: conv.r8
-		IL_02e1: ldstr ""
-		IL_02e6: ldc.i4.0
-		IL_02e7: ldc.i4.0
-		IL_02e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L40C19/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L40C19/FunctionObject>(!!0)
-		IL_02f2: stloc.s 11
-		IL_02f4: ldloc.s 4
-		IL_02f6: ldstr "on"
-		IL_02fb: ldstr "close"
-		IL_0300: ldloc.s 11
-		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0307: pop
-		IL_0308: ret
+		IL_0180: pop
+		IL_0181: ldloc.0
+		IL_0182: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_0187: volatile.
+		IL_0189: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_018e: brfalse IL_01a2
+
+		IL_0193: ldstr "stderr"
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019d: br IL_01b6
+
+		IL_01a2: ldstr "stderr"
+		IL_01a7: ldstr "Require_ChildProcess_Fork_Kill_And_Env:Modules.Require_ChildProcess_Fork_Kill_And_Env:__js_module_init__:50"
+		IL_01ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_01b6: stloc.s 4
+		IL_01b8: ldloc.s 4
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bf: stloc.s 4
+		IL_01c1: ldc.i4.1
+		IL_01c2: newarr [System.Runtime]System.Object
+		IL_01c7: dup
+		IL_01c8: ldc.i4.0
+		IL_01c9: ldloc.0
+		IL_01ca: stelem.ref
+		IL_01cb: stloc.s 6
+		IL_01cd: ldloc.s 6
+		IL_01cf: ldc.i4.0
+		IL_01d0: ldelem.ref
+		IL_01d1: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
+		IL_01d6: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L20C25/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope)
+		IL_01db: ldc.i4.1
+		IL_01dc: conv.r8
+		IL_01dd: ldstr ""
+		IL_01e2: ldc.i4.0
+		IL_01e3: ldc.i4.0
+		IL_01e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L20C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L20C25/FunctionObject>(!!0)
+		IL_01ee: stloc.s 7
+		IL_01f0: ldloc.s 4
+		IL_01f2: ldstr "on"
+		IL_01f7: ldstr "data"
+		IL_01fc: ldloc.s 7
+		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0203: pop
+		IL_0204: ldloc.0
+		IL_0205: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020f: stloc.s 4
+		IL_0211: ldc.i4.1
+		IL_0212: newarr [System.Runtime]System.Object
+		IL_0217: dup
+		IL_0218: ldc.i4.0
+		IL_0219: ldloc.0
+		IL_021a: stelem.ref
+		IL_021b: stloc.s 6
+		IL_021d: ldloc.s 6
+		IL_021f: ldc.i4.0
+		IL_0220: ldelem.ref
+		IL_0221: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
+		IL_0226: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L24C21/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope)
+		IL_022b: ldc.i4.1
+		IL_022c: conv.r8
+		IL_022d: ldstr ""
+		IL_0232: ldc.i4.0
+		IL_0233: ldc.i4.0
+		IL_0234: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L24C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0239: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L24C21/FunctionObject>(!!0)
+		IL_023e: stloc.s 8
+		IL_0240: ldloc.s 4
+		IL_0242: ldstr "on"
+		IL_0247: ldstr "message"
+		IL_024c: ldloc.s 8
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0253: pop
+		IL_0254: ldloc.0
+		IL_0255: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025f: stloc.s 4
+		IL_0261: ldc.i4.1
+		IL_0262: newarr [System.Runtime]System.Object
+		IL_0267: dup
+		IL_0268: ldc.i4.0
+		IL_0269: ldloc.0
+		IL_026a: stelem.ref
+		IL_026b: stloc.s 6
+		IL_026d: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L30C24/FunctionObject::.ctor()
+		IL_0272: ldc.i4.0
+		IL_0273: conv.r8
+		IL_0274: ldstr ""
+		IL_0279: ldc.i4.0
+		IL_027a: ldc.i4.0
+		IL_027b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L30C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0280: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L30C24/FunctionObject>(!!0)
+		IL_0285: stloc.s 9
+		IL_0287: ldloc.s 4
+		IL_0289: ldstr "on"
+		IL_028e: ldstr "disconnect"
+		IL_0293: ldloc.s 9
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_029a: pop
+		IL_029b: ldloc.0
+		IL_029c: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a6: stloc.s 4
+		IL_02a8: ldc.i4.1
+		IL_02a9: newarr [System.Runtime]System.Object
+		IL_02ae: dup
+		IL_02af: ldc.i4.0
+		IL_02b0: ldloc.0
+		IL_02b1: stelem.ref
+		IL_02b2: stloc.s 6
+		IL_02b4: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L34C18/FunctionObject::.ctor()
+		IL_02b9: ldc.i4.2
+		IL_02ba: conv.r8
+		IL_02bb: ldstr ""
+		IL_02c0: ldc.i4.0
+		IL_02c1: ldc.i4.0
+		IL_02c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L34C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L34C18/FunctionObject>(!!0)
+		IL_02cc: stloc.s 10
+		IL_02ce: ldloc.s 4
+		IL_02d0: ldstr "on"
+		IL_02d5: ldstr "exit"
+		IL_02da: ldloc.s 10
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02e1: pop
+		IL_02e2: ldloc.0
+		IL_02e3: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::child
+		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ed: stloc.s 4
+		IL_02ef: ldc.i4.1
+		IL_02f0: newarr [System.Runtime]System.Object
+		IL_02f5: dup
+		IL_02f6: ldc.i4.0
+		IL_02f7: ldloc.0
+		IL_02f8: stelem.ref
+		IL_02f9: stloc.s 6
+		IL_02fb: ldloc.s 6
+		IL_02fd: ldc.i4.0
+		IL_02fe: ldelem.ref
+		IL_02ff: castclass Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope
+		IL_0304: newobj instance void Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L40C19/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope)
+		IL_0309: ldc.i4.2
+		IL_030a: conv.r8
+		IL_030b: ldstr ""
+		IL_0310: ldc.i4.0
+		IL_0311: ldc.i4.0
+		IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L40C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0317: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Kill_And_Env/ArrowFunction_L40C19/FunctionObject>(!!0)
+		IL_031c: stloc.s 11
+		IL_031e: ldloc.s 4
+		IL_0320: ldstr "on"
+		IL_0325: ldstr "close"
+		IL_032a: ldloc.s 11
+		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0331: pop
+		IL_0332: ret
 	} // end of method Require_ChildProcess_Fork_Kill_And_Env::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Kill_And_Env
@@ -1332,7 +1356,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 243 (0xf3)
+			// Code size: 282 (0x11a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1348,7 +1372,7 @@
 			IL_0010: ldstr "process"
 			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_001a: volatile.
-			IL_001c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_001c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_0021: brfalse IL_0035
 
 			IL_0026: ldstr "env"
@@ -1357,12 +1381,12 @@
 
 			IL_0035: ldstr "env"
 			IL_003a: ldstr "Require_ChildProcess_Fork_Kill_And_Env_Child:<TwoPhaseDummy_M11>:__js_call__:7"
-			IL_003f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_003f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0049: stloc.1
 			IL_004a: volatile.
-			IL_004c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_004c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_0051: brfalse IL_0066
 
 			IL_0056: ldloc.1
@@ -1373,14 +1397,14 @@
 			IL_0066: ldloc.1
 			IL_0067: ldstr "JROC_KILL_MARKER"
 			IL_006c: ldstr "Require_ChildProcess_Fork_Kill_And_Env_Child:<TwoPhaseDummy_M11>:__js_call__:9"
-			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_007b: stloc.1
 			IL_007c: ldstr "process"
 			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0086: volatile.
-			IL_0088: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0088: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_008d: brfalse IL_00a1
 
 			IL_0092: ldstr "argv"
@@ -1389,7 +1413,7 @@
 
 			IL_00a1: ldstr "argv"
 			IL_00a6: ldstr "Require_ChildProcess_Fork_Kill_And_Env_Child:<TwoPhaseDummy_M11>:__js_call__:13"
-			IL_00ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_00ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00b5: stloc.2
@@ -1407,13 +1431,26 @@
 			IL_00dd: ldloc.2
 			IL_00de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_00e3: stloc.3
-			IL_00e4: ldloc.0
-			IL_00e5: ldstr "send"
-			IL_00ea: ldloc.3
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f0: pop
-			IL_00f1: ldnull
-			IL_00f2: ret
+			IL_00e4: volatile.
+			IL_00e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_00eb: brfalse IL_0101
+
+			IL_00f0: ldloc.0
+			IL_00f1: ldstr "send"
+			IL_00f6: ldloc.3
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00fc: br IL_0117
+
+			IL_0101: ldloc.0
+			IL_0102: ldstr "send"
+			IL_0107: ldloc.3
+			IL_0108: ldstr "Require_ChildProcess_Fork_Kill_And_Env_Child:<TwoPhaseDummy_M11>:__js_call__:17"
+			IL_010d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0117: pop
+			IL_0118: ldnull
+			IL_0119: ret
 		} // end of method ArrowFunction_L3C12::__js_call__
 
 	} // end of class ArrowFunction_L3C12
@@ -1647,6 +1684,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_18
 	.field assembly static int32 __jroc_dynamicLookup_19
 	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
@@ -525,7 +525,7 @@
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
 			// Header size: 12
-			// Code size: 443 (0x1bb)
+			// Code size: 481 (0x1e1)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -535,7 +535,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 			IL_0007: brfalse IL_001c
 
 			IL_000c: ldarg.2
@@ -546,7 +546,7 @@
 			IL_001c: ldarg.2
 			IL_001d: ldstr "stage"
 			IL_0022: ldstr "Require_ChildProcess_Fork_MessagePassing:<TwoPhaseDummy_M8>:__js_call__:3"
-			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0031: stloc.0
@@ -555,7 +555,7 @@
 			IL_0038: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_003d: stloc.1
 			IL_003e: ldloc.1
-			IL_003f: brfalse IL_0130
+			IL_003f: brfalse IL_0156
 
 			IL_0044: ldarg.0
 			IL_0045: ldc.i4.1
@@ -564,7 +564,7 @@
 			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0055: stloc.2
 			IL_0056: volatile.
-			IL_0058: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0058: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 			IL_005d: brfalse IL_0072
 
 			IL_0062: ldarg.2
@@ -575,7 +575,7 @@
 			IL_0072: ldarg.2
 			IL_0073: ldstr "argv2"
 			IL_0078: ldstr "Require_ChildProcess_Fork_MessagePassing:<TwoPhaseDummy_M8>:__js_call__:16"
-			IL_007d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_007d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0087: stloc.0
@@ -587,7 +587,7 @@
 			IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_009a: stloc.2
 			IL_009b: volatile.
-			IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_00a2: brfalse IL_00b7
 
 			IL_00a7: ldarg.2
@@ -598,7 +598,7 @@
 			IL_00b7: ldarg.2
 			IL_00b8: ldstr "env"
 			IL_00bd: ldstr "Require_ChildProcess_Fork_MessagePassing:<TwoPhaseDummy_M8>:__js_call__:23"
-			IL_00c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_00c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00cc: stloc.0
@@ -622,67 +622,79 @@
 			IL_0106: ldc.r8 41
 			IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 			IL_0114: stloc.3
-			IL_0115: ldstr "send"
-			IL_011a: ldloc.3
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0120: stloc.0
-			IL_0121: ldloc.2
-			IL_0122: ldstr "send result:"
-			IL_0127: ldloc.0
-			IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_012d: pop
-			IL_012e: ldnull
-			IL_012f: ret
+			IL_0115: volatile.
+			IL_0117: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_011c: brfalse IL_0131
 
-			IL_0130: volatile.
-			IL_0132: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-			IL_0137: brfalse IL_014c
+			IL_0121: ldstr "send"
+			IL_0126: ldloc.3
+			IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_012c: br IL_0146
 
-			IL_013c: ldarg.2
-			IL_013d: ldstr "stage"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0147: br IL_0161
+			IL_0131: ldstr "send"
+			IL_0136: ldloc.3
+			IL_0137: ldstr "Require_ChildProcess_Fork_MessagePassing:<TwoPhaseDummy_M8>:__js_call__:33"
+			IL_013c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_014c: ldarg.2
-			IL_014d: ldstr "stage"
-			IL_0152: ldstr "Require_ChildProcess_Fork_MessagePassing:<TwoPhaseDummy_M8>:__js_call__:42"
-			IL_0157: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0146: stloc.0
+			IL_0147: ldloc.2
+			IL_0148: ldstr "send result:"
+			IL_014d: ldloc.0
+			IL_014e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0153: pop
+			IL_0154: ldnull
+			IL_0155: ret
 
-			IL_0161: stloc.0
-			IL_0162: ldloc.0
-			IL_0163: ldstr "child"
-			IL_0168: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_016d: stloc.1
-			IL_016e: ldloc.1
-			IL_016f: brfalse IL_01b9
+			IL_0156: volatile.
+			IL_0158: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_015d: brfalse IL_0172
 
-			IL_0174: ldarg.0
-			IL_0175: ldc.i4.1
-			IL_0176: box [System.Runtime]System.Boolean
-			IL_017b: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::replyReceived
-			IL_0180: volatile.
-			IL_0182: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_0187: brfalse IL_019c
+			IL_0162: ldarg.2
+			IL_0163: ldstr "stage"
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016d: br IL_0187
 
-			IL_018c: ldarg.2
-			IL_018d: ldstr "value"
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0197: br IL_01b1
+			IL_0172: ldarg.2
+			IL_0173: ldstr "stage"
+			IL_0178: ldstr "Require_ChildProcess_Fork_MessagePassing:<TwoPhaseDummy_M8>:__js_call__:42"
+			IL_017d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_019c: ldarg.2
-			IL_019d: ldstr "value"
-			IL_01a2: ldstr "Require_ChildProcess_Fork_MessagePassing:<TwoPhaseDummy_M8>:__js_call__:53"
-			IL_01a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0187: stloc.0
+			IL_0188: ldloc.0
+			IL_0189: ldstr "child"
+			IL_018e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0193: stloc.1
+			IL_0194: ldloc.1
+			IL_0195: brfalse IL_01df
 
-			IL_01b1: stloc.0
-			IL_01b2: ldarg.0
-			IL_01b3: ldloc.0
-			IL_01b4: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::replyValue
+			IL_019a: ldarg.0
+			IL_019b: ldc.i4.1
+			IL_019c: box [System.Runtime]System.Boolean
+			IL_01a1: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::replyReceived
+			IL_01a6: volatile.
+			IL_01a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_01ad: brfalse IL_01c2
 
-			IL_01b9: ldnull
-			IL_01ba: ret
+			IL_01b2: ldarg.2
+			IL_01b3: ldstr "value"
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01bd: br IL_01d7
+
+			IL_01c2: ldarg.2
+			IL_01c3: ldstr "value"
+			IL_01c8: ldstr "Require_ChildProcess_Fork_MessagePassing:<TwoPhaseDummy_M8>:__js_call__:53"
+			IL_01cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_01d7: stloc.0
+			IL_01d8: ldarg.0
+			IL_01d9: ldloc.0
+			IL_01da: stfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::replyValue
+
+			IL_01df: ldnull
+			IL_01e0: ret
 		} // end of method ArrowFunction_L34C21::__js_call__
 
 	} // end of class ArrowFunction_L34C21
@@ -921,7 +933,7 @@
 			IL_000e: brfalse IL_004d
 
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldarg.1
@@ -932,7 +944,7 @@
 			IL_002f: ldarg.1
 			IL_0030: ldstr "message"
 			IL_0035: ldstr "Require_ChildProcess_Fork_MessagePassing:<TwoPhaseDummy_M10>:__js_call__:8"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0044: stloc.2
@@ -1457,7 +1469,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1271 (0x4f7)
+		// Code size: 1393 (0x571)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_MessagePassing/Scope,
@@ -1629,278 +1641,314 @@
 		IL_01de: stloc.s 4
 		IL_01e0: ldloc.s 4
 		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e7: ldstr "setEncoding"
-		IL_01ec: ldstr "utf8"
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f6: pop
-		IL_01f7: ldloc.0
-		IL_01f8: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_01fd: volatile.
-		IL_01ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0204: brfalse IL_0218
+		IL_01e7: volatile.
+		IL_01e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_01ee: brfalse IL_0207
 
-		IL_0209: ldstr "stdout"
-		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0213: br IL_022c
+		IL_01f3: ldstr "setEncoding"
+		IL_01f8: ldstr "utf8"
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0202: br IL_0220
 
-		IL_0218: ldstr "stdout"
-		IL_021d: ldstr "Require_ChildProcess_Fork_MessagePassing:Modules.Require_ChildProcess_Fork_MessagePassing:__js_module_init__:80"
-		IL_0222: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0207: ldstr "setEncoding"
+		IL_020c: ldstr "utf8"
+		IL_0211: ldstr "Require_ChildProcess_Fork_MessagePassing:Modules.Require_ChildProcess_Fork_MessagePassing:__js_module_init__:76"
+		IL_0216: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_022c: stloc.s 4
-		IL_022e: ldloc.s 4
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0235: stloc.s 4
-		IL_0237: ldc.i4.1
-		IL_0238: newarr [System.Runtime]System.Object
-		IL_023d: dup
-		IL_023e: ldc.i4.0
-		IL_023f: ldloc.0
-		IL_0240: stelem.ref
-		IL_0241: stloc.s 8
-		IL_0243: ldloc.s 8
-		IL_0245: ldc.i4.0
-		IL_0246: ldelem.ref
-		IL_0247: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
-		IL_024c: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L26C25/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
-		IL_0251: ldc.i4.1
-		IL_0252: conv.r8
-		IL_0253: ldstr ""
-		IL_0258: ldc.i4.0
-		IL_0259: ldc.i4.0
-		IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L26C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_025f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L26C25/FunctionObject>(!!0)
-		IL_0264: stloc.s 9
-		IL_0266: ldloc.s 4
-		IL_0268: ldstr "on"
-		IL_026d: ldstr "data"
-		IL_0272: ldloc.s 9
-		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0279: pop
-		IL_027a: ldloc.0
-		IL_027b: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_0280: volatile.
-		IL_0282: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0287: brfalse IL_029b
+		IL_0220: pop
+		IL_0221: ldloc.0
+		IL_0222: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_0227: volatile.
+		IL_0229: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_022e: brfalse IL_0242
 
-		IL_028c: ldstr "stderr"
-		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0296: br IL_02af
+		IL_0233: ldstr "stdout"
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023d: br IL_0256
 
-		IL_029b: ldstr "stderr"
-		IL_02a0: ldstr "Require_ChildProcess_Fork_MessagePassing:Modules.Require_ChildProcess_Fork_MessagePassing:__js_module_init__:89"
-		IL_02a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0242: ldstr "stdout"
+		IL_0247: ldstr "Require_ChildProcess_Fork_MessagePassing:Modules.Require_ChildProcess_Fork_MessagePassing:__js_module_init__:80"
+		IL_024c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02af: stloc.s 4
-		IL_02b1: ldloc.s 4
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b8: ldstr "setEncoding"
-		IL_02bd: ldstr "utf8"
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c7: pop
-		IL_02c8: ldloc.0
-		IL_02c9: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_02ce: volatile.
-		IL_02d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_02d5: brfalse IL_02e9
+		IL_0256: stloc.s 4
+		IL_0258: ldloc.s 4
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025f: stloc.s 4
+		IL_0261: ldc.i4.1
+		IL_0262: newarr [System.Runtime]System.Object
+		IL_0267: dup
+		IL_0268: ldc.i4.0
+		IL_0269: ldloc.0
+		IL_026a: stelem.ref
+		IL_026b: stloc.s 8
+		IL_026d: ldloc.s 8
+		IL_026f: ldc.i4.0
+		IL_0270: ldelem.ref
+		IL_0271: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
+		IL_0276: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L26C25/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
+		IL_027b: ldc.i4.1
+		IL_027c: conv.r8
+		IL_027d: ldstr ""
+		IL_0282: ldc.i4.0
+		IL_0283: ldc.i4.0
+		IL_0284: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L26C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0289: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L26C25/FunctionObject>(!!0)
+		IL_028e: stloc.s 9
+		IL_0290: ldloc.s 4
+		IL_0292: ldstr "on"
+		IL_0297: ldstr "data"
+		IL_029c: ldloc.s 9
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02a3: pop
+		IL_02a4: ldloc.0
+		IL_02a5: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_02aa: volatile.
+		IL_02ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_02b1: brfalse IL_02c5
 
-		IL_02da: ldstr "stderr"
-		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e4: br IL_02fd
+		IL_02b6: ldstr "stderr"
+		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02c0: br IL_02d9
 
-		IL_02e9: ldstr "stderr"
-		IL_02ee: ldstr "Require_ChildProcess_Fork_MessagePassing:Modules.Require_ChildProcess_Fork_MessagePassing:__js_module_init__:96"
-		IL_02f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02c5: ldstr "stderr"
+		IL_02ca: ldstr "Require_ChildProcess_Fork_MessagePassing:Modules.Require_ChildProcess_Fork_MessagePassing:__js_module_init__:89"
+		IL_02cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02fd: stloc.s 4
-		IL_02ff: ldloc.s 4
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0306: stloc.s 4
-		IL_0308: ldc.i4.1
-		IL_0309: newarr [System.Runtime]System.Object
-		IL_030e: dup
-		IL_030f: ldc.i4.0
-		IL_0310: ldloc.0
-		IL_0311: stelem.ref
-		IL_0312: stloc.s 8
-		IL_0314: ldloc.s 8
-		IL_0316: ldc.i4.0
-		IL_0317: ldelem.ref
-		IL_0318: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
-		IL_031d: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C25/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
-		IL_0322: ldc.i4.1
-		IL_0323: conv.r8
-		IL_0324: ldstr ""
-		IL_0329: ldc.i4.0
-		IL_032a: ldc.i4.0
-		IL_032b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C25/FunctionObject>(!!0)
-		IL_0335: stloc.s 10
-		IL_0337: ldloc.s 4
-		IL_0339: ldstr "on"
-		IL_033e: ldstr "data"
-		IL_0343: ldloc.s 10
-		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_034a: pop
-		IL_034b: ldloc.0
-		IL_034c: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0356: stloc.s 4
-		IL_0358: ldc.i4.1
-		IL_0359: newarr [System.Runtime]System.Object
-		IL_035e: dup
-		IL_035f: ldc.i4.0
-		IL_0360: ldloc.0
-		IL_0361: stelem.ref
-		IL_0362: stloc.s 8
-		IL_0364: ldloc.s 8
-		IL_0366: ldc.i4.0
-		IL_0367: ldelem.ref
-		IL_0368: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
-		IL_036d: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L34C21/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
-		IL_0372: ldc.i4.1
-		IL_0373: conv.r8
-		IL_0374: ldstr ""
-		IL_0379: ldc.i4.0
-		IL_037a: ldc.i4.0
-		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L34C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0380: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L34C21/FunctionObject>(!!0)
-		IL_0385: stloc.s 11
-		IL_0387: ldloc.s 4
-		IL_0389: ldstr "on"
-		IL_038e: ldstr "message"
-		IL_0393: ldloc.s 11
-		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_039a: pop
-		IL_039b: ldloc.0
-		IL_039c: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03a6: stloc.s 4
-		IL_03a8: ldc.i4.1
-		IL_03a9: newarr [System.Runtime]System.Object
-		IL_03ae: dup
-		IL_03af: ldc.i4.0
-		IL_03b0: ldloc.0
-		IL_03b1: stelem.ref
-		IL_03b2: stloc.s 8
-		IL_03b4: ldloc.s 8
-		IL_03b6: ldc.i4.0
-		IL_03b7: ldelem.ref
-		IL_03b8: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
-		IL_03bd: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L49C24/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
-		IL_03c2: ldc.i4.0
-		IL_03c3: conv.r8
-		IL_03c4: ldstr ""
-		IL_03c9: ldc.i4.0
-		IL_03ca: ldc.i4.0
-		IL_03cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L49C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L49C24/FunctionObject>(!!0)
-		IL_03d5: stloc.s 12
-		IL_03d7: ldloc.s 4
-		IL_03d9: ldstr "on"
-		IL_03de: ldstr "disconnect"
-		IL_03e3: ldloc.s 12
-		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03ea: pop
-		IL_03eb: ldloc.0
-		IL_03ec: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03f6: stloc.s 4
-		IL_03f8: ldc.i4.1
-		IL_03f9: newarr [System.Runtime]System.Object
-		IL_03fe: dup
-		IL_03ff: ldc.i4.0
-		IL_0400: ldloc.0
-		IL_0401: stelem.ref
-		IL_0402: stloc.s 8
-		IL_0404: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L53C19/FunctionObject::.ctor()
-		IL_0409: ldc.i4.1
-		IL_040a: conv.r8
-		IL_040b: ldstr ""
-		IL_0410: ldc.i4.0
-		IL_0411: ldc.i4.0
-		IL_0412: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L53C19/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0417: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L53C19/FunctionObject>(!!0)
-		IL_041c: stloc.s 13
-		IL_041e: ldloc.s 4
-		IL_0420: ldstr "on"
-		IL_0425: ldstr "error"
-		IL_042a: ldloc.s 13
-		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0431: pop
-		IL_0432: ldloc.0
-		IL_0433: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_043d: stloc.s 4
-		IL_043f: ldc.i4.1
-		IL_0440: newarr [System.Runtime]System.Object
-		IL_0445: dup
-		IL_0446: ldc.i4.0
-		IL_0447: ldloc.0
-		IL_0448: stelem.ref
-		IL_0449: stloc.s 8
-		IL_044b: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L57C18/FunctionObject::.ctor()
-		IL_0450: ldc.i4.2
-		IL_0451: conv.r8
-		IL_0452: ldstr ""
-		IL_0457: ldc.i4.0
-		IL_0458: ldc.i4.0
-		IL_0459: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L57C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_045e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L57C18/FunctionObject>(!!0)
-		IL_0463: stloc.s 14
-		IL_0465: ldloc.s 4
-		IL_0467: ldstr "on"
-		IL_046c: ldstr "exit"
-		IL_0471: ldloc.s 14
-		IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0478: pop
-		IL_0479: ldloc.0
-		IL_047a: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0484: stloc.s 4
-		IL_0486: ldc.i4.1
-		IL_0487: newarr [System.Runtime]System.Object
-		IL_048c: dup
-		IL_048d: ldc.i4.0
-		IL_048e: ldloc.0
-		IL_048f: stelem.ref
-		IL_0490: stloc.s 8
-		IL_0492: ldloc.s 8
-		IL_0494: ldc.i4.0
-		IL_0495: ldelem.ref
-		IL_0496: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
-		IL_049b: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L63C19/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
-		IL_04a0: ldc.i4.2
-		IL_04a1: conv.r8
-		IL_04a2: ldstr ""
-		IL_04a7: ldc.i4.0
-		IL_04a8: ldc.i4.0
-		IL_04a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L63C19/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L63C19/FunctionObject>(!!0)
-		IL_04b3: stloc.s 15
-		IL_04b5: ldloc.s 4
-		IL_04b7: ldstr "on"
-		IL_04bc: ldstr "close"
-		IL_04c1: ldloc.s 15
-		IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_04c8: pop
-		IL_04c9: ldloc.0
-		IL_04ca: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
-		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04d9: dup
-		IL_04da: ldstr "stage"
-		IL_04df: ldstr "init"
-		IL_04e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_04e9: stloc.3
-		IL_04ea: ldstr "send"
-		IL_04ef: ldloc.3
-		IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04f5: pop
-		IL_04f6: ret
+		IL_02d9: stloc.s 4
+		IL_02db: ldloc.s 4
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e2: volatile.
+		IL_02e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_02e9: brfalse IL_0302
+
+		IL_02ee: ldstr "setEncoding"
+		IL_02f3: ldstr "utf8"
+		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02fd: br IL_031b
+
+		IL_0302: ldstr "setEncoding"
+		IL_0307: ldstr "utf8"
+		IL_030c: ldstr "Require_ChildProcess_Fork_MessagePassing:Modules.Require_ChildProcess_Fork_MessagePassing:__js_module_init__:92"
+		IL_0311: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_031b: pop
+		IL_031c: ldloc.0
+		IL_031d: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_0322: volatile.
+		IL_0324: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0329: brfalse IL_033d
+
+		IL_032e: ldstr "stderr"
+		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0338: br IL_0351
+
+		IL_033d: ldstr "stderr"
+		IL_0342: ldstr "Require_ChildProcess_Fork_MessagePassing:Modules.Require_ChildProcess_Fork_MessagePassing:__js_module_init__:96"
+		IL_0347: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0351: stloc.s 4
+		IL_0353: ldloc.s 4
+		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_035a: stloc.s 4
+		IL_035c: ldc.i4.1
+		IL_035d: newarr [System.Runtime]System.Object
+		IL_0362: dup
+		IL_0363: ldc.i4.0
+		IL_0364: ldloc.0
+		IL_0365: stelem.ref
+		IL_0366: stloc.s 8
+		IL_0368: ldloc.s 8
+		IL_036a: ldc.i4.0
+		IL_036b: ldelem.ref
+		IL_036c: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
+		IL_0371: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C25/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
+		IL_0376: ldc.i4.1
+		IL_0377: conv.r8
+		IL_0378: ldstr ""
+		IL_037d: ldc.i4.0
+		IL_037e: ldc.i4.0
+		IL_037f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0384: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L30C25/FunctionObject>(!!0)
+		IL_0389: stloc.s 10
+		IL_038b: ldloc.s 4
+		IL_038d: ldstr "on"
+		IL_0392: ldstr "data"
+		IL_0397: ldloc.s 10
+		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_039e: pop
+		IL_039f: ldloc.0
+		IL_03a0: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03aa: stloc.s 4
+		IL_03ac: ldc.i4.1
+		IL_03ad: newarr [System.Runtime]System.Object
+		IL_03b2: dup
+		IL_03b3: ldc.i4.0
+		IL_03b4: ldloc.0
+		IL_03b5: stelem.ref
+		IL_03b6: stloc.s 8
+		IL_03b8: ldloc.s 8
+		IL_03ba: ldc.i4.0
+		IL_03bb: ldelem.ref
+		IL_03bc: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
+		IL_03c1: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L34C21/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
+		IL_03c6: ldc.i4.1
+		IL_03c7: conv.r8
+		IL_03c8: ldstr ""
+		IL_03cd: ldc.i4.0
+		IL_03ce: ldc.i4.0
+		IL_03cf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L34C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L34C21/FunctionObject>(!!0)
+		IL_03d9: stloc.s 11
+		IL_03db: ldloc.s 4
+		IL_03dd: ldstr "on"
+		IL_03e2: ldstr "message"
+		IL_03e7: ldloc.s 11
+		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03ee: pop
+		IL_03ef: ldloc.0
+		IL_03f0: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03fa: stloc.s 4
+		IL_03fc: ldc.i4.1
+		IL_03fd: newarr [System.Runtime]System.Object
+		IL_0402: dup
+		IL_0403: ldc.i4.0
+		IL_0404: ldloc.0
+		IL_0405: stelem.ref
+		IL_0406: stloc.s 8
+		IL_0408: ldloc.s 8
+		IL_040a: ldc.i4.0
+		IL_040b: ldelem.ref
+		IL_040c: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
+		IL_0411: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L49C24/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
+		IL_0416: ldc.i4.0
+		IL_0417: conv.r8
+		IL_0418: ldstr ""
+		IL_041d: ldc.i4.0
+		IL_041e: ldc.i4.0
+		IL_041f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L49C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0424: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L49C24/FunctionObject>(!!0)
+		IL_0429: stloc.s 12
+		IL_042b: ldloc.s 4
+		IL_042d: ldstr "on"
+		IL_0432: ldstr "disconnect"
+		IL_0437: ldloc.s 12
+		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_043e: pop
+		IL_043f: ldloc.0
+		IL_0440: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_044a: stloc.s 4
+		IL_044c: ldc.i4.1
+		IL_044d: newarr [System.Runtime]System.Object
+		IL_0452: dup
+		IL_0453: ldc.i4.0
+		IL_0454: ldloc.0
+		IL_0455: stelem.ref
+		IL_0456: stloc.s 8
+		IL_0458: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L53C19/FunctionObject::.ctor()
+		IL_045d: ldc.i4.1
+		IL_045e: conv.r8
+		IL_045f: ldstr ""
+		IL_0464: ldc.i4.0
+		IL_0465: ldc.i4.0
+		IL_0466: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L53C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_046b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L53C19/FunctionObject>(!!0)
+		IL_0470: stloc.s 13
+		IL_0472: ldloc.s 4
+		IL_0474: ldstr "on"
+		IL_0479: ldstr "error"
+		IL_047e: ldloc.s 13
+		IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0485: pop
+		IL_0486: ldloc.0
+		IL_0487: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0491: stloc.s 4
+		IL_0493: ldc.i4.1
+		IL_0494: newarr [System.Runtime]System.Object
+		IL_0499: dup
+		IL_049a: ldc.i4.0
+		IL_049b: ldloc.0
+		IL_049c: stelem.ref
+		IL_049d: stloc.s 8
+		IL_049f: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L57C18/FunctionObject::.ctor()
+		IL_04a4: ldc.i4.2
+		IL_04a5: conv.r8
+		IL_04a6: ldstr ""
+		IL_04ab: ldc.i4.0
+		IL_04ac: ldc.i4.0
+		IL_04ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L57C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L57C18/FunctionObject>(!!0)
+		IL_04b7: stloc.s 14
+		IL_04b9: ldloc.s 4
+		IL_04bb: ldstr "on"
+		IL_04c0: ldstr "exit"
+		IL_04c5: ldloc.s 14
+		IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04cc: pop
+		IL_04cd: ldloc.0
+		IL_04ce: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d8: stloc.s 4
+		IL_04da: ldc.i4.1
+		IL_04db: newarr [System.Runtime]System.Object
+		IL_04e0: dup
+		IL_04e1: ldc.i4.0
+		IL_04e2: ldloc.0
+		IL_04e3: stelem.ref
+		IL_04e4: stloc.s 8
+		IL_04e6: ldloc.s 8
+		IL_04e8: ldc.i4.0
+		IL_04e9: ldelem.ref
+		IL_04ea: castclass Modules.Require_ChildProcess_Fork_MessagePassing/Scope
+		IL_04ef: newobj instance void Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L63C19/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_MessagePassing/Scope)
+		IL_04f4: ldc.i4.2
+		IL_04f5: conv.r8
+		IL_04f6: ldstr ""
+		IL_04fb: ldc.i4.0
+		IL_04fc: ldc.i4.0
+		IL_04fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L63C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0502: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_MessagePassing/ArrowFunction_L63C19/FunctionObject>(!!0)
+		IL_0507: stloc.s 15
+		IL_0509: ldloc.s 4
+		IL_050b: ldstr "on"
+		IL_0510: ldstr "close"
+		IL_0515: ldloc.s 15
+		IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_051c: pop
+		IL_051d: ldloc.0
+		IL_051e: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::child
+		IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0528: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_052d: dup
+		IL_052e: ldstr "stage"
+		IL_0533: ldstr "init"
+		IL_0538: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_053d: stloc.3
+		IL_053e: volatile.
+		IL_0540: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0545: brfalse IL_055a
+
+		IL_054a: ldstr "send"
+		IL_054f: ldloc.3
+		IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0555: br IL_056f
+
+		IL_055a: ldstr "send"
+		IL_055f: ldloc.3
+		IL_0560: ldstr "Require_ChildProcess_Fork_MessagePassing:Modules.Require_ChildProcess_Fork_MessagePassing:__js_module_init__:142"
+		IL_0565: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_056f: pop
+		IL_0570: ret
 	} // end of method Require_ChildProcess_Fork_MessagePassing::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_MessagePassing
@@ -1997,20 +2045,33 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 42 (0x2a)
+			// Header size: 12
+			// Code size: 93 (0x5d)
 			.maxstack 8
 
 			IL_0000: ldstr "process"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000f: ldstr "exit"
-			IL_0014: ldc.r8 0.0
-			IL_001d: box [System.Runtime]System.Double
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0027: pop
-			IL_0028: ldnull
-			IL_0029: ret
+			IL_000f: volatile.
+			IL_0011: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_0016: brfalse IL_0038
+
+			IL_001b: ldstr "exit"
+			IL_0020: ldc.r8 0.0
+			IL_0029: box [System.Runtime]System.Double
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0033: br IL_005a
+
+			IL_0038: ldstr "exit"
+			IL_003d: ldc.r8 0.0
+			IL_0046: box [System.Runtime]System.Double
+			IL_004b: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M13>:__js_call__:6"
+			IL_0050: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method ArrowFunction_L3C33::__js_call__
 
 	} // end of class ArrowFunction_L3C33
@@ -2168,7 +2229,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 971 (0x3cb)
+			// Code size: 1102 (0x44e)
 			.maxstack 8
 			.locals init (
 				[0] bool,
@@ -2191,7 +2252,7 @@
 			IL_0008: brfalse IL_005a
 
 			IL_000d: volatile.
-			IL_000f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_000f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 			IL_0014: brfalse IL_0029
 
 			IL_0019: ldarg.2
@@ -2202,7 +2263,7 @@
 			IL_0029: ldarg.2
 			IL_002a: ldstr "stage"
 			IL_002f: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:6"
-			IL_0034: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0034: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_003e: stloc.1
@@ -2224,7 +2285,7 @@
 			IL_005f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0064: stloc.0
 			IL_0065: ldloc.0
-			IL_0066: brfalse IL_01f1
+			IL_0066: brfalse IL_0219
 
 			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0070: stloc.s 5
@@ -2237,7 +2298,7 @@
 			IL_0086: ldstr "process"
 			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0090: volatile.
-			IL_0092: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0092: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 			IL_0097: brfalse IL_00ab
 
 			IL_009c: ldstr "connected"
@@ -2246,7 +2307,7 @@
 
 			IL_00ab: ldstr "connected"
 			IL_00b0: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:27"
-			IL_00b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_00b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00bf: stloc.1
@@ -2264,7 +2325,7 @@
 			IL_00e5: ldstr "process"
 			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_00ef: volatile.
-			IL_00f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_00f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 			IL_00f6: brfalse IL_010a
 
 			IL_00fb: ldstr "argv"
@@ -2273,7 +2334,7 @@
 
 			IL_010a: ldstr "argv"
 			IL_010f: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:39"
-			IL_0114: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0114: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_011e: stloc.s 6
@@ -2284,7 +2345,7 @@
 			IL_0132: ldstr "process"
 			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_013c: volatile.
-			IL_013e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_013e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 			IL_0143: brfalse IL_0157
 
 			IL_0148: ldstr "env"
@@ -2293,12 +2354,12 @@
 
 			IL_0157: ldstr "env"
 			IL_015c: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:45"
-			IL_0161: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_0161: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_016b: stloc.s 7
 			IL_016d: volatile.
-			IL_016f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_016f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 			IL_0174: brfalse IL_018a
 
 			IL_0179: ldloc.s 7
@@ -2309,7 +2370,7 @@
 			IL_018a: ldloc.s 7
 			IL_018c: ldstr "JROC_FORK_TEST_MARKER"
 			IL_0191: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:47"
-			IL_0196: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_0196: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01a0: stloc.s 7
@@ -2327,174 +2388,213 @@
 			IL_01ca: ldloc.s 7
 			IL_01cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_01d1: stloc.s 8
-			IL_01d3: ldloc.1
-			IL_01d4: ldstr "send"
-			IL_01d9: ldloc.s 8
-			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01e0: stloc.1
-			IL_01e1: ldloc.s 5
-			IL_01e3: ldstr "ready sent:"
-			IL_01e8: ldloc.1
-			IL_01e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01ee: pop
-			IL_01ef: ldnull
-			IL_01f0: ret
+			IL_01d3: volatile.
+			IL_01d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_01da: brfalse IL_01f1
 
-			IL_01f1: ldarg.2
-			IL_01f2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01f7: ldc.i4.0
-			IL_01f8: ceq
-			IL_01fa: stloc.0
-			IL_01fb: ldloc.0
-			IL_01fc: box [System.Runtime]System.Boolean
-			IL_0201: stloc.2
-			IL_0202: ldloc.2
-			IL_0203: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0208: stloc.0
-			IL_0209: ldloc.0
-			IL_020a: brtrue IL_025e
+			IL_01df: ldloc.1
+			IL_01e0: ldstr "send"
+			IL_01e5: ldloc.s 8
+			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ec: br IL_0208
 
-			IL_020f: volatile.
-			IL_0211: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_0216: brfalse IL_022b
+			IL_01f1: ldloc.1
+			IL_01f2: ldstr "send"
+			IL_01f7: ldloc.s 8
+			IL_01f9: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:49"
+			IL_01fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_021b: ldarg.2
-			IL_021c: ldstr "stage"
-			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0226: br IL_0240
+			IL_0208: stloc.1
+			IL_0209: ldloc.s 5
+			IL_020b: ldstr "ready sent:"
+			IL_0210: ldloc.1
+			IL_0211: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0216: pop
+			IL_0217: ldnull
+			IL_0218: ret
 
-			IL_022b: ldarg.2
-			IL_022c: ldstr "stage"
-			IL_0231: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:63"
-			IL_0236: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0219: ldarg.2
+			IL_021a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_021f: ldc.i4.0
+			IL_0220: ceq
+			IL_0222: stloc.0
+			IL_0223: ldloc.0
+			IL_0224: box [System.Runtime]System.Boolean
+			IL_0229: stloc.2
+			IL_022a: ldloc.2
+			IL_022b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0230: stloc.0
+			IL_0231: ldloc.0
+			IL_0232: brtrue IL_0286
 
-			IL_0240: stloc.1
-			IL_0241: ldloc.1
-			IL_0242: ldstr "parent"
-			IL_0247: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_024c: stloc.0
-			IL_024d: ldloc.0
-			IL_024e: box [System.Runtime]System.Boolean
-			IL_0253: stloc.s 9
-			IL_0255: ldloc.s 9
-			IL_0257: stloc.s 10
-			IL_0259: br IL_0261
+			IL_0237: volatile.
+			IL_0239: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_023e: brfalse IL_0253
 
-			IL_025e: ldloc.2
-			IL_025f: stloc.s 10
+			IL_0243: ldarg.2
+			IL_0244: ldstr "stage"
+			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_024e: br IL_0268
 
-			IL_0261: ldloc.s 10
-			IL_0263: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0268: stloc.0
-			IL_0269: ldloc.0
-			IL_026a: brfalse IL_0271
+			IL_0253: ldarg.2
+			IL_0254: ldstr "stage"
+			IL_0259: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:63"
+			IL_025e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_026f: ldnull
-			IL_0270: ret
+			IL_0268: stloc.1
+			IL_0269: ldloc.1
+			IL_026a: ldstr "parent"
+			IL_026f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0274: stloc.0
+			IL_0275: ldloc.0
+			IL_0276: box [System.Runtime]System.Boolean
+			IL_027b: stloc.s 9
+			IL_027d: ldloc.s 9
+			IL_027f: stloc.s 10
+			IL_0281: br IL_0289
 
-			IL_0271: ldarg.0
-			IL_0272: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing_Child/Scope::fallbackExit
-			IL_0277: stloc.1
-			IL_0278: ldloc.1
-			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearTimeout(object)
-			IL_027e: pop
-			IL_027f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0284: stloc.s 5
-			IL_0286: volatile.
-			IL_0288: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-			IL_028d: brfalse IL_02a2
+			IL_0286: ldloc.2
+			IL_0287: stloc.s 10
 
-			IL_0292: ldarg.2
-			IL_0293: ldstr "value"
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029d: br IL_02b7
+			IL_0289: ldloc.s 10
+			IL_028b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0290: stloc.0
+			IL_0291: ldloc.0
+			IL_0292: brfalse IL_0299
 
-			IL_02a2: ldarg.2
-			IL_02a3: ldstr "value"
-			IL_02a8: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:86"
-			IL_02ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0297: ldnull
+			IL_0298: ret
 
-			IL_02b7: stloc.1
-			IL_02b8: ldloc.s 5
-			IL_02ba: ldstr "child received:"
-			IL_02bf: ldloc.1
-			IL_02c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_02c5: pop
-			IL_02c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02cb: stloc.s 5
-			IL_02cd: ldstr "process"
-			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02dc: stloc.1
-			IL_02dd: volatile.
-			IL_02df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-			IL_02e4: brfalse IL_02f9
+			IL_0299: ldarg.0
+			IL_029a: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing_Child/Scope::fallbackExit
+			IL_029f: stloc.1
+			IL_02a0: ldloc.1
+			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearTimeout(object)
+			IL_02a6: pop
+			IL_02a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02ac: stloc.s 5
+			IL_02ae: volatile.
+			IL_02b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_02b5: brfalse IL_02ca
 
-			IL_02e9: ldarg.2
-			IL_02ea: ldstr "value"
-			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f4: br IL_030e
+			IL_02ba: ldarg.2
+			IL_02bb: ldstr "value"
+			IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c5: br IL_02df
 
-			IL_02f9: ldarg.2
-			IL_02fa: ldstr "value"
-			IL_02ff: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:97"
-			IL_0304: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02ca: ldarg.2
+			IL_02cb: ldstr "value"
+			IL_02d0: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:86"
+			IL_02d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_030e: stloc.s 7
-			IL_0310: ldloc.s 7
-			IL_0312: ldc.r8 1
-			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0320: stloc.s 10
-			IL_0322: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0327: dup
-			IL_0328: ldstr "stage"
-			IL_032d: ldstr "child"
-			IL_0332: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0337: dup
-			IL_0338: ldstr "value"
-			IL_033d: ldloc.s 10
-			IL_033f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0344: stloc.s 8
-			IL_0346: ldloc.1
-			IL_0347: ldstr "send"
-			IL_034c: ldloc.s 8
-			IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0353: stloc.1
-			IL_0354: ldloc.s 5
-			IL_0356: ldstr "reply sent:"
-			IL_035b: ldloc.1
-			IL_035c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0361: pop
-			IL_0362: ldstr "process"
-			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0371: volatile.
-			IL_0373: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-			IL_0378: brfalse IL_038c
+			IL_02df: stloc.1
+			IL_02e0: ldloc.s 5
+			IL_02e2: ldstr "child received:"
+			IL_02e7: ldloc.1
+			IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_02ed: pop
+			IL_02ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02f3: stloc.s 5
+			IL_02f5: ldstr "process"
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0304: stloc.1
+			IL_0305: volatile.
+			IL_0307: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_030c: brfalse IL_0321
 
-			IL_037d: ldstr "disconnect"
-			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0387: br IL_03a0
+			IL_0311: ldarg.2
+			IL_0312: ldstr "value"
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_031c: br IL_0336
 
-			IL_038c: ldstr "disconnect"
-			IL_0391: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:107"
-			IL_0396: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-			IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0321: ldarg.2
+			IL_0322: ldstr "value"
+			IL_0327: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:97"
+			IL_032c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03a0: pop
-			IL_03a1: ldstr "process"
-			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b0: ldstr "exit"
-			IL_03b5: ldc.r8 0.0
-			IL_03be: box [System.Runtime]System.Double
-			IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03c8: pop
-			IL_03c9: ldnull
-			IL_03ca: ret
+			IL_0336: stloc.s 7
+			IL_0338: ldloc.s 7
+			IL_033a: ldc.r8 1
+			IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0348: stloc.s 10
+			IL_034a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_034f: dup
+			IL_0350: ldstr "stage"
+			IL_0355: ldstr "child"
+			IL_035a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_035f: dup
+			IL_0360: ldstr "value"
+			IL_0365: ldloc.s 10
+			IL_0367: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_036c: stloc.s 8
+			IL_036e: volatile.
+			IL_0370: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_0375: brfalse IL_038c
+
+			IL_037a: ldloc.1
+			IL_037b: ldstr "send"
+			IL_0380: ldloc.s 8
+			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0387: br IL_03a3
+
+			IL_038c: ldloc.1
+			IL_038d: ldstr "send"
+			IL_0392: ldloc.s 8
+			IL_0394: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:101"
+			IL_0399: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_03a3: stloc.1
+			IL_03a4: ldloc.s 5
+			IL_03a6: ldstr "reply sent:"
+			IL_03ab: ldloc.1
+			IL_03ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_03b1: pop
+			IL_03b2: ldstr "process"
+			IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03c1: volatile.
+			IL_03c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_03c8: brfalse IL_03dc
+
+			IL_03cd: ldstr "disconnect"
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_03d7: br IL_03f0
+
+			IL_03dc: ldstr "disconnect"
+			IL_03e1: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:107"
+			IL_03e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+			IL_03f0: pop
+			IL_03f1: ldstr "process"
+			IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0400: volatile.
+			IL_0402: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_0407: brfalse IL_0429
+
+			IL_040c: ldstr "exit"
+			IL_0411: ldc.r8 0.0
+			IL_041a: box [System.Runtime]System.Double
+			IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0424: br IL_044b
+
+			IL_0429: ldstr "exit"
+			IL_042e: ldc.r8 0.0
+			IL_0437: box [System.Runtime]System.Double
+			IL_043c: ldstr "Require_ChildProcess_Fork_MessagePassing_Child:<TwoPhaseDummy_M14>:__js_call__:114"
+			IL_0441: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_044b: pop
+			IL_044c: ldnull
+			IL_044d: ret
 		} // end of method ArrowFunction_L7C23::__js_call__
 
 	} // end of class ArrowFunction_L7C23
@@ -2658,6 +2758,14 @@
 	.field assembly static int32 __jroc_dynamicLookup_42
 	.field assembly static int32 __jroc_dynamicLookup_43
 	.field assembly static int32 __jroc_dynamicLookup_44
+	.field assembly static int32 __jroc_dynamicLookup_45
+	.field assembly static int32 __jroc_dynamicLookup_46
+	.field assembly static int32 __jroc_dynamicLookup_47
+	.field assembly static int32 __jroc_dynamicLookup_48
+	.field assembly static int32 __jroc_dynamicLookup_49
+	.field assembly static int32 __jroc_dynamicLookup_50
+	.field assembly static int32 __jroc_dynamicLookup_51
+	.field assembly static int32 __jroc_dynamicLookup_52
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -525,7 +525,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 124 (0x7c)
+				// Code size: 166 (0xa6)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -535,7 +535,7 @@
 				IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_0005: stloc.0
 				IL_0006: volatile.
-				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
 				IL_000d: brfalse IL_0022
 
 				IL_0012: ldarg.2
@@ -546,7 +546,7 @@
 				IL_0022: ldarg.2
 				IL_0023: ldstr "mode"
 				IL_0028: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M10>:__js_call__:5"
-				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
 				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0037: stloc.1
@@ -563,17 +563,29 @@
 				IL_004e: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
 				IL_0053: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
 				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_005d: ldstr "send"
-				IL_0062: ldstr "shutdown"
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_006c: stloc.1
-				IL_006d: ldloc.0
-				IL_006e: ldstr "silent true send:"
-				IL_0073: ldloc.1
-				IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0079: pop
-				IL_007a: ldnull
-				IL_007b: ret
+				IL_005d: volatile.
+				IL_005f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+				IL_0064: brfalse IL_007d
+
+				IL_0069: ldstr "send"
+				IL_006e: ldstr "shutdown"
+				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0078: br IL_0096
+
+				IL_007d: ldstr "send"
+				IL_0082: ldstr "shutdown"
+				IL_0087: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M10>:__js_call__:13"
+				IL_008c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+				IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0096: stloc.1
+				IL_0097: ldloc.0
+				IL_0098: ldstr "silent true send:"
+				IL_009d: ldloc.1
+				IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_00a3: pop
+				IL_00a4: ldnull
+				IL_00a5: ret
 			} // end of method ArrowFunction_L26C25::__js_call__
 
 		} // end of class ArrowFunction_L26C25
@@ -997,7 +1009,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1040 (0x410)
+			// Code size: 1166 (0x48e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope,
@@ -1046,7 +1058,7 @@
 			IL_004f: ldloc.0
 			IL_0050: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
 			IL_0055: volatile.
-			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_005c: brfalse IL_0070
 
 			IL_0061: ldstr "stdout"
@@ -1055,7 +1067,7 @@
 
 			IL_0070: ldstr "stdout"
 			IL_0075: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:15"
-			IL_007a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_007a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0084: stloc.s 4
@@ -1077,7 +1089,7 @@
 			IL_00b4: ldloc.0
 			IL_00b5: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
 			IL_00ba: volatile.
-			IL_00bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_00bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_00c1: brfalse IL_00d5
 
 			IL_00c6: ldstr "stderr"
@@ -1086,7 +1098,7 @@
 
 			IL_00d5: ldstr "stderr"
 			IL_00da: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:26"
-			IL_00df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_00df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00e9: stloc.s 4
@@ -1108,7 +1120,7 @@
 			IL_0119: ldloc.0
 			IL_011a: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
 			IL_011f: volatile.
-			IL_0121: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0121: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_0126: brfalse IL_013a
 
 			IL_012b: ldstr "connected"
@@ -1117,7 +1129,7 @@
 
 			IL_013a: ldstr "connected"
 			IL_013f: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:37"
-			IL_0144: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0144: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_014e: stloc.s 4
@@ -1135,7 +1147,7 @@
 			IL_0175: ldloc.0
 			IL_0176: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
 			IL_017b: volatile.
-			IL_017d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_017d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 			IL_0182: brfalse IL_0196
 
 			IL_0187: ldstr "stdout"
@@ -1144,233 +1156,269 @@
 
 			IL_0196: ldstr "stdout"
 			IL_019b: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:48"
-			IL_01a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_01a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01aa: stloc.s 4
 			IL_01ac: ldloc.s 4
 			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b3: ldstr "setEncoding"
-			IL_01b8: ldstr "utf8"
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01c2: pop
-			IL_01c3: ldloc.0
-			IL_01c4: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_01c9: volatile.
-			IL_01cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-			IL_01d0: brfalse IL_01e4
+			IL_01b3: volatile.
+			IL_01b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_01ba: brfalse IL_01d3
 
-			IL_01d5: ldstr "stdout"
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01df: br IL_01f8
+			IL_01bf: ldstr "setEncoding"
+			IL_01c4: ldstr "utf8"
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ce: br IL_01ec
 
-			IL_01e4: ldstr "stdout"
-			IL_01e9: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:55"
-			IL_01ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01d3: ldstr "setEncoding"
+			IL_01d8: ldstr "utf8"
+			IL_01dd: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:51"
+			IL_01e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_01f8: stloc.s 4
-			IL_01fa: ldloc.s 4
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0201: stloc.s 4
-			IL_0203: ldc.i4.2
-			IL_0204: newarr [System.Runtime]System.Object
-			IL_0209: dup
-			IL_020a: ldc.i4.0
-			IL_020b: ldarg.0
-			IL_020c: stelem.ref
-			IL_020d: dup
-			IL_020e: ldc.i4.1
-			IL_020f: ldloc.0
-			IL_0210: stelem.ref
-			IL_0211: stloc.s 8
-			IL_0213: ldloc.s 8
-			IL_0215: ldc.i4.0
-			IL_0216: ldelem.ref
-			IL_0217: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-			IL_021c: ldloc.s 8
-			IL_021e: ldc.i4.1
-			IL_021f: ldelem.ref
-			IL_0220: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
-			IL_0225: ldloc.s 8
-			IL_0227: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope, class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope, object[])
-			IL_022c: ldc.i4.1
-			IL_022d: conv.r8
-			IL_022e: ldstr ""
-			IL_0233: ldc.i4.0
+			IL_01ec: pop
+			IL_01ed: ldloc.0
+			IL_01ee: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_01f3: volatile.
+			IL_01f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_01fa: brfalse IL_020e
+
+			IL_01ff: ldstr "stdout"
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0209: br IL_0222
+
+			IL_020e: ldstr "stdout"
+			IL_0213: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:55"
+			IL_0218: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0222: stloc.s 4
+			IL_0224: ldloc.s 4
+			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_022b: stloc.s 4
+			IL_022d: ldc.i4.2
+			IL_022e: newarr [System.Runtime]System.Object
+			IL_0233: dup
 			IL_0234: ldc.i4.0
-			IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_023a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29/FunctionObject>(!!0)
-			IL_023f: stloc.s 9
-			IL_0241: ldloc.s 4
-			IL_0243: ldstr "on"
-			IL_0248: ldstr "data"
-			IL_024d: ldloc.s 9
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0254: pop
-			IL_0255: ldloc.0
-			IL_0256: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_025b: volatile.
-			IL_025d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-			IL_0262: brfalse IL_0276
+			IL_0235: ldarg.0
+			IL_0236: stelem.ref
+			IL_0237: dup
+			IL_0238: ldc.i4.1
+			IL_0239: ldloc.0
+			IL_023a: stelem.ref
+			IL_023b: stloc.s 8
+			IL_023d: ldloc.s 8
+			IL_023f: ldc.i4.0
+			IL_0240: ldelem.ref
+			IL_0241: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+			IL_0246: ldloc.s 8
+			IL_0248: ldc.i4.1
+			IL_0249: ldelem.ref
+			IL_024a: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
+			IL_024f: ldloc.s 8
+			IL_0251: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope, class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope, object[])
+			IL_0256: ldc.i4.1
+			IL_0257: conv.r8
+			IL_0258: ldstr ""
+			IL_025d: ldc.i4.0
+			IL_025e: ldc.i4.0
+			IL_025f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0264: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L18C29/FunctionObject>(!!0)
+			IL_0269: stloc.s 9
+			IL_026b: ldloc.s 4
+			IL_026d: ldstr "on"
+			IL_0272: ldstr "data"
+			IL_0277: ldloc.s 9
+			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_027e: pop
+			IL_027f: ldloc.0
+			IL_0280: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_0285: volatile.
+			IL_0287: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_028c: brfalse IL_02a0
 
-			IL_0267: ldstr "stderr"
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0271: br IL_028a
+			IL_0291: ldstr "stderr"
+			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029b: br IL_02b4
 
-			IL_0276: ldstr "stderr"
-			IL_027b: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:64"
-			IL_0280: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02a0: ldstr "stderr"
+			IL_02a5: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:64"
+			IL_02aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_028a: stloc.s 4
-			IL_028c: ldloc.s 4
-			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0293: ldstr "setEncoding"
-			IL_0298: ldstr "utf8"
-			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02a2: pop
-			IL_02a3: ldloc.0
-			IL_02a4: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_02a9: volatile.
-			IL_02ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_02b0: brfalse IL_02c4
+			IL_02b4: stloc.s 4
+			IL_02b6: ldloc.s 4
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02bd: volatile.
+			IL_02bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_02c4: brfalse IL_02dd
 
-			IL_02b5: ldstr "stderr"
-			IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02bf: br IL_02d8
+			IL_02c9: ldstr "setEncoding"
+			IL_02ce: ldstr "utf8"
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02d8: br IL_02f6
 
-			IL_02c4: ldstr "stderr"
-			IL_02c9: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:71"
-			IL_02ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02dd: ldstr "setEncoding"
+			IL_02e2: ldstr "utf8"
+			IL_02e7: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:67"
+			IL_02ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_02d8: stloc.s 4
-			IL_02da: ldloc.s 4
-			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e1: stloc.s 4
-			IL_02e3: ldc.i4.2
-			IL_02e4: newarr [System.Runtime]System.Object
-			IL_02e9: dup
-			IL_02ea: ldc.i4.0
-			IL_02eb: ldarg.0
-			IL_02ec: stelem.ref
-			IL_02ed: dup
-			IL_02ee: ldc.i4.1
-			IL_02ef: ldloc.0
-			IL_02f0: stelem.ref
-			IL_02f1: stloc.s 8
-			IL_02f3: ldloc.s 8
-			IL_02f5: ldc.i4.0
-			IL_02f6: ldelem.ref
-			IL_02f7: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-			IL_02fc: ldloc.s 8
-			IL_02fe: ldc.i4.1
-			IL_02ff: ldelem.ref
-			IL_0300: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
-			IL_0305: ldloc.s 8
-			IL_0307: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope, class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope, object[])
-			IL_030c: ldc.i4.1
-			IL_030d: conv.r8
-			IL_030e: ldstr ""
-			IL_0313: ldc.i4.0
-			IL_0314: ldc.i4.0
-			IL_0315: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_031a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29/FunctionObject>(!!0)
-			IL_031f: stloc.s 10
-			IL_0321: ldloc.s 4
-			IL_0323: ldstr "on"
-			IL_0328: ldstr "data"
-			IL_032d: ldloc.s 10
-			IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0334: pop
-			IL_0335: ldloc.0
-			IL_0336: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0340: stloc.s 4
-			IL_0342: ldc.i4.2
-			IL_0343: newarr [System.Runtime]System.Object
-			IL_0348: dup
+			IL_02f6: pop
+			IL_02f7: ldloc.0
+			IL_02f8: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_02fd: volatile.
+			IL_02ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_0304: brfalse IL_0318
+
+			IL_0309: ldstr "stderr"
+			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0313: br IL_032c
+
+			IL_0318: ldstr "stderr"
+			IL_031d: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:71"
+			IL_0322: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_032c: stloc.s 4
+			IL_032e: ldloc.s 4
+			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0335: stloc.s 4
+			IL_0337: ldc.i4.2
+			IL_0338: newarr [System.Runtime]System.Object
+			IL_033d: dup
+			IL_033e: ldc.i4.0
+			IL_033f: ldarg.0
+			IL_0340: stelem.ref
+			IL_0341: dup
+			IL_0342: ldc.i4.1
+			IL_0343: ldloc.0
+			IL_0344: stelem.ref
+			IL_0345: stloc.s 8
+			IL_0347: ldloc.s 8
 			IL_0349: ldc.i4.0
-			IL_034a: ldarg.0
-			IL_034b: stelem.ref
-			IL_034c: dup
-			IL_034d: ldc.i4.1
-			IL_034e: ldloc.0
-			IL_034f: stelem.ref
-			IL_0350: stloc.s 8
-			IL_0352: ldloc.s 8
-			IL_0354: ldc.i4.0
-			IL_0355: ldelem.ref
-			IL_0356: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-			IL_035b: ldloc.s 8
-			IL_035d: ldc.i4.1
-			IL_035e: ldelem.ref
-			IL_035f: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
-			IL_0364: ldloc.s 8
-			IL_0366: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope, class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope, object[])
-			IL_036b: ldc.i4.1
-			IL_036c: conv.r8
-			IL_036d: ldstr ""
-			IL_0372: ldc.i4.0
-			IL_0373: ldc.i4.0
-			IL_0374: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0379: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25/FunctionObject>(!!0)
-			IL_037e: stloc.s 11
-			IL_0380: ldloc.s 4
-			IL_0382: ldstr "on"
-			IL_0387: ldstr "message"
-			IL_038c: ldloc.s 11
-			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0393: pop
-			IL_0394: ldloc.0
-			IL_0395: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_039f: stloc.s 4
-			IL_03a1: ldc.i4.2
-			IL_03a2: newarr [System.Runtime]System.Object
-			IL_03a7: dup
+			IL_034a: ldelem.ref
+			IL_034b: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+			IL_0350: ldloc.s 8
+			IL_0352: ldc.i4.1
+			IL_0353: ldelem.ref
+			IL_0354: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
+			IL_0359: ldloc.s 8
+			IL_035b: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope, class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope, object[])
+			IL_0360: ldc.i4.1
+			IL_0361: conv.r8
+			IL_0362: ldstr ""
+			IL_0367: ldc.i4.0
+			IL_0368: ldc.i4.0
+			IL_0369: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_036e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L22C29/FunctionObject>(!!0)
+			IL_0373: stloc.s 10
+			IL_0375: ldloc.s 4
+			IL_0377: ldstr "on"
+			IL_037c: ldstr "data"
+			IL_0381: ldloc.s 10
+			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0388: pop
+			IL_0389: ldloc.0
+			IL_038a: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0394: stloc.s 4
+			IL_0396: ldc.i4.2
+			IL_0397: newarr [System.Runtime]System.Object
+			IL_039c: dup
+			IL_039d: ldc.i4.0
+			IL_039e: ldarg.0
+			IL_039f: stelem.ref
+			IL_03a0: dup
+			IL_03a1: ldc.i4.1
+			IL_03a2: ldloc.0
+			IL_03a3: stelem.ref
+			IL_03a4: stloc.s 8
+			IL_03a6: ldloc.s 8
 			IL_03a8: ldc.i4.0
-			IL_03a9: ldarg.0
-			IL_03aa: stelem.ref
-			IL_03ab: dup
-			IL_03ac: ldc.i4.1
-			IL_03ad: ldloc.0
-			IL_03ae: stelem.ref
-			IL_03af: stloc.s 8
-			IL_03b1: ldloc.s 8
-			IL_03b3: ldc.i4.0
-			IL_03b4: ldelem.ref
-			IL_03b5: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-			IL_03ba: ldloc.s 8
-			IL_03bc: ldc.i4.1
-			IL_03bd: ldelem.ref
-			IL_03be: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
-			IL_03c3: ldloc.s 8
-			IL_03c5: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope, class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope, object[])
-			IL_03ca: ldc.i4.1
-			IL_03cb: conv.r8
-			IL_03cc: ldstr ""
-			IL_03d1: ldc.i4.0
-			IL_03d2: ldc.i4.0
-			IL_03d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_03d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23/FunctionObject>(!!0)
-			IL_03dd: stloc.s 12
-			IL_03df: ldloc.s 4
-			IL_03e1: ldstr "on"
-			IL_03e6: ldstr "close"
-			IL_03eb: ldloc.s 12
-			IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_03f2: pop
-			IL_03f3: ldloc.0
-			IL_03f4: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
-			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03fe: ldstr "send"
-			IL_0403: ldstr "init"
-			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_040d: pop
-			IL_040e: ldnull
-			IL_040f: ret
+			IL_03a9: ldelem.ref
+			IL_03aa: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+			IL_03af: ldloc.s 8
+			IL_03b1: ldc.i4.1
+			IL_03b2: ldelem.ref
+			IL_03b3: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
+			IL_03b8: ldloc.s 8
+			IL_03ba: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope, class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope, object[])
+			IL_03bf: ldc.i4.1
+			IL_03c0: conv.r8
+			IL_03c1: ldstr ""
+			IL_03c6: ldc.i4.0
+			IL_03c7: ldc.i4.0
+			IL_03c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_03cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L26C25/FunctionObject>(!!0)
+			IL_03d2: stloc.s 11
+			IL_03d4: ldloc.s 4
+			IL_03d6: ldstr "on"
+			IL_03db: ldstr "message"
+			IL_03e0: ldloc.s 11
+			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_03e7: pop
+			IL_03e8: ldloc.0
+			IL_03e9: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03f3: stloc.s 4
+			IL_03f5: ldc.i4.2
+			IL_03f6: newarr [System.Runtime]System.Object
+			IL_03fb: dup
+			IL_03fc: ldc.i4.0
+			IL_03fd: ldarg.0
+			IL_03fe: stelem.ref
+			IL_03ff: dup
+			IL_0400: ldc.i4.1
+			IL_0401: ldloc.0
+			IL_0402: stelem.ref
+			IL_0403: stloc.s 8
+			IL_0405: ldloc.s 8
+			IL_0407: ldc.i4.0
+			IL_0408: ldelem.ref
+			IL_0409: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+			IL_040e: ldloc.s 8
+			IL_0410: ldc.i4.1
+			IL_0411: ldelem.ref
+			IL_0412: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
+			IL_0417: ldloc.s 8
+			IL_0419: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope, class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope, object[])
+			IL_041e: ldc.i4.1
+			IL_041f: conv.r8
+			IL_0420: ldstr ""
+			IL_0425: ldc.i4.0
+			IL_0426: ldc.i4.0
+			IL_0427: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_042c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/ArrowFunction_L31C23/FunctionObject>(!!0)
+			IL_0431: stloc.s 12
+			IL_0433: ldloc.s 4
+			IL_0435: ldstr "on"
+			IL_043a: ldstr "close"
+			IL_043f: ldloc.s 12
+			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0446: pop
+			IL_0447: ldloc.0
+			IL_0448: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::child
+			IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0452: volatile.
+			IL_0454: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_0459: brfalse IL_0472
+
+			IL_045e: ldstr "send"
+			IL_0463: ldstr "init"
+			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_046d: br IL_048b
+
+			IL_0472: ldstr "send"
+			IL_0477: ldstr "init"
+			IL_047c: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M6>:__js_call__:95"
+			IL_0481: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_048b: pop
+			IL_048c: ldnull
+			IL_048d: ret
 		} // end of method runSilentTrue::__js_call__
 
 	} // end of class runSilentTrue
@@ -1500,7 +1548,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 124 (0x7c)
+				// Code size: 166 (0xa6)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -1510,7 +1558,7 @@
 				IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_0005: stloc.0
 				IL_0006: volatile.
-				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
 				IL_000d: brfalse IL_0022
 
 				IL_0012: ldarg.2
@@ -1521,7 +1569,7 @@
 				IL_0022: ldarg.2
 				IL_0023: ldstr "mode"
 				IL_0028: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M12>:__js_call__:5"
-				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
 				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0037: stloc.1
@@ -1538,17 +1586,29 @@
 				IL_004e: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope
 				IL_0053: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
 				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_005d: ldstr "send"
-				IL_0062: ldstr "shutdown"
-				IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_006c: stloc.1
-				IL_006d: ldloc.0
-				IL_006e: ldstr "silent false send:"
-				IL_0073: ldloc.1
-				IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0079: pop
-				IL_007a: ldnull
-				IL_007b: ret
+				IL_005d: volatile.
+				IL_005f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+				IL_0064: brfalse IL_007d
+
+				IL_0069: ldstr "send"
+				IL_006e: ldstr "shutdown"
+				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0078: br IL_0096
+
+				IL_007d: ldstr "send"
+				IL_0082: ldstr "shutdown"
+				IL_0087: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M12>:__js_call__:13"
+				IL_008c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+				IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0096: stloc.1
+				IL_0097: ldloc.0
+				IL_0098: ldstr "silent false send:"
+				IL_009d: ldloc.1
+				IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_00a3: pop
+				IL_00a4: ldnull
+				IL_00a5: ret
 			} // end of method ArrowFunction_L47C25::__js_call__
 
 		} // end of class ArrowFunction_L47C25
@@ -1813,7 +1873,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 546 (0x222)
+			// Code size: 588 (0x24c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope,
@@ -1860,7 +1920,7 @@
 			IL_004f: ldloc.0
 			IL_0050: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
 			IL_0055: volatile.
-			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_005c: brfalse IL_0070
 
 			IL_0061: ldstr "stdout"
@@ -1869,7 +1929,7 @@
 
 			IL_0070: ldstr "stdout"
 			IL_0075: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M7>:__js_call__:15"
-			IL_007a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_007a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0084: stloc.s 4
@@ -1891,7 +1951,7 @@
 			IL_00b4: ldloc.0
 			IL_00b5: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
 			IL_00ba: volatile.
-			IL_00bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_00bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
 			IL_00c1: brfalse IL_00d5
 
 			IL_00c6: ldstr "stderr"
@@ -1900,7 +1960,7 @@
 
 			IL_00d5: ldstr "stderr"
 			IL_00da: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M7>:__js_call__:26"
-			IL_00df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_00df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
 			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00e9: stloc.s 4
@@ -1922,7 +1982,7 @@
 			IL_0119: ldloc.0
 			IL_011a: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
 			IL_011f: volatile.
-			IL_0121: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_0121: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
 			IL_0126: brfalse IL_013a
 
 			IL_012b: ldstr "connected"
@@ -1931,7 +1991,7 @@
 
 			IL_013a: ldstr "connected"
 			IL_013f: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M7>:__js_call__:37"
-			IL_0144: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_0144: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
 			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_014e: stloc.s 4
@@ -2008,12 +2068,24 @@
 			IL_0205: ldloc.0
 			IL_0206: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/Scope::child
 			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0210: ldstr "send"
-			IL_0215: ldstr "init"
-			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_021f: pop
-			IL_0220: ldnull
-			IL_0221: ret
+			IL_0210: volatile.
+			IL_0212: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_0217: brfalse IL_0230
+
+			IL_021c: ldstr "send"
+			IL_0221: ldstr "init"
+			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_022b: br IL_0249
+
+			IL_0230: ldstr "send"
+			IL_0235: ldstr "init"
+			IL_023a: ldstr "Require_ChildProcess_Fork_Silent:<TwoPhaseDummy_M7>:__js_call__:57"
+			IL_023f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0249: pop
+			IL_024a: ldnull
+			IL_024b: ret
 		} // end of method runSilentFalse::__js_call__
 
 	} // end of class runSilentFalse
@@ -2256,20 +2328,33 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 42 (0x2a)
+			// Header size: 12
+			// Code size: 93 (0x5d)
 			.maxstack 8
 
 			IL_0000: ldstr "process"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000f: ldstr "exit"
-			IL_0014: ldc.r8 0.0
-			IL_001d: box [System.Runtime]System.Double
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0027: pop
-			IL_0028: ldnull
-			IL_0029: ret
+			IL_000f: volatile.
+			IL_0011: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_0016: brfalse IL_0038
+
+			IL_001b: ldstr "exit"
+			IL_0020: ldc.r8 0.0
+			IL_0029: box [System.Runtime]System.Double
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0033: br IL_005a
+
+			IL_0038: ldstr "exit"
+			IL_003d: ldc.r8 0.0
+			IL_0046: box [System.Runtime]System.Double
+			IL_004b: ldstr "Require_ChildProcess_Fork_Silent_Child:<TwoPhaseDummy_M14>:__js_call__:6"
+			IL_0050: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method ArrowFunction_L8C33::__js_call__
 
 	} // end of class ArrowFunction_L8C33
@@ -2427,7 +2512,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 309 (0x135)
+			// Code size: 400 (0x190)
 			.maxstack 8
 			.locals init (
 				[0] bool,
@@ -2443,7 +2528,7 @@
 			IL_0006: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
-			IL_000d: brfalse IL_00ac
+			IL_000d: brfalse IL_00d4
 
 			IL_0012: ldstr "process"
 			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -2452,7 +2537,7 @@
 			IL_0022: ldstr "process"
 			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_002c: volatile.
-			IL_002e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_002e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 			IL_0033: brfalse IL_0047
 
 			IL_0038: ldstr "argv"
@@ -2461,7 +2546,7 @@
 
 			IL_0047: ldstr "argv"
 			IL_004c: ldstr "Require_ChildProcess_Fork_Silent_Child:<TwoPhaseDummy_M15>:__js_call__:12"
-			IL_0051: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_0051: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_005b: stloc.2
@@ -2488,55 +2573,81 @@
 			IL_0093: ldloc.s 4
 			IL_0095: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_009a: stloc.s 5
-			IL_009c: ldloc.1
-			IL_009d: ldstr "send"
-			IL_00a2: ldloc.s 5
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a9: pop
-			IL_00aa: ldnull
-			IL_00ab: ret
+			IL_009c: volatile.
+			IL_009e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_00a3: brfalse IL_00ba
 
-			IL_00ac: ldarg.2
-			IL_00ad: ldstr "shutdown"
-			IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00b7: stloc.0
-			IL_00b8: ldloc.0
-			IL_00b9: brfalse IL_0133
+			IL_00a8: ldloc.1
+			IL_00a9: ldstr "send"
+			IL_00ae: ldloc.s 5
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b5: br IL_00d1
 
-			IL_00be: ldarg.0
-			IL_00bf: ldfld object Modules.Require_ChildProcess_Fork_Silent_Child/Scope::fallbackExit
-			IL_00c4: stloc.1
-			IL_00c5: ldloc.1
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearTimeout(object)
-			IL_00cb: pop
-			IL_00cc: ldstr "process"
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00db: volatile.
-			IL_00dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_00e2: brfalse IL_00f6
+			IL_00ba: ldloc.1
+			IL_00bb: ldstr "send"
+			IL_00c0: ldloc.s 5
+			IL_00c2: ldstr "Require_ChildProcess_Fork_Silent_Child:<TwoPhaseDummy_M15>:__js_call__:24"
+			IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_00e7: ldstr "disconnect"
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00f1: br IL_010a
+			IL_00d1: pop
+			IL_00d2: ldnull
+			IL_00d3: ret
 
-			IL_00f6: ldstr "disconnect"
-			IL_00fb: ldstr "Require_ChildProcess_Fork_Silent_Child:<TwoPhaseDummy_M15>:__js_call__:41"
-			IL_0100: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_00d4: ldarg.2
+			IL_00d5: ldstr "shutdown"
+			IL_00da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00df: stloc.0
+			IL_00e0: ldloc.0
+			IL_00e1: brfalse IL_018e
 
-			IL_010a: pop
-			IL_010b: ldstr "process"
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011a: ldstr "exit"
-			IL_011f: ldc.r8 0.0
-			IL_0128: box [System.Runtime]System.Double
-			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e6: ldarg.0
+			IL_00e7: ldfld object Modules.Require_ChildProcess_Fork_Silent_Child/Scope::fallbackExit
+			IL_00ec: stloc.1
+			IL_00ed: ldloc.1
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::clearTimeout(object)
+			IL_00f3: pop
+			IL_00f4: ldstr "process"
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0103: volatile.
+			IL_0105: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_010a: brfalse IL_011e
+
+			IL_010f: ldstr "disconnect"
+			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0119: br IL_0132
+
+			IL_011e: ldstr "disconnect"
+			IL_0123: ldstr "Require_ChildProcess_Fork_Silent_Child:<TwoPhaseDummy_M15>:__js_call__:41"
+			IL_0128: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
 			IL_0132: pop
+			IL_0133: ldstr "process"
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0142: volatile.
+			IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0149: brfalse IL_016b
 
-			IL_0133: ldnull
-			IL_0134: ret
+			IL_014e: ldstr "exit"
+			IL_0153: ldc.r8 0.0
+			IL_015c: box [System.Runtime]System.Double
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0166: br IL_018d
+
+			IL_016b: ldstr "exit"
+			IL_0170: ldc.r8 0.0
+			IL_0179: box [System.Runtime]System.Double
+			IL_017e: ldstr "Require_ChildProcess_Fork_Silent_Child:<TwoPhaseDummy_M15>:__js_call__:48"
+			IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_018d: pop
+
+			IL_018e: ldnull
+			IL_018f: ret
 		} // end of method ArrowFunction_L12C23::__js_call__
 
 	} // end of class ArrowFunction_L12C23
@@ -2601,7 +2712,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 304 (0x130)
+		// Code size: 346 (0x15a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Silent_Child/Scope,
@@ -2641,7 +2752,7 @@
 		IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_005c: stloc.2
 		IL_005d: ldloc.2
-		IL_005e: brfalse IL_0094
+		IL_005e: brfalse IL_00be
 
 		IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0068: stloc.3
@@ -2652,68 +2763,80 @@
 		IL_0075: ldstr "console"
 		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0084: ldstr "error"
-		IL_0089: ldstr "silent child stderr"
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0093: pop
+		IL_0084: volatile.
+		IL_0086: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_008b: brfalse IL_00a4
 
-		IL_0094: ldc.i4.1
-		IL_0095: newarr [System.Runtime]System.Object
-		IL_009a: dup
-		IL_009b: ldc.i4.0
-		IL_009c: ldloc.0
-		IL_009d: stelem.ref
-		IL_009e: stloc.s 4
-		IL_00a0: newobj instance void Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L8C33/FunctionObject::.ctor()
-		IL_00a5: ldc.i4.0
-		IL_00a6: conv.r8
-		IL_00a7: ldstr ""
-		IL_00ac: ldc.i4.0
-		IL_00ad: ldc.i4.0
-		IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L8C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L8C33/FunctionObject>(!!0)
-		IL_00b8: stloc.s 5
-		IL_00ba: ldloc.s 5
-		IL_00bc: ldc.r8 15000
-		IL_00c5: box [System.Runtime]System.Double
-		IL_00ca: ldc.i4.0
-		IL_00cb: newarr [System.Runtime]System.Object
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
-		IL_00d5: stloc.1
-		IL_00d6: ldloc.0
-		IL_00d7: ldloc.1
-		IL_00d8: stfld object Modules.Require_ChildProcess_Fork_Silent_Child/Scope::fallbackExit
-		IL_00dd: ldstr "process"
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ec: stloc.1
-		IL_00ed: ldc.i4.1
-		IL_00ee: newarr [System.Runtime]System.Object
-		IL_00f3: dup
+		IL_0090: ldstr "error"
+		IL_0095: ldstr "silent child stderr"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009f: br IL_00bd
+
+		IL_00a4: ldstr "error"
+		IL_00a9: ldstr "silent child stderr"
+		IL_00ae: ldstr "Require_ChildProcess_Fork_Silent_Child:Modules.Require_ChildProcess_Fork_Silent_Child:__js_module_init__:22"
+		IL_00b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00bd: pop
+
+		IL_00be: ldc.i4.1
+		IL_00bf: newarr [System.Runtime]System.Object
+		IL_00c4: dup
+		IL_00c5: ldc.i4.0
+		IL_00c6: ldloc.0
+		IL_00c7: stelem.ref
+		IL_00c8: stloc.s 4
+		IL_00ca: newobj instance void Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L8C33/FunctionObject::.ctor()
+		IL_00cf: ldc.i4.0
+		IL_00d0: conv.r8
+		IL_00d1: ldstr ""
+		IL_00d6: ldc.i4.0
+		IL_00d7: ldc.i4.0
+		IL_00d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L8C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L8C33/FunctionObject>(!!0)
+		IL_00e2: stloc.s 5
+		IL_00e4: ldloc.s 5
+		IL_00e6: ldc.r8 15000
+		IL_00ef: box [System.Runtime]System.Double
 		IL_00f4: ldc.i4.0
-		IL_00f5: ldloc.0
-		IL_00f6: stelem.ref
-		IL_00f7: stloc.s 4
-		IL_00f9: ldloc.s 4
-		IL_00fb: ldc.i4.0
-		IL_00fc: ldelem.ref
-		IL_00fd: castclass Modules.Require_ChildProcess_Fork_Silent_Child/Scope
-		IL_0102: newobj instance void Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L12C23/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent_Child/Scope)
-		IL_0107: ldc.i4.1
-		IL_0108: conv.r8
-		IL_0109: ldstr ""
-		IL_010e: ldc.i4.0
-		IL_010f: ldc.i4.0
-		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L12C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0115: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L12C23/FunctionObject>(!!0)
-		IL_011a: stloc.s 6
-		IL_011c: ldloc.1
-		IL_011d: ldstr "on"
-		IL_0122: ldstr "message"
-		IL_0127: ldloc.s 6
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_012e: pop
-		IL_012f: ret
+		IL_00f5: newarr [System.Runtime]System.Object
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
+		IL_00ff: stloc.1
+		IL_0100: ldloc.0
+		IL_0101: ldloc.1
+		IL_0102: stfld object Modules.Require_ChildProcess_Fork_Silent_Child/Scope::fallbackExit
+		IL_0107: ldstr "process"
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0116: stloc.1
+		IL_0117: ldc.i4.1
+		IL_0118: newarr [System.Runtime]System.Object
+		IL_011d: dup
+		IL_011e: ldc.i4.0
+		IL_011f: ldloc.0
+		IL_0120: stelem.ref
+		IL_0121: stloc.s 4
+		IL_0123: ldloc.s 4
+		IL_0125: ldc.i4.0
+		IL_0126: ldelem.ref
+		IL_0127: castclass Modules.Require_ChildProcess_Fork_Silent_Child/Scope
+		IL_012c: newobj instance void Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L12C23/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent_Child/Scope)
+		IL_0131: ldc.i4.1
+		IL_0132: conv.r8
+		IL_0133: ldstr ""
+		IL_0138: ldc.i4.0
+		IL_0139: ldc.i4.0
+		IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L12C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_013f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Fork_Silent_Child/ArrowFunction_L12C23/FunctionObject>(!!0)
+		IL_0144: stloc.s 6
+		IL_0146: ldloc.1
+		IL_0147: ldstr "on"
+		IL_014c: ldstr "message"
+		IL_0151: ldloc.s 6
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0158: pop
+		IL_0159: ret
 	} // end of method Require_ChildProcess_Fork_Silent_Child::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Silent_Child
@@ -2758,6 +2881,16 @@
 	.field assembly static int32 __jroc_dynamicLookup_46
 	.field assembly static int32 __jroc_dynamicLookup_47
 	.field assembly static int32 __jroc_dynamicLookup_48
+	.field assembly static int32 __jroc_dynamicLookup_49
+	.field assembly static int32 __jroc_dynamicLookup_50
+	.field assembly static int32 __jroc_dynamicLookup_51
+	.field assembly static int32 __jroc_dynamicLookup_52
+	.field assembly static int32 __jroc_dynamicLookup_53
+	.field assembly static int32 __jroc_dynamicLookup_54
+	.field assembly static int32 __jroc_dynamicLookup_55
+	.field assembly static int32 __jroc_dynamicLookup_56
+	.field assembly static int32 __jroc_dynamicLookup_57
+	.field assembly static int32 __jroc_dynamicLookup_58
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_ComputedGlobalPropertyReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_ComputedGlobalPropertyReplacement.verified.txt
@@ -248,7 +248,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 181 (0xb5)
+		// Code size: 223 (0xdf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope,
@@ -312,11 +312,23 @@
 		IL_0095: ldstr "console"
 		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a4: ldstr "log"
-		IL_00a9: ldstr "global"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b3: pop
-		IL_00b4: ret
+		IL_00a4: volatile.
+		IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ab: brfalse IL_00c4
+
+		IL_00b0: ldstr "log"
+		IL_00b5: ldstr "global"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bf: br IL_00dd
+
+		IL_00c4: ldstr "log"
+		IL_00c9: ldstr "global"
+		IL_00ce: ldstr "Console_GlobalLog_ComputedGlobalPropertyReplacement:Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement:__js_module_init__:26"
+		IL_00d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00dd: pop
+		IL_00de: ret
 	} // end of method Console_GlobalLog_ComputedGlobalPropertyReplacement::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement
@@ -341,4 +353,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_Deletion.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_Deletion.verified.txt
@@ -143,7 +143,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 223 (0xdf)
+		// Code size: 265 (0x109)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_GlobalLog_Deletion/Scope,
@@ -181,64 +181,76 @@
 			IL_0046: ldstr "console"
 			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0055: ldstr "log"
-			IL_005a: ldstr "unreachable"
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0064: pop
-			IL_0065: leave IL_00db
+			IL_0055: volatile.
+			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_005c: brfalse IL_0075
+
+			IL_0061: ldstr "log"
+			IL_0066: ldstr "unreachable"
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0070: br IL_008e
+
+			IL_0075: ldstr "log"
+			IL_007a: ldstr "unreachable"
+			IL_007f: ldstr "Console_GlobalLog_Deletion:Modules.Console_GlobalLog_Deletion:__js_module_init__:25"
+			IL_0084: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_008e: pop
+			IL_008f: leave IL_0105
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_006a: stloc.2
-			IL_006b: ldloc.2
-			IL_006c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0071: dup
-			IL_0072: brtrue IL_0087
+			IL_0094: stloc.2
+			IL_0095: ldloc.2
+			IL_0096: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_009b: dup
+			IL_009c: brtrue IL_00b1
 
-			IL_0077: pop
-			IL_0078: ldloc.2
-			IL_0079: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_007e: dup
-			IL_007f: brtrue IL_0092
+			IL_00a1: pop
+			IL_00a2: ldloc.2
+			IL_00a3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00a8: dup
+			IL_00a9: brtrue IL_00bc
 
-			IL_0084: pop
-			IL_0085: rethrow
+			IL_00ae: pop
+			IL_00af: rethrow
 
-			IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_008c: stloc.3
-			IL_008d: br IL_0093
+			IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00b6: stloc.3
+			IL_00b7: br IL_00bd
 
-			IL_0092: stloc.3
+			IL_00bc: stloc.3
 
-			IL_0093: ldloc.3
-			IL_0094: stloc.s 4
-			IL_0096: ldloc.1
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009c: stloc.s 7
-			IL_009e: ldloc.s 4
-			IL_00a0: stloc.s 8
-			IL_00a2: ldstr "ReferenceError"
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ac: stloc.s 9
-			IL_00ae: ldloc.s 8
-			IL_00b0: ldloc.s 9
-			IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_00b7: stloc.s 6
-			IL_00b9: ldloc.s 6
-			IL_00bb: box [System.Runtime]System.Boolean
-			IL_00c0: stloc.s 10
-			IL_00c2: ldloc.s 7
-			IL_00c4: ldstr "log"
-			IL_00c9: ldstr "deleted"
-			IL_00ce: ldloc.s 10
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00d5: pop
-			IL_00d6: leave IL_00db
+			IL_00bd: ldloc.3
+			IL_00be: stloc.s 4
+			IL_00c0: ldloc.1
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c6: stloc.s 7
+			IL_00c8: ldloc.s 4
+			IL_00ca: stloc.s 8
+			IL_00cc: ldstr "ReferenceError"
+			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00d6: stloc.s 9
+			IL_00d8: ldloc.s 8
+			IL_00da: ldloc.s 9
+			IL_00dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_00e1: stloc.s 6
+			IL_00e3: ldloc.s 6
+			IL_00e5: box [System.Runtime]System.Boolean
+			IL_00ea: stloc.s 10
+			IL_00ec: ldloc.s 7
+			IL_00ee: ldstr "log"
+			IL_00f3: ldstr "deleted"
+			IL_00f8: ldloc.s 10
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00ff: pop
+			IL_0100: leave IL_0105
 		} // end handler
 
-		IL_00db: ldnull
-		IL_00dc: stloc.s 5
-		IL_00de: ret
+		IL_0105: ldnull
+		IL_0106: stloc.s 5
+		IL_0108: ret
 	} // end of method Console_GlobalLog_Deletion::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_Deletion
@@ -263,4 +275,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_DescriptorReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_DescriptorReplacement.verified.txt
@@ -248,7 +248,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 222 (0xde)
+		// Code size: 264 (0x108)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Console_GlobalLog_DescriptorReplacement/Scope,
@@ -325,11 +325,23 @@
 		IL_00be: ldstr "console"
 		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cd: ldstr "log"
-		IL_00d2: ldstr "global"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00dc: pop
-		IL_00dd: ret
+		IL_00cd: volatile.
+		IL_00cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d4: brfalse IL_00ed
+
+		IL_00d9: ldstr "log"
+		IL_00de: ldstr "global"
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e8: br IL_0106
+
+		IL_00ed: ldstr "log"
+		IL_00f2: ldstr "global"
+		IL_00f7: ldstr "Console_GlobalLog_DescriptorReplacement:Modules.Console_GlobalLog_DescriptorReplacement:__js_module_init__:29"
+		IL_00fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0106: pop
+		IL_0107: ret
 	} // end of method Console_GlobalLog_DescriptorReplacement::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_DescriptorReplacement
@@ -354,4 +366,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalPropertyReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalPropertyReplacement.verified.txt
@@ -248,7 +248,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 181 (0xb5)
+		// Code size: 223 (0xdf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope,
@@ -312,11 +312,23 @@
 		IL_0095: ldstr "console"
 		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a4: ldstr "log"
-		IL_00a9: ldstr "global"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b3: pop
-		IL_00b4: ret
+		IL_00a4: volatile.
+		IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ab: brfalse IL_00c4
+
+		IL_00b0: ldstr "log"
+		IL_00b5: ldstr "global"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bf: br IL_00dd
+
+		IL_00c4: ldstr "log"
+		IL_00c9: ldstr "global"
+		IL_00ce: ldstr "Console_GlobalLog_GlobalPropertyReplacement:Modules.Console_GlobalLog_GlobalPropertyReplacement:__js_module_init__:26"
+		IL_00d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00dd: pop
+		IL_00de: ret
 	} // end of method Console_GlobalLog_GlobalPropertyReplacement::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_GlobalPropertyReplacement
@@ -341,4 +353,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalThisAliasReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalThisAliasReplacement.verified.txt
@@ -248,7 +248,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 183 (0xb7)
+		// Code size: 225 (0xe1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope,
@@ -313,11 +313,23 @@
 		IL_0097: ldstr "console"
 		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a6: ldstr "log"
-		IL_00ab: ldstr "global"
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b5: pop
-		IL_00b6: ret
+		IL_00a6: volatile.
+		IL_00a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ad: brfalse IL_00c6
+
+		IL_00b2: ldstr "log"
+		IL_00b7: ldstr "global"
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c1: br IL_00df
+
+		IL_00c6: ldstr "log"
+		IL_00cb: ldstr "global"
+		IL_00d0: ldstr "Console_GlobalLog_GlobalThisAliasReplacement:Modules.Console_GlobalLog_GlobalThisAliasReplacement:__js_module_init__:28"
+		IL_00d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00df: pop
+		IL_00e0: ret
 	} // end of method Console_GlobalLog_GlobalThisAliasReplacement::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_GlobalThisAliasReplacement
@@ -342,4 +354,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_LocalBindingShadowing.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_LocalBindingShadowing.verified.txt
@@ -188,7 +188,7 @@
 			IL_0000: ldstr "globalThis"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_000a: volatile.
-			IL_000c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_000c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
 			IL_0011: brfalse IL_0025
 
 			IL_0016: ldstr "console"
@@ -197,7 +197,7 @@
 
 			IL_0025: ldstr "console"
 			IL_002a: ldstr "Console_GlobalLog_LocalBindingShadowing:<TwoPhaseDummy_M4>:__js_call__:4"
-			IL_002f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_002f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
 			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0039: stloc.0
@@ -245,7 +245,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 88 (0x58)
+		// Code size: 131 (0x83)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_GlobalLog_LocalBindingShadowing/Scope,
@@ -283,12 +283,25 @@
 		IL_0043: pop
 		IL_0044: ldloc.2
 		IL_0045: stloc.1
-		IL_0046: ldloc.1
-		IL_0047: ldstr "log"
-		IL_004c: ldstr "local"
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0056: pop
-		IL_0057: ret
+		IL_0046: volatile.
+		IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_004d: brfalse IL_0067
+
+		IL_0052: ldloc.1
+		IL_0053: ldstr "log"
+		IL_0058: ldstr "local"
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0062: br IL_0081
+
+		IL_0067: ldloc.1
+		IL_0068: ldstr "log"
+		IL_006d: ldstr "local"
+		IL_0072: ldstr "Console_GlobalLog_LocalBindingShadowing:Modules.Console_GlobalLog_LocalBindingShadowing:__js_module_init__:10"
+		IL_0077: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0081: pop
+		IL_0082: ret
 	} // end of method Console_GlobalLog_LocalBindingShadowing::__js_module_init__
 
 } // end of class Modules.Console_GlobalLog_LocalBindingShadowing
@@ -319,6 +332,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_Undici_Transform_Table.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_Undici_Transform_Table.verified.txt
@@ -225,7 +225,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 588 (0x24c)
+		// Code size: 627 (0x273)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Console_Undici_Transform_Table/Scope,
@@ -384,49 +384,61 @@
 		IL_01b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_01b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_01bc: stloc.s 10
-		IL_01be: ldstr "table"
-		IL_01c3: ldloc.s 10
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ca: pop
-		IL_01cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d0: stloc.s 11
-		IL_01d2: ldloc.3
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d8: volatile.
-		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_01df: brfalse IL_01f3
+		IL_01be: volatile.
+		IL_01c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_01c5: brfalse IL_01db
 
-		IL_01e4: ldstr "read"
-		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01ee: br IL_0207
+		IL_01ca: ldstr "table"
+		IL_01cf: ldloc.s 10
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d6: br IL_01f1
 
-		IL_01f3: ldstr "read"
-		IL_01f8: ldstr "Console_Undici_Transform_Table:Modules.Console_Undici_Transform_Table:__js_module_init__:58"
-		IL_01fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01db: ldstr "table"
+		IL_01e0: ldloc.s 10
+		IL_01e2: ldstr "Console_Undici_Transform_Table:Modules.Console_Undici_Transform_Table:__js_module_init__:54"
+		IL_01e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0207: stloc.s 12
-		IL_0209: ldloc.s 12
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0210: volatile.
-		IL_0212: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0217: brfalse IL_022b
+		IL_01f1: pop
+		IL_01f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f7: stloc.s 11
+		IL_01f9: ldloc.3
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ff: volatile.
+		IL_0201: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0206: brfalse IL_021a
 
-		IL_021c: ldstr "toString"
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0226: br IL_023f
+		IL_020b: ldstr "read"
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0215: br IL_022e
 
-		IL_022b: ldstr "toString"
-		IL_0230: ldstr "Console_Undici_Transform_Table:Modules.Console_Undici_Transform_Table:__js_module_init__:60"
-		IL_0235: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_021a: ldstr "read"
+		IL_021f: ldstr "Console_Undici_Transform_Table:Modules.Console_Undici_Transform_Table:__js_module_init__:58"
+		IL_0224: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_023f: stloc.s 12
-		IL_0241: ldloc.s 11
-		IL_0243: ldloc.s 12
-		IL_0245: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024a: pop
-		IL_024b: ret
+		IL_022e: stloc.s 12
+		IL_0230: ldloc.s 12
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0237: volatile.
+		IL_0239: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_023e: brfalse IL_0252
+
+		IL_0243: ldstr "toString"
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_024d: br IL_0266
+
+		IL_0252: ldstr "toString"
+		IL_0257: ldstr "Console_Undici_Transform_Table:Modules.Console_Undici_Transform_Table:__js_module_init__:60"
+		IL_025c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0266: stloc.s 12
+		IL_0268: ldloc.s 11
+		IL_026a: ldloc.s 12
+		IL_026c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0271: pop
+		IL_0272: ret
 	} // end of method Console_Undici_Transform_Table::__js_module_init__
 
 } // end of class Modules.Console_Undici_Transform_Table
@@ -460,6 +472,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_CreateHash_And_RandomBytes.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_CreateHash_And_RandomBytes.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 520 (0x208)
+		// Code size: 772 (0x304)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_CreateHash_And_RandomBytes/Scope,
@@ -129,147 +129,219 @@
 		IL_001e: stloc.2
 		IL_001f: ldloc.2
 		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0025: ldstr "update"
-		IL_002a: ldstr "a"
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0034: pop
-		IL_0035: ldloc.2
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_003b: ldstr "update"
-		IL_0040: ldstr "bc"
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004a: pop
-		IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0050: stloc.s 5
-		IL_0052: ldloc.2
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0058: ldstr "digest"
-		IL_005d: ldstr "hex"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0067: stloc.s 6
-		IL_0069: ldloc.s 5
-		IL_006b: ldstr "sha256 hex:"
-		IL_0070: ldloc.s 6
-		IL_0072: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0077: pop
-		IL_0078: ldloc.1
-		IL_0079: ldstr "sha256"
-		IL_007e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHash(string)
-		IL_0083: stloc.s 6
-		IL_0085: ldloc.s 6
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008c: ldstr "update"
-		IL_0091: ldstr "abc"
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009b: stloc.s 6
-		IL_009d: ldloc.s 6
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a4: volatile.
-		IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00ab: brfalse IL_00bf
+		IL_0025: volatile.
+		IL_0027: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_002c: brfalse IL_0045
 
-		IL_00b0: ldstr "digest"
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00ba: br IL_00d3
+		IL_0031: ldstr "update"
+		IL_0036: ldstr "a"
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0040: br IL_005e
 
-		IL_00bf: ldstr "digest"
-		IL_00c4: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:34"
-		IL_00c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0045: ldstr "update"
+		IL_004a: ldstr "a"
+		IL_004f: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:15"
+		IL_0054: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00d3: stloc.3
-		IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d9: stloc.s 5
-		IL_00db: ldloc.3
-		IL_00dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_00e1: box [System.Runtime]System.Boolean
-		IL_00e6: stloc.s 7
-		IL_00e8: ldloc.s 5
-		IL_00ea: ldstr "digest buffer:"
-		IL_00ef: ldloc.s 7
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00f6: pop
-		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fc: stloc.s 5
-		IL_00fe: ldloc.3
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0104: ldstr "toString"
-		IL_0109: ldstr "hex"
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0113: stloc.s 6
-		IL_0115: ldloc.s 5
-		IL_0117: ldstr "digest buffer hex:"
-		IL_011c: ldloc.s 6
-		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0123: pop
-		IL_0124: ldloc.1
-		IL_0125: ldc.r8 8
-		IL_012e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::randomBytes(float64)
-		IL_0133: stloc.s 4
-		IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013a: stloc.s 5
-		IL_013c: ldloc.s 4
-		IL_013e: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_0143: box [System.Runtime]System.Boolean
-		IL_0148: stloc.s 7
-		IL_014a: ldloc.s 5
-		IL_014c: ldstr "random buffer:"
-		IL_0151: ldloc.s 7
-		IL_0153: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0158: pop
-		IL_0159: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015e: stloc.s 5
-		IL_0160: volatile.
-		IL_0162: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0167: brfalse IL_017d
+		IL_005e: pop
+		IL_005f: ldloc.2
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_006c: brfalse IL_0085
 
-		IL_016c: ldloc.s 4
-		IL_016e: ldstr "length"
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0178: br IL_0193
+		IL_0071: ldstr "update"
+		IL_0076: ldstr "bc"
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: br IL_009e
 
-		IL_017d: ldloc.s 4
-		IL_017f: ldstr "length"
-		IL_0184: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:64"
-		IL_0189: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0085: ldstr "update"
+		IL_008a: ldstr "bc"
+		IL_008f: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:19"
+		IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0193: stloc.s 6
-		IL_0195: ldloc.s 5
-		IL_0197: ldstr "random length:"
-		IL_019c: ldloc.s 6
-		IL_019e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01a3: pop
-		IL_01a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a9: stloc.s 5
-		IL_01ab: ldloc.s 4
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b2: ldstr "toString"
-		IL_01b7: ldstr "hex"
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c1: stloc.s 6
-		IL_01c3: volatile.
-		IL_01c5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_01ca: brfalse IL_01e0
+		IL_009e: pop
+		IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a4: stloc.s 5
+		IL_00a6: ldloc.2
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ac: volatile.
+		IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b3: brfalse IL_00cc
 
-		IL_01cf: ldloc.s 6
-		IL_01d1: ldstr "length"
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01db: br IL_01f6
+		IL_00b8: ldstr "digest"
+		IL_00bd: ldstr "hex"
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c7: br IL_00e5
 
-		IL_01e0: ldloc.s 6
-		IL_01e2: ldstr "length"
-		IL_01e7: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:73"
-		IL_01ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00cc: ldstr "digest"
+		IL_00d1: ldstr "hex"
+		IL_00d6: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:25"
+		IL_00db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01f6: stloc.s 6
-		IL_01f8: ldloc.s 5
-		IL_01fa: ldstr "random hex length:"
-		IL_01ff: ldloc.s 6
-		IL_0201: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0206: pop
-		IL_0207: ret
+		IL_00e5: stloc.s 6
+		IL_00e7: ldloc.s 5
+		IL_00e9: ldstr "sha256 hex:"
+		IL_00ee: ldloc.s 6
+		IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00f5: pop
+		IL_00f6: ldloc.1
+		IL_00f7: ldstr "sha256"
+		IL_00fc: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHash(string)
+		IL_0101: stloc.s 6
+		IL_0103: ldloc.s 6
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010a: volatile.
+		IL_010c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0111: brfalse IL_012a
+
+		IL_0116: ldstr "update"
+		IL_011b: ldstr "abc"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0125: br IL_0143
+
+		IL_012a: ldstr "update"
+		IL_012f: ldstr "abc"
+		IL_0134: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:32"
+		IL_0139: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0143: stloc.s 6
+		IL_0145: ldloc.s 6
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014c: volatile.
+		IL_014e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0153: brfalse IL_0167
+
+		IL_0158: ldstr "digest"
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0162: br IL_017b
+
+		IL_0167: ldstr "digest"
+		IL_016c: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:34"
+		IL_0171: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_017b: stloc.3
+		IL_017c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0181: stloc.s 5
+		IL_0183: ldloc.3
+		IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_0189: box [System.Runtime]System.Boolean
+		IL_018e: stloc.s 7
+		IL_0190: ldloc.s 5
+		IL_0192: ldstr "digest buffer:"
+		IL_0197: ldloc.s 7
+		IL_0199: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_019e: pop
+		IL_019f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a4: stloc.s 5
+		IL_01a6: ldloc.3
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ac: volatile.
+		IL_01ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01b3: brfalse IL_01cc
+
+		IL_01b8: ldstr "toString"
+		IL_01bd: ldstr "hex"
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c7: br IL_01e5
+
+		IL_01cc: ldstr "toString"
+		IL_01d1: ldstr "hex"
+		IL_01d6: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:47"
+		IL_01db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01e5: stloc.s 6
+		IL_01e7: ldloc.s 5
+		IL_01e9: ldstr "digest buffer hex:"
+		IL_01ee: ldloc.s 6
+		IL_01f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01f5: pop
+		IL_01f6: ldloc.1
+		IL_01f7: ldc.r8 8
+		IL_0200: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::randomBytes(float64)
+		IL_0205: stloc.s 4
+		IL_0207: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_020c: stloc.s 5
+		IL_020e: ldloc.s 4
+		IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_0215: box [System.Runtime]System.Boolean
+		IL_021a: stloc.s 7
+		IL_021c: ldloc.s 5
+		IL_021e: ldstr "random buffer:"
+		IL_0223: ldloc.s 7
+		IL_0225: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_022a: pop
+		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0230: stloc.s 5
+		IL_0232: volatile.
+		IL_0234: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0239: brfalse IL_024f
+
+		IL_023e: ldloc.s 4
+		IL_0240: ldstr "length"
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024a: br IL_0265
+
+		IL_024f: ldloc.s 4
+		IL_0251: ldstr "length"
+		IL_0256: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:64"
+		IL_025b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0265: stloc.s 6
+		IL_0267: ldloc.s 5
+		IL_0269: ldstr "random length:"
+		IL_026e: ldloc.s 6
+		IL_0270: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0275: pop
+		IL_0276: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_027b: stloc.s 5
+		IL_027d: ldloc.s 4
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0284: volatile.
+		IL_0286: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_028b: brfalse IL_02a4
+
+		IL_0290: ldstr "toString"
+		IL_0295: ldstr "hex"
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029f: br IL_02bd
+
+		IL_02a4: ldstr "toString"
+		IL_02a9: ldstr "hex"
+		IL_02ae: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:71"
+		IL_02b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02bd: stloc.s 6
+		IL_02bf: volatile.
+		IL_02c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02c6: brfalse IL_02dc
+
+		IL_02cb: ldloc.s 6
+		IL_02cd: ldstr "length"
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02d7: br IL_02f2
+
+		IL_02dc: ldloc.s 6
+		IL_02de: ldstr "length"
+		IL_02e3: ldstr "Require_Crypto_CreateHash_And_RandomBytes:Modules.Require_Crypto_CreateHash_And_RandomBytes:__js_module_init__:73"
+		IL_02e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02f2: stloc.s 6
+		IL_02f4: ldloc.s 5
+		IL_02f6: ldstr "random hex length:"
+		IL_02fb: ldloc.s 6
+		IL_02fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0302: pop
+		IL_0303: ret
 	} // end of method Require_Crypto_CreateHash_And_RandomBytes::__js_module_init__
 
 } // end of class Modules.Require_Crypto_CreateHash_And_RandomBytes
@@ -302,6 +374,12 @@
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_CreateHmac.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_CreateHmac.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 585 (0x249)
+		// Code size: 1044 (0x414)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_CreateHmac/Scope,
@@ -130,159 +130,291 @@
 		IL_0023: stloc.2
 		IL_0024: ldloc.2
 		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_002a: ldstr "update"
-		IL_002f: ldstr "a"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0039: pop
-		IL_003a: ldloc.2
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0040: ldstr "bc"
-		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_004a: stloc.s 4
-		IL_004c: ldstr "update"
-		IL_0051: ldloc.s 4
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0058: pop
-		IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005e: stloc.s 5
-		IL_0060: ldloc.2
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0066: ldstr "digest"
-		IL_006b: ldstr "hex"
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0075: stloc.s 6
-		IL_0077: ldloc.s 5
-		IL_0079: ldstr "hmac sha256 hex:"
-		IL_007e: ldloc.s 6
-		IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0085: pop
-		IL_0086: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008b: stloc.s 5
-		IL_008d: ldloc.1
-		IL_008e: ldstr "md5"
-		IL_0093: ldstr "key"
-		IL_0098: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-		IL_009d: stloc.s 6
-		IL_009f: ldloc.s 6
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a6: ldstr "update"
-		IL_00ab: ldstr "abc"
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b5: stloc.s 6
-		IL_00b7: ldloc.s 6
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00be: ldstr "digest"
-		IL_00c3: ldstr "hex"
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cd: stloc.s 6
-		IL_00cf: ldloc.s 5
-		IL_00d1: ldstr "hmac md5 hex:"
-		IL_00d6: ldloc.s 6
-		IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00dd: pop
-		IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e3: stloc.s 5
-		IL_00e5: ldloc.1
-		IL_00e6: ldstr "sha384"
-		IL_00eb: ldstr "key"
-		IL_00f0: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-		IL_00f5: stloc.s 6
-		IL_00f7: ldloc.s 6
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fe: ldstr "update"
-		IL_0103: ldstr "abc"
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010d: stloc.s 6
-		IL_010f: ldloc.s 6
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0116: ldstr "digest"
-		IL_011b: ldstr "hex"
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0125: stloc.s 6
-		IL_0127: ldloc.s 5
-		IL_0129: ldstr "hmac sha384 hex:"
-		IL_012e: ldloc.s 6
-		IL_0130: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0135: pop
-		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013b: stloc.s 5
-		IL_013d: ldloc.1
-		IL_013e: ldstr "sha512"
-		IL_0143: ldstr "key"
-		IL_0148: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-		IL_014d: stloc.s 6
-		IL_014f: ldloc.s 6
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0156: ldstr "update"
-		IL_015b: ldstr "abc"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0165: stloc.s 6
-		IL_0167: ldloc.s 6
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016e: ldstr "digest"
-		IL_0173: ldstr "hex"
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017d: stloc.s 6
-		IL_017f: ldloc.s 5
-		IL_0181: ldstr "hmac sha512 hex:"
-		IL_0186: ldloc.s 6
-		IL_0188: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_018d: pop
-		IL_018e: ldstr "key"
-		IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0198: stloc.s 4
-		IL_019a: ldloc.1
-		IL_019b: ldstr "sha1"
-		IL_01a0: ldloc.s 4
-		IL_01a2: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-		IL_01a7: stloc.s 6
-		IL_01a9: ldloc.s 6
-		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b0: ldstr "update"
-		IL_01b5: ldstr "abc"
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bf: stloc.s 6
-		IL_01c1: ldloc.s 6
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c8: volatile.
-		IL_01ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_01cf: brfalse IL_01e3
+		IL_002a: volatile.
+		IL_002c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0031: brfalse IL_004a
 
-		IL_01d4: ldstr "digest"
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01de: br IL_01f7
+		IL_0036: ldstr "update"
+		IL_003b: ldstr "a"
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0045: br IL_0063
 
-		IL_01e3: ldstr "digest"
-		IL_01e8: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:77"
-		IL_01ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_004a: ldstr "update"
+		IL_004f: ldstr "a"
+		IL_0054: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:16"
+		IL_0059: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01f7: stloc.3
-		IL_01f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fd: stloc.s 5
-		IL_01ff: ldloc.3
-		IL_0200: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_0205: box [System.Runtime]System.Boolean
-		IL_020a: stloc.s 7
-		IL_020c: ldloc.s 5
-		IL_020e: ldstr "hmac buffer:"
-		IL_0213: ldloc.s 7
-		IL_0215: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_021a: pop
-		IL_021b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0220: stloc.s 5
-		IL_0222: ldloc.3
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0228: ldstr "toString"
-		IL_022d: ldstr "hex"
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0237: stloc.s 6
-		IL_0239: ldloc.s 5
-		IL_023b: ldstr "hmac sha1 hex:"
-		IL_0240: ldloc.s 6
-		IL_0242: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0247: pop
-		IL_0248: ret
+		IL_0063: pop
+		IL_0064: ldloc.2
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_006a: ldstr "bc"
+		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0074: stloc.s 4
+		IL_0076: volatile.
+		IL_0078: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007d: brfalse IL_0093
+
+		IL_0082: ldstr "update"
+		IL_0087: ldloc.s 4
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008e: br IL_00a9
+
+		IL_0093: ldstr "update"
+		IL_0098: ldloc.s 4
+		IL_009a: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:21"
+		IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a9: pop
+		IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00af: stloc.s 5
+		IL_00b1: ldloc.2
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b7: volatile.
+		IL_00b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00be: brfalse IL_00d7
+
+		IL_00c3: ldstr "digest"
+		IL_00c8: ldstr "hex"
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d2: br IL_00f0
+
+		IL_00d7: ldstr "digest"
+		IL_00dc: ldstr "hex"
+		IL_00e1: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:27"
+		IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f0: stloc.s 6
+		IL_00f2: ldloc.s 5
+		IL_00f4: ldstr "hmac sha256 hex:"
+		IL_00f9: ldloc.s 6
+		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0100: pop
+		IL_0101: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0106: stloc.s 5
+		IL_0108: ldloc.1
+		IL_0109: ldstr "md5"
+		IL_010e: ldstr "key"
+		IL_0113: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+		IL_0118: stloc.s 6
+		IL_011a: ldloc.s 6
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0121: volatile.
+		IL_0123: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0128: brfalse IL_0141
+
+		IL_012d: ldstr "update"
+		IL_0132: ldstr "abc"
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013c: br IL_015a
+
+		IL_0141: ldstr "update"
+		IL_0146: ldstr "abc"
+		IL_014b: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:37"
+		IL_0150: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_015a: stloc.s 6
+		IL_015c: ldloc.s 6
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0163: volatile.
+		IL_0165: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_016a: brfalse IL_0183
+
+		IL_016f: ldstr "digest"
+		IL_0174: ldstr "hex"
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017e: br IL_019c
+
+		IL_0183: ldstr "digest"
+		IL_0188: ldstr "hex"
+		IL_018d: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:40"
+		IL_0192: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_019c: stloc.s 6
+		IL_019e: ldloc.s 5
+		IL_01a0: ldstr "hmac md5 hex:"
+		IL_01a5: ldloc.s 6
+		IL_01a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01ac: pop
+		IL_01ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b2: stloc.s 5
+		IL_01b4: ldloc.1
+		IL_01b5: ldstr "sha384"
+		IL_01ba: ldstr "key"
+		IL_01bf: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+		IL_01c4: stloc.s 6
+		IL_01c6: ldloc.s 6
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01cd: volatile.
+		IL_01cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01d4: brfalse IL_01ed
+
+		IL_01d9: ldstr "update"
+		IL_01de: ldstr "abc"
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e8: br IL_0206
+
+		IL_01ed: ldstr "update"
+		IL_01f2: ldstr "abc"
+		IL_01f7: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:50"
+		IL_01fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0206: stloc.s 6
+		IL_0208: ldloc.s 6
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020f: volatile.
+		IL_0211: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0216: brfalse IL_022f
+
+		IL_021b: ldstr "digest"
+		IL_0220: ldstr "hex"
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022a: br IL_0248
+
+		IL_022f: ldstr "digest"
+		IL_0234: ldstr "hex"
+		IL_0239: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:53"
+		IL_023e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0248: stloc.s 6
+		IL_024a: ldloc.s 5
+		IL_024c: ldstr "hmac sha384 hex:"
+		IL_0251: ldloc.s 6
+		IL_0253: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0258: pop
+		IL_0259: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025e: stloc.s 5
+		IL_0260: ldloc.1
+		IL_0261: ldstr "sha512"
+		IL_0266: ldstr "key"
+		IL_026b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+		IL_0270: stloc.s 6
+		IL_0272: ldloc.s 6
+		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0279: volatile.
+		IL_027b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0280: brfalse IL_0299
+
+		IL_0285: ldstr "update"
+		IL_028a: ldstr "abc"
+		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0294: br IL_02b2
+
+		IL_0299: ldstr "update"
+		IL_029e: ldstr "abc"
+		IL_02a3: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:63"
+		IL_02a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02b2: stloc.s 6
+		IL_02b4: ldloc.s 6
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02bb: volatile.
+		IL_02bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02c2: brfalse IL_02db
+
+		IL_02c7: ldstr "digest"
+		IL_02cc: ldstr "hex"
+		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d6: br IL_02f4
+
+		IL_02db: ldstr "digest"
+		IL_02e0: ldstr "hex"
+		IL_02e5: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:66"
+		IL_02ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02f4: stloc.s 6
+		IL_02f6: ldloc.s 5
+		IL_02f8: ldstr "hmac sha512 hex:"
+		IL_02fd: ldloc.s 6
+		IL_02ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0304: pop
+		IL_0305: ldstr "key"
+		IL_030a: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_030f: stloc.s 4
+		IL_0311: ldloc.1
+		IL_0312: ldstr "sha1"
+		IL_0317: ldloc.s 4
+		IL_0319: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+		IL_031e: stloc.s 6
+		IL_0320: ldloc.s 6
+		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0327: volatile.
+		IL_0329: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_032e: brfalse IL_0347
+
+		IL_0333: ldstr "update"
+		IL_0338: ldstr "abc"
+		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0342: br IL_0360
+
+		IL_0347: ldstr "update"
+		IL_034c: ldstr "abc"
+		IL_0351: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:75"
+		IL_0356: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0360: stloc.s 6
+		IL_0362: ldloc.s 6
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0369: volatile.
+		IL_036b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0370: brfalse IL_0384
+
+		IL_0375: ldstr "digest"
+		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_037f: br IL_0398
+
+		IL_0384: ldstr "digest"
+		IL_0389: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:77"
+		IL_038e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0398: stloc.3
+		IL_0399: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_039e: stloc.s 5
+		IL_03a0: ldloc.3
+		IL_03a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_03a6: box [System.Runtime]System.Boolean
+		IL_03ab: stloc.s 7
+		IL_03ad: ldloc.s 5
+		IL_03af: ldstr "hmac buffer:"
+		IL_03b4: ldloc.s 7
+		IL_03b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03bb: pop
+		IL_03bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03c1: stloc.s 5
+		IL_03c3: ldloc.3
+		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c9: volatile.
+		IL_03cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_03d0: brfalse IL_03e9
+
+		IL_03d5: ldstr "toString"
+		IL_03da: ldstr "hex"
+		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03e4: br IL_0402
+
+		IL_03e9: ldstr "toString"
+		IL_03ee: ldstr "hex"
+		IL_03f3: ldstr "Require_Crypto_CreateHmac:Modules.Require_Crypto_CreateHmac:__js_module_init__:90"
+		IL_03f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0402: stloc.s 6
+		IL_0404: ldloc.s 5
+		IL_0406: ldstr "hmac sha1 hex:"
+		IL_040b: ldloc.s 6
+		IL_040d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0412: pop
+		IL_0413: ret
 	} // end of method Require_Crypto_CreateHmac::__js_module_init__
 
 } // end of class Modules.Require_Crypto_CreateHmac
@@ -313,6 +445,17 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -328,7 +328,7 @@
 				IL_0092: call string [System.Runtime]System.String::Concat(string, string)
 				IL_0097: stloc.s 5
 				IL_0099: volatile.
-				IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+				IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 				IL_00a0: brfalse IL_00b5
 
 				IL_00a5: ldloc.2
@@ -339,7 +339,7 @@
 				IL_00b5: ldloc.2
 				IL_00b6: ldstr "name"
 				IL_00bb: ldstr "Require_Crypto_ErrorPaths:<TwoPhaseDummy_M4>:__js_call__:36"
-				IL_00c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+				IL_00c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00ca: stloc.s 6
@@ -355,7 +355,7 @@
 				IL_00e5: call string [System.Runtime]System.String::Concat(string, string)
 				IL_00ea: stloc.s 5
 				IL_00ec: volatile.
-				IL_00ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+				IL_00ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 				IL_00f3: brfalse IL_0108
 
 				IL_00f8: ldloc.2
@@ -366,7 +366,7 @@
 				IL_0108: ldloc.2
 				IL_0109: ldstr "message"
 				IL_010e: ldstr "Require_Crypto_ErrorPaths:<TwoPhaseDummy_M4>:__js_call__:44"
-				IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+				IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 				IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_011d: stloc.s 6
@@ -488,7 +488,7 @@
 				74 61 54 6f 6b 65 6e 27 00 00 02
 			)
 			// Header size: 12
-			// Code size: 33 (0x21)
+			// Code size: 84 (0x54)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -496,13 +496,26 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "createHash"
-			IL_000b: ldc.r8 123
-			IL_0014: box [System.Runtime]System.Double
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001e: stloc.0
-			IL_001f: ldloc.0
-			IL_0020: ret
+			IL_0006: volatile.
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_000d: brfalse IL_002f
+
+			IL_0012: ldstr "createHash"
+			IL_0017: ldc.r8 123
+			IL_0020: box [System.Runtime]System.Double
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002a: br IL_0051
+
+			IL_002f: ldstr "createHash"
+			IL_0034: ldc.r8 123
+			IL_003d: box [System.Runtime]System.Double
+			IL_0042: ldstr "Require_Crypto_ErrorPaths:<TwoPhaseDummy_M5>:__js_call__:3"
+			IL_0047: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0051: stloc.0
+			IL_0052: ldloc.0
+			IL_0053: ret
 		} // end of method ArrowFunction_L16C28::__js_call__
 
 	} // end of class ArrowFunction_L16C28
@@ -2372,7 +2385,7 @@
 				74 61 54 6f 6b 65 6e 27 00 00 02
 			)
 			// Header size: 12
-			// Code size: 24 (0x18)
+			// Code size: 66 (0x42)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2380,12 +2393,24 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
-			IL_0006: ldstr "randomBytes"
-			IL_000b: ldstr "4"
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0015: stloc.0
-			IL_0016: ldloc.0
-			IL_0017: ret
+			IL_0006: volatile.
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_000d: brfalse IL_0026
+
+			IL_0012: ldstr "randomBytes"
+			IL_0017: ldstr "4"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0021: br IL_003f
+
+			IL_0026: ldstr "randomBytes"
+			IL_002b: ldstr "4"
+			IL_0030: ldstr "Require_Crypto_ErrorPaths:<TwoPhaseDummy_M20>:__js_call__:2"
+			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_003f: stloc.0
+			IL_0040: ldloc.0
+			IL_0041: ret
 		} // end of method ArrowFunction_L31C30::__js_call__
 
 	} // end of class ArrowFunction_L31C30
@@ -2622,7 +2647,7 @@
 				74 61 54 6f 6b 65 6e 27 00 00 02
 			)
 			// Header size: 12
-			// Code size: 29 (0x1d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2631,12 +2656,24 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000b: ldstr "digest"
-			IL_0010: ldstr "hex"
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001a: stloc.0
-			IL_001b: ldloc.0
-			IL_001c: ret
+			IL_000b: volatile.
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_0012: brfalse IL_002b
+
+			IL_0017: ldstr "digest"
+			IL_001c: ldstr "hex"
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0026: br IL_0044
+
+			IL_002b: ldstr "digest"
+			IL_0030: ldstr "hex"
+			IL_0035: ldstr "Require_Crypto_ErrorPaths:<TwoPhaseDummy_M22>:__js_call__:3"
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0044: stloc.0
+			IL_0045: ldloc.0
+			IL_0046: ret
 		} // end of method ArrowFunction_L37C26::__js_call__
 
 	} // end of class ArrowFunction_L37C26
@@ -2743,7 +2780,7 @@
 				74 61 54 6f 6b 65 6e 27 00 00 02
 			)
 			// Header size: 12
-			// Code size: 38 (0x26)
+			// Code size: 89 (0x59)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2752,13 +2789,26 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000b: ldstr "update"
-			IL_0010: ldc.r8 123
-			IL_0019: box [System.Runtime]System.Double
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0023: stloc.0
-			IL_0024: ldloc.0
-			IL_0025: ret
+			IL_000b: volatile.
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0012: brfalse IL_0034
+
+			IL_0017: ldstr "update"
+			IL_001c: ldc.r8 123
+			IL_0025: box [System.Runtime]System.Double
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002f: br IL_0056
+
+			IL_0034: ldstr "update"
+			IL_0039: ldc.r8 123
+			IL_0042: box [System.Runtime]System.Double
+			IL_0047: ldstr "Require_Crypto_ErrorPaths:<TwoPhaseDummy_M23>:__js_call__:4"
+			IL_004c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0056: stloc.0
+			IL_0057: ldloc.0
+			IL_0058: ret
 		} // end of method ArrowFunction_L40C30::__js_call__
 
 	} // end of class ArrowFunction_L40C30
@@ -3114,7 +3164,7 @@
 			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_019b: stloc.s 5
 			IL_019d: volatile.
-			IL_019f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_019f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_01a4: brfalse IL_01b9
 
 			IL_01a9: ldloc.1
@@ -3125,7 +3175,7 @@
 			IL_01b9: ldloc.1
 			IL_01ba: ldstr "name"
 			IL_01bf: ldstr "Require_Crypto_ErrorPaths:<TwoPhaseDummy_M24>:__js_call__:38"
-			IL_01c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_01c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01ce: stloc.3
@@ -3141,7 +3191,7 @@
 			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_01ec: stloc.s 5
 			IL_01ee: volatile.
-			IL_01f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_01f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_01f5: brfalse IL_020a
 
 			IL_01fa: ldloc.1
@@ -3152,7 +3202,7 @@
 			IL_020a: ldloc.1
 			IL_020b: ldstr "message"
 			IL_0210: ldstr "Require_Crypto_ErrorPaths:<TwoPhaseDummy_M24>:__js_call__:46"
-			IL_0215: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_0215: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_021f: stloc.3
@@ -5020,7 +5070,7 @@
 			IL_0170: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::get_webcrypto()
 			IL_0175: stloc.2
 			IL_0176: volatile.
-			IL_0178: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_0178: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_017d: brfalse IL_0192
 
 			IL_0182: ldloc.2
@@ -5031,7 +5081,7 @@
 			IL_0192: ldloc.2
 			IL_0193: ldstr "subtle"
 			IL_0198: ldstr "Require_Crypto_ErrorPaths:<TwoPhaseDummy_M25>:__js_call__:5"
-			IL_019d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_019d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01a7: stloc.2
@@ -6730,7 +6780,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1662 (0x67e)
+		// Code size: 1787 (0x6fb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_ErrorPaths/Scope,
@@ -7320,122 +7370,159 @@
 		IL_0539: ldloc.0
 		IL_053a: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
 		IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0544: ldstr "update"
-		IL_0549: ldstr "abc"
-		IL_054e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0553: pop
-		IL_0554: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0559: stloc.s 25
-		IL_055b: ldloc.0
-		IL_055c: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0566: ldstr "digest"
-		IL_056b: ldstr "hex"
-		IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0575: stloc.s 24
-		IL_0577: ldloc.s 25
-		IL_0579: ldstr "digest first:"
-		IL_057e: ldloc.s 24
-		IL_0580: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0585: pop
-		IL_0586: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_058b: stloc.3
-		IL_058c: ldc.i4.1
-		IL_058d: newarr [System.Runtime]System.Object
-		IL_0592: dup
-		IL_0593: ldc.i4.0
-		IL_0594: ldloc.0
-		IL_0595: stelem.ref
-		IL_0596: stloc.s 6
-		IL_0598: ldloc.s 6
-		IL_059a: ldc.i4.0
-		IL_059b: ldelem.ref
-		IL_059c: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_05a1: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_05a6: ldc.i4.0
-		IL_05a7: conv.r8
-		IL_05a8: ldstr ""
-		IL_05ad: ldc.i4.0
-		IL_05ae: ldc.i4.0
-		IL_05af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject>(!!0)
-		IL_05b9: stloc.s 26
-		IL_05bb: ldloc.1
-		IL_05bc: ldloc.3
-		IL_05bd: ldstr "digest twice"
-		IL_05c2: ldloc.s 26
-		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_05c9: pop
-		IL_05ca: ldloc.0
-		IL_05cb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_05d0: stloc.s 5
-		IL_05d2: ldloc.s 5
-		IL_05d4: ldstr "sha256"
-		IL_05d9: ldstr "key"
-		IL_05de: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-		IL_05e3: stloc.s 24
-		IL_05e5: ldloc.0
-		IL_05e6: ldloc.s 24
-		IL_05e8: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
-		IL_05ed: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05f2: stloc.3
-		IL_05f3: ldc.i4.1
-		IL_05f4: newarr [System.Runtime]System.Object
-		IL_05f9: dup
+		IL_0544: volatile.
+		IL_0546: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_054b: brfalse IL_0564
+
+		IL_0550: ldstr "update"
+		IL_0555: ldstr "abc"
+		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_055f: br IL_057d
+
+		IL_0564: ldstr "update"
+		IL_0569: ldstr "abc"
+		IL_056e: ldstr "Require_Crypto_ErrorPaths:Modules.Require_Crypto_ErrorPaths:__js_module_init__:129"
+		IL_0573: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_057d: pop
+		IL_057e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0583: stloc.s 25
+		IL_0585: ldloc.0
+		IL_0586: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0590: volatile.
+		IL_0592: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_0597: brfalse IL_05b0
+
+		IL_059c: ldstr "digest"
+		IL_05a1: ldstr "hex"
+		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05ab: br IL_05c9
+
+		IL_05b0: ldstr "digest"
+		IL_05b5: ldstr "hex"
+		IL_05ba: ldstr "Require_Crypto_ErrorPaths:Modules.Require_Crypto_ErrorPaths:__js_module_init__:136"
+		IL_05bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_05c9: stloc.s 24
+		IL_05cb: ldloc.s 25
+		IL_05cd: ldstr "digest first:"
+		IL_05d2: ldloc.s 24
+		IL_05d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_05d9: pop
+		IL_05da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05df: stloc.3
+		IL_05e0: ldc.i4.1
+		IL_05e1: newarr [System.Runtime]System.Object
+		IL_05e6: dup
+		IL_05e7: ldc.i4.0
+		IL_05e8: ldloc.0
+		IL_05e9: stelem.ref
+		IL_05ea: stloc.s 6
+		IL_05ec: ldloc.s 6
+		IL_05ee: ldc.i4.0
+		IL_05ef: ldelem.ref
+		IL_05f0: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_05f5: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
 		IL_05fa: ldc.i4.0
-		IL_05fb: ldloc.0
-		IL_05fc: stelem.ref
-		IL_05fd: stloc.s 6
-		IL_05ff: ldloc.s 6
+		IL_05fb: conv.r8
+		IL_05fc: ldstr ""
 		IL_0601: ldc.i4.0
-		IL_0602: ldelem.ref
-		IL_0603: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0608: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_060d: ldc.i4.0
-		IL_060e: conv.r8
-		IL_060f: ldstr ""
-		IL_0614: ldc.i4.0
-		IL_0615: ldc.i4.0
-		IL_0616: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_061b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject>(!!0)
-		IL_0620: stloc.s 27
-		IL_0622: ldloc.1
-		IL_0623: ldloc.3
-		IL_0624: ldstr "hmac update type"
-		IL_0629: ldloc.s 27
-		IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0630: pop
-		IL_0631: nop
-		IL_0632: nop
-		IL_0633: ldloc.2
-		IL_0634: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0639: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_063e: stloc.s 24
-		IL_0640: ldloc.s 24
-		IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0647: stloc.s 24
-		IL_0649: ldc.i4.1
-		IL_064a: newarr [System.Runtime]System.Object
-		IL_064f: dup
-		IL_0650: ldc.i4.0
-		IL_0651: ldloc.0
-		IL_0652: stelem.ref
-		IL_0653: stloc.3
-		IL_0654: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject::.ctor()
-		IL_0659: ldc.i4.0
-		IL_065a: conv.r8
-		IL_065b: ldstr ""
-		IL_0660: ldc.i4.0
+		IL_0602: ldc.i4.0
+		IL_0603: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0608: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject>(!!0)
+		IL_060d: stloc.s 26
+		IL_060f: ldloc.1
+		IL_0610: ldloc.3
+		IL_0611: ldstr "digest twice"
+		IL_0616: ldloc.s 26
+		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_061d: pop
+		IL_061e: ldloc.0
+		IL_061f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+		IL_0624: stloc.s 5
+		IL_0626: ldloc.s 5
+		IL_0628: ldstr "sha256"
+		IL_062d: ldstr "key"
+		IL_0632: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+		IL_0637: stloc.s 24
+		IL_0639: ldloc.0
+		IL_063a: ldloc.s 24
+		IL_063c: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
+		IL_0641: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0646: stloc.3
+		IL_0647: ldc.i4.1
+		IL_0648: newarr [System.Runtime]System.Object
+		IL_064d: dup
+		IL_064e: ldc.i4.0
+		IL_064f: ldloc.0
+		IL_0650: stelem.ref
+		IL_0651: stloc.s 6
+		IL_0653: ldloc.s 6
+		IL_0655: ldc.i4.0
+		IL_0656: ldelem.ref
+		IL_0657: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_065c: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
 		IL_0661: ldc.i4.0
-		IL_0662: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0667: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject>(!!0)
-		IL_066c: stloc.s 28
-		IL_066e: ldloc.s 24
-		IL_0670: ldstr "then"
-		IL_0675: ldloc.s 28
-		IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_067c: pop
-		IL_067d: ret
+		IL_0662: conv.r8
+		IL_0663: ldstr ""
+		IL_0668: ldc.i4.0
+		IL_0669: ldc.i4.0
+		IL_066a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_066f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject>(!!0)
+		IL_0674: stloc.s 27
+		IL_0676: ldloc.1
+		IL_0677: ldloc.3
+		IL_0678: ldstr "hmac update type"
+		IL_067d: ldloc.s 27
+		IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0684: pop
+		IL_0685: nop
+		IL_0686: nop
+		IL_0687: ldloc.2
+		IL_0688: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0692: stloc.s 24
+		IL_0694: ldloc.s 24
+		IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_069b: stloc.s 24
+		IL_069d: ldc.i4.1
+		IL_069e: newarr [System.Runtime]System.Object
+		IL_06a3: dup
+		IL_06a4: ldc.i4.0
+		IL_06a5: ldloc.0
+		IL_06a6: stelem.ref
+		IL_06a7: stloc.3
+		IL_06a8: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject::.ctor()
+		IL_06ad: ldc.i4.0
+		IL_06ae: conv.r8
+		IL_06af: ldstr ""
+		IL_06b4: ldc.i4.0
+		IL_06b5: ldc.i4.0
+		IL_06b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject>(!!0)
+		IL_06c0: stloc.s 28
+		IL_06c2: volatile.
+		IL_06c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_06c9: brfalse IL_06e1
+
+		IL_06ce: ldloc.s 24
+		IL_06d0: ldstr "then"
+		IL_06d5: ldloc.s 28
+		IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06dc: br IL_06f9
+
+		IL_06e1: ldloc.s 24
+		IL_06e3: ldstr "then"
+		IL_06e8: ldloc.s 28
+		IL_06ea: ldstr "Require_Crypto_ErrorPaths:Modules.Require_Crypto_ErrorPaths:__js_module_init__:164"
+		IL_06ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_06f9: pop
+		IL_06fa: ret
 	} // end of method Require_Crypto_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Crypto_ErrorPaths
@@ -7470,6 +7557,13 @@
 	.field assembly static int32 __jroc_dynamicLookup_75
 	.field assembly static int32 __jroc_dynamicLookup_76
 	.field assembly static int32 __jroc_dynamicLookup_77
+	.field assembly static int32 __jroc_dynamicLookup_78
+	.field assembly static int32 __jroc_dynamicLookup_79
+	.field assembly static int32 __jroc_dynamicLookup_80
+	.field assembly static int32 __jroc_dynamicLookup_81
+	.field assembly static int32 __jroc_dynamicLookup_82
+	.field assembly static int32 __jroc_dynamicLookup_83
+	.field assembly static int32 __jroc_dynamicLookup_84
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_Pbkdf2Sync.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_Pbkdf2Sync.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 561 (0x231)
+		// Code size: 729 (0x2d9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_Pbkdf2Sync/Scope,
@@ -134,138 +134,186 @@
 		IL_0040: stloc.3
 		IL_0041: ldloc.3
 		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0047: ldstr "toString"
-		IL_004c: ldstr "hex"
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0056: stloc.3
-		IL_0057: ldloc.2
-		IL_0058: ldstr "pbkdf2 sha256 hex:"
-		IL_005d: ldloc.3
-		IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0063: pop
-		IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0069: stloc.2
-		IL_006a: ldloc.1
-		IL_006b: ldstr "password"
-		IL_0070: ldstr "salt"
-		IL_0075: ldc.r8 2
-		IL_007e: ldc.r8 20
-		IL_0087: ldstr "sha1"
-		IL_008c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-		IL_0091: stloc.3
-		IL_0092: ldloc.3
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0098: ldstr "toString"
-		IL_009d: ldstr "hex"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a7: stloc.3
-		IL_00a8: ldloc.2
-		IL_00a9: ldstr "pbkdf2 sha1 hex:"
-		IL_00ae: ldloc.3
-		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00b4: pop
-		IL_00b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ba: stloc.2
-		IL_00bb: ldloc.1
-		IL_00bc: ldstr "password"
-		IL_00c1: ldstr "salt"
-		IL_00c6: ldc.r8 2
-		IL_00cf: ldc.r8 24
-		IL_00d8: ldstr "sha384"
-		IL_00dd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-		IL_00e2: stloc.3
-		IL_00e3: ldloc.3
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e9: ldstr "toString"
-		IL_00ee: ldstr "hex"
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f8: stloc.3
-		IL_00f9: ldloc.2
-		IL_00fa: ldstr "pbkdf2 sha384 hex:"
-		IL_00ff: ldloc.3
-		IL_0100: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0105: pop
-		IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010b: stloc.2
-		IL_010c: ldc.i4.3
-		IL_010d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0112: dup
-		IL_0113: ldc.r8 1
-		IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0121: dup
-		IL_0122: ldc.r8 2
-		IL_012b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0130: dup
-		IL_0131: ldc.r8 3
-		IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0144: stloc.s 4
-		IL_0146: ldc.i4.2
-		IL_0147: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_014c: dup
-		IL_014d: ldc.r8 4
-		IL_0156: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_015b: dup
-		IL_015c: ldc.r8 5
-		IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_016a: stloc.s 5
-		IL_016c: ldloc.s 5
-		IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0173: stloc.s 6
-		IL_0175: ldloc.1
-		IL_0176: ldloc.s 4
-		IL_0178: ldloc.s 6
-		IL_017a: ldc.r8 3
-		IL_0183: ldc.r8 16
-		IL_018c: ldstr "sha512"
-		IL_0191: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-		IL_0196: stloc.3
-		IL_0197: ldloc.3
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019d: ldstr "toString"
-		IL_01a2: ldstr "hex"
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ac: stloc.3
-		IL_01ad: ldloc.2
-		IL_01ae: ldstr "pbkdf2 sha512 hex:"
-		IL_01b3: ldloc.3
-		IL_01b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01b9: pop
-		IL_01ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01bf: stloc.2
-		IL_01c0: ldstr "salt"
-		IL_01c5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_01ca: stloc.s 4
-		IL_01cc: ldloc.1
-		IL_01cd: ldstr "password"
-		IL_01d2: ldloc.s 4
-		IL_01d4: ldc.r8 1
-		IL_01dd: ldc.r8 0.0
-		IL_01e6: ldstr "sha256"
-		IL_01eb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
-		IL_01f0: stloc.3
-		IL_01f1: volatile.
-		IL_01f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_01f8: brfalse IL_020d
+		IL_0047: volatile.
+		IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_004e: brfalse IL_0067
 
-		IL_01fd: ldloc.3
-		IL_01fe: ldstr "length"
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0208: br IL_0222
+		IL_0053: ldstr "toString"
+		IL_0058: ldstr "hex"
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0062: br IL_0080
 
-		IL_020d: ldloc.3
-		IL_020e: ldstr "length"
-		IL_0213: ldstr "Require_Crypto_Pbkdf2Sync:Modules.Require_Crypto_Pbkdf2Sync:__js_module_init__:88"
-		IL_0218: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0067: ldstr "toString"
+		IL_006c: ldstr "hex"
+		IL_0071: ldstr "Require_Crypto_Pbkdf2Sync:Modules.Require_Crypto_Pbkdf2Sync:__js_module_init__:21"
+		IL_0076: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0222: stloc.3
-		IL_0223: ldloc.2
-		IL_0224: ldstr "pbkdf2 empty length:"
-		IL_0229: ldloc.3
-		IL_022a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_022f: pop
-		IL_0230: ret
+		IL_0080: stloc.3
+		IL_0081: ldloc.2
+		IL_0082: ldstr "pbkdf2 sha256 hex:"
+		IL_0087: ldloc.3
+		IL_0088: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008d: pop
+		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0093: stloc.2
+		IL_0094: ldloc.1
+		IL_0095: ldstr "password"
+		IL_009a: ldstr "salt"
+		IL_009f: ldc.r8 2
+		IL_00a8: ldc.r8 20
+		IL_00b1: ldstr "sha1"
+		IL_00b6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+		IL_00bb: stloc.3
+		IL_00bc: ldloc.3
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c2: volatile.
+		IL_00c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c9: brfalse IL_00e2
+
+		IL_00ce: ldstr "toString"
+		IL_00d3: ldstr "hex"
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00dd: br IL_00fb
+
+		IL_00e2: ldstr "toString"
+		IL_00e7: ldstr "hex"
+		IL_00ec: ldstr "Require_Crypto_Pbkdf2Sync:Modules.Require_Crypto_Pbkdf2Sync:__js_module_init__:36"
+		IL_00f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00fb: stloc.3
+		IL_00fc: ldloc.2
+		IL_00fd: ldstr "pbkdf2 sha1 hex:"
+		IL_0102: ldloc.3
+		IL_0103: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0108: pop
+		IL_0109: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010e: stloc.2
+		IL_010f: ldloc.1
+		IL_0110: ldstr "password"
+		IL_0115: ldstr "salt"
+		IL_011a: ldc.r8 2
+		IL_0123: ldc.r8 24
+		IL_012c: ldstr "sha384"
+		IL_0131: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+		IL_0136: stloc.3
+		IL_0137: ldloc.3
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013d: volatile.
+		IL_013f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0144: brfalse IL_015d
+
+		IL_0149: ldstr "toString"
+		IL_014e: ldstr "hex"
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0158: br IL_0176
+
+		IL_015d: ldstr "toString"
+		IL_0162: ldstr "hex"
+		IL_0167: ldstr "Require_Crypto_Pbkdf2Sync:Modules.Require_Crypto_Pbkdf2Sync:__js_module_init__:51"
+		IL_016c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0176: stloc.3
+		IL_0177: ldloc.2
+		IL_0178: ldstr "pbkdf2 sha384 hex:"
+		IL_017d: ldloc.3
+		IL_017e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0183: pop
+		IL_0184: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0189: stloc.2
+		IL_018a: ldc.i4.3
+		IL_018b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0190: dup
+		IL_0191: ldc.r8 1
+		IL_019a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_019f: dup
+		IL_01a0: ldc.r8 2
+		IL_01a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01ae: dup
+		IL_01af: ldc.r8 3
+		IL_01b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01bd: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_01c2: stloc.s 4
+		IL_01c4: ldc.i4.2
+		IL_01c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01ca: dup
+		IL_01cb: ldc.r8 4
+		IL_01d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01d9: dup
+		IL_01da: ldc.r8 5
+		IL_01e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01e8: stloc.s 5
+		IL_01ea: ldloc.s 5
+		IL_01ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_01f1: stloc.s 6
+		IL_01f3: ldloc.1
+		IL_01f4: ldloc.s 4
+		IL_01f6: ldloc.s 6
+		IL_01f8: ldc.r8 3
+		IL_0201: ldc.r8 16
+		IL_020a: ldstr "sha512"
+		IL_020f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+		IL_0214: stloc.3
+		IL_0215: ldloc.3
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021b: volatile.
+		IL_021d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0222: brfalse IL_023b
+
+		IL_0227: ldstr "toString"
+		IL_022c: ldstr "hex"
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0236: br IL_0254
+
+		IL_023b: ldstr "toString"
+		IL_0240: ldstr "hex"
+		IL_0245: ldstr "Require_Crypto_Pbkdf2Sync:Modules.Require_Crypto_Pbkdf2Sync:__js_module_init__:73"
+		IL_024a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0254: stloc.3
+		IL_0255: ldloc.2
+		IL_0256: ldstr "pbkdf2 sha512 hex:"
+		IL_025b: ldloc.3
+		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0261: pop
+		IL_0262: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0267: stloc.2
+		IL_0268: ldstr "salt"
+		IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0272: stloc.s 4
+		IL_0274: ldloc.1
+		IL_0275: ldstr "password"
+		IL_027a: ldloc.s 4
+		IL_027c: ldc.r8 1
+		IL_0285: ldc.r8 0.0
+		IL_028e: ldstr "sha256"
+		IL_0293: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::pbkdf2Sync(object, object, float64, float64, string)
+		IL_0298: stloc.3
+		IL_0299: volatile.
+		IL_029b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_02a0: brfalse IL_02b5
+
+		IL_02a5: ldloc.3
+		IL_02a6: ldstr "length"
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b0: br IL_02ca
+
+		IL_02b5: ldloc.3
+		IL_02b6: ldstr "length"
+		IL_02bb: ldstr "Require_Crypto_Pbkdf2Sync:Modules.Require_Crypto_Pbkdf2Sync:__js_module_init__:88"
+		IL_02c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02ca: stloc.3
+		IL_02cb: ldloc.2
+		IL_02cc: ldstr "pbkdf2 empty length:"
+		IL_02d1: ldloc.3
+		IL_02d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02d7: pop
+		IL_02d8: ret
 	} // end of method Require_Crypto_Pbkdf2Sync::__js_module_init__
 
 } // end of class Modules.Require_Crypto_Pbkdf2Sync
@@ -296,6 +344,10 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_GetRandomValues.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_GetRandomValues.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 529 (0x211)
+		// Code size: 650 (0x28a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_WebCrypto_GetRandomValues/Scope,
@@ -139,154 +139,191 @@
 		IL_002d: stloc.s 8
 		IL_002f: ldloc.s 8
 		IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0036: ldstr "getRandomValues"
-		IL_003b: ldloc.2
-		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0041: stloc.3
-		IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0047: stloc.s 9
-		IL_0049: ldloc.3
-		IL_004a: ldloc.2
-		IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0050: stloc.s 10
-		IL_0052: ldloc.s 10
-		IL_0054: box [System.Runtime]System.Boolean
-		IL_0059: stloc.s 11
-		IL_005b: ldloc.s 9
-		IL_005d: ldstr "same uint8:"
-		IL_0062: ldloc.s 11
-		IL_0064: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0069: pop
-		IL_006a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006f: stloc.s 9
-		IL_0071: ldloc.2
-		IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-		IL_0077: stloc.s 12
-		IL_0079: ldloc.s 12
-		IL_007b: box [System.Runtime]System.Double
-		IL_0080: stloc.s 13
-		IL_0082: ldloc.s 9
-		IL_0084: ldstr "uint8 length:"
-		IL_0089: ldloc.s 13
-		IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0090: pop
-		IL_0091: ldc.r8 2
-		IL_009a: box [System.Runtime]System.Double
-		IL_009f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_00a4: stloc.s 4
-		IL_00a6: ldloc.1
-		IL_00a7: ldloc.s 4
-		IL_00a9: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::getRandomValues(object)
-		IL_00ae: stloc.s 5
-		IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b5: stloc.s 9
-		IL_00b7: ldloc.s 5
-		IL_00b9: ldloc.s 4
-		IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00c0: stloc.s 10
-		IL_00c2: ldloc.s 10
-		IL_00c4: box [System.Runtime]System.Boolean
-		IL_00c9: stloc.s 11
-		IL_00cb: ldloc.s 9
-		IL_00cd: ldstr "same int32:"
-		IL_00d2: ldloc.s 11
-		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00d9: pop
-		IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00df: stloc.s 9
-		IL_00e1: volatile.
-		IL_00e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00e8: brfalse IL_00fe
+		IL_0036: volatile.
+		IL_0038: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_003d: brfalse IL_0052
 
-		IL_00ed: ldloc.s 4
-		IL_00ef: ldstr "byteLength"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f9: br IL_0114
+		IL_0042: ldstr "getRandomValues"
+		IL_0047: ldloc.2
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004d: br IL_0067
 
-		IL_00fe: ldloc.s 4
-		IL_0100: ldstr "byteLength"
-		IL_0105: ldstr "Require_Crypto_WebCrypto_GetRandomValues:Modules.Require_Crypto_WebCrypto_GetRandomValues:__js_module_init__:48"
-		IL_010a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0052: ldstr "getRandomValues"
+		IL_0057: ldloc.2
+		IL_0058: ldstr "Require_Crypto_WebCrypto_GetRandomValues:Modules.Require_Crypto_WebCrypto_GetRandomValues:__js_module_init__:16"
+		IL_005d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0114: stloc.s 8
-		IL_0116: ldloc.s 9
-		IL_0118: ldstr "int32 byteLength:"
-		IL_011d: ldloc.s 8
-		IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0124: pop
-		IL_0125: ldc.r8 6
-		IL_012e: box [System.Runtime]System.Double
-		IL_0133: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
-		IL_0138: stloc.s 6
-		IL_013a: ldloc.1
-		IL_013b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::get_webcrypto()
-		IL_0140: stloc.s 8
-		IL_0142: ldloc.s 8
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0149: ldstr "getRandomValues"
-		IL_014e: ldloc.s 6
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0155: stloc.s 7
-		IL_0157: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015c: stloc.s 9
-		IL_015e: ldloc.s 7
-		IL_0160: ldloc.s 6
-		IL_0162: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0167: stloc.s 10
-		IL_0169: ldloc.s 10
-		IL_016b: box [System.Runtime]System.Boolean
-		IL_0170: stloc.s 11
-		IL_0172: ldloc.s 9
-		IL_0174: ldstr "same buffer:"
-		IL_0179: ldloc.s 11
-		IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0180: pop
-		IL_0181: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0186: stloc.s 9
-		IL_0188: ldloc.s 6
-		IL_018a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
-		IL_018f: stloc.s 12
-		IL_0191: ldloc.s 12
-		IL_0193: box [System.Runtime]System.Double
-		IL_0198: stloc.s 13
-		IL_019a: ldloc.s 9
-		IL_019c: ldstr "buffer length:"
-		IL_01a1: ldloc.s 13
-		IL_01a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01a8: pop
-		IL_01a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ae: stloc.s 9
-		IL_01b0: ldloc.s 6
-		IL_01b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-		IL_01b7: stloc.s 14
-		IL_01b9: ldloc.s 14
-		IL_01bb: ldstr "toString"
-		IL_01c0: ldstr "hex"
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ca: stloc.s 8
-		IL_01cc: volatile.
-		IL_01ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_01d3: brfalse IL_01e9
+		IL_0067: stloc.3
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: stloc.s 9
+		IL_006f: ldloc.3
+		IL_0070: ldloc.2
+		IL_0071: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0076: stloc.s 10
+		IL_0078: ldloc.s 10
+		IL_007a: box [System.Runtime]System.Boolean
+		IL_007f: stloc.s 11
+		IL_0081: ldloc.s 9
+		IL_0083: ldstr "same uint8:"
+		IL_0088: ldloc.s 11
+		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008f: pop
+		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0095: stloc.s 9
+		IL_0097: ldloc.2
+		IL_0098: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
+		IL_009d: stloc.s 12
+		IL_009f: ldloc.s 12
+		IL_00a1: box [System.Runtime]System.Double
+		IL_00a6: stloc.s 13
+		IL_00a8: ldloc.s 9
+		IL_00aa: ldstr "uint8 length:"
+		IL_00af: ldloc.s 13
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00b6: pop
+		IL_00b7: ldc.r8 2
+		IL_00c0: box [System.Runtime]System.Double
+		IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_00ca: stloc.s 4
+		IL_00cc: ldloc.1
+		IL_00cd: ldloc.s 4
+		IL_00cf: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::getRandomValues(object)
+		IL_00d4: stloc.s 5
+		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00db: stloc.s 9
+		IL_00dd: ldloc.s 5
+		IL_00df: ldloc.s 4
+		IL_00e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00e6: stloc.s 10
+		IL_00e8: ldloc.s 10
+		IL_00ea: box [System.Runtime]System.Boolean
+		IL_00ef: stloc.s 11
+		IL_00f1: ldloc.s 9
+		IL_00f3: ldstr "same int32:"
+		IL_00f8: ldloc.s 11
+		IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00ff: pop
+		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0105: stloc.s 9
+		IL_0107: volatile.
+		IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_010e: brfalse IL_0124
 
-		IL_01d8: ldloc.s 8
-		IL_01da: ldstr "length"
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e4: br IL_01ff
+		IL_0113: ldloc.s 4
+		IL_0115: ldstr "byteLength"
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011f: br IL_013a
 
-		IL_01e9: ldloc.s 8
-		IL_01eb: ldstr "length"
-		IL_01f0: ldstr "Require_Crypto_WebCrypto_GetRandomValues:Modules.Require_Crypto_WebCrypto_GetRandomValues:__js_module_init__:79"
-		IL_01f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0124: ldloc.s 4
+		IL_0126: ldstr "byteLength"
+		IL_012b: ldstr "Require_Crypto_WebCrypto_GetRandomValues:Modules.Require_Crypto_WebCrypto_GetRandomValues:__js_module_init__:48"
+		IL_0130: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01ff: stloc.s 8
-		IL_0201: ldloc.s 9
-		IL_0203: ldstr "buffer hex length:"
-		IL_0208: ldloc.s 8
-		IL_020a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_020f: pop
-		IL_0210: ret
+		IL_013a: stloc.s 8
+		IL_013c: ldloc.s 9
+		IL_013e: ldstr "int32 byteLength:"
+		IL_0143: ldloc.s 8
+		IL_0145: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_014a: pop
+		IL_014b: ldc.r8 6
+		IL_0154: box [System.Runtime]System.Double
+		IL_0159: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::alloc(object)
+		IL_015e: stloc.s 6
+		IL_0160: ldloc.1
+		IL_0161: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::get_webcrypto()
+		IL_0166: stloc.s 8
+		IL_0168: ldloc.s 8
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016f: volatile.
+		IL_0171: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0176: brfalse IL_018c
+
+		IL_017b: ldstr "getRandomValues"
+		IL_0180: ldloc.s 6
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0187: br IL_01a2
+
+		IL_018c: ldstr "getRandomValues"
+		IL_0191: ldloc.s 6
+		IL_0193: ldstr "Require_Crypto_WebCrypto_GetRandomValues:Modules.Require_Crypto_WebCrypto_GetRandomValues:__js_module_init__:58"
+		IL_0198: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01a2: stloc.s 7
+		IL_01a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a9: stloc.s 9
+		IL_01ab: ldloc.s 7
+		IL_01ad: ldloc.s 6
+		IL_01af: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01b4: stloc.s 10
+		IL_01b6: ldloc.s 10
+		IL_01b8: box [System.Runtime]System.Boolean
+		IL_01bd: stloc.s 11
+		IL_01bf: ldloc.s 9
+		IL_01c1: ldstr "same buffer:"
+		IL_01c6: ldloc.s 11
+		IL_01c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01cd: pop
+		IL_01ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01d3: stloc.s 9
+		IL_01d5: ldloc.s 6
+		IL_01d7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::get_length()
+		IL_01dc: stloc.s 12
+		IL_01de: ldloc.s 12
+		IL_01e0: box [System.Runtime]System.Double
+		IL_01e5: stloc.s 13
+		IL_01e7: ldloc.s 9
+		IL_01e9: ldstr "buffer length:"
+		IL_01ee: ldloc.s 13
+		IL_01f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01f5: pop
+		IL_01f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01fb: stloc.s 9
+		IL_01fd: ldloc.s 6
+		IL_01ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+		IL_0204: stloc.s 14
+		IL_0206: volatile.
+		IL_0208: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_020d: brfalse IL_0228
+
+		IL_0212: ldloc.s 14
+		IL_0214: ldstr "toString"
+		IL_0219: ldstr "hex"
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0223: br IL_0243
+
+		IL_0228: ldloc.s 14
+		IL_022a: ldstr "toString"
+		IL_022f: ldstr "hex"
+		IL_0234: ldstr "Require_Crypto_WebCrypto_GetRandomValues:Modules.Require_Crypto_WebCrypto_GetRandomValues:__js_module_init__:77"
+		IL_0239: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0243: stloc.s 8
+		IL_0245: volatile.
+		IL_0247: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_024c: brfalse IL_0262
+
+		IL_0251: ldloc.s 8
+		IL_0253: ldstr "length"
+		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_025d: br IL_0278
+
+		IL_0262: ldloc.s 8
+		IL_0264: ldstr "length"
+		IL_0269: ldstr "Require_Crypto_WebCrypto_GetRandomValues:Modules.Require_Crypto_WebCrypto_GetRandomValues:__js_module_init__:79"
+		IL_026e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0278: stloc.s 8
+		IL_027a: ldloc.s 9
+		IL_027c: ldstr "buffer hex length:"
+		IL_0281: ldloc.s 8
+		IL_0283: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0288: pop
+		IL_0289: ret
 	} // end of method Require_Crypto_WebCrypto_GetRandomValues::__js_module_init__
 
 } // end of class Modules.Require_Crypto_WebCrypto_GetRandomValues
@@ -318,6 +355,9 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
@@ -203,7 +203,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 3097 (0xc19)
+			// Code size: 3361 (0xd21)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Require_Crypto_WebCrypto_Subtle/run/Scope,
@@ -344,7 +344,7 @@
 
 			IL_00fc: ldloc.0
 			IL_00fd: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0102: switch (IL_012b, IL_021d, IL_0364, IL_045f, IL_055a, IL_06b1, IL_0993, IL_0a99, IL_0bd7)
+			IL_0102: switch (IL_012b, IL_021d, IL_0390, IL_04b7, IL_05de, IL_0761, IL_0a6f, IL_0ba1, IL_0cdf)
 
 			IL_012b: ldarg.0
 			IL_012c: ldc.i4.1
@@ -356,7 +356,7 @@
 			IL_013c: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::get_webcrypto()
 			IL_0141: stloc.s 9
 			IL_0143: volatile.
-			IL_0145: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0145: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_014a: brfalse IL_0160
 
 			IL_014f: ldloc.s 9
@@ -367,7 +367,7 @@
 			IL_0160: ldloc.s 9
 			IL_0162: ldstr "subtle"
 			IL_0167: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:5"
-			IL_016c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_016c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0176: stloc.1
@@ -471,7 +471,7 @@
 			IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0230: stloc.s 11
 			IL_0232: volatile.
-			IL_0234: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0234: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_0239: brfalse IL_024e
 
 			IL_023e: ldloc.2
@@ -482,7 +482,7 @@
 			IL_024e: ldloc.2
 			IL_024f: ldstr "byteLength"
 			IL_0254: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:22"
-			IL_0259: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0259: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0263: stloc.s 9
@@ -502,1040 +502,1118 @@
 			IL_028c: ldloc.s 10
 			IL_028e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 			IL_0293: stloc.s 10
-			IL_0295: ldloc.s 10
-			IL_0297: ldstr "toString"
-			IL_029c: ldstr "hex"
-			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02a6: stloc.s 9
-			IL_02a8: ldloc.s 11
-			IL_02aa: ldstr "digest hex:"
-			IL_02af: ldloc.s 9
-			IL_02b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_02b6: pop
-			IL_02b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02bc: stloc.s 11
-			IL_02be: ldloc.1
-			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02c4: stloc.s 9
-			IL_02c6: ldstr "abc"
-			IL_02cb: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_02d0: stloc.s 10
-			IL_02d2: ldloc.s 9
-			IL_02d4: ldstr "digest"
-			IL_02d9: ldstr "SHA-1"
-			IL_02de: ldloc.s 10
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_02e5: stloc.s 9
-			IL_02e7: ldloc.0
-			IL_02e8: ldc.i4.2
-			IL_02e9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02ee: ldloc.0
-			IL_02ef: ldloc.s 9
-			IL_02f1: ldarg.0
-			IL_02f2: ldc.i4.2
-			IL_02f3: ldloc.0
-			IL_02f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_02fe: ldloc.0
-			IL_02ff: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0304: dup
-			IL_0305: ldc.i4.0
-			IL_0306: ldloc.1
-			IL_0307: stelem.ref
-			IL_0308: dup
-			IL_0309: ldc.i4.1
-			IL_030a: ldloc.2
-			IL_030b: stelem.ref
-			IL_030c: dup
-			IL_030d: ldc.i4.2
-			IL_030e: ldloc.3
-			IL_030f: stelem.ref
-			IL_0310: dup
-			IL_0311: ldc.i4.3
-			IL_0312: ldloc.s 4
-			IL_0314: stelem.ref
-			IL_0315: dup
-			IL_0316: ldc.i4.4
-			IL_0317: ldloc.s 5
-			IL_0319: stelem.ref
-			IL_031a: dup
-			IL_031b: ldc.i4.5
-			IL_031c: ldloc.s 6
-			IL_031e: stelem.ref
-			IL_031f: dup
-			IL_0320: ldc.i4.6
-			IL_0321: ldloc.s 7
-			IL_0323: stelem.ref
-			IL_0324: dup
-			IL_0325: ldc.i4.7
-			IL_0326: ldloc.s 8
-			IL_0328: stelem.ref
-			IL_0329: dup
-			IL_032a: ldc.i4.8
-			IL_032b: ldloc.s 9
-			IL_032d: stelem.ref
-			IL_032e: dup
-			IL_032f: ldc.i4.s 9
-			IL_0331: ldloc.s 10
+			IL_0295: volatile.
+			IL_0297: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_029c: brfalse IL_02b7
+
+			IL_02a1: ldloc.s 10
+			IL_02a3: ldstr "toString"
+			IL_02a8: ldstr "hex"
+			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02b2: br IL_02d2
+
+			IL_02b7: ldloc.s 10
+			IL_02b9: ldstr "toString"
+			IL_02be: ldstr "hex"
+			IL_02c3: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:31"
+			IL_02c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_02d2: stloc.s 9
+			IL_02d4: ldloc.s 11
+			IL_02d6: ldstr "digest hex:"
+			IL_02db: ldloc.s 9
+			IL_02dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_02e2: pop
+			IL_02e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02e8: stloc.s 11
+			IL_02ea: ldloc.1
+			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02f0: stloc.s 9
+			IL_02f2: ldstr "abc"
+			IL_02f7: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_02fc: stloc.s 10
+			IL_02fe: ldloc.s 9
+			IL_0300: ldstr "digest"
+			IL_0305: ldstr "SHA-1"
+			IL_030a: ldloc.s 10
+			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0311: stloc.s 9
+			IL_0313: ldloc.0
+			IL_0314: ldc.i4.2
+			IL_0315: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_031a: ldloc.0
+			IL_031b: ldloc.s 9
+			IL_031d: ldarg.0
+			IL_031e: ldc.i4.2
+			IL_031f: ldloc.0
+			IL_0320: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0325: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_032a: ldloc.0
+			IL_032b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0330: dup
+			IL_0331: ldc.i4.0
+			IL_0332: ldloc.1
 			IL_0333: stelem.ref
 			IL_0334: dup
-			IL_0335: ldc.i4.s 10
-			IL_0337: ldloc.s 11
-			IL_0339: stelem.ref
-			IL_033a: dup
-			IL_033b: ldc.i4.s 11
-			IL_033d: ldloc.s 12
-			IL_033f: stelem.ref
-			IL_0340: dup
-			IL_0341: ldc.i4.s 12
-			IL_0343: ldloc.s 13
+			IL_0335: ldc.i4.1
+			IL_0336: ldloc.2
+			IL_0337: stelem.ref
+			IL_0338: dup
+			IL_0339: ldc.i4.2
+			IL_033a: ldloc.3
+			IL_033b: stelem.ref
+			IL_033c: dup
+			IL_033d: ldc.i4.3
+			IL_033e: ldloc.s 4
+			IL_0340: stelem.ref
+			IL_0341: dup
+			IL_0342: ldc.i4.4
+			IL_0343: ldloc.s 5
 			IL_0345: stelem.ref
 			IL_0346: dup
-			IL_0347: ldc.i4.s 13
-			IL_0349: ldloc.s 14
-			IL_034b: stelem.ref
-			IL_034c: dup
-			IL_034d: ldc.i4.s 14
-			IL_034f: ldloc.s 15
-			IL_0351: box [System.Runtime]System.Double
-			IL_0356: stelem.ref
-			IL_0357: pop
-			IL_0358: ldloc.0
-			IL_0359: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_035e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0363: ret
+			IL_0347: ldc.i4.5
+			IL_0348: ldloc.s 6
+			IL_034a: stelem.ref
+			IL_034b: dup
+			IL_034c: ldc.i4.6
+			IL_034d: ldloc.s 7
+			IL_034f: stelem.ref
+			IL_0350: dup
+			IL_0351: ldc.i4.7
+			IL_0352: ldloc.s 8
+			IL_0354: stelem.ref
+			IL_0355: dup
+			IL_0356: ldc.i4.8
+			IL_0357: ldloc.s 9
+			IL_0359: stelem.ref
+			IL_035a: dup
+			IL_035b: ldc.i4.s 9
+			IL_035d: ldloc.s 10
+			IL_035f: stelem.ref
+			IL_0360: dup
+			IL_0361: ldc.i4.s 10
+			IL_0363: ldloc.s 11
+			IL_0365: stelem.ref
+			IL_0366: dup
+			IL_0367: ldc.i4.s 11
+			IL_0369: ldloc.s 12
+			IL_036b: stelem.ref
+			IL_036c: dup
+			IL_036d: ldc.i4.s 12
+			IL_036f: ldloc.s 13
+			IL_0371: stelem.ref
+			IL_0372: dup
+			IL_0373: ldc.i4.s 13
+			IL_0375: ldloc.s 14
+			IL_0377: stelem.ref
+			IL_0378: dup
+			IL_0379: ldc.i4.s 14
+			IL_037b: ldloc.s 15
+			IL_037d: box [System.Runtime]System.Double
+			IL_0382: stelem.ref
+			IL_0383: pop
+			IL_0384: ldloc.0
+			IL_0385: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_038a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_038f: ret
 
-			IL_0364: ldloc.0
-			IL_0365: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited2
-			IL_036a: stloc.s 9
-			IL_036c: ldloc.s 9
-			IL_036e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_0373: stloc.s 13
-			IL_0375: ldloc.s 13
-			IL_0377: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_037c: stloc.s 12
-			IL_037e: ldloc.s 12
-			IL_0380: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0385: stloc.s 10
-			IL_0387: ldloc.s 10
-			IL_0389: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-			IL_038e: stloc.s 10
-			IL_0390: ldloc.s 10
-			IL_0392: ldstr "toString"
-			IL_0397: ldstr "hex"
-			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03a1: stloc.s 9
-			IL_03a3: ldloc.s 11
-			IL_03a5: ldstr "digest sha1 hex:"
-			IL_03aa: ldloc.s 9
-			IL_03ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_03b1: pop
-			IL_03b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03b7: stloc.s 11
-			IL_03b9: ldloc.1
-			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03bf: stloc.s 9
-			IL_03c1: ldstr "abc"
-			IL_03c6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_03cb: stloc.s 10
-			IL_03cd: ldloc.s 9
-			IL_03cf: ldstr "digest"
-			IL_03d4: ldstr "SHA-384"
-			IL_03d9: ldloc.s 10
-			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_03e0: stloc.s 9
-			IL_03e2: ldloc.0
-			IL_03e3: ldc.i4.3
-			IL_03e4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03e9: ldloc.0
-			IL_03ea: ldloc.s 9
-			IL_03ec: ldarg.0
-			IL_03ed: ldc.i4.3
-			IL_03ee: ldloc.0
-			IL_03ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_03f9: ldloc.0
-			IL_03fa: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03ff: dup
-			IL_0400: ldc.i4.0
-			IL_0401: ldloc.1
-			IL_0402: stelem.ref
-			IL_0403: dup
-			IL_0404: ldc.i4.1
-			IL_0405: ldloc.2
-			IL_0406: stelem.ref
-			IL_0407: dup
-			IL_0408: ldc.i4.2
-			IL_0409: ldloc.3
-			IL_040a: stelem.ref
-			IL_040b: dup
-			IL_040c: ldc.i4.3
-			IL_040d: ldloc.s 4
-			IL_040f: stelem.ref
-			IL_0410: dup
-			IL_0411: ldc.i4.4
-			IL_0412: ldloc.s 5
-			IL_0414: stelem.ref
-			IL_0415: dup
-			IL_0416: ldc.i4.5
-			IL_0417: ldloc.s 6
-			IL_0419: stelem.ref
-			IL_041a: dup
-			IL_041b: ldc.i4.6
-			IL_041c: ldloc.s 7
-			IL_041e: stelem.ref
-			IL_041f: dup
-			IL_0420: ldc.i4.7
-			IL_0421: ldloc.s 8
-			IL_0423: stelem.ref
-			IL_0424: dup
-			IL_0425: ldc.i4.8
-			IL_0426: ldloc.s 9
-			IL_0428: stelem.ref
-			IL_0429: dup
-			IL_042a: ldc.i4.s 9
-			IL_042c: ldloc.s 10
-			IL_042e: stelem.ref
-			IL_042f: dup
-			IL_0430: ldc.i4.s 10
-			IL_0432: ldloc.s 11
-			IL_0434: stelem.ref
-			IL_0435: dup
-			IL_0436: ldc.i4.s 11
-			IL_0438: ldloc.s 12
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.s 12
-			IL_043e: ldloc.s 13
-			IL_0440: stelem.ref
-			IL_0441: dup
-			IL_0442: ldc.i4.s 13
-			IL_0444: ldloc.s 14
-			IL_0446: stelem.ref
-			IL_0447: dup
-			IL_0448: ldc.i4.s 14
-			IL_044a: ldloc.s 15
-			IL_044c: box [System.Runtime]System.Double
-			IL_0451: stelem.ref
-			IL_0452: pop
-			IL_0453: ldloc.0
-			IL_0454: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0459: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_045e: ret
+			IL_0390: ldloc.0
+			IL_0391: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited2
+			IL_0396: stloc.s 9
+			IL_0398: ldloc.s 9
+			IL_039a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_039f: stloc.s 13
+			IL_03a1: ldloc.s 13
+			IL_03a3: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_03a8: stloc.s 12
+			IL_03aa: ldloc.s 12
+			IL_03ac: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_03b1: stloc.s 10
+			IL_03b3: ldloc.s 10
+			IL_03b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_03ba: stloc.s 10
+			IL_03bc: volatile.
+			IL_03be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_03c3: brfalse IL_03de
 
-			IL_045f: ldloc.0
-			IL_0460: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited3
-			IL_0465: stloc.s 9
-			IL_0467: ldloc.s 9
-			IL_0469: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_046e: stloc.s 13
-			IL_0470: ldloc.s 13
-			IL_0472: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0477: stloc.s 12
-			IL_0479: ldloc.s 12
-			IL_047b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0480: stloc.s 10
-			IL_0482: ldloc.s 10
-			IL_0484: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-			IL_0489: stloc.s 10
-			IL_048b: ldloc.s 10
-			IL_048d: ldstr "toString"
-			IL_0492: ldstr "hex"
-			IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_049c: stloc.s 9
-			IL_049e: ldloc.s 11
-			IL_04a0: ldstr "digest sha384 hex:"
-			IL_04a5: ldloc.s 9
-			IL_04a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_04ac: pop
-			IL_04ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04b2: stloc.s 11
-			IL_04b4: ldloc.1
-			IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04ba: stloc.s 9
-			IL_04bc: ldstr "abc"
-			IL_04c1: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_04c6: stloc.s 10
-			IL_04c8: ldloc.s 9
-			IL_04ca: ldstr "digest"
-			IL_04cf: ldstr "SHA-512"
-			IL_04d4: ldloc.s 10
-			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_04db: stloc.s 9
-			IL_04dd: ldloc.0
-			IL_04de: ldc.i4.4
-			IL_04df: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04e4: ldloc.0
-			IL_04e5: ldloc.s 9
-			IL_04e7: ldarg.0
-			IL_04e8: ldc.i4.4
-			IL_04e9: ldloc.0
-			IL_04ea: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_04ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_04f4: ldloc.0
-			IL_04f5: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_04fa: dup
-			IL_04fb: ldc.i4.0
-			IL_04fc: ldloc.1
-			IL_04fd: stelem.ref
-			IL_04fe: dup
-			IL_04ff: ldc.i4.1
-			IL_0500: ldloc.2
-			IL_0501: stelem.ref
-			IL_0502: dup
-			IL_0503: ldc.i4.2
-			IL_0504: ldloc.3
-			IL_0505: stelem.ref
-			IL_0506: dup
-			IL_0507: ldc.i4.3
-			IL_0508: ldloc.s 4
-			IL_050a: stelem.ref
-			IL_050b: dup
-			IL_050c: ldc.i4.4
-			IL_050d: ldloc.s 5
-			IL_050f: stelem.ref
-			IL_0510: dup
-			IL_0511: ldc.i4.5
-			IL_0512: ldloc.s 6
-			IL_0514: stelem.ref
-			IL_0515: dup
-			IL_0516: ldc.i4.6
-			IL_0517: ldloc.s 7
-			IL_0519: stelem.ref
-			IL_051a: dup
-			IL_051b: ldc.i4.7
-			IL_051c: ldloc.s 8
-			IL_051e: stelem.ref
-			IL_051f: dup
-			IL_0520: ldc.i4.8
-			IL_0521: ldloc.s 9
-			IL_0523: stelem.ref
-			IL_0524: dup
-			IL_0525: ldc.i4.s 9
-			IL_0527: ldloc.s 10
-			IL_0529: stelem.ref
-			IL_052a: dup
-			IL_052b: ldc.i4.s 10
-			IL_052d: ldloc.s 11
-			IL_052f: stelem.ref
-			IL_0530: dup
-			IL_0531: ldc.i4.s 11
-			IL_0533: ldloc.s 12
-			IL_0535: stelem.ref
-			IL_0536: dup
-			IL_0537: ldc.i4.s 12
-			IL_0539: ldloc.s 13
-			IL_053b: stelem.ref
-			IL_053c: dup
-			IL_053d: ldc.i4.s 13
-			IL_053f: ldloc.s 14
-			IL_0541: stelem.ref
-			IL_0542: dup
-			IL_0543: ldc.i4.s 14
-			IL_0545: ldloc.s 15
-			IL_0547: box [System.Runtime]System.Double
-			IL_054c: stelem.ref
-			IL_054d: pop
-			IL_054e: ldloc.0
-			IL_054f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0554: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0559: ret
+			IL_03c8: ldloc.s 10
+			IL_03ca: ldstr "toString"
+			IL_03cf: ldstr "hex"
+			IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03d9: br IL_03f9
 
-			IL_055a: ldloc.0
-			IL_055b: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited4
-			IL_0560: stloc.s 9
-			IL_0562: ldloc.s 9
-			IL_0564: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_0569: stloc.s 13
-			IL_056b: ldloc.s 13
-			IL_056d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0572: stloc.s 12
-			IL_0574: ldloc.s 12
-			IL_0576: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_057b: stloc.s 10
-			IL_057d: ldloc.s 10
-			IL_057f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-			IL_0584: stloc.s 10
-			IL_0586: ldloc.s 10
-			IL_0588: ldstr "toString"
-			IL_058d: ldstr "hex"
-			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0597: stloc.s 9
-			IL_0599: ldloc.s 11
-			IL_059b: ldstr "digest sha512 hex:"
-			IL_05a0: ldloc.s 9
-			IL_05a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_05a7: pop
-			IL_05a8: ldloc.1
-			IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ae: stloc.s 9
-			IL_05b0: ldstr "key"
-			IL_05b5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_05ba: stloc.s 10
-			IL_05bc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05c1: dup
-			IL_05c2: ldstr "name"
-			IL_05c7: ldstr "HMAC"
-			IL_05cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05d1: dup
-			IL_05d2: ldstr "hash"
-			IL_05d7: ldstr "SHA-256"
-			IL_05dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05e1: dup
-			IL_05e2: ldstr "length"
-			IL_05e7: ldc.r8 24
-			IL_05f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_05f5: stloc.s 14
-			IL_05f7: ldc.i4.2
-			IL_05f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_05fd: dup
-			IL_05fe: ldstr "sign"
-			IL_0603: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0608: dup
-			IL_0609: ldstr "verify"
-			IL_060e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0613: stloc.s 12
-			IL_0615: ldloc.s 9
-			IL_0617: ldstr "importKey"
-			IL_061c: ldstr "raw"
-			IL_0621: ldloc.s 10
-			IL_0623: ldloc.s 14
-			IL_0625: ldc.i4.0
-			IL_0626: box [System.Runtime]System.Boolean
-			IL_062b: ldloc.s 12
-			IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember5(object, string, object, object, object, object, object)
-			IL_0632: stloc.s 9
-			IL_0634: ldloc.0
-			IL_0635: ldc.i4.5
-			IL_0636: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_063b: ldloc.0
-			IL_063c: ldloc.s 9
-			IL_063e: ldarg.0
-			IL_063f: ldc.i4.5
-			IL_0640: ldloc.0
-			IL_0641: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0646: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_064b: ldloc.0
-			IL_064c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0651: dup
-			IL_0652: ldc.i4.0
-			IL_0653: ldloc.1
-			IL_0654: stelem.ref
-			IL_0655: dup
-			IL_0656: ldc.i4.1
-			IL_0657: ldloc.2
-			IL_0658: stelem.ref
-			IL_0659: dup
-			IL_065a: ldc.i4.2
-			IL_065b: ldloc.3
-			IL_065c: stelem.ref
-			IL_065d: dup
-			IL_065e: ldc.i4.3
-			IL_065f: ldloc.s 4
-			IL_0661: stelem.ref
-			IL_0662: dup
-			IL_0663: ldc.i4.4
-			IL_0664: ldloc.s 5
-			IL_0666: stelem.ref
-			IL_0667: dup
-			IL_0668: ldc.i4.5
-			IL_0669: ldloc.s 6
-			IL_066b: stelem.ref
-			IL_066c: dup
-			IL_066d: ldc.i4.6
-			IL_066e: ldloc.s 7
-			IL_0670: stelem.ref
+			IL_03de: ldloc.s 10
+			IL_03e0: ldstr "toString"
+			IL_03e5: ldstr "hex"
+			IL_03ea: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:47"
+			IL_03ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_03f9: stloc.s 9
+			IL_03fb: ldloc.s 11
+			IL_03fd: ldstr "digest sha1 hex:"
+			IL_0402: ldloc.s 9
+			IL_0404: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0409: pop
+			IL_040a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_040f: stloc.s 11
+			IL_0411: ldloc.1
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0417: stloc.s 9
+			IL_0419: ldstr "abc"
+			IL_041e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0423: stloc.s 10
+			IL_0425: ldloc.s 9
+			IL_0427: ldstr "digest"
+			IL_042c: ldstr "SHA-384"
+			IL_0431: ldloc.s 10
+			IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0438: stloc.s 9
+			IL_043a: ldloc.0
+			IL_043b: ldc.i4.3
+			IL_043c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0441: ldloc.0
+			IL_0442: ldloc.s 9
+			IL_0444: ldarg.0
+			IL_0445: ldc.i4.3
+			IL_0446: ldloc.0
+			IL_0447: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_044c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0451: ldloc.0
+			IL_0452: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0457: dup
+			IL_0458: ldc.i4.0
+			IL_0459: ldloc.1
+			IL_045a: stelem.ref
+			IL_045b: dup
+			IL_045c: ldc.i4.1
+			IL_045d: ldloc.2
+			IL_045e: stelem.ref
+			IL_045f: dup
+			IL_0460: ldc.i4.2
+			IL_0461: ldloc.3
+			IL_0462: stelem.ref
+			IL_0463: dup
+			IL_0464: ldc.i4.3
+			IL_0465: ldloc.s 4
+			IL_0467: stelem.ref
+			IL_0468: dup
+			IL_0469: ldc.i4.4
+			IL_046a: ldloc.s 5
+			IL_046c: stelem.ref
+			IL_046d: dup
+			IL_046e: ldc.i4.5
+			IL_046f: ldloc.s 6
+			IL_0471: stelem.ref
+			IL_0472: dup
+			IL_0473: ldc.i4.6
+			IL_0474: ldloc.s 7
+			IL_0476: stelem.ref
+			IL_0477: dup
+			IL_0478: ldc.i4.7
+			IL_0479: ldloc.s 8
+			IL_047b: stelem.ref
+			IL_047c: dup
+			IL_047d: ldc.i4.8
+			IL_047e: ldloc.s 9
+			IL_0480: stelem.ref
+			IL_0481: dup
+			IL_0482: ldc.i4.s 9
+			IL_0484: ldloc.s 10
+			IL_0486: stelem.ref
+			IL_0487: dup
+			IL_0488: ldc.i4.s 10
+			IL_048a: ldloc.s 11
+			IL_048c: stelem.ref
+			IL_048d: dup
+			IL_048e: ldc.i4.s 11
+			IL_0490: ldloc.s 12
+			IL_0492: stelem.ref
+			IL_0493: dup
+			IL_0494: ldc.i4.s 12
+			IL_0496: ldloc.s 13
+			IL_0498: stelem.ref
+			IL_0499: dup
+			IL_049a: ldc.i4.s 13
+			IL_049c: ldloc.s 14
+			IL_049e: stelem.ref
+			IL_049f: dup
+			IL_04a0: ldc.i4.s 14
+			IL_04a2: ldloc.s 15
+			IL_04a4: box [System.Runtime]System.Double
+			IL_04a9: stelem.ref
+			IL_04aa: pop
+			IL_04ab: ldloc.0
+			IL_04ac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04b1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04b6: ret
+
+			IL_04b7: ldloc.0
+			IL_04b8: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited3
+			IL_04bd: stloc.s 9
+			IL_04bf: ldloc.s 9
+			IL_04c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_04c6: stloc.s 13
+			IL_04c8: ldloc.s 13
+			IL_04ca: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_04cf: stloc.s 12
+			IL_04d1: ldloc.s 12
+			IL_04d3: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_04d8: stloc.s 10
+			IL_04da: ldloc.s 10
+			IL_04dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_04e1: stloc.s 10
+			IL_04e3: volatile.
+			IL_04e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_04ea: brfalse IL_0505
+
+			IL_04ef: ldloc.s 10
+			IL_04f1: ldstr "toString"
+			IL_04f6: ldstr "hex"
+			IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0500: br IL_0520
+
+			IL_0505: ldloc.s 10
+			IL_0507: ldstr "toString"
+			IL_050c: ldstr "hex"
+			IL_0511: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:63"
+			IL_0516: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0520: stloc.s 9
+			IL_0522: ldloc.s 11
+			IL_0524: ldstr "digest sha384 hex:"
+			IL_0529: ldloc.s 9
+			IL_052b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0530: pop
+			IL_0531: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0536: stloc.s 11
+			IL_0538: ldloc.1
+			IL_0539: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_053e: stloc.s 9
+			IL_0540: ldstr "abc"
+			IL_0545: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_054a: stloc.s 10
+			IL_054c: ldloc.s 9
+			IL_054e: ldstr "digest"
+			IL_0553: ldstr "SHA-512"
+			IL_0558: ldloc.s 10
+			IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_055f: stloc.s 9
+			IL_0561: ldloc.0
+			IL_0562: ldc.i4.4
+			IL_0563: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0568: ldloc.0
+			IL_0569: ldloc.s 9
+			IL_056b: ldarg.0
+			IL_056c: ldc.i4.4
+			IL_056d: ldloc.0
+			IL_056e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0573: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0578: ldloc.0
+			IL_0579: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_057e: dup
+			IL_057f: ldc.i4.0
+			IL_0580: ldloc.1
+			IL_0581: stelem.ref
+			IL_0582: dup
+			IL_0583: ldc.i4.1
+			IL_0584: ldloc.2
+			IL_0585: stelem.ref
+			IL_0586: dup
+			IL_0587: ldc.i4.2
+			IL_0588: ldloc.3
+			IL_0589: stelem.ref
+			IL_058a: dup
+			IL_058b: ldc.i4.3
+			IL_058c: ldloc.s 4
+			IL_058e: stelem.ref
+			IL_058f: dup
+			IL_0590: ldc.i4.4
+			IL_0591: ldloc.s 5
+			IL_0593: stelem.ref
+			IL_0594: dup
+			IL_0595: ldc.i4.5
+			IL_0596: ldloc.s 6
+			IL_0598: stelem.ref
+			IL_0599: dup
+			IL_059a: ldc.i4.6
+			IL_059b: ldloc.s 7
+			IL_059d: stelem.ref
+			IL_059e: dup
+			IL_059f: ldc.i4.7
+			IL_05a0: ldloc.s 8
+			IL_05a2: stelem.ref
+			IL_05a3: dup
+			IL_05a4: ldc.i4.8
+			IL_05a5: ldloc.s 9
+			IL_05a7: stelem.ref
+			IL_05a8: dup
+			IL_05a9: ldc.i4.s 9
+			IL_05ab: ldloc.s 10
+			IL_05ad: stelem.ref
+			IL_05ae: dup
+			IL_05af: ldc.i4.s 10
+			IL_05b1: ldloc.s 11
+			IL_05b3: stelem.ref
+			IL_05b4: dup
+			IL_05b5: ldc.i4.s 11
+			IL_05b7: ldloc.s 12
+			IL_05b9: stelem.ref
+			IL_05ba: dup
+			IL_05bb: ldc.i4.s 12
+			IL_05bd: ldloc.s 13
+			IL_05bf: stelem.ref
+			IL_05c0: dup
+			IL_05c1: ldc.i4.s 13
+			IL_05c3: ldloc.s 14
+			IL_05c5: stelem.ref
+			IL_05c6: dup
+			IL_05c7: ldc.i4.s 14
+			IL_05c9: ldloc.s 15
+			IL_05cb: box [System.Runtime]System.Double
+			IL_05d0: stelem.ref
+			IL_05d1: pop
+			IL_05d2: ldloc.0
+			IL_05d3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05d8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05dd: ret
+
+			IL_05de: ldloc.0
+			IL_05df: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited4
+			IL_05e4: stloc.s 9
+			IL_05e6: ldloc.s 9
+			IL_05e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_05ed: stloc.s 13
+			IL_05ef: ldloc.s 13
+			IL_05f1: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_05f6: stloc.s 12
+			IL_05f8: ldloc.s 12
+			IL_05fa: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_05ff: stloc.s 10
+			IL_0601: ldloc.s 10
+			IL_0603: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_0608: stloc.s 10
+			IL_060a: volatile.
+			IL_060c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0611: brfalse IL_062c
+
+			IL_0616: ldloc.s 10
+			IL_0618: ldstr "toString"
+			IL_061d: ldstr "hex"
+			IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0627: br IL_0647
+
+			IL_062c: ldloc.s 10
+			IL_062e: ldstr "toString"
+			IL_0633: ldstr "hex"
+			IL_0638: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:79"
+			IL_063d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0647: stloc.s 9
+			IL_0649: ldloc.s 11
+			IL_064b: ldstr "digest sha512 hex:"
+			IL_0650: ldloc.s 9
+			IL_0652: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0657: pop
+			IL_0658: ldloc.1
+			IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_065e: stloc.s 9
+			IL_0660: ldstr "key"
+			IL_0665: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_066a: stloc.s 10
+			IL_066c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0671: dup
-			IL_0672: ldc.i4.7
-			IL_0673: ldloc.s 8
-			IL_0675: stelem.ref
-			IL_0676: dup
-			IL_0677: ldc.i4.8
-			IL_0678: ldloc.s 9
-			IL_067a: stelem.ref
-			IL_067b: dup
-			IL_067c: ldc.i4.s 9
-			IL_067e: ldloc.s 10
-			IL_0680: stelem.ref
+			IL_0672: ldstr "name"
+			IL_0677: ldstr "HMAC"
+			IL_067c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0681: dup
-			IL_0682: ldc.i4.s 10
-			IL_0684: ldloc.s 11
-			IL_0686: stelem.ref
-			IL_0687: dup
-			IL_0688: ldc.i4.s 11
-			IL_068a: ldloc.s 12
-			IL_068c: stelem.ref
-			IL_068d: dup
-			IL_068e: ldc.i4.s 12
-			IL_0690: ldloc.s 13
-			IL_0692: stelem.ref
-			IL_0693: dup
-			IL_0694: ldc.i4.s 13
-			IL_0696: ldloc.s 14
-			IL_0698: stelem.ref
-			IL_0699: dup
-			IL_069a: ldc.i4.s 14
-			IL_069c: ldloc.s 15
-			IL_069e: box [System.Runtime]System.Double
-			IL_06a3: stelem.ref
-			IL_06a4: pop
-			IL_06a5: ldloc.0
-			IL_06a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06ab: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06b0: ret
+			IL_0682: ldstr "hash"
+			IL_0687: ldstr "SHA-256"
+			IL_068c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0691: dup
+			IL_0692: ldstr "length"
+			IL_0697: ldc.r8 24
+			IL_06a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_06a5: stloc.s 14
+			IL_06a7: ldc.i4.2
+			IL_06a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_06ad: dup
+			IL_06ae: ldstr "sign"
+			IL_06b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_06b8: dup
+			IL_06b9: ldstr "verify"
+			IL_06be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_06c3: stloc.s 12
+			IL_06c5: ldloc.s 9
+			IL_06c7: ldstr "importKey"
+			IL_06cc: ldstr "raw"
+			IL_06d1: ldloc.s 10
+			IL_06d3: ldloc.s 14
+			IL_06d5: ldc.i4.0
+			IL_06d6: box [System.Runtime]System.Boolean
+			IL_06db: ldloc.s 12
+			IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember5(object, string, object, object, object, object, object)
+			IL_06e2: stloc.s 9
+			IL_06e4: ldloc.0
+			IL_06e5: ldc.i4.5
+			IL_06e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06eb: ldloc.0
+			IL_06ec: ldloc.s 9
+			IL_06ee: ldarg.0
+			IL_06ef: ldc.i4.5
+			IL_06f0: ldloc.0
+			IL_06f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_06f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_06fb: ldloc.0
+			IL_06fc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0701: dup
+			IL_0702: ldc.i4.0
+			IL_0703: ldloc.1
+			IL_0704: stelem.ref
+			IL_0705: dup
+			IL_0706: ldc.i4.1
+			IL_0707: ldloc.2
+			IL_0708: stelem.ref
+			IL_0709: dup
+			IL_070a: ldc.i4.2
+			IL_070b: ldloc.3
+			IL_070c: stelem.ref
+			IL_070d: dup
+			IL_070e: ldc.i4.3
+			IL_070f: ldloc.s 4
+			IL_0711: stelem.ref
+			IL_0712: dup
+			IL_0713: ldc.i4.4
+			IL_0714: ldloc.s 5
+			IL_0716: stelem.ref
+			IL_0717: dup
+			IL_0718: ldc.i4.5
+			IL_0719: ldloc.s 6
+			IL_071b: stelem.ref
+			IL_071c: dup
+			IL_071d: ldc.i4.6
+			IL_071e: ldloc.s 7
+			IL_0720: stelem.ref
+			IL_0721: dup
+			IL_0722: ldc.i4.7
+			IL_0723: ldloc.s 8
+			IL_0725: stelem.ref
+			IL_0726: dup
+			IL_0727: ldc.i4.8
+			IL_0728: ldloc.s 9
+			IL_072a: stelem.ref
+			IL_072b: dup
+			IL_072c: ldc.i4.s 9
+			IL_072e: ldloc.s 10
+			IL_0730: stelem.ref
+			IL_0731: dup
+			IL_0732: ldc.i4.s 10
+			IL_0734: ldloc.s 11
+			IL_0736: stelem.ref
+			IL_0737: dup
+			IL_0738: ldc.i4.s 11
+			IL_073a: ldloc.s 12
+			IL_073c: stelem.ref
+			IL_073d: dup
+			IL_073e: ldc.i4.s 12
+			IL_0740: ldloc.s 13
+			IL_0742: stelem.ref
+			IL_0743: dup
+			IL_0744: ldc.i4.s 13
+			IL_0746: ldloc.s 14
+			IL_0748: stelem.ref
+			IL_0749: dup
+			IL_074a: ldc.i4.s 14
+			IL_074c: ldloc.s 15
+			IL_074e: box [System.Runtime]System.Double
+			IL_0753: stelem.ref
+			IL_0754: pop
+			IL_0755: ldloc.0
+			IL_0756: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_075b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0760: ret
 
-			IL_06b1: ldloc.0
-			IL_06b2: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited5
-			IL_06b7: stloc.s 4
-			IL_06b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06be: stloc.s 11
-			IL_06c0: volatile.
-			IL_06c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_06c7: brfalse IL_06dd
+			IL_0761: ldloc.0
+			IL_0762: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited5
+			IL_0767: stloc.s 4
+			IL_0769: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_076e: stloc.s 11
+			IL_0770: volatile.
+			IL_0772: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0777: brfalse IL_078d
 
-			IL_06cc: ldloc.s 4
-			IL_06ce: ldstr "type"
-			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06d8: br IL_06f3
+			IL_077c: ldloc.s 4
+			IL_077e: ldstr "type"
+			IL_0783: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0788: br IL_07a3
 
-			IL_06dd: ldloc.s 4
-			IL_06df: ldstr "type"
-			IL_06e4: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:102"
-			IL_06e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_06ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_078d: ldloc.s 4
+			IL_078f: ldstr "type"
+			IL_0794: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:102"
+			IL_0799: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06f3: stloc.s 9
-			IL_06f5: ldloc.s 11
-			IL_06f7: ldstr "key type:"
-			IL_06fc: ldloc.s 9
-			IL_06fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0703: pop
-			IL_0704: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0709: stloc.s 11
-			IL_070b: volatile.
-			IL_070d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0712: brfalse IL_0728
+			IL_07a3: stloc.s 9
+			IL_07a5: ldloc.s 11
+			IL_07a7: ldstr "key type:"
+			IL_07ac: ldloc.s 9
+			IL_07ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_07b3: pop
+			IL_07b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07b9: stloc.s 11
+			IL_07bb: volatile.
+			IL_07bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_07c2: brfalse IL_07d8
 
-			IL_0717: ldloc.s 4
-			IL_0719: ldstr "algorithm"
-			IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0723: br IL_073e
+			IL_07c7: ldloc.s 4
+			IL_07c9: ldstr "algorithm"
+			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d3: br IL_07ee
 
-			IL_0728: ldloc.s 4
-			IL_072a: ldstr "algorithm"
-			IL_072f: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:108"
-			IL_0734: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07d8: ldloc.s 4
+			IL_07da: ldstr "algorithm"
+			IL_07df: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:108"
+			IL_07e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_07e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_073e: stloc.s 9
-			IL_0740: volatile.
-			IL_0742: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0747: brfalse IL_075d
+			IL_07ee: stloc.s 9
+			IL_07f0: volatile.
+			IL_07f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_07f7: brfalse IL_080d
 
-			IL_074c: ldloc.s 9
-			IL_074e: ldstr "name"
-			IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0758: br IL_0773
+			IL_07fc: ldloc.s 9
+			IL_07fe: ldstr "name"
+			IL_0803: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0808: br IL_0823
 
-			IL_075d: ldloc.s 9
-			IL_075f: ldstr "name"
-			IL_0764: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:110"
-			IL_0769: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_080d: ldloc.s 9
+			IL_080f: ldstr "name"
+			IL_0814: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:110"
+			IL_0819: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_081e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0773: stloc.s 9
-			IL_0775: ldloc.s 11
-			IL_0777: ldstr "key algorithm:"
-			IL_077c: ldloc.s 9
-			IL_077e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0783: pop
-			IL_0784: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0789: stloc.s 11
-			IL_078b: volatile.
-			IL_078d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0792: brfalse IL_07a8
+			IL_0823: stloc.s 9
+			IL_0825: ldloc.s 11
+			IL_0827: ldstr "key algorithm:"
+			IL_082c: ldloc.s 9
+			IL_082e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0833: pop
+			IL_0834: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0839: stloc.s 11
+			IL_083b: volatile.
+			IL_083d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0842: brfalse IL_0858
 
-			IL_0797: ldloc.s 4
-			IL_0799: ldstr "algorithm"
-			IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a3: br IL_07be
+			IL_0847: ldloc.s 4
+			IL_0849: ldstr "algorithm"
+			IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0853: br IL_086e
 
-			IL_07a8: ldloc.s 4
-			IL_07aa: ldstr "algorithm"
-			IL_07af: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:116"
-			IL_07b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0858: ldloc.s 4
+			IL_085a: ldstr "algorithm"
+			IL_085f: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:116"
+			IL_0864: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0869: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07be: stloc.s 9
-			IL_07c0: volatile.
-			IL_07c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_07c7: brfalse IL_07dd
+			IL_086e: stloc.s 9
+			IL_0870: volatile.
+			IL_0872: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0877: brfalse IL_088d
 
-			IL_07cc: ldloc.s 9
-			IL_07ce: ldstr "hash"
-			IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07d8: br IL_07f3
-
-			IL_07dd: ldloc.s 9
-			IL_07df: ldstr "hash"
-			IL_07e4: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:118"
-			IL_07e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_07ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_07f3: stloc.s 9
-			IL_07f5: volatile.
-			IL_07f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_07fc: brfalse IL_0812
-
-			IL_0801: ldloc.s 9
-			IL_0803: ldstr "name"
-			IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_080d: br IL_0828
-
-			IL_0812: ldloc.s 9
-			IL_0814: ldstr "name"
-			IL_0819: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:120"
-			IL_081e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0828: stloc.s 9
-			IL_082a: ldloc.s 11
-			IL_082c: ldstr "key hash:"
-			IL_0831: ldloc.s 9
-			IL_0833: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0838: pop
-			IL_0839: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_083e: stloc.s 11
-			IL_0840: volatile.
-			IL_0842: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_0847: brfalse IL_085d
-
-			IL_084c: ldloc.s 4
-			IL_084e: ldstr "extractable"
-			IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0858: br IL_0873
-
-			IL_085d: ldloc.s 4
-			IL_085f: ldstr "extractable"
-			IL_0864: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:126"
-			IL_0869: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0873: stloc.s 9
-			IL_0875: ldloc.s 11
-			IL_0877: ldstr "key extractable:"
 			IL_087c: ldloc.s 9
-			IL_087e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0883: pop
-			IL_0884: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0889: stloc.s 11
-			IL_088b: volatile.
-			IL_088d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_0892: brfalse IL_08a8
+			IL_087e: ldstr "hash"
+			IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0888: br IL_08a3
 
-			IL_0897: ldloc.s 4
-			IL_0899: ldstr "usages"
-			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a3: br IL_08be
+			IL_088d: ldloc.s 9
+			IL_088f: ldstr "hash"
+			IL_0894: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:118"
+			IL_0899: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08a8: ldloc.s 4
-			IL_08aa: ldstr "usages"
-			IL_08af: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:132"
-			IL_08b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_08b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_08a3: stloc.s 9
+			IL_08a5: volatile.
+			IL_08a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_08ac: brfalse IL_08c2
 
-			IL_08be: stloc.s 9
-			IL_08c0: ldloc.s 9
-			IL_08c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08c7: stloc.s 9
-			IL_08c9: ldloc.s 9
-			IL_08cb: ldstr "join"
-			IL_08d0: ldstr ","
-			IL_08d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_08da: stloc.s 9
-			IL_08dc: ldloc.s 11
-			IL_08de: ldstr "key usages:"
-			IL_08e3: ldloc.s 9
-			IL_08e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_08ea: pop
-			IL_08eb: ldloc.1
-			IL_08ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08f1: stloc.s 9
-			IL_08f3: ldstr "abc"
-			IL_08f8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_08fd: stloc.s 10
-			IL_08ff: ldloc.s 9
-			IL_0901: ldstr "sign"
-			IL_0906: ldstr "HMAC"
-			IL_090b: ldloc.s 4
-			IL_090d: ldloc.s 10
-			IL_090f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0914: stloc.s 9
-			IL_0916: ldloc.0
-			IL_0917: ldc.i4.6
-			IL_0918: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_091d: ldloc.0
-			IL_091e: ldloc.s 9
-			IL_0920: ldarg.0
-			IL_0921: ldc.i4.6
-			IL_0922: ldloc.0
-			IL_0923: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0928: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_092d: ldloc.0
-			IL_092e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0933: dup
-			IL_0934: ldc.i4.0
-			IL_0935: ldloc.1
-			IL_0936: stelem.ref
-			IL_0937: dup
-			IL_0938: ldc.i4.1
-			IL_0939: ldloc.2
-			IL_093a: stelem.ref
-			IL_093b: dup
-			IL_093c: ldc.i4.2
-			IL_093d: ldloc.3
-			IL_093e: stelem.ref
-			IL_093f: dup
-			IL_0940: ldc.i4.3
-			IL_0941: ldloc.s 4
-			IL_0943: stelem.ref
-			IL_0944: dup
-			IL_0945: ldc.i4.4
-			IL_0946: ldloc.s 5
-			IL_0948: stelem.ref
-			IL_0949: dup
-			IL_094a: ldc.i4.5
-			IL_094b: ldloc.s 6
-			IL_094d: stelem.ref
-			IL_094e: dup
-			IL_094f: ldc.i4.6
-			IL_0950: ldloc.s 7
-			IL_0952: stelem.ref
-			IL_0953: dup
-			IL_0954: ldc.i4.7
-			IL_0955: ldloc.s 8
-			IL_0957: stelem.ref
-			IL_0958: dup
-			IL_0959: ldc.i4.8
-			IL_095a: ldloc.s 9
-			IL_095c: stelem.ref
-			IL_095d: dup
-			IL_095e: ldc.i4.s 9
-			IL_0960: ldloc.s 10
-			IL_0962: stelem.ref
-			IL_0963: dup
-			IL_0964: ldc.i4.s 10
-			IL_0966: ldloc.s 11
-			IL_0968: stelem.ref
-			IL_0969: dup
-			IL_096a: ldc.i4.s 11
-			IL_096c: ldloc.s 12
-			IL_096e: stelem.ref
-			IL_096f: dup
-			IL_0970: ldc.i4.s 12
-			IL_0972: ldloc.s 13
-			IL_0974: stelem.ref
-			IL_0975: dup
-			IL_0976: ldc.i4.s 13
-			IL_0978: ldloc.s 14
-			IL_097a: stelem.ref
-			IL_097b: dup
-			IL_097c: ldc.i4.s 14
-			IL_097e: ldloc.s 15
-			IL_0980: box [System.Runtime]System.Double
-			IL_0985: stelem.ref
-			IL_0986: pop
-			IL_0987: ldloc.0
-			IL_0988: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_098d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0992: ret
+			IL_08b1: ldloc.s 9
+			IL_08b3: ldstr "name"
+			IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08bd: br IL_08d8
 
-			IL_0993: ldloc.0
-			IL_0994: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited6
-			IL_0999: stloc.s 5
-			IL_099b: ldloc.s 5
-			IL_099d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-			IL_09a2: stloc.s 6
-			IL_09a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09a9: stloc.s 11
-			IL_09ab: ldloc.s 6
-			IL_09ad: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_09b2: stloc.s 12
-			IL_09b4: ldloc.s 12
-			IL_09b6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_09bb: stloc.s 10
-			IL_09bd: ldloc.s 10
-			IL_09bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-			IL_09c4: stloc.s 10
-			IL_09c6: ldloc.s 10
-			IL_09c8: ldstr "toString"
-			IL_09cd: ldstr "hex"
-			IL_09d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_09d7: stloc.s 9
-			IL_09d9: ldloc.s 11
-			IL_09db: ldstr "signature hex:"
-			IL_09e0: ldloc.s 9
-			IL_09e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_09e7: pop
-			IL_09e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09ed: stloc.s 11
-			IL_09ef: ldloc.1
-			IL_09f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09f5: stloc.s 9
-			IL_09f7: ldstr "abc"
-			IL_09fc: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0a01: stloc.s 10
-			IL_0a03: ldloc.s 9
-			IL_0a05: ldstr "verify"
-			IL_0a0a: ldstr "HMAC"
-			IL_0a0f: ldloc.s 4
-			IL_0a11: ldloc.s 5
-			IL_0a13: ldloc.s 10
-			IL_0a15: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember4(object, string, object, object, object, object)
-			IL_0a1a: stloc.s 9
-			IL_0a1c: ldloc.0
-			IL_0a1d: ldc.i4.7
-			IL_0a1e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0a23: ldloc.0
-			IL_0a24: ldloc.s 9
-			IL_0a26: ldarg.0
-			IL_0a27: ldc.i4.7
-			IL_0a28: ldloc.0
-			IL_0a29: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0a2e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0a33: ldloc.0
-			IL_0a34: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08c2: ldloc.s 9
+			IL_08c4: ldstr "name"
+			IL_08c9: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:120"
+			IL_08ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_08d8: stloc.s 9
+			IL_08da: ldloc.s 11
+			IL_08dc: ldstr "key hash:"
+			IL_08e1: ldloc.s 9
+			IL_08e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_08e8: pop
+			IL_08e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08ee: stloc.s 11
+			IL_08f0: volatile.
+			IL_08f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_08f7: brfalse IL_090d
+
+			IL_08fc: ldloc.s 4
+			IL_08fe: ldstr "extractable"
+			IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0908: br IL_0923
+
+			IL_090d: ldloc.s 4
+			IL_090f: ldstr "extractable"
+			IL_0914: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:126"
+			IL_0919: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_091e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0923: stloc.s 9
+			IL_0925: ldloc.s 11
+			IL_0927: ldstr "key extractable:"
+			IL_092c: ldloc.s 9
+			IL_092e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0933: pop
+			IL_0934: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0939: stloc.s 11
+			IL_093b: volatile.
+			IL_093d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0942: brfalse IL_0958
+
+			IL_0947: ldloc.s 4
+			IL_0949: ldstr "usages"
+			IL_094e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0953: br IL_096e
+
+			IL_0958: ldloc.s 4
+			IL_095a: ldstr "usages"
+			IL_095f: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:132"
+			IL_0964: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0969: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_096e: stloc.s 9
+			IL_0970: ldloc.s 9
+			IL_0972: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0977: stloc.s 9
+			IL_0979: volatile.
+			IL_097b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0980: brfalse IL_099b
+
+			IL_0985: ldloc.s 9
+			IL_0987: ldstr "join"
+			IL_098c: ldstr ","
+			IL_0991: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0996: br IL_09b6
+
+			IL_099b: ldloc.s 9
+			IL_099d: ldstr "join"
+			IL_09a2: ldstr ","
+			IL_09a7: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:135"
+			IL_09ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_09b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_09b6: stloc.s 9
+			IL_09b8: ldloc.s 11
+			IL_09ba: ldstr "key usages:"
+			IL_09bf: ldloc.s 9
+			IL_09c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_09c6: pop
+			IL_09c7: ldloc.1
+			IL_09c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_09cd: stloc.s 9
+			IL_09cf: ldstr "abc"
+			IL_09d4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_09d9: stloc.s 10
+			IL_09db: ldloc.s 9
+			IL_09dd: ldstr "sign"
+			IL_09e2: ldstr "HMAC"
+			IL_09e7: ldloc.s 4
+			IL_09e9: ldloc.s 10
+			IL_09eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_09f0: stloc.s 9
+			IL_09f2: ldloc.0
+			IL_09f3: ldc.i4.6
+			IL_09f4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_09f9: ldloc.0
+			IL_09fa: ldloc.s 9
+			IL_09fc: ldarg.0
+			IL_09fd: ldc.i4.6
+			IL_09fe: ldloc.0
+			IL_09ff: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0a04: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0a09: ldloc.0
+			IL_0a0a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0a0f: dup
+			IL_0a10: ldc.i4.0
+			IL_0a11: ldloc.1
+			IL_0a12: stelem.ref
+			IL_0a13: dup
+			IL_0a14: ldc.i4.1
+			IL_0a15: ldloc.2
+			IL_0a16: stelem.ref
+			IL_0a17: dup
+			IL_0a18: ldc.i4.2
+			IL_0a19: ldloc.3
+			IL_0a1a: stelem.ref
+			IL_0a1b: dup
+			IL_0a1c: ldc.i4.3
+			IL_0a1d: ldloc.s 4
+			IL_0a1f: stelem.ref
+			IL_0a20: dup
+			IL_0a21: ldc.i4.4
+			IL_0a22: ldloc.s 5
+			IL_0a24: stelem.ref
+			IL_0a25: dup
+			IL_0a26: ldc.i4.5
+			IL_0a27: ldloc.s 6
+			IL_0a29: stelem.ref
+			IL_0a2a: dup
+			IL_0a2b: ldc.i4.6
+			IL_0a2c: ldloc.s 7
+			IL_0a2e: stelem.ref
+			IL_0a2f: dup
+			IL_0a30: ldc.i4.7
+			IL_0a31: ldloc.s 8
+			IL_0a33: stelem.ref
+			IL_0a34: dup
+			IL_0a35: ldc.i4.8
+			IL_0a36: ldloc.s 9
+			IL_0a38: stelem.ref
 			IL_0a39: dup
-			IL_0a3a: ldc.i4.0
-			IL_0a3b: ldloc.1
-			IL_0a3c: stelem.ref
-			IL_0a3d: dup
-			IL_0a3e: ldc.i4.1
-			IL_0a3f: ldloc.2
-			IL_0a40: stelem.ref
-			IL_0a41: dup
-			IL_0a42: ldc.i4.2
-			IL_0a43: ldloc.3
+			IL_0a3a: ldc.i4.s 9
+			IL_0a3c: ldloc.s 10
+			IL_0a3e: stelem.ref
+			IL_0a3f: dup
+			IL_0a40: ldc.i4.s 10
+			IL_0a42: ldloc.s 11
 			IL_0a44: stelem.ref
 			IL_0a45: dup
-			IL_0a46: ldc.i4.3
-			IL_0a47: ldloc.s 4
-			IL_0a49: stelem.ref
-			IL_0a4a: dup
-			IL_0a4b: ldc.i4.4
-			IL_0a4c: ldloc.s 5
-			IL_0a4e: stelem.ref
-			IL_0a4f: dup
-			IL_0a50: ldc.i4.5
-			IL_0a51: ldloc.s 6
-			IL_0a53: stelem.ref
-			IL_0a54: dup
-			IL_0a55: ldc.i4.6
-			IL_0a56: ldloc.s 7
-			IL_0a58: stelem.ref
-			IL_0a59: dup
-			IL_0a5a: ldc.i4.7
-			IL_0a5b: ldloc.s 8
-			IL_0a5d: stelem.ref
-			IL_0a5e: dup
-			IL_0a5f: ldc.i4.8
-			IL_0a60: ldloc.s 9
-			IL_0a62: stelem.ref
-			IL_0a63: dup
-			IL_0a64: ldc.i4.s 9
-			IL_0a66: ldloc.s 10
-			IL_0a68: stelem.ref
-			IL_0a69: dup
-			IL_0a6a: ldc.i4.s 10
-			IL_0a6c: ldloc.s 11
-			IL_0a6e: stelem.ref
-			IL_0a6f: dup
-			IL_0a70: ldc.i4.s 11
-			IL_0a72: ldloc.s 12
-			IL_0a74: stelem.ref
-			IL_0a75: dup
-			IL_0a76: ldc.i4.s 12
-			IL_0a78: ldloc.s 13
-			IL_0a7a: stelem.ref
-			IL_0a7b: dup
-			IL_0a7c: ldc.i4.s 13
-			IL_0a7e: ldloc.s 14
-			IL_0a80: stelem.ref
-			IL_0a81: dup
-			IL_0a82: ldc.i4.s 14
-			IL_0a84: ldloc.s 15
-			IL_0a86: box [System.Runtime]System.Double
-			IL_0a8b: stelem.ref
-			IL_0a8c: pop
-			IL_0a8d: ldloc.0
-			IL_0a8e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a93: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a98: ret
+			IL_0a46: ldc.i4.s 11
+			IL_0a48: ldloc.s 12
+			IL_0a4a: stelem.ref
+			IL_0a4b: dup
+			IL_0a4c: ldc.i4.s 12
+			IL_0a4e: ldloc.s 13
+			IL_0a50: stelem.ref
+			IL_0a51: dup
+			IL_0a52: ldc.i4.s 13
+			IL_0a54: ldloc.s 14
+			IL_0a56: stelem.ref
+			IL_0a57: dup
+			IL_0a58: ldc.i4.s 14
+			IL_0a5a: ldloc.s 15
+			IL_0a5c: box [System.Runtime]System.Double
+			IL_0a61: stelem.ref
+			IL_0a62: pop
+			IL_0a63: ldloc.0
+			IL_0a64: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a69: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a6e: ret
 
-			IL_0a99: ldloc.0
-			IL_0a9a: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited7
-			IL_0a9f: stloc.s 9
-			IL_0aa1: ldloc.s 11
-			IL_0aa3: ldstr "verify true:"
-			IL_0aa8: ldloc.s 9
-			IL_0aaa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0aaf: pop
-			IL_0ab0: ldloc.s 6
-			IL_0ab2: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_0ab7: stloc.s 12
-			IL_0ab9: ldloc.s 12
-			IL_0abb: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0ac0: stloc.s 7
-			IL_0ac2: ldloc.s 7
-			IL_0ac4: ldc.r8 0.0
-			IL_0acd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ad2: stloc.s 9
-			IL_0ad4: ldloc.s 9
-			IL_0ad6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0adb: stloc.s 15
-			IL_0add: ldloc.s 15
-			IL_0adf: conv.i4
-			IL_0ae0: ldc.r8 255
-			IL_0ae9: conv.i4
-			IL_0aea: xor
-			IL_0aeb: conv.r8
-			IL_0aec: stloc.s 15
-			IL_0aee: ldloc.s 15
-			IL_0af0: conv.i4
-			IL_0af1: ldc.r8 255
-			IL_0afa: conv.i4
-			IL_0afb: and
-			IL_0afc: conv.r8
-			IL_0afd: stloc.s 15
-			IL_0aff: ldloc.s 7
-			IL_0b01: ldc.r8 0.0
-			IL_0b0a: ldloc.s 15
-			IL_0b0c: ldc.i4.1
-			IL_0b0d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_0b12: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b17: stloc.s 11
-			IL_0b19: ldloc.1
-			IL_0b1a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b1f: stloc.s 9
-			IL_0b21: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0b26: dup
-			IL_0b27: ldstr "name"
-			IL_0b2c: ldstr "HMAC"
-			IL_0b31: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0b36: stloc.s 14
-			IL_0b38: ldstr "abc"
-			IL_0b3d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0b42: stloc.s 10
-			IL_0b44: ldloc.s 9
-			IL_0b46: ldstr "verify"
-			IL_0b4b: ldloc.s 14
-			IL_0b4d: ldloc.s 4
-			IL_0b4f: ldloc.s 7
-			IL_0b51: ldloc.s 10
-			IL_0b53: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember4(object, string, object, object, object, object)
-			IL_0b58: stloc.s 9
-			IL_0b5a: ldloc.0
-			IL_0b5b: ldc.i4.8
-			IL_0b5c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b61: ldloc.0
-			IL_0b62: ldloc.s 9
-			IL_0b64: ldarg.0
-			IL_0b65: ldc.i4.8
-			IL_0b66: ldloc.0
-			IL_0b67: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0b6c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0b71: ldloc.0
-			IL_0b72: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0a6f: ldloc.0
+			IL_0a70: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited6
+			IL_0a75: stloc.s 5
+			IL_0a77: ldloc.s 5
+			IL_0a79: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+			IL_0a7e: stloc.s 6
+			IL_0a80: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a85: stloc.s 11
+			IL_0a87: ldloc.s 6
+			IL_0a89: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0a8e: stloc.s 12
+			IL_0a90: ldloc.s 12
+			IL_0a92: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0a97: stloc.s 10
+			IL_0a99: ldloc.s 10
+			IL_0a9b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_0aa0: stloc.s 10
+			IL_0aa2: volatile.
+			IL_0aa4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0aa9: brfalse IL_0ac4
+
+			IL_0aae: ldloc.s 10
+			IL_0ab0: ldstr "toString"
+			IL_0ab5: ldstr "hex"
+			IL_0aba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0abf: br IL_0adf
+
+			IL_0ac4: ldloc.s 10
+			IL_0ac6: ldstr "toString"
+			IL_0acb: ldstr "hex"
+			IL_0ad0: ldstr "Require_Crypto_WebCrypto_Subtle:<TwoPhaseDummy_M4>:__js_call__:155"
+			IL_0ad5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0ada: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0adf: stloc.s 9
+			IL_0ae1: ldloc.s 11
+			IL_0ae3: ldstr "signature hex:"
+			IL_0ae8: ldloc.s 9
+			IL_0aea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0aef: pop
+			IL_0af0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0af5: stloc.s 11
+			IL_0af7: ldloc.1
+			IL_0af8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0afd: stloc.s 9
+			IL_0aff: ldstr "abc"
+			IL_0b04: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0b09: stloc.s 10
+			IL_0b0b: ldloc.s 9
+			IL_0b0d: ldstr "verify"
+			IL_0b12: ldstr "HMAC"
+			IL_0b17: ldloc.s 4
+			IL_0b19: ldloc.s 5
+			IL_0b1b: ldloc.s 10
+			IL_0b1d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember4(object, string, object, object, object, object)
+			IL_0b22: stloc.s 9
+			IL_0b24: ldloc.0
+			IL_0b25: ldc.i4.7
+			IL_0b26: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b2b: ldloc.0
+			IL_0b2c: ldloc.s 9
+			IL_0b2e: ldarg.0
+			IL_0b2f: ldc.i4.7
+			IL_0b30: ldloc.0
+			IL_0b31: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0b36: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0b3b: ldloc.0
+			IL_0b3c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0b41: dup
+			IL_0b42: ldc.i4.0
+			IL_0b43: ldloc.1
+			IL_0b44: stelem.ref
+			IL_0b45: dup
+			IL_0b46: ldc.i4.1
+			IL_0b47: ldloc.2
+			IL_0b48: stelem.ref
+			IL_0b49: dup
+			IL_0b4a: ldc.i4.2
+			IL_0b4b: ldloc.3
+			IL_0b4c: stelem.ref
+			IL_0b4d: dup
+			IL_0b4e: ldc.i4.3
+			IL_0b4f: ldloc.s 4
+			IL_0b51: stelem.ref
+			IL_0b52: dup
+			IL_0b53: ldc.i4.4
+			IL_0b54: ldloc.s 5
+			IL_0b56: stelem.ref
+			IL_0b57: dup
+			IL_0b58: ldc.i4.5
+			IL_0b59: ldloc.s 6
+			IL_0b5b: stelem.ref
+			IL_0b5c: dup
+			IL_0b5d: ldc.i4.6
+			IL_0b5e: ldloc.s 7
+			IL_0b60: stelem.ref
+			IL_0b61: dup
+			IL_0b62: ldc.i4.7
+			IL_0b63: ldloc.s 8
+			IL_0b65: stelem.ref
+			IL_0b66: dup
+			IL_0b67: ldc.i4.8
+			IL_0b68: ldloc.s 9
+			IL_0b6a: stelem.ref
+			IL_0b6b: dup
+			IL_0b6c: ldc.i4.s 9
+			IL_0b6e: ldloc.s 10
+			IL_0b70: stelem.ref
+			IL_0b71: dup
+			IL_0b72: ldc.i4.s 10
+			IL_0b74: ldloc.s 11
+			IL_0b76: stelem.ref
 			IL_0b77: dup
-			IL_0b78: ldc.i4.0
-			IL_0b79: ldloc.1
-			IL_0b7a: stelem.ref
-			IL_0b7b: dup
-			IL_0b7c: ldc.i4.1
-			IL_0b7d: ldloc.2
-			IL_0b7e: stelem.ref
-			IL_0b7f: dup
-			IL_0b80: ldc.i4.2
-			IL_0b81: ldloc.3
+			IL_0b78: ldc.i4.s 11
+			IL_0b7a: ldloc.s 12
+			IL_0b7c: stelem.ref
+			IL_0b7d: dup
+			IL_0b7e: ldc.i4.s 12
+			IL_0b80: ldloc.s 13
 			IL_0b82: stelem.ref
 			IL_0b83: dup
-			IL_0b84: ldc.i4.3
-			IL_0b85: ldloc.s 4
-			IL_0b87: stelem.ref
-			IL_0b88: dup
-			IL_0b89: ldc.i4.4
-			IL_0b8a: ldloc.s 5
-			IL_0b8c: stelem.ref
-			IL_0b8d: dup
-			IL_0b8e: ldc.i4.5
-			IL_0b8f: ldloc.s 6
-			IL_0b91: stelem.ref
-			IL_0b92: dup
-			IL_0b93: ldc.i4.6
-			IL_0b94: ldloc.s 7
-			IL_0b96: stelem.ref
-			IL_0b97: dup
-			IL_0b98: ldc.i4.7
-			IL_0b99: ldloc.s 8
-			IL_0b9b: stelem.ref
-			IL_0b9c: dup
-			IL_0b9d: ldc.i4.8
-			IL_0b9e: ldloc.s 9
-			IL_0ba0: stelem.ref
-			IL_0ba1: dup
-			IL_0ba2: ldc.i4.s 9
-			IL_0ba4: ldloc.s 10
-			IL_0ba6: stelem.ref
-			IL_0ba7: dup
-			IL_0ba8: ldc.i4.s 10
-			IL_0baa: ldloc.s 11
-			IL_0bac: stelem.ref
-			IL_0bad: dup
-			IL_0bae: ldc.i4.s 11
-			IL_0bb0: ldloc.s 12
-			IL_0bb2: stelem.ref
-			IL_0bb3: dup
-			IL_0bb4: ldc.i4.s 12
-			IL_0bb6: ldloc.s 13
-			IL_0bb8: stelem.ref
-			IL_0bb9: dup
-			IL_0bba: ldc.i4.s 13
-			IL_0bbc: ldloc.s 14
-			IL_0bbe: stelem.ref
-			IL_0bbf: dup
-			IL_0bc0: ldc.i4.s 14
-			IL_0bc2: ldloc.s 15
-			IL_0bc4: box [System.Runtime]System.Double
-			IL_0bc9: stelem.ref
-			IL_0bca: pop
-			IL_0bcb: ldloc.0
-			IL_0bcc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bd1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bd6: ret
+			IL_0b84: ldc.i4.s 13
+			IL_0b86: ldloc.s 14
+			IL_0b88: stelem.ref
+			IL_0b89: dup
+			IL_0b8a: ldc.i4.s 14
+			IL_0b8c: ldloc.s 15
+			IL_0b8e: box [System.Runtime]System.Double
+			IL_0b93: stelem.ref
+			IL_0b94: pop
+			IL_0b95: ldloc.0
+			IL_0b96: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b9b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0ba0: ret
 
-			IL_0bd7: ldloc.0
-			IL_0bd8: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited8
-			IL_0bdd: stloc.s 9
-			IL_0bdf: ldloc.s 11
-			IL_0be1: ldstr "verify false:"
-			IL_0be6: ldloc.s 9
-			IL_0be8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0bed: pop
-			IL_0bee: ldloc.0
-			IL_0bef: ldc.i4.m1
-			IL_0bf0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0bf5: ldloc.0
-			IL_0bf6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bfb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c00: ldarg.0
-			IL_0c01: ldc.i4.1
-			IL_0c02: newarr [System.Runtime]System.Object
-			IL_0c07: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c0c: pop
-			IL_0c0d: ldloc.0
-			IL_0c0e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c13: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c18: ret
+			IL_0ba1: ldloc.0
+			IL_0ba2: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited7
+			IL_0ba7: stloc.s 9
+			IL_0ba9: ldloc.s 11
+			IL_0bab: ldstr "verify true:"
+			IL_0bb0: ldloc.s 9
+			IL_0bb2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0bb7: pop
+			IL_0bb8: ldloc.s 6
+			IL_0bba: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0bbf: stloc.s 12
+			IL_0bc1: ldloc.s 12
+			IL_0bc3: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0bc8: stloc.s 7
+			IL_0bca: ldloc.s 7
+			IL_0bcc: ldc.r8 0.0
+			IL_0bd5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0bda: stloc.s 9
+			IL_0bdc: ldloc.s 9
+			IL_0bde: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0be3: stloc.s 15
+			IL_0be5: ldloc.s 15
+			IL_0be7: conv.i4
+			IL_0be8: ldc.r8 255
+			IL_0bf1: conv.i4
+			IL_0bf2: xor
+			IL_0bf3: conv.r8
+			IL_0bf4: stloc.s 15
+			IL_0bf6: ldloc.s 15
+			IL_0bf8: conv.i4
+			IL_0bf9: ldc.r8 255
+			IL_0c02: conv.i4
+			IL_0c03: and
+			IL_0c04: conv.r8
+			IL_0c05: stloc.s 15
+			IL_0c07: ldloc.s 7
+			IL_0c09: ldc.r8 0.0
+			IL_0c12: ldloc.s 15
+			IL_0c14: ldc.i4.1
+			IL_0c15: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_0c1a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c1f: stloc.s 11
+			IL_0c21: ldloc.1
+			IL_0c22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c27: stloc.s 9
+			IL_0c29: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0c2e: dup
+			IL_0c2f: ldstr "name"
+			IL_0c34: ldstr "HMAC"
+			IL_0c39: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0c3e: stloc.s 14
+			IL_0c40: ldstr "abc"
+			IL_0c45: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0c4a: stloc.s 10
+			IL_0c4c: ldloc.s 9
+			IL_0c4e: ldstr "verify"
+			IL_0c53: ldloc.s 14
+			IL_0c55: ldloc.s 4
+			IL_0c57: ldloc.s 7
+			IL_0c59: ldloc.s 10
+			IL_0c5b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember4(object, string, object, object, object, object)
+			IL_0c60: stloc.s 9
+			IL_0c62: ldloc.0
+			IL_0c63: ldc.i4.8
+			IL_0c64: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c69: ldloc.0
+			IL_0c6a: ldloc.s 9
+			IL_0c6c: ldarg.0
+			IL_0c6d: ldc.i4.8
+			IL_0c6e: ldloc.0
+			IL_0c6f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0c74: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0c79: ldloc.0
+			IL_0c7a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0c7f: dup
+			IL_0c80: ldc.i4.0
+			IL_0c81: ldloc.1
+			IL_0c82: stelem.ref
+			IL_0c83: dup
+			IL_0c84: ldc.i4.1
+			IL_0c85: ldloc.2
+			IL_0c86: stelem.ref
+			IL_0c87: dup
+			IL_0c88: ldc.i4.2
+			IL_0c89: ldloc.3
+			IL_0c8a: stelem.ref
+			IL_0c8b: dup
+			IL_0c8c: ldc.i4.3
+			IL_0c8d: ldloc.s 4
+			IL_0c8f: stelem.ref
+			IL_0c90: dup
+			IL_0c91: ldc.i4.4
+			IL_0c92: ldloc.s 5
+			IL_0c94: stelem.ref
+			IL_0c95: dup
+			IL_0c96: ldc.i4.5
+			IL_0c97: ldloc.s 6
+			IL_0c99: stelem.ref
+			IL_0c9a: dup
+			IL_0c9b: ldc.i4.6
+			IL_0c9c: ldloc.s 7
+			IL_0c9e: stelem.ref
+			IL_0c9f: dup
+			IL_0ca0: ldc.i4.7
+			IL_0ca1: ldloc.s 8
+			IL_0ca3: stelem.ref
+			IL_0ca4: dup
+			IL_0ca5: ldc.i4.8
+			IL_0ca6: ldloc.s 9
+			IL_0ca8: stelem.ref
+			IL_0ca9: dup
+			IL_0caa: ldc.i4.s 9
+			IL_0cac: ldloc.s 10
+			IL_0cae: stelem.ref
+			IL_0caf: dup
+			IL_0cb0: ldc.i4.s 10
+			IL_0cb2: ldloc.s 11
+			IL_0cb4: stelem.ref
+			IL_0cb5: dup
+			IL_0cb6: ldc.i4.s 11
+			IL_0cb8: ldloc.s 12
+			IL_0cba: stelem.ref
+			IL_0cbb: dup
+			IL_0cbc: ldc.i4.s 12
+			IL_0cbe: ldloc.s 13
+			IL_0cc0: stelem.ref
+			IL_0cc1: dup
+			IL_0cc2: ldc.i4.s 13
+			IL_0cc4: ldloc.s 14
+			IL_0cc6: stelem.ref
+			IL_0cc7: dup
+			IL_0cc8: ldc.i4.s 14
+			IL_0cca: ldloc.s 15
+			IL_0ccc: box [System.Runtime]System.Double
+			IL_0cd1: stelem.ref
+			IL_0cd2: pop
+			IL_0cd3: ldloc.0
+			IL_0cd4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0cd9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0cde: ret
+
+			IL_0cdf: ldloc.0
+			IL_0ce0: ldfld object Modules.Require_Crypto_WebCrypto_Subtle/run/Scope::_awaited8
+			IL_0ce5: stloc.s 9
+			IL_0ce7: ldloc.s 11
+			IL_0ce9: ldstr "verify false:"
+			IL_0cee: ldloc.s 9
+			IL_0cf0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0cf5: pop
+			IL_0cf6: ldloc.0
+			IL_0cf7: ldc.i4.m1
+			IL_0cf8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0cfd: ldloc.0
+			IL_0cfe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0d03: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0d08: ldarg.0
+			IL_0d09: ldc.i4.1
+			IL_0d0a: newarr [System.Runtime]System.Object
+			IL_0d0f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0d14: pop
+			IL_0d15: ldloc.0
+			IL_0d16: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0d1b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0d20: ret
 		} // end of method run::__js_call__
 
 	} // end of class run
@@ -1687,7 +1765,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 147 (0x93)
+		// Code size: 188 (0xbc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_WebCrypto_Subtle/Scope,
@@ -1753,12 +1831,25 @@
 		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_WebCrypto_Subtle/ArrowFunction_L39C12/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_WebCrypto_Subtle/ArrowFunction_L39C12/FunctionObject>(!!0)
 		IL_0081: stloc.s 5
-		IL_0083: ldloc.s 4
-		IL_0085: ldstr "then"
-		IL_008a: ldloc.s 5
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0091: pop
-		IL_0092: ret
+		IL_0083: volatile.
+		IL_0085: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_008a: brfalse IL_00a2
+
+		IL_008f: ldloc.s 4
+		IL_0091: ldstr "then"
+		IL_0096: ldloc.s 5
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009d: br IL_00ba
+
+		IL_00a2: ldloc.s 4
+		IL_00a4: ldstr "then"
+		IL_00a9: ldloc.s 5
+		IL_00ab: ldstr "Require_Crypto_WebCrypto_Subtle:Modules.Require_Crypto_WebCrypto_Subtle:__js_module_init__:18"
+		IL_00b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ba: pop
+		IL_00bb: ret
 	} // end of method Require_Crypto_WebCrypto_Subtle::__js_module_init__
 
 } // end of class Modules.Require_Crypto_WebCrypto_Subtle
@@ -1798,6 +1889,13 @@
 	.field assembly static int32 __jroc_dynamicLookup_20
 	.field assembly static int32 __jroc_dynamicLookup_21
 	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/DiagnosticsChannel/Snapshots/GeneratorTests.Require_DiagnosticsChannel.verified.txt
+++ b/tests/Jroc.Tests/Node/DiagnosticsChannel/Snapshots/GeneratorTests.Require_DiagnosticsChannel.verified.txt
@@ -314,7 +314,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 909 (0x38d)
+		// Code size: 990 (0x3de)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_DiagnosticsChannel/Scope,
@@ -503,144 +503,168 @@
 		IL_01d6: pop
 		IL_01d7: ldloc.3
 		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dd: ldstr "publish"
-		IL_01e2: ldstr "published"
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ec: pop
-		IL_01ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f2: stloc.s 6
-		IL_01f4: ldloc.0
-		IL_01f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_DiagnosticsChannel/Scope::messages
-		IL_01fa: ldc.i4.1
-		IL_01fb: newarr [System.Runtime]System.Object
-		IL_0200: dup
-		IL_0201: ldc.i4.0
-		IL_0202: ldstr ","
-		IL_0207: stelem.ref
-		IL_0208: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_020d: stloc.s 12
-		IL_020f: ldloc.s 6
-		IL_0211: ldstr "synchronous:"
-		IL_0216: ldloc.s 12
-		IL_0218: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_021d: pop
-		IL_021e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0223: stloc.s 6
-		IL_0225: ldloc.2
-		IL_0226: ldstr "unsubscribe"
-		IL_022b: ldstr "jroc:diagnostics"
-		IL_0230: ldloc.1
-		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0236: stloc.s 10
-		IL_0238: ldloc.s 6
-		IL_023a: ldstr "removed:"
-		IL_023f: ldloc.s 10
-		IL_0241: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0246: pop
-		IL_0247: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_024c: stloc.s 6
-		IL_024e: volatile.
-		IL_0250: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0255: brfalse IL_026a
+		IL_01dd: volatile.
+		IL_01df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01e4: brfalse IL_01fd
 
-		IL_025a: ldloc.3
-		IL_025b: ldstr "hasSubscribers"
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0265: br IL_027f
+		IL_01e9: ldstr "publish"
+		IL_01ee: ldstr "published"
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f8: br IL_0216
 
-		IL_026a: ldloc.3
-		IL_026b: ldstr "hasSubscribers"
-		IL_0270: ldstr "Require_DiagnosticsChannel:Modules.Require_DiagnosticsChannel:__js_module_init__:72"
-		IL_0275: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01fd: ldstr "publish"
+		IL_0202: ldstr "published"
+		IL_0207: ldstr "Require_DiagnosticsChannel:Modules.Require_DiagnosticsChannel:__js_module_init__:54"
+		IL_020c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_027f: stloc.s 10
-		IL_0281: ldloc.s 6
-		IL_0283: ldstr "final subscribers:"
-		IL_0288: ldloc.s 10
-		IL_028a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_028f: pop
-		IL_0290: ldloc.2
-		IL_0291: ldstr "channel"
-		IL_0296: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_029b: brtrue IL_02b2
+		IL_0216: pop
+		IL_0217: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_021c: stloc.s 6
+		IL_021e: ldloc.0
+		IL_021f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_DiagnosticsChannel/Scope::messages
+		IL_0224: ldc.i4.1
+		IL_0225: newarr [System.Runtime]System.Object
+		IL_022a: dup
+		IL_022b: ldc.i4.0
+		IL_022c: ldstr ","
+		IL_0231: stelem.ref
+		IL_0232: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0237: stloc.s 12
+		IL_0239: ldloc.s 6
+		IL_023b: ldstr "synchronous:"
+		IL_0240: ldloc.s 12
+		IL_0242: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0247: pop
+		IL_0248: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_024d: stloc.s 6
+		IL_024f: ldloc.2
+		IL_0250: ldstr "unsubscribe"
+		IL_0255: ldstr "jroc:diagnostics"
+		IL_025a: ldloc.1
+		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0260: stloc.s 10
+		IL_0262: ldloc.s 6
+		IL_0264: ldstr "removed:"
+		IL_0269: ldloc.s 10
+		IL_026b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0270: pop
+		IL_0271: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0276: stloc.s 6
+		IL_0278: volatile.
+		IL_027a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_027f: brfalse IL_0294
 
-		IL_02a0: ldloc.2
-		IL_02a1: ldstr "undici:request:pending-requests"
-		IL_02a6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IDiagnosticsChannelModule::channel(object)
-		IL_02ab: stloc.s 4
-		IL_02ad: br IL_02cd
+		IL_0284: ldloc.3
+		IL_0285: ldstr "hasSubscribers"
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028f: br IL_02a9
 
-		IL_02b2: ldloc.2
-		IL_02b3: ldstr "channel"
-		IL_02b8: ldc.i4.1
-		IL_02b9: newarr [System.Runtime]System.Object
-		IL_02be: dup
-		IL_02bf: ldc.i4.0
-		IL_02c0: ldstr "undici:request:pending-requests"
-		IL_02c5: stelem.ref
-		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-		IL_02cb: stloc.s 4
+		IL_0294: ldloc.3
+		IL_0295: ldstr "hasSubscribers"
+		IL_029a: ldstr "Require_DiagnosticsChannel:Modules.Require_DiagnosticsChannel:__js_module_init__:72"
+		IL_029f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02cd: volatile.
-		IL_02cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02d4: brfalse IL_02ea
+		IL_02a9: stloc.s 10
+		IL_02ab: ldloc.s 6
+		IL_02ad: ldstr "final subscribers:"
+		IL_02b2: ldloc.s 10
+		IL_02b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02b9: pop
+		IL_02ba: ldloc.2
+		IL_02bb: ldstr "channel"
+		IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_02c5: brtrue IL_02dc
 
-		IL_02d9: ldloc.s 4
-		IL_02db: ldstr "hasSubscribers"
-		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e5: br IL_0300
+		IL_02ca: ldloc.2
+		IL_02cb: ldstr "undici:request:pending-requests"
+		IL_02d0: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IDiagnosticsChannelModule::channel(object)
+		IL_02d5: stloc.s 4
+		IL_02d7: br IL_02f7
 
-		IL_02ea: ldloc.s 4
-		IL_02ec: ldstr "hasSubscribers"
-		IL_02f1: ldstr "Require_DiagnosticsChannel:Modules.Require_DiagnosticsChannel:__js_module_init__:80"
-		IL_02f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02dc: ldloc.2
+		IL_02dd: ldstr "channel"
+		IL_02e2: ldc.i4.1
+		IL_02e3: newarr [System.Runtime]System.Object
+		IL_02e8: dup
+		IL_02e9: ldc.i4.0
+		IL_02ea: ldstr "undici:request:pending-requests"
+		IL_02ef: stelem.ref
+		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_02f5: stloc.s 4
 
-		IL_0300: stloc.s 10
-		IL_0302: ldloc.s 10
-		IL_0304: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_0309: stloc.s 8
-		IL_030b: ldloc.s 8
-		IL_030d: brfalse IL_0341
+		IL_02f7: volatile.
+		IL_02f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02fe: brfalse IL_0314
 
-		IL_0312: ldloc.s 4
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0319: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_031e: dup
-		IL_031f: ldstr "size"
-		IL_0324: ldc.r8 1
-		IL_032d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0332: stloc.s 13
-		IL_0334: ldstr "publish"
-		IL_0339: ldloc.s 13
-		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0340: pop
+		IL_0303: ldloc.s 4
+		IL_0305: ldstr "hasSubscribers"
+		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_030f: br IL_032a
 
-		IL_0341: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0346: stloc.s 6
-		IL_0348: volatile.
-		IL_034a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_034f: brfalse IL_0365
+		IL_0314: ldloc.s 4
+		IL_0316: ldstr "hasSubscribers"
+		IL_031b: ldstr "Require_DiagnosticsChannel:Modules.Require_DiagnosticsChannel:__js_module_init__:80"
+		IL_0320: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0354: ldloc.s 4
-		IL_0356: ldstr "hasSubscribers"
-		IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0360: br IL_037b
+		IL_032a: stloc.s 10
+		IL_032c: ldloc.s 10
+		IL_032e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0333: stloc.s 8
+		IL_0335: ldloc.s 8
+		IL_0337: brfalse IL_0392
 
-		IL_0365: ldloc.s 4
-		IL_0367: ldstr "hasSubscribers"
-		IL_036c: ldstr "Require_DiagnosticsChannel:Modules.Require_DiagnosticsChannel:__js_module_init__:93"
-		IL_0371: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_033c: ldloc.s 4
+		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0343: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0348: dup
+		IL_0349: ldstr "size"
+		IL_034e: ldc.r8 1
+		IL_0357: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_035c: stloc.s 13
+		IL_035e: volatile.
+		IL_0360: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0365: brfalse IL_037b
 
-		IL_037b: stloc.s 10
-		IL_037d: ldloc.s 6
-		IL_037f: ldstr "guarded publish:"
-		IL_0384: ldloc.s 10
-		IL_0386: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_038b: pop
-		IL_038c: ret
+		IL_036a: ldstr "publish"
+		IL_036f: ldloc.s 13
+		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0376: br IL_0391
+
+		IL_037b: ldstr "publish"
+		IL_0380: ldloc.s 13
+		IL_0382: ldstr "Require_DiagnosticsChannel:Modules.Require_DiagnosticsChannel:__js_module_init__:87"
+		IL_0387: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0391: pop
+
+		IL_0392: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0397: stloc.s 6
+		IL_0399: volatile.
+		IL_039b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_03a0: brfalse IL_03b6
+
+		IL_03a5: ldloc.s 4
+		IL_03a7: ldstr "hasSubscribers"
+		IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03b1: br IL_03cc
+
+		IL_03b6: ldloc.s 4
+		IL_03b8: ldstr "hasSubscribers"
+		IL_03bd: ldstr "Require_DiagnosticsChannel:Modules.Require_DiagnosticsChannel:__js_module_init__:93"
+		IL_03c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_03cc: stloc.s 10
+		IL_03ce: ldloc.s 6
+		IL_03d0: ldstr "guarded publish:"
+		IL_03d5: ldloc.s 10
+		IL_03d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03dc: pop
+		IL_03dd: ret
 	} // end of method Require_DiagnosticsChannel::__js_module_init__
 
 } // end of class Modules.Require_DiagnosticsChannel
@@ -674,6 +698,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
@@ -557,7 +557,7 @@
 			IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_02b4: stloc.s 13
 			IL_02b6: volatile.
-			IL_02b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_02b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_02bd: brfalse IL_02d3
 
 			IL_02c2: ldloc.s 7
@@ -568,7 +568,7 @@
 			IL_02d3: ldloc.s 7
 			IL_02d5: ldstr "length"
 			IL_02da: ldstr "Events_AsyncHelpers_On_Once:<TwoPhaseDummy_M4>:__js_call__:50"
-			IL_02df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_02df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02e9: stloc.s 10
@@ -2078,7 +2078,7 @@
 			IL_0160: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0165: stloc.s 6
 			IL_0167: volatile.
-			IL_0169: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0169: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_016e: brfalse IL_0183
 
 			IL_0173: ldloc.3
@@ -2089,7 +2089,7 @@
 			IL_0183: ldloc.3
 			IL_0184: ldstr "length"
 			IL_0189: ldstr "Events_AsyncHelpers_On_Once:<TwoPhaseDummy_M6>:__js_call__:23"
-			IL_018e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_018e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0198: stloc.s 4
@@ -2664,7 +2664,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 387 (0x183)
+		// Code size: 543 (0x21f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_AsyncHelpers_On_Once/Scope,
@@ -2791,47 +2791,96 @@
 		IL_0105: stloc.s 7
 		IL_0107: ldloc.s 7
 		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010e: ldstr "then"
-		IL_0113: ldloc.2
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0119: stloc.s 7
-		IL_011b: ldloc.s 7
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0122: ldstr "then"
-		IL_0127: ldloc.3
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012d: stloc.s 7
-		IL_012f: ldloc.s 7
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0136: ldstr "then"
-		IL_013b: ldloc.s 4
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0142: stloc.s 7
-		IL_0144: ldloc.s 7
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014b: stloc.s 7
-		IL_014d: ldc.i4.1
-		IL_014e: newarr [System.Runtime]System.Object
-		IL_0153: dup
-		IL_0154: ldc.i4.0
-		IL_0155: ldloc.0
-		IL_0156: stelem.ref
-		IL_0157: stloc.s 5
-		IL_0159: newobj instance void Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9/FunctionObject::.ctor()
-		IL_015e: ldc.i4.0
-		IL_015f: conv.r8
-		IL_0160: ldstr ""
-		IL_0165: ldc.i4.0
-		IL_0166: ldc.i4.0
-		IL_0167: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_016c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9/FunctionObject>(!!0)
-		IL_0171: stloc.s 8
-		IL_0173: ldloc.s 7
-		IL_0175: ldstr "then"
-		IL_017a: ldloc.s 8
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0181: pop
-		IL_0182: ret
+		IL_010e: volatile.
+		IL_0110: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0115: brfalse IL_012a
+
+		IL_011a: ldstr "then"
+		IL_011f: ldloc.2
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0125: br IL_013f
+
+		IL_012a: ldstr "then"
+		IL_012f: ldloc.2
+		IL_0130: ldstr "Events_AsyncHelpers_On_Once:Modules.Events_AsyncHelpers_On_Once:__js_module_init__:32"
+		IL_0135: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_013f: stloc.s 7
+		IL_0141: ldloc.s 7
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0148: volatile.
+		IL_014a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_014f: brfalse IL_0164
+
+		IL_0154: ldstr "then"
+		IL_0159: ldloc.3
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015f: br IL_0179
+
+		IL_0164: ldstr "then"
+		IL_0169: ldloc.3
+		IL_016a: ldstr "Events_AsyncHelpers_On_Once:Modules.Events_AsyncHelpers_On_Once:__js_module_init__:34"
+		IL_016f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0179: stloc.s 7
+		IL_017b: ldloc.s 7
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0182: volatile.
+		IL_0184: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0189: brfalse IL_019f
+
+		IL_018e: ldstr "then"
+		IL_0193: ldloc.s 4
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019a: br IL_01b5
+
+		IL_019f: ldstr "then"
+		IL_01a4: ldloc.s 4
+		IL_01a6: ldstr "Events_AsyncHelpers_On_Once:Modules.Events_AsyncHelpers_On_Once:__js_module_init__:36"
+		IL_01ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01b5: stloc.s 7
+		IL_01b7: ldloc.s 7
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01be: stloc.s 7
+		IL_01c0: ldc.i4.1
+		IL_01c1: newarr [System.Runtime]System.Object
+		IL_01c6: dup
+		IL_01c7: ldc.i4.0
+		IL_01c8: ldloc.0
+		IL_01c9: stelem.ref
+		IL_01ca: stloc.s 5
+		IL_01cc: newobj instance void Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9/FunctionObject::.ctor()
+		IL_01d1: ldc.i4.0
+		IL_01d2: conv.r8
+		IL_01d3: ldstr ""
+		IL_01d8: ldc.i4.0
+		IL_01d9: ldc.i4.0
+		IL_01da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9/FunctionObject>(!!0)
+		IL_01e4: stloc.s 8
+		IL_01e6: volatile.
+		IL_01e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_01ed: brfalse IL_0205
+
+		IL_01f2: ldloc.s 7
+		IL_01f4: ldstr "then"
+		IL_01f9: ldloc.s 8
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0200: br IL_021d
+
+		IL_0205: ldloc.s 7
+		IL_0207: ldstr "then"
+		IL_020c: ldloc.s 8
+		IL_020e: ldstr "Events_AsyncHelpers_On_Once:Modules.Events_AsyncHelpers_On_Once:__js_module_init__:40"
+		IL_0213: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_021d: pop
+		IL_021e: ret
 	} // end of method Events_AsyncHelpers_On_Once::__js_module_init__
 
 } // end of class Modules.Events_AsyncHelpers_On_Once
@@ -2863,6 +2912,10 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_Callback_Identity_And_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_Callback_Identity_And_Function_Objects.verified.txt
@@ -385,7 +385,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 58 (0x3a)
+			// Code size: 100 (0x64)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -395,25 +395,37 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000b: ldstr "listenerCount"
-			IL_0010: ldstr "raw-once"
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001a: stloc.0
-			IL_001b: ldarg.0
-			IL_001c: ldloc.0
-			IL_001d: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawCountDuringCall
-			IL_0022: ldarg.0
-			IL_0023: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawTotal
-			IL_0028: stloc.0
-			IL_0029: ldloc.0
-			IL_002a: ldarg.2
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0030: stloc.1
-			IL_0031: ldarg.0
-			IL_0032: ldloc.1
-			IL_0033: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawTotal
-			IL_0038: ldnull
-			IL_0039: ret
+			IL_000b: volatile.
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0012: brfalse IL_002b
+
+			IL_0017: ldstr "listenerCount"
+			IL_001c: ldstr "raw-once"
+			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0026: br IL_0044
+
+			IL_002b: ldstr "listenerCount"
+			IL_0030: ldstr "raw-once"
+			IL_0035: ldstr "Events_Callback_Identity_And_Function_Objects:<TwoPhaseDummy_M5>:__js_call__:4"
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0044: stloc.0
+			IL_0045: ldarg.0
+			IL_0046: ldloc.0
+			IL_0047: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawCountDuringCall
+			IL_004c: ldarg.0
+			IL_004d: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawTotal
+			IL_0052: stloc.0
+			IL_0053: ldloc.0
+			IL_0054: ldarg.2
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_005a: stloc.1
+			IL_005b: ldarg.0
+			IL_005c: ldloc.1
+			IL_005d: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawTotal
+			IL_0062: ldnull
+			IL_0063: ret
 		} // end of method rawListener::__js_call__
 
 	} // end of class rawListener
@@ -1102,7 +1114,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2175 (0x87f)
+		// Code size: 2553 (0x9f9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_Callback_Identity_And_Function_Objects/Scope,
@@ -1287,537 +1299,645 @@
 		IL_0190: ldloc.0
 		IL_0191: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
 		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019b: ldstr "listeners"
-		IL_01a0: ldstr "once"
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01aa: stloc.s 15
-		IL_01ac: ldloc.s 15
-		IL_01ae: ldc.r8 0.0
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01bc: stloc.s 15
-		IL_01be: ldloc.s 15
-		IL_01c0: ldloc.1
-		IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01c6: stloc.s 17
-		IL_01c8: ldloc.s 17
-		IL_01ca: box [System.Runtime]System.Boolean
-		IL_01cf: stloc.s 18
-		IL_01d1: ldstr "listeners-identity:"
-		IL_01d6: ldloc.s 18
-		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01dd: stloc.s 19
-		IL_01df: ldloc.s 16
-		IL_01e1: ldloc.s 19
-		IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e8: pop
-		IL_01e9: ldloc.0
-		IL_01ea: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f4: ldstr "off"
-		IL_01f9: ldstr "once"
-		IL_01fe: ldloc.1
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0204: pop
-		IL_0205: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_020a: stloc.s 16
-		IL_020c: ldloc.0
-		IL_020d: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0217: ldstr "listenerCount"
-		IL_021c: ldstr "once"
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0226: stloc.s 15
-		IL_0228: ldstr "off-once-count:"
-		IL_022d: ldloc.s 15
-		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0234: stloc.s 19
-		IL_0236: ldloc.s 16
-		IL_0238: ldloc.s 19
-		IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023f: pop
-		IL_0240: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0245: stloc.s 16
-		IL_0247: ldloc.0
-		IL_0248: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0252: ldstr "emit"
-		IL_0257: ldstr "once"
-		IL_025c: ldc.r8 1
-		IL_0265: box [System.Runtime]System.Double
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_026f: stloc.s 15
-		IL_0271: ldstr "off-once-emitted:"
-		IL_0276: ldloc.s 15
-		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_027d: stloc.s 19
-		IL_027f: ldloc.s 16
-		IL_0281: ldloc.s 19
-		IL_0283: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0288: pop
-		IL_0289: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_028e: stloc.s 16
-		IL_0290: ldloc.0
-		IL_0291: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::total
-		IL_0296: stloc.s 15
-		IL_0298: ldstr "total:"
-		IL_029d: ldloc.s 15
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02a4: stloc.s 19
-		IL_02a6: ldloc.s 16
-		IL_02a8: ldloc.s 19
-		IL_02aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02af: pop
-		IL_02b0: ldloc.0
-		IL_02b1: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02bb: ldstr "on"
-		IL_02c0: ldstr "duplicate"
-		IL_02c5: ldloc.1
-		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02cb: pop
-		IL_02cc: ldloc.0
-		IL_02cd: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d7: ldstr "on"
-		IL_02dc: ldstr "duplicate"
-		IL_02e1: ldloc.1
-		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02e7: pop
-		IL_02e8: ldloc.0
-		IL_02e9: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f3: ldstr "off"
-		IL_02f8: ldstr "duplicate"
-		IL_02fd: ldloc.1
-		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_019b: volatile.
+		IL_019d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_01a2: brfalse IL_01bb
+
+		IL_01a7: ldstr "listeners"
+		IL_01ac: ldstr "once"
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b6: br IL_01d4
+
+		IL_01bb: ldstr "listeners"
+		IL_01c0: ldstr "once"
+		IL_01c5: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:51"
+		IL_01ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01d4: stloc.s 15
+		IL_01d6: ldloc.s 15
+		IL_01d8: ldc.r8 0.0
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01e6: stloc.s 15
+		IL_01e8: ldloc.s 15
+		IL_01ea: ldloc.1
+		IL_01eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01f0: stloc.s 17
+		IL_01f2: ldloc.s 17
+		IL_01f4: box [System.Runtime]System.Boolean
+		IL_01f9: stloc.s 18
+		IL_01fb: ldstr "listeners-identity:"
+		IL_0200: ldloc.s 18
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0207: stloc.s 19
+		IL_0209: ldloc.s 16
+		IL_020b: ldloc.s 19
+		IL_020d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0212: pop
+		IL_0213: ldloc.0
+		IL_0214: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021e: ldstr "off"
+		IL_0223: ldstr "once"
+		IL_0228: ldloc.1
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_022e: pop
+		IL_022f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0234: stloc.s 16
+		IL_0236: ldloc.0
+		IL_0237: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0241: volatile.
+		IL_0243: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0248: brfalse IL_0261
+
+		IL_024d: ldstr "listenerCount"
+		IL_0252: ldstr "once"
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025c: br IL_027a
+
+		IL_0261: ldstr "listenerCount"
+		IL_0266: ldstr "once"
+		IL_026b: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:69"
+		IL_0270: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_027a: stloc.s 15
+		IL_027c: ldstr "off-once-count:"
+		IL_0281: ldloc.s 15
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0288: stloc.s 19
+		IL_028a: ldloc.s 16
+		IL_028c: ldloc.s 19
+		IL_028e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0293: pop
+		IL_0294: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0299: stloc.s 16
+		IL_029b: ldloc.0
+		IL_029c: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a6: ldstr "emit"
+		IL_02ab: ldstr "once"
+		IL_02b0: ldc.r8 1
+		IL_02b9: box [System.Runtime]System.Double
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02c3: stloc.s 15
+		IL_02c5: ldstr "off-once-emitted:"
+		IL_02ca: ldloc.s 15
+		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02d1: stloc.s 19
+		IL_02d3: ldloc.s 16
+		IL_02d5: ldloc.s 19
+		IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02dc: pop
+		IL_02dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02e2: stloc.s 16
+		IL_02e4: ldloc.0
+		IL_02e5: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::total
+		IL_02ea: stloc.s 15
+		IL_02ec: ldstr "total:"
+		IL_02f1: ldloc.s 15
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02f8: stloc.s 19
+		IL_02fa: ldloc.s 16
+		IL_02fc: ldloc.s 19
+		IL_02fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0303: pop
-		IL_0304: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0309: stloc.s 16
-		IL_030b: ldloc.0
-		IL_030c: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0316: ldstr "listenerCount"
-		IL_031b: ldstr "duplicate"
-		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0325: stloc.s 15
-		IL_0327: ldstr "duplicate-count:"
-		IL_032c: ldloc.s 15
-		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0333: stloc.s 19
-		IL_0335: ldloc.s 16
-		IL_0337: ldloc.s 19
-		IL_0339: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_033e: pop
-		IL_033f: ldloc.0
-		IL_0340: ldc.r8 0.0
-		IL_0349: box [System.Runtime]System.Double
-		IL_034e: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawTotal
-		IL_0353: ldc.r8 1
-		IL_035c: neg
-		IL_035d: stloc.s 20
-		IL_035f: ldloc.s 20
-		IL_0361: box [System.Runtime]System.Double
-		IL_0366: stloc.s 21
-		IL_0368: ldloc.0
-		IL_0369: ldloc.s 21
-		IL_036b: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawCountDuringCall
-		IL_0370: nop
-		IL_0371: ldloc.0
-		IL_0372: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037c: ldstr "once"
-		IL_0381: ldstr "raw-once"
-		IL_0386: ldloc.2
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_038c: pop
-		IL_038d: ldloc.0
-		IL_038e: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0398: ldstr "rawListeners"
-		IL_039d: ldstr "raw-once"
-		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03a7: stloc.s 15
-		IL_03a9: ldloc.s 15
-		IL_03ab: ldc.r8 0.0
-		IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03b9: stloc.s 7
-		IL_03bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03c0: stloc.s 16
-		IL_03c2: volatile.
-		IL_03c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_03c9: brfalse IL_03df
+		IL_0304: ldloc.0
+		IL_0305: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_030f: ldstr "on"
+		IL_0314: ldstr "duplicate"
+		IL_0319: ldloc.1
+		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_031f: pop
+		IL_0320: ldloc.0
+		IL_0321: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_032b: ldstr "on"
+		IL_0330: ldstr "duplicate"
+		IL_0335: ldloc.1
+		IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_033b: pop
+		IL_033c: ldloc.0
+		IL_033d: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0347: ldstr "off"
+		IL_034c: ldstr "duplicate"
+		IL_0351: ldloc.1
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0357: pop
+		IL_0358: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_035d: stloc.s 16
+		IL_035f: ldloc.0
+		IL_0360: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_036a: volatile.
+		IL_036c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0371: brfalse IL_038a
 
-		IL_03ce: ldloc.s 7
-		IL_03d0: ldstr "listener"
-		IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03da: br IL_03f5
+		IL_0376: ldstr "listenerCount"
+		IL_037b: ldstr "duplicate"
+		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0385: br IL_03a3
 
-		IL_03df: ldloc.s 7
-		IL_03e1: ldstr "listener"
-		IL_03e6: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:140"
-		IL_03eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_038a: ldstr "listenerCount"
+		IL_038f: ldstr "duplicate"
+		IL_0394: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:110"
+		IL_0399: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03f5: stloc.s 15
-		IL_03f7: ldloc.s 15
-		IL_03f9: ldloc.2
-		IL_03fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03ff: stloc.s 17
-		IL_0401: ldloc.s 17
-		IL_0403: box [System.Runtime]System.Boolean
-		IL_0408: stloc.s 18
-		IL_040a: ldstr "raw-listener:"
-		IL_040f: ldloc.s 18
-		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0416: stloc.s 19
-		IL_0418: ldloc.s 16
-		IL_041a: ldloc.s 19
-		IL_041c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0421: pop
-		IL_0422: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0427: stloc.s 13
-		IL_0429: ldloc.s 7
-		IL_042b: ldloc.s 13
-		IL_042d: ldc.r8 2
-		IL_0436: box [System.Runtime]System.Double
-		IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0440: pop
-		IL_0441: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0446: stloc.s 13
-		IL_0448: ldloc.s 7
-		IL_044a: ldloc.s 13
-		IL_044c: ldc.r8 4
-		IL_0455: box [System.Runtime]System.Double
-		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_045f: pop
-		IL_0460: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0465: stloc.s 16
-		IL_0467: ldloc.0
-		IL_0468: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawCountDuringCall
-		IL_046d: stloc.s 15
-		IL_046f: ldstr "raw-removal-count:"
-		IL_0474: ldloc.s 15
-		IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_047b: stloc.s 19
-		IL_047d: ldloc.s 16
-		IL_047f: ldloc.s 19
-		IL_0481: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0486: pop
-		IL_0487: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_048c: stloc.s 16
-		IL_048e: ldloc.0
-		IL_048f: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0499: ldstr "listenerCount"
-		IL_049e: ldstr "raw-once"
-		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04a8: stloc.s 15
-		IL_04aa: ldstr "raw-count:"
-		IL_04af: ldloc.s 15
-		IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_04b6: stloc.s 19
-		IL_04b8: ldloc.s 16
-		IL_04ba: ldloc.s 19
-		IL_04bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04c1: pop
-		IL_04c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04c7: stloc.s 16
-		IL_04c9: ldloc.0
-		IL_04ca: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawTotal
-		IL_04cf: stloc.s 15
-		IL_04d1: ldstr "raw-total:"
-		IL_04d6: ldloc.s 15
-		IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_04dd: stloc.s 19
-		IL_04df: ldloc.s 16
-		IL_04e1: ldloc.s 19
-		IL_04e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03a3: stloc.s 15
+		IL_03a5: ldstr "duplicate-count:"
+		IL_03aa: ldloc.s 15
+		IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03b1: stloc.s 19
+		IL_03b3: ldloc.s 16
+		IL_03b5: ldloc.s 19
+		IL_03b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03bc: pop
+		IL_03bd: ldloc.0
+		IL_03be: ldc.r8 0.0
+		IL_03c7: box [System.Runtime]System.Double
+		IL_03cc: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawTotal
+		IL_03d1: ldc.r8 1
+		IL_03da: neg
+		IL_03db: stloc.s 20
+		IL_03dd: ldloc.s 20
+		IL_03df: box [System.Runtime]System.Double
+		IL_03e4: stloc.s 21
+		IL_03e6: ldloc.0
+		IL_03e7: ldloc.s 21
+		IL_03e9: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawCountDuringCall
+		IL_03ee: nop
+		IL_03ef: ldloc.0
+		IL_03f0: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03fa: ldstr "once"
+		IL_03ff: ldstr "raw-once"
+		IL_0404: ldloc.2
+		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_040a: pop
+		IL_040b: ldloc.0
+		IL_040c: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0416: volatile.
+		IL_0418: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_041d: brfalse IL_0436
+
+		IL_0422: ldstr "rawListeners"
+		IL_0427: ldstr "raw-once"
+		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0431: br IL_044f
+
+		IL_0436: ldstr "rawListeners"
+		IL_043b: ldstr "raw-once"
+		IL_0440: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:132"
+		IL_0445: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_044f: stloc.s 15
+		IL_0451: ldloc.s 15
+		IL_0453: ldc.r8 0.0
+		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0461: stloc.s 7
+		IL_0463: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0468: stloc.s 16
+		IL_046a: volatile.
+		IL_046c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0471: brfalse IL_0487
+
+		IL_0476: ldloc.s 7
+		IL_0478: ldstr "listener"
+		IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0482: br IL_049d
+
+		IL_0487: ldloc.s 7
+		IL_0489: ldstr "listener"
+		IL_048e: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:140"
+		IL_0493: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_049d: stloc.s 15
+		IL_049f: ldloc.s 15
+		IL_04a1: ldloc.2
+		IL_04a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04a7: stloc.s 17
+		IL_04a9: ldloc.s 17
+		IL_04ab: box [System.Runtime]System.Boolean
+		IL_04b0: stloc.s 18
+		IL_04b2: ldstr "raw-listener:"
+		IL_04b7: ldloc.s 18
+		IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_04be: stloc.s 19
+		IL_04c0: ldloc.s 16
+		IL_04c2: ldloc.s 19
+		IL_04c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04c9: pop
+		IL_04ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04cf: stloc.s 13
+		IL_04d1: ldloc.s 7
+		IL_04d3: ldloc.s 13
+		IL_04d5: ldc.r8 2
+		IL_04de: box [System.Runtime]System.Double
+		IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 		IL_04e8: pop
-		IL_04e9: ldloc.0
-		IL_04ea: ldc.r8 0.0
-		IL_04f3: box [System.Runtime]System.Double
-		IL_04f8: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::duplicateOnceCalls
-		IL_04fd: nop
-		IL_04fe: ldloc.0
-		IL_04ff: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0509: ldstr "once"
-		IL_050e: ldstr "duplicate-once"
-		IL_0513: ldloc.3
-		IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0519: pop
-		IL_051a: ldloc.0
-		IL_051b: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0525: ldstr "once"
-		IL_052a: ldstr "duplicate-once"
-		IL_052f: ldloc.3
-		IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0535: pop
+		IL_04e9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04ee: stloc.s 13
+		IL_04f0: ldloc.s 7
+		IL_04f2: ldloc.s 13
+		IL_04f4: ldc.r8 4
+		IL_04fd: box [System.Runtime]System.Double
+		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0507: pop
+		IL_0508: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_050d: stloc.s 16
+		IL_050f: ldloc.0
+		IL_0510: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawCountDuringCall
+		IL_0515: stloc.s 15
+		IL_0517: ldstr "raw-removal-count:"
+		IL_051c: ldloc.s 15
+		IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0523: stloc.s 19
+		IL_0525: ldloc.s 16
+		IL_0527: ldloc.s 19
+		IL_0529: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_052e: pop
+		IL_052f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0534: stloc.s 16
 		IL_0536: ldloc.0
 		IL_0537: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
 		IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0541: ldstr "listeners"
-		IL_0546: ldstr "duplicate-once"
-		IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0550: stloc.s 8
-		IL_0552: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0557: stloc.s 16
-		IL_0559: ldloc.s 8
-		IL_055b: ldc.r8 0.0
-		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0569: stloc.s 15
-		IL_056b: ldloc.s 15
-		IL_056d: ldloc.3
-		IL_056e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0573: stloc.s 17
-		IL_0575: ldloc.s 17
-		IL_0577: box [System.Runtime]System.Boolean
-		IL_057c: stloc.s 18
-		IL_057e: ldloc.s 18
-		IL_0580: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_0585: stloc.s 17
-		IL_0587: ldloc.s 17
-		IL_0589: brfalse IL_05bc
+		IL_0541: volatile.
+		IL_0543: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0548: brfalse IL_0561
 
-		IL_058e: ldloc.s 8
-		IL_0590: ldc.r8 1
-		IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_059e: stloc.s 15
-		IL_05a0: ldloc.s 15
-		IL_05a2: ldloc.3
-		IL_05a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05a8: stloc.s 17
-		IL_05aa: ldloc.s 17
-		IL_05ac: box [System.Runtime]System.Boolean
-		IL_05b1: stloc.s 22
-		IL_05b3: ldloc.s 22
-		IL_05b5: stloc.s 23
-		IL_05b7: br IL_05c0
+		IL_054d: ldstr "listenerCount"
+		IL_0552: ldstr "raw-once"
+		IL_0557: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_055c: br IL_057a
 
-		IL_05bc: ldloc.s 18
-		IL_05be: stloc.s 23
+		IL_0561: ldstr "listenerCount"
+		IL_0566: ldstr "raw-once"
+		IL_056b: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:167"
+		IL_0570: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_05c0: ldstr "duplicate-once-identities:"
-		IL_05c5: ldloc.s 23
-		IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_05cc: stloc.s 23
-		IL_05ce: ldloc.s 16
-		IL_05d0: ldloc.s 23
-		IL_05d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05d7: pop
-		IL_05d8: ldloc.0
-		IL_05d9: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05e3: ldstr "removeListener"
-		IL_05e8: ldstr "duplicate-once"
-		IL_05ed: ldloc.3
-		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_05f3: pop
-		IL_05f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05f9: stloc.s 16
-		IL_05fb: ldloc.0
-		IL_05fc: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0606: ldstr "listenerCount"
-		IL_060b: ldstr "duplicate-once"
-		IL_0610: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0615: stloc.s 15
-		IL_0617: ldstr "duplicate-once-after-remove:"
-		IL_061c: ldloc.s 15
-		IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0623: stloc.s 23
-		IL_0625: ldloc.s 16
-		IL_0627: ldloc.s 23
-		IL_0629: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_062e: pop
-		IL_062f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0634: stloc.s 16
-		IL_0636: ldloc.0
-		IL_0637: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0641: ldstr "emit"
-		IL_0646: ldstr "duplicate-once"
-		IL_064b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0650: stloc.s 15
-		IL_0652: ldstr "duplicate-once-emitted:"
-		IL_0657: ldloc.s 15
-		IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_065e: stloc.s 23
-		IL_0660: ldloc.s 16
-		IL_0662: ldloc.s 23
-		IL_0664: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0669: pop
-		IL_066a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_066f: stloc.s 16
-		IL_0671: ldloc.0
-		IL_0672: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::duplicateOnceCalls
-		IL_0677: stloc.s 15
-		IL_0679: ldstr "duplicate-once-calls:"
-		IL_067e: ldloc.s 15
-		IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0685: stloc.s 23
-		IL_0687: ldloc.s 16
-		IL_0689: ldloc.s 23
-		IL_068b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0690: pop
-		IL_0691: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0696: stloc.s 16
-		IL_0698: ldloc.0
-		IL_0699: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_069e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06a3: ldstr "listenerCount"
-		IL_06a8: ldstr "duplicate-once"
-		IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06b2: stloc.s 15
-		IL_06b4: ldstr "duplicate-once-final-count:"
-		IL_06b9: ldloc.s 15
-		IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_06c0: stloc.s 23
-		IL_06c2: ldloc.s 16
-		IL_06c4: ldloc.s 23
-		IL_06c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06cb: pop
-		IL_06cc: nop
-		IL_06cd: nop
-		IL_06ce: ldloc.0
-		IL_06cf: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_06d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06d9: ldstr "on"
-		IL_06de: ldstr "async"
-		IL_06e3: ldloc.s 4
-		IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06ea: pop
-		IL_06eb: ldloc.0
-		IL_06ec: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_06f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06f6: ldstr "on"
-		IL_06fb: ldstr "generator"
-		IL_0700: ldloc.s 5
-		IL_0702: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0707: pop
-		IL_0708: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_070d: stloc.s 16
-		IL_070f: ldloc.0
-		IL_0710: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_0715: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_071a: ldstr "emit"
-		IL_071f: ldstr "async"
-		IL_0724: ldc.r8 2
-		IL_072d: box [System.Runtime]System.Double
-		IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0737: stloc.s 15
-		IL_0739: ldstr "async-emitted:"
-		IL_073e: ldloc.s 15
-		IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0745: stloc.s 23
-		IL_0747: ldloc.s 16
-		IL_0749: ldloc.s 23
-		IL_074b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0750: pop
-		IL_0751: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0756: stloc.s 16
-		IL_0758: ldloc.0
-		IL_0759: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-		IL_075e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0763: ldstr "emit"
-		IL_0768: ldstr "generator"
-		IL_076d: ldc.r8 3
-		IL_0776: box [System.Runtime]System.Double
-		IL_077b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0780: stloc.s 15
-		IL_0782: ldstr "generator-emitted:"
-		IL_0787: ldloc.s 15
-		IL_0789: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_078e: stloc.s 23
-		IL_0790: ldloc.s 16
-		IL_0792: ldloc.s 23
-		IL_0794: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0799: pop
-		IL_079a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_079f: stloc.s 16
-		IL_07a1: ldloc.0
-		IL_07a2: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::total
-		IL_07a7: stloc.s 15
-		IL_07a9: ldstr "async-total:"
-		IL_07ae: ldloc.s 15
-		IL_07b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_07b5: stloc.s 23
-		IL_07b7: ldloc.s 16
-		IL_07b9: ldloc.s 23
-		IL_07bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07c0: pop
+		IL_057a: stloc.s 15
+		IL_057c: ldstr "raw-count:"
+		IL_0581: ldloc.s 15
+		IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0588: stloc.s 19
+		IL_058a: ldloc.s 16
+		IL_058c: ldloc.s 19
+		IL_058e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0593: pop
+		IL_0594: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0599: stloc.s 16
+		IL_059b: ldloc.0
+		IL_059c: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::rawTotal
+		IL_05a1: stloc.s 15
+		IL_05a3: ldstr "raw-total:"
+		IL_05a8: ldloc.s 15
+		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_05af: stloc.s 19
+		IL_05b1: ldloc.s 16
+		IL_05b3: ldloc.s 19
+		IL_05b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05ba: pop
+		IL_05bb: ldloc.0
+		IL_05bc: ldc.r8 0.0
+		IL_05c5: box [System.Runtime]System.Double
+		IL_05ca: stfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::duplicateOnceCalls
+		IL_05cf: nop
+		IL_05d0: ldloc.0
+		IL_05d1: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05db: ldstr "once"
+		IL_05e0: ldstr "duplicate-once"
+		IL_05e5: ldloc.3
+		IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05eb: pop
+		IL_05ec: ldloc.0
+		IL_05ed: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05f7: ldstr "once"
+		IL_05fc: ldstr "duplicate-once"
+		IL_0601: ldloc.3
+		IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0607: pop
+		IL_0608: ldloc.0
+		IL_0609: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0613: volatile.
+		IL_0615: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_061a: brfalse IL_0633
+
+		IL_061f: ldstr "listeners"
+		IL_0624: ldstr "duplicate-once"
+		IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_062e: br IL_064c
+
+		IL_0633: ldstr "listeners"
+		IL_0638: ldstr "duplicate-once"
+		IL_063d: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:195"
+		IL_0642: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_064c: stloc.s 8
+		IL_064e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0653: stloc.s 16
+		IL_0655: ldloc.s 8
+		IL_0657: ldc.r8 0.0
+		IL_0660: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0665: stloc.s 15
+		IL_0667: ldloc.s 15
+		IL_0669: ldloc.3
+		IL_066a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_066f: stloc.s 17
+		IL_0671: ldloc.s 17
+		IL_0673: box [System.Runtime]System.Boolean
+		IL_0678: stloc.s 18
+		IL_067a: ldloc.s 18
+		IL_067c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0681: stloc.s 17
+		IL_0683: ldloc.s 17
+		IL_0685: brfalse IL_06b8
+
+		IL_068a: ldloc.s 8
+		IL_068c: ldc.r8 1
+		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_069a: stloc.s 15
+		IL_069c: ldloc.s 15
+		IL_069e: ldloc.3
+		IL_069f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06a4: stloc.s 17
+		IL_06a6: ldloc.s 17
+		IL_06a8: box [System.Runtime]System.Boolean
+		IL_06ad: stloc.s 22
+		IL_06af: ldloc.s 22
+		IL_06b1: stloc.s 23
+		IL_06b3: br IL_06bc
+
+		IL_06b8: ldloc.s 18
+		IL_06ba: stloc.s 23
+
+		IL_06bc: ldstr "duplicate-once-identities:"
+		IL_06c1: ldloc.s 23
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_06c8: stloc.s 23
+		IL_06ca: ldloc.s 16
+		IL_06cc: ldloc.s 23
+		IL_06ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06d3: pop
+		IL_06d4: ldloc.0
+		IL_06d5: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06df: ldstr "removeListener"
+		IL_06e4: ldstr "duplicate-once"
+		IL_06e9: ldloc.3
+		IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_06ef: pop
+		IL_06f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06f5: stloc.s 16
+		IL_06f7: ldloc.0
+		IL_06f8: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0702: volatile.
+		IL_0704: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0709: brfalse IL_0722
+
+		IL_070e: ldstr "listenerCount"
+		IL_0713: ldstr "duplicate-once"
+		IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_071d: br IL_073b
+
+		IL_0722: ldstr "listenerCount"
+		IL_0727: ldstr "duplicate-once"
+		IL_072c: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:228"
+		IL_0731: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_073b: stloc.s 15
+		IL_073d: ldstr "duplicate-once-after-remove:"
+		IL_0742: ldloc.s 15
+		IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0749: stloc.s 23
+		IL_074b: ldloc.s 16
+		IL_074d: ldloc.s 23
+		IL_074f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0754: pop
+		IL_0755: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_075a: stloc.s 16
+		IL_075c: ldloc.0
+		IL_075d: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0767: volatile.
+		IL_0769: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_076e: brfalse IL_0787
+
+		IL_0773: ldstr "emit"
+		IL_0778: ldstr "duplicate-once"
+		IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0782: br IL_07a0
+
+		IL_0787: ldstr "emit"
+		IL_078c: ldstr "duplicate-once"
+		IL_0791: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:237"
+		IL_0796: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_079b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_07a0: stloc.s 15
+		IL_07a2: ldstr "duplicate-once-emitted:"
+		IL_07a7: ldloc.s 15
+		IL_07a9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_07ae: stloc.s 23
+		IL_07b0: ldloc.s 16
+		IL_07b2: ldloc.s 23
+		IL_07b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07b9: pop
+		IL_07ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07bf: stloc.s 16
+		IL_07c1: ldloc.0
+		IL_07c2: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::duplicateOnceCalls
+		IL_07c7: stloc.s 15
+		IL_07c9: ldstr "duplicate-once-calls:"
+		IL_07ce: ldloc.s 15
+		IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_07d5: stloc.s 23
+		IL_07d7: ldloc.s 16
+		IL_07d9: ldloc.s 23
+		IL_07db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07e0: pop
+		IL_07e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07e6: stloc.s 16
+		IL_07e8: ldloc.0
+		IL_07e9: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_07ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07f3: volatile.
+		IL_07f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_07fa: brfalse IL_0813
+
+		IL_07ff: ldstr "listenerCount"
+		IL_0804: ldstr "duplicate-once"
+		IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_080e: br IL_082c
+
+		IL_0813: ldstr "listenerCount"
+		IL_0818: ldstr "duplicate-once"
+		IL_081d: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:252"
+		IL_0822: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0827: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_082c: stloc.s 15
+		IL_082e: ldstr "duplicate-once-final-count:"
+		IL_0833: ldloc.s 15
+		IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_083a: stloc.s 23
+		IL_083c: ldloc.s 16
+		IL_083e: ldloc.s 23
+		IL_0840: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0845: pop
+		IL_0846: nop
+		IL_0847: nop
+		IL_0848: ldloc.0
+		IL_0849: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0853: ldstr "on"
+		IL_0858: ldstr "async"
+		IL_085d: ldloc.s 4
+		IL_085f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0864: pop
+		IL_0865: ldloc.0
+		IL_0866: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_086b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0870: ldstr "on"
+		IL_0875: ldstr "generator"
+		IL_087a: ldloc.s 5
+		IL_087c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0881: pop
+		IL_0882: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0887: stloc.s 16
+		IL_0889: ldloc.0
+		IL_088a: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_088f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0894: ldstr "emit"
+		IL_0899: ldstr "async"
+		IL_089e: ldc.r8 2
+		IL_08a7: box [System.Runtime]System.Double
+		IL_08ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_08b1: stloc.s 15
+		IL_08b3: ldstr "async-emitted:"
+		IL_08b8: ldloc.s 15
+		IL_08ba: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_08bf: stloc.s 23
+		IL_08c1: ldloc.s 16
+		IL_08c3: ldloc.s 23
+		IL_08c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08ca: pop
+		IL_08cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08d0: stloc.s 16
+		IL_08d2: ldloc.0
+		IL_08d3: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+		IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08dd: ldstr "emit"
+		IL_08e2: ldstr "generator"
+		IL_08e7: ldc.r8 3
+		IL_08f0: box [System.Runtime]System.Double
+		IL_08f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_08fa: stloc.s 15
+		IL_08fc: ldstr "generator-emitted:"
+		IL_0901: ldloc.s 15
+		IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0908: stloc.s 23
+		IL_090a: ldloc.s 16
+		IL_090c: ldloc.s 23
+		IL_090e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0913: pop
+		IL_0914: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0919: stloc.s 16
+		IL_091b: ldloc.0
+		IL_091c: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::total
+		IL_0921: stloc.s 15
+		IL_0923: ldstr "async-total:"
+		IL_0928: ldloc.s 15
+		IL_092a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_092f: stloc.s 23
+		IL_0931: ldloc.s 16
+		IL_0933: ldloc.s 23
+		IL_0935: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_093a: pop
 		.try
 		{
-			IL_07c1: nop
-			IL_07c2: ldloc.0
-			IL_07c3: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
-			IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07cd: ldstr "off"
-			IL_07d2: ldstr "generator"
-			IL_07d7: ldc.r8 42
-			IL_07e0: box [System.Runtime]System.Double
-			IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_07ea: pop
-			IL_07eb: leave IL_087b
+			IL_093b: nop
+			IL_093c: ldloc.0
+			IL_093d: ldfld object Modules.Events_Callback_Identity_And_Function_Objects/Scope::emitter
+			IL_0942: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0947: ldstr "off"
+			IL_094c: ldstr "generator"
+			IL_0951: ldc.r8 42
+			IL_095a: box [System.Runtime]System.Double
+			IL_095f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0964: pop
+			IL_0965: leave IL_09f5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_07f0: stloc.s 9
-			IL_07f2: ldloc.s 9
-			IL_07f4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_07f9: dup
-			IL_07fa: brtrue IL_0810
+			IL_096a: stloc.s 9
+			IL_096c: ldloc.s 9
+			IL_096e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0973: dup
+			IL_0974: brtrue IL_098a
 
-			IL_07ff: pop
-			IL_0800: ldloc.s 9
-			IL_0802: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0807: dup
-			IL_0808: brtrue IL_081c
+			IL_0979: pop
+			IL_097a: ldloc.s 9
+			IL_097c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0981: dup
+			IL_0982: brtrue IL_0996
 
-			IL_080d: pop
-			IL_080e: rethrow
+			IL_0987: pop
+			IL_0988: rethrow
 
-			IL_0810: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0815: stloc.s 10
-			IL_0817: br IL_081e
+			IL_098a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_098f: stloc.s 10
+			IL_0991: br IL_0998
 
-			IL_081c: stloc.s 10
+			IL_0996: stloc.s 10
 
-			IL_081e: ldloc.s 10
-			IL_0820: stloc.s 11
-			IL_0822: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0827: stloc.s 16
-			IL_0829: volatile.
-			IL_082b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0830: brfalse IL_0846
+			IL_0998: ldloc.s 10
+			IL_099a: stloc.s 11
+			IL_099c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09a1: stloc.s 16
+			IL_09a3: volatile.
+			IL_09a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_09aa: brfalse IL_09c0
 
-			IL_0835: ldloc.s 11
-			IL_0837: ldstr "message"
-			IL_083c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0841: br IL_085c
+			IL_09af: ldloc.s 11
+			IL_09b1: ldstr "message"
+			IL_09b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09bb: br IL_09d6
 
-			IL_0846: ldloc.s 11
-			IL_0848: ldstr "message"
-			IL_084d: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:316"
-			IL_0852: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_09c0: ldloc.s 11
+			IL_09c2: ldstr "message"
+			IL_09c7: ldstr "Events_Callback_Identity_And_Function_Objects:Modules.Events_Callback_Identity_And_Function_Objects:__js_module_init__:316"
+			IL_09cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_09d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_085c: stloc.s 15
-			IL_085e: ldstr "error:"
-			IL_0863: ldloc.s 15
-			IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_086a: stloc.s 23
-			IL_086c: ldloc.s 16
-			IL_086e: ldloc.s 23
-			IL_0870: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0875: pop
-			IL_0876: leave IL_087b
+			IL_09d6: stloc.s 15
+			IL_09d8: ldstr "error:"
+			IL_09dd: ldloc.s 15
+			IL_09df: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09e4: stloc.s 23
+			IL_09e6: ldloc.s 16
+			IL_09e8: ldloc.s 23
+			IL_09ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_09ef: pop
+			IL_09f0: leave IL_09f5
 		} // end handler
 
-		IL_087b: ldnull
-		IL_087c: stloc.s 12
-		IL_087e: ret
+		IL_09f5: ldnull
+		IL_09f6: stloc.s 12
+		IL_09f8: ret
 	} // end of method Events_Callback_Identity_And_Function_Objects::__js_module_init__
 
 } // end of class Modules.Events_Callback_Identity_And_Function_Objects
@@ -1850,6 +1970,16 @@
 	.field assembly static int32 __jroc_dynamicLookup_18
 	.field assembly static int32 __jroc_dynamicLookup_19
 	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
@@ -1950,7 +1950,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2475 (0x9ab)
+		// Code size: 2964 (0xb94)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_Complete/Scope,
@@ -2166,313 +2166,315 @@
 		IL_01ec: stloc.s 20
 		IL_01ee: ldloc.s 7
 		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f5: ldstr "listeners"
-		IL_01fa: ldstr "test"
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0204: stloc.s 21
-		IL_0206: volatile.
-		IL_0208: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_020d: brfalse IL_0223
+		IL_01f5: volatile.
+		IL_01f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_01fc: brfalse IL_0215
 
-		IL_0212: ldloc.s 21
-		IL_0214: ldstr "length"
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_021e: br IL_0239
+		IL_0201: ldstr "listeners"
+		IL_0206: ldstr "test"
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0210: br IL_022e
 
-		IL_0223: ldloc.s 21
-		IL_0225: ldstr "length"
-		IL_022a: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:57"
-		IL_022f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0215: ldstr "listeners"
+		IL_021a: ldstr "test"
+		IL_021f: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:55"
+		IL_0224: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0239: stloc.s 21
-		IL_023b: ldloc.s 20
-		IL_023d: ldloc.s 21
-		IL_023f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0244: pop
-		IL_0245: nop
-		IL_0246: nop
-		IL_0247: ldloc.s 7
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024e: ldstr "on"
-		IL_0253: ldstr "test"
-		IL_0258: ldloc.1
-		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_025e: pop
-		IL_025f: ldloc.s 7
-		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0266: ldstr "on"
-		IL_026b: ldstr "test"
-		IL_0270: ldloc.2
-		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0276: pop
-		IL_0277: ldloc.s 7
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027e: ldstr "listeners"
-		IL_0283: ldstr "test"
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_028d: stloc.s 8
-		IL_028f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0294: stloc.s 20
-		IL_0296: volatile.
-		IL_0298: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_029d: brfalse IL_02b3
+		IL_022e: stloc.s 21
+		IL_0230: volatile.
+		IL_0232: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0237: brfalse IL_024d
 
-		IL_02a2: ldloc.s 8
-		IL_02a4: ldstr "length"
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ae: br IL_02c9
+		IL_023c: ldloc.s 21
+		IL_023e: ldstr "length"
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0248: br IL_0263
 
-		IL_02b3: ldloc.s 8
-		IL_02b5: ldstr "length"
-		IL_02ba: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:77"
-		IL_02bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_024d: ldloc.s 21
+		IL_024f: ldstr "length"
+		IL_0254: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:57"
+		IL_0259: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02c9: stloc.s 21
-		IL_02cb: ldloc.s 20
-		IL_02cd: ldloc.s 21
-		IL_02cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d4: pop
-		IL_02d5: ldloc.s 4
-		IL_02d7: dup
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_02dd: stloc.s 9
-		IL_02df: ldloc.0
-		IL_02e0: ldstr ""
-		IL_02e5: stfld object Modules.Events_EventEmitter_Complete/Scope::order
-		IL_02ea: ldloc.s 9
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f1: stloc.s 21
-		IL_02f3: ldc.i4.1
-		IL_02f4: newarr [System.Runtime]System.Object
-		IL_02f9: dup
-		IL_02fa: ldc.i4.0
-		IL_02fb: ldloc.0
-		IL_02fc: stelem.ref
-		IL_02fd: stloc.s 19
-		IL_02ff: ldloc.s 19
-		IL_0301: ldc.i4.0
-		IL_0302: ldelem.ref
-		IL_0303: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_0308: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
-		IL_030d: ldc.i4.0
-		IL_030e: conv.r8
-		IL_030f: ldstr ""
-		IL_0314: ldc.i4.0
-		IL_0315: ldc.i4.1
-		IL_0316: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_031b: stloc.s 24
-		IL_031d: ldloc.s 21
-		IL_031f: ldstr "on"
-		IL_0324: ldstr "event"
-		IL_0329: ldloc.s 24
-		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0330: pop
-		IL_0331: ldloc.s 9
-		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0338: stloc.s 21
-		IL_033a: ldc.i4.1
-		IL_033b: newarr [System.Runtime]System.Object
-		IL_0340: dup
-		IL_0341: ldc.i4.0
-		IL_0342: ldloc.0
-		IL_0343: stelem.ref
-		IL_0344: stloc.s 19
-		IL_0346: ldloc.s 19
-		IL_0348: ldc.i4.0
-		IL_0349: ldelem.ref
-		IL_034a: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_034f: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
-		IL_0354: ldc.i4.0
-		IL_0355: conv.r8
-		IL_0356: ldstr ""
-		IL_035b: ldc.i4.0
-		IL_035c: ldc.i4.1
-		IL_035d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0362: stloc.s 25
-		IL_0364: ldloc.s 21
-		IL_0366: ldstr "prependListener"
-		IL_036b: ldstr "event"
-		IL_0370: ldloc.s 25
-		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0377: pop
-		IL_0378: ldloc.s 9
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037f: ldstr "emit"
-		IL_0384: ldstr "event"
-		IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_038e: pop
-		IL_038f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0394: stloc.s 20
+		IL_0263: stloc.s 21
+		IL_0265: ldloc.s 20
+		IL_0267: ldloc.s 21
+		IL_0269: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_026e: pop
+		IL_026f: nop
+		IL_0270: nop
+		IL_0271: ldloc.s 7
+		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0278: ldstr "on"
+		IL_027d: ldstr "test"
+		IL_0282: ldloc.1
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0288: pop
+		IL_0289: ldloc.s 7
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0290: ldstr "on"
+		IL_0295: ldstr "test"
+		IL_029a: ldloc.2
+		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02a0: pop
+		IL_02a1: ldloc.s 7
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a8: volatile.
+		IL_02aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_02af: brfalse IL_02c8
+
+		IL_02b4: ldstr "listeners"
+		IL_02b9: ldstr "test"
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c3: br IL_02e1
+
+		IL_02c8: ldstr "listeners"
+		IL_02cd: ldstr "test"
+		IL_02d2: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:72"
+		IL_02d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02e1: stloc.s 8
+		IL_02e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02e8: stloc.s 20
+		IL_02ea: volatile.
+		IL_02ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_02f1: brfalse IL_0307
+
+		IL_02f6: ldloc.s 8
+		IL_02f8: ldstr "length"
+		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0302: br IL_031d
+
+		IL_0307: ldloc.s 8
+		IL_0309: ldstr "length"
+		IL_030e: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:77"
+		IL_0313: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_031d: stloc.s 21
+		IL_031f: ldloc.s 20
+		IL_0321: ldloc.s 21
+		IL_0323: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0328: pop
+		IL_0329: ldloc.s 4
+		IL_032b: dup
+		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0331: stloc.s 9
+		IL_0333: ldloc.0
+		IL_0334: ldstr ""
+		IL_0339: stfld object Modules.Events_EventEmitter_Complete/Scope::order
+		IL_033e: ldloc.s 9
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0345: stloc.s 21
+		IL_0347: ldc.i4.1
+		IL_0348: newarr [System.Runtime]System.Object
+		IL_034d: dup
+		IL_034e: ldc.i4.0
+		IL_034f: ldloc.0
+		IL_0350: stelem.ref
+		IL_0351: stloc.s 19
+		IL_0353: ldloc.s 19
+		IL_0355: ldc.i4.0
+		IL_0356: ldelem.ref
+		IL_0357: castclass Modules.Events_EventEmitter_Complete/Scope
+		IL_035c: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_0361: ldc.i4.0
+		IL_0362: conv.r8
+		IL_0363: ldstr ""
+		IL_0368: ldc.i4.0
+		IL_0369: ldc.i4.1
+		IL_036a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_036f: stloc.s 24
+		IL_0371: ldloc.s 21
+		IL_0373: ldstr "on"
+		IL_0378: ldstr "event"
+		IL_037d: ldloc.s 24
+		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0384: pop
+		IL_0385: ldloc.s 9
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_038c: stloc.s 21
+		IL_038e: ldc.i4.1
+		IL_038f: newarr [System.Runtime]System.Object
+		IL_0394: dup
+		IL_0395: ldc.i4.0
 		IL_0396: ldloc.0
-		IL_0397: ldfld object Modules.Events_EventEmitter_Complete/Scope::order
-		IL_039c: stloc.s 21
-		IL_039e: ldloc.s 20
-		IL_03a0: ldloc.s 21
-		IL_03a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03a7: pop
-		IL_03a8: ldloc.s 4
-		IL_03aa: dup
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_03b0: stloc.s 10
-		IL_03b2: ldloc.0
-		IL_03b3: ldstr ""
-		IL_03b8: stfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-		IL_03bd: ldloc.s 10
-		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03c4: stloc.s 21
-		IL_03c6: ldc.i4.1
-		IL_03c7: newarr [System.Runtime]System.Object
-		IL_03cc: dup
-		IL_03cd: ldc.i4.0
-		IL_03ce: ldloc.0
-		IL_03cf: stelem.ref
-		IL_03d0: stloc.s 19
-		IL_03d2: ldloc.s 19
-		IL_03d4: ldc.i4.0
-		IL_03d5: ldelem.ref
-		IL_03d6: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_03db: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
-		IL_03e0: ldc.i4.0
-		IL_03e1: conv.r8
-		IL_03e2: ldstr ""
-		IL_03e7: ldc.i4.0
-		IL_03e8: ldc.i4.1
-		IL_03e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03ee: stloc.s 26
-		IL_03f0: ldloc.s 21
-		IL_03f2: ldstr "on"
-		IL_03f7: ldstr "tick"
-		IL_03fc: ldloc.s 26
-		IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0403: pop
-		IL_0404: ldloc.s 10
-		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040b: stloc.s 21
-		IL_040d: ldc.i4.1
-		IL_040e: newarr [System.Runtime]System.Object
-		IL_0413: dup
-		IL_0414: ldc.i4.0
-		IL_0415: ldloc.0
-		IL_0416: stelem.ref
-		IL_0417: stloc.s 19
-		IL_0419: ldloc.s 19
-		IL_041b: ldc.i4.0
-		IL_041c: ldelem.ref
-		IL_041d: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_0422: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
-		IL_0427: ldc.i4.0
-		IL_0428: conv.r8
-		IL_0429: ldstr ""
-		IL_042e: ldc.i4.0
-		IL_042f: ldc.i4.1
-		IL_0430: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0435: stloc.s 27
-		IL_0437: ldloc.s 21
-		IL_0439: ldstr "prependOnceListener"
-		IL_043e: ldstr "tick"
-		IL_0443: ldloc.s 27
-		IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_044a: pop
-		IL_044b: ldloc.s 10
-		IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0452: ldstr "emit"
-		IL_0457: ldstr "tick"
-		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0461: pop
-		IL_0462: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0467: stloc.s 20
-		IL_0469: ldloc.0
-		IL_046a: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-		IL_046f: stloc.s 21
-		IL_0471: ldloc.s 20
-		IL_0473: ldloc.s 21
-		IL_0475: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_047a: pop
-		IL_047b: ldloc.s 10
-		IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0482: ldstr "emit"
-		IL_0487: ldstr "tick"
-		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0491: pop
-		IL_0492: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0497: stloc.s 20
-		IL_0499: ldloc.0
-		IL_049a: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
-		IL_049f: stloc.s 21
-		IL_04a1: ldloc.s 20
-		IL_04a3: ldloc.s 21
-		IL_04a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04aa: pop
-		IL_04ab: ldloc.s 4
-		IL_04ad: dup
-		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_04b3: stloc.s 11
-		IL_04b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04ba: stloc.s 20
-		IL_04bc: ldloc.s 11
-		IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c3: volatile.
-		IL_04c5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_04ca: brfalse IL_04de
+		IL_0397: stelem.ref
+		IL_0398: stloc.s 19
+		IL_039a: ldloc.s 19
+		IL_039c: ldc.i4.0
+		IL_039d: ldelem.ref
+		IL_039e: castclass Modules.Events_EventEmitter_Complete/Scope
+		IL_03a3: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_03a8: ldc.i4.0
+		IL_03a9: conv.r8
+		IL_03aa: ldstr ""
+		IL_03af: ldc.i4.0
+		IL_03b0: ldc.i4.1
+		IL_03b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03b6: stloc.s 25
+		IL_03b8: ldloc.s 21
+		IL_03ba: ldstr "prependListener"
+		IL_03bf: ldstr "event"
+		IL_03c4: ldloc.s 25
+		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03cb: pop
+		IL_03cc: ldloc.s 9
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03d3: volatile.
+		IL_03d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_03da: brfalse IL_03f3
 
-		IL_04cf: ldstr "getMaxListeners"
-		IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_04d9: br IL_04f2
+		IL_03df: ldstr "emit"
+		IL_03e4: ldstr "event"
+		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03ee: br IL_040c
 
-		IL_04de: ldstr "getMaxListeners"
-		IL_04e3: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:145"
-		IL_04e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_03f3: ldstr "emit"
+		IL_03f8: ldstr "event"
+		IL_03fd: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:100"
+		IL_0402: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_04f2: stloc.s 21
-		IL_04f4: ldloc.s 20
-		IL_04f6: ldloc.s 21
-		IL_04f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04fd: pop
-		IL_04fe: ldloc.s 11
-		IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0505: ldstr "setMaxListeners"
-		IL_050a: ldc.r8 20
-		IL_0513: box [System.Runtime]System.Double
-		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_051d: pop
-		IL_051e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0523: stloc.s 20
-		IL_0525: ldloc.s 11
-		IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_052c: volatile.
-		IL_052e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0533: brfalse IL_0547
+		IL_040c: pop
+		IL_040d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0412: stloc.s 20
+		IL_0414: ldloc.0
+		IL_0415: ldfld object Modules.Events_EventEmitter_Complete/Scope::order
+		IL_041a: stloc.s 21
+		IL_041c: ldloc.s 20
+		IL_041e: ldloc.s 21
+		IL_0420: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0425: pop
+		IL_0426: ldloc.s 4
+		IL_0428: dup
+		IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_042e: stloc.s 10
+		IL_0430: ldloc.0
+		IL_0431: ldstr ""
+		IL_0436: stfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
+		IL_043b: ldloc.s 10
+		IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0442: stloc.s 21
+		IL_0444: ldc.i4.1
+		IL_0445: newarr [System.Runtime]System.Object
+		IL_044a: dup
+		IL_044b: ldc.i4.0
+		IL_044c: ldloc.0
+		IL_044d: stelem.ref
+		IL_044e: stloc.s 19
+		IL_0450: ldloc.s 19
+		IL_0452: ldc.i4.0
+		IL_0453: ldelem.ref
+		IL_0454: castclass Modules.Events_EventEmitter_Complete/Scope
+		IL_0459: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_045e: ldc.i4.0
+		IL_045f: conv.r8
+		IL_0460: ldstr ""
+		IL_0465: ldc.i4.0
+		IL_0466: ldc.i4.1
+		IL_0467: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_046c: stloc.s 26
+		IL_046e: ldloc.s 21
+		IL_0470: ldstr "on"
+		IL_0475: ldstr "tick"
+		IL_047a: ldloc.s 26
+		IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0481: pop
+		IL_0482: ldloc.s 10
+		IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0489: stloc.s 21
+		IL_048b: ldc.i4.1
+		IL_048c: newarr [System.Runtime]System.Object
+		IL_0491: dup
+		IL_0492: ldc.i4.0
+		IL_0493: ldloc.0
+		IL_0494: stelem.ref
+		IL_0495: stloc.s 19
+		IL_0497: ldloc.s 19
+		IL_0499: ldc.i4.0
+		IL_049a: ldelem.ref
+		IL_049b: castclass Modules.Events_EventEmitter_Complete/Scope
+		IL_04a0: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_04a5: ldc.i4.0
+		IL_04a6: conv.r8
+		IL_04a7: ldstr ""
+		IL_04ac: ldc.i4.0
+		IL_04ad: ldc.i4.1
+		IL_04ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04b3: stloc.s 27
+		IL_04b5: ldloc.s 21
+		IL_04b7: ldstr "prependOnceListener"
+		IL_04bc: ldstr "tick"
+		IL_04c1: ldloc.s 27
+		IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04c8: pop
+		IL_04c9: ldloc.s 10
+		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d0: volatile.
+		IL_04d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_04d7: brfalse IL_04f0
 
-		IL_0538: ldstr "getMaxListeners"
-		IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0542: br IL_055b
+		IL_04dc: ldstr "emit"
+		IL_04e1: ldstr "tick"
+		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04eb: br IL_0509
 
-		IL_0547: ldstr "getMaxListeners"
-		IL_054c: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:155"
-		IL_0551: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_04f0: ldstr "emit"
+		IL_04f5: ldstr "tick"
+		IL_04fa: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:126"
+		IL_04ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_055b: stloc.s 21
-		IL_055d: ldloc.s 20
-		IL_055f: ldloc.s 21
-		IL_0561: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0566: pop
-		IL_0567: ldloc.s 11
-		IL_0569: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_056e: ldstr "setMaxListeners"
-		IL_0573: ldc.r8 5
-		IL_057c: box [System.Runtime]System.Double
-		IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0586: pop
+		IL_0509: pop
+		IL_050a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_050f: stloc.s 20
+		IL_0511: ldloc.0
+		IL_0512: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
+		IL_0517: stloc.s 21
+		IL_0519: ldloc.s 20
+		IL_051b: ldloc.s 21
+		IL_051d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0522: pop
+		IL_0523: ldloc.s 10
+		IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_052a: volatile.
+		IL_052c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0531: brfalse IL_054a
+
+		IL_0536: ldstr "emit"
+		IL_053b: ldstr "tick"
+		IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0545: br IL_0563
+
+		IL_054a: ldstr "emit"
+		IL_054f: ldstr "tick"
+		IL_0554: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:134"
+		IL_0559: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0563: pop
+		IL_0564: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0569: stloc.s 20
+		IL_056b: ldloc.0
+		IL_056c: ldfld object Modules.Events_EventEmitter_Complete/Scope::prependOnceOrder
+		IL_0571: stloc.s 21
+		IL_0573: ldloc.s 20
+		IL_0575: ldloc.s 21
+		IL_0577: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_057c: pop
+		IL_057d: ldloc.s 4
+		IL_057f: dup
+		IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0585: stloc.s 11
 		IL_0587: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_058c: stloc.s 20
 		IL_058e: ldloc.s 11
 		IL_0590: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_0595: volatile.
-		IL_0597: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0597: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 		IL_059c: brfalse IL_05b0
 
 		IL_05a1: ldstr "getMaxListeners"
@@ -2480,8 +2482,8 @@
 		IL_05ab: br IL_05c4
 
 		IL_05b0: ldstr "getMaxListeners"
-		IL_05b5: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:165"
-		IL_05ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_05b5: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:145"
+		IL_05ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 		IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 		IL_05c4: stloc.s 21
@@ -2489,332 +2491,465 @@
 		IL_05c8: ldloc.s 21
 		IL_05ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_05cf: pop
-		IL_05d0: ldloc.s 4
-		IL_05d2: dup
-		IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_05d8: stloc.s 12
-		IL_05da: ldloc.s 12
-		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05e1: stloc.s 21
-		IL_05e3: ldc.i4.1
-		IL_05e4: newarr [System.Runtime]System.Object
-		IL_05e9: dup
-		IL_05ea: ldc.i4.0
-		IL_05eb: ldloc.0
-		IL_05ec: stelem.ref
-		IL_05ed: stloc.s 19
-		IL_05ef: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject::.ctor()
-		IL_05f4: ldc.i4.0
-		IL_05f5: conv.r8
-		IL_05f6: ldstr ""
-		IL_05fb: ldc.i4.0
-		IL_05fc: ldc.i4.1
-		IL_05fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0602: stloc.s 28
-		IL_0604: ldloc.s 21
-		IL_0606: ldstr "on"
-		IL_060b: ldstr "raw"
-		IL_0610: ldloc.s 28
-		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0617: pop
-		IL_0618: ldloc.s 12
-		IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_061f: stloc.s 21
-		IL_0621: ldc.i4.1
-		IL_0622: newarr [System.Runtime]System.Object
-		IL_0627: dup
-		IL_0628: ldc.i4.0
-		IL_0629: ldloc.0
-		IL_062a: stelem.ref
-		IL_062b: stloc.s 19
-		IL_062d: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject::.ctor()
-		IL_0632: ldc.i4.0
-		IL_0633: conv.r8
-		IL_0634: ldstr ""
-		IL_0639: ldc.i4.0
-		IL_063a: ldc.i4.1
-		IL_063b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0640: stloc.s 29
-		IL_0642: ldloc.s 21
-		IL_0644: ldstr "once"
-		IL_0649: ldstr "raw"
-		IL_064e: ldloc.s 29
-		IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0655: pop
-		IL_0656: ldloc.s 12
-		IL_0658: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_065d: ldstr "rawListeners"
-		IL_0662: ldstr "raw"
-		IL_0667: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_066c: stloc.s 13
-		IL_066e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0673: stloc.s 20
-		IL_0675: volatile.
-		IL_0677: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_067c: brfalse IL_0692
+		IL_05d0: ldloc.s 11
+		IL_05d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05d7: volatile.
+		IL_05d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_05de: brfalse IL_0600
 
-		IL_0681: ldloc.s 13
-		IL_0683: ldstr "length"
-		IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_068d: br IL_06a8
+		IL_05e3: ldstr "setMaxListeners"
+		IL_05e8: ldc.r8 20
+		IL_05f1: box [System.Runtime]System.Double
+		IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05fb: br IL_0622
 
-		IL_0692: ldloc.s 13
-		IL_0694: ldstr "length"
-		IL_0699: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:190"
-		IL_069e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0600: ldstr "setMaxListeners"
+		IL_0605: ldc.r8 20
+		IL_060e: box [System.Runtime]System.Double
+		IL_0613: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:151"
+		IL_0618: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_06a8: stloc.s 21
-		IL_06aa: ldloc.s 20
-		IL_06ac: ldloc.s 21
-		IL_06ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06b3: pop
-		IL_06b4: ldloc.s 4
-		IL_06b6: dup
-		IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_06bc: stloc.s 14
-		IL_06be: ldloc.s 14
-		IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06c5: stloc.s 21
-		IL_06c7: ldc.i4.1
-		IL_06c8: newarr [System.Runtime]System.Object
-		IL_06cd: dup
-		IL_06ce: ldc.i4.0
-		IL_06cf: ldloc.0
-		IL_06d0: stelem.ref
-		IL_06d1: stloc.s 19
-		IL_06d3: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject::.ctor()
-		IL_06d8: ldc.i4.0
-		IL_06d9: conv.r8
-		IL_06da: ldstr ""
-		IL_06df: ldc.i4.0
-		IL_06e0: ldc.i4.1
-		IL_06e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06e6: stloc.s 30
-		IL_06e8: ldloc.s 21
-		IL_06ea: ldstr "on"
-		IL_06ef: ldstr "a"
-		IL_06f4: ldloc.s 30
-		IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06fb: stloc.s 21
-		IL_06fd: ldloc.s 21
-		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0704: stloc.s 21
-		IL_0706: ldc.i4.1
-		IL_0707: newarr [System.Runtime]System.Object
-		IL_070c: dup
-		IL_070d: ldc.i4.0
-		IL_070e: ldloc.0
-		IL_070f: stelem.ref
-		IL_0710: stloc.s 19
-		IL_0712: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject::.ctor()
-		IL_0717: ldc.i4.0
-		IL_0718: conv.r8
-		IL_0719: ldstr ""
-		IL_071e: ldc.i4.0
-		IL_071f: ldc.i4.1
-		IL_0720: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0725: stloc.s 31
-		IL_0727: ldloc.s 21
-		IL_0729: ldstr "prependListener"
-		IL_072e: ldstr "b"
-		IL_0733: ldloc.s 31
-		IL_0735: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_073a: stloc.s 21
+		IL_0622: pop
+		IL_0623: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0628: stloc.s 20
+		IL_062a: ldloc.s 11
+		IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0631: volatile.
+		IL_0633: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0638: brfalse IL_064c
+
+		IL_063d: ldstr "getMaxListeners"
+		IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0647: br IL_0660
+
+		IL_064c: ldstr "getMaxListeners"
+		IL_0651: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:155"
+		IL_0656: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0660: stloc.s 21
+		IL_0662: ldloc.s 20
+		IL_0664: ldloc.s 21
+		IL_0666: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_066b: pop
+		IL_066c: ldloc.s 11
+		IL_066e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0673: volatile.
+		IL_0675: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_067a: brfalse IL_069c
+
+		IL_067f: ldstr "setMaxListeners"
+		IL_0684: ldc.r8 5
+		IL_068d: box [System.Runtime]System.Double
+		IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0697: br IL_06be
+
+		IL_069c: ldstr "setMaxListeners"
+		IL_06a1: ldc.r8 5
+		IL_06aa: box [System.Runtime]System.Double
+		IL_06af: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:161"
+		IL_06b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_06be: pop
+		IL_06bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06c4: stloc.s 20
+		IL_06c6: ldloc.s 11
+		IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06cd: volatile.
+		IL_06cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_06d4: brfalse IL_06e8
+
+		IL_06d9: ldstr "getMaxListeners"
+		IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_06e3: br IL_06fc
+
+		IL_06e8: ldstr "getMaxListeners"
+		IL_06ed: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:165"
+		IL_06f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_06fc: stloc.s 21
+		IL_06fe: ldloc.s 20
+		IL_0700: ldloc.s 21
+		IL_0702: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0707: pop
+		IL_0708: ldloc.s 4
+		IL_070a: dup
+		IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0710: stloc.s 12
+		IL_0712: ldloc.s 12
+		IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0719: stloc.s 21
+		IL_071b: ldc.i4.1
+		IL_071c: newarr [System.Runtime]System.Object
+		IL_0721: dup
+		IL_0722: ldc.i4.0
+		IL_0723: ldloc.0
+		IL_0724: stelem.ref
+		IL_0725: stloc.s 19
+		IL_0727: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject::.ctor()
+		IL_072c: ldc.i4.0
+		IL_072d: conv.r8
+		IL_072e: ldstr ""
+		IL_0733: ldc.i4.0
+		IL_0734: ldc.i4.1
+		IL_0735: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_073a: stloc.s 28
 		IL_073c: ldloc.s 21
-		IL_073e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0743: ldstr "setMaxListeners"
-		IL_0748: ldc.r8 15
-		IL_0751: box [System.Runtime]System.Double
-		IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_075b: stloc.s 21
-		IL_075d: ldloc.s 21
-		IL_075f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0764: volatile.
-		IL_0766: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_076b: brfalse IL_077f
+		IL_073e: ldstr "on"
+		IL_0743: ldstr "raw"
+		IL_0748: ldloc.s 28
+		IL_074a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_074f: pop
+		IL_0750: ldloc.s 12
+		IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0757: stloc.s 21
+		IL_0759: ldc.i4.1
+		IL_075a: newarr [System.Runtime]System.Object
+		IL_075f: dup
+		IL_0760: ldc.i4.0
+		IL_0761: ldloc.0
+		IL_0762: stelem.ref
+		IL_0763: stloc.s 19
+		IL_0765: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject::.ctor()
+		IL_076a: ldc.i4.0
+		IL_076b: conv.r8
+		IL_076c: ldstr ""
+		IL_0771: ldc.i4.0
+		IL_0772: ldc.i4.1
+		IL_0773: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0778: stloc.s 29
+		IL_077a: ldloc.s 21
+		IL_077c: ldstr "once"
+		IL_0781: ldstr "raw"
+		IL_0786: ldloc.s 29
+		IL_0788: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_078d: pop
+		IL_078e: ldloc.s 12
+		IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0795: volatile.
+		IL_0797: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_079c: brfalse IL_07b5
 
-		IL_0770: ldstr "removeAllListeners"
-		IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_077a: br IL_0793
+		IL_07a1: ldstr "rawListeners"
+		IL_07a6: ldstr "raw"
+		IL_07ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07b0: br IL_07ce
 
-		IL_077f: ldstr "removeAllListeners"
-		IL_0784: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:211"
-		IL_0789: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_07b5: ldstr "rawListeners"
+		IL_07ba: ldstr "raw"
+		IL_07bf: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:185"
+		IL_07c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0793: stloc.s 15
-		IL_0795: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_079a: stloc.s 20
-		IL_079c: ldloc.s 15
-		IL_079e: ldloc.s 14
-		IL_07a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_07a5: stloc.s 32
-		IL_07a7: ldloc.s 32
-		IL_07a9: box [System.Runtime]System.Boolean
-		IL_07ae: stloc.s 33
-		IL_07b0: ldloc.s 20
-		IL_07b2: ldloc.s 33
-		IL_07b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07b9: pop
-		IL_07ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07bf: stloc.s 20
-		IL_07c1: ldloc.s 14
-		IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07c8: volatile.
-		IL_07ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_07cf: brfalse IL_07e3
+		IL_07ce: stloc.s 13
+		IL_07d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07d5: stloc.s 20
+		IL_07d7: volatile.
+		IL_07d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_07de: brfalse IL_07f4
 
-		IL_07d4: ldstr "eventNames"
-		IL_07d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_07de: br IL_07f7
+		IL_07e3: ldloc.s 13
+		IL_07e5: ldstr "length"
+		IL_07ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07ef: br IL_080a
 
-		IL_07e3: ldstr "eventNames"
-		IL_07e8: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:221"
-		IL_07ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_07f4: ldloc.s 13
+		IL_07f6: ldstr "length"
+		IL_07fb: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:190"
+		IL_0800: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07f7: stloc.s 21
-		IL_07f9: volatile.
-		IL_07fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0800: brfalse IL_0816
+		IL_080a: stloc.s 21
+		IL_080c: ldloc.s 20
+		IL_080e: ldloc.s 21
+		IL_0810: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0815: pop
+		IL_0816: ldloc.s 4
+		IL_0818: dup
+		IL_0819: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_081e: stloc.s 14
+		IL_0820: ldloc.s 14
+		IL_0822: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0827: stloc.s 21
+		IL_0829: ldc.i4.1
+		IL_082a: newarr [System.Runtime]System.Object
+		IL_082f: dup
+		IL_0830: ldc.i4.0
+		IL_0831: ldloc.0
+		IL_0832: stelem.ref
+		IL_0833: stloc.s 19
+		IL_0835: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject::.ctor()
+		IL_083a: ldc.i4.0
+		IL_083b: conv.r8
+		IL_083c: ldstr ""
+		IL_0841: ldc.i4.0
+		IL_0842: ldc.i4.1
+		IL_0843: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0848: stloc.s 30
+		IL_084a: ldloc.s 21
+		IL_084c: ldstr "on"
+		IL_0851: ldstr "a"
+		IL_0856: ldloc.s 30
+		IL_0858: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_085d: stloc.s 21
+		IL_085f: ldloc.s 21
+		IL_0861: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0866: stloc.s 21
+		IL_0868: ldc.i4.1
+		IL_0869: newarr [System.Runtime]System.Object
+		IL_086e: dup
+		IL_086f: ldc.i4.0
+		IL_0870: ldloc.0
+		IL_0871: stelem.ref
+		IL_0872: stloc.s 19
+		IL_0874: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject::.ctor()
+		IL_0879: ldc.i4.0
+		IL_087a: conv.r8
+		IL_087b: ldstr ""
+		IL_0880: ldc.i4.0
+		IL_0881: ldc.i4.1
+		IL_0882: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0887: stloc.s 31
+		IL_0889: ldloc.s 21
+		IL_088b: ldstr "prependListener"
+		IL_0890: ldstr "b"
+		IL_0895: ldloc.s 31
+		IL_0897: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_089c: stloc.s 21
+		IL_089e: ldloc.s 21
+		IL_08a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08a5: volatile.
+		IL_08a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_08ac: brfalse IL_08ce
 
-		IL_0805: ldloc.s 21
-		IL_0807: ldstr "length"
-		IL_080c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0811: br IL_082c
+		IL_08b1: ldstr "setMaxListeners"
+		IL_08b6: ldc.r8 15
+		IL_08bf: box [System.Runtime]System.Double
+		IL_08c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_08c9: br IL_08f0
 
-		IL_0816: ldloc.s 21
-		IL_0818: ldstr "length"
-		IL_081d: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:223"
-		IL_0822: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0827: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_08ce: ldstr "setMaxListeners"
+		IL_08d3: ldc.r8 15
+		IL_08dc: box [System.Runtime]System.Double
+		IL_08e1: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:209"
+		IL_08e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_08eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_082c: stloc.s 21
-		IL_082e: ldloc.s 20
-		IL_0830: ldloc.s 21
-		IL_0832: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0837: pop
-		IL_0838: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_083d: stloc.s 20
-		IL_083f: ldloc.s 14
-		IL_0841: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0846: volatile.
-		IL_0848: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_084d: brfalse IL_0861
+		IL_08f0: stloc.s 21
+		IL_08f2: ldloc.s 21
+		IL_08f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08f9: volatile.
+		IL_08fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0900: brfalse IL_0914
 
-		IL_0852: ldstr "getMaxListeners"
-		IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_085c: br IL_0875
+		IL_0905: ldstr "removeAllListeners"
+		IL_090a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_090f: br IL_0928
 
-		IL_0861: ldstr "getMaxListeners"
-		IL_0866: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:228"
-		IL_086b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0870: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0914: ldstr "removeAllListeners"
+		IL_0919: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:211"
+		IL_091e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0875: stloc.s 21
-		IL_0877: ldloc.s 20
-		IL_0879: ldloc.s 21
-		IL_087b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0880: pop
-		IL_0881: ldloc.s 4
-		IL_0883: dup
-		IL_0884: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_0889: stloc.s 16
-		IL_088b: ldloc.s 16
-		IL_088d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0892: stloc.s 21
-		IL_0894: ldc.i4.1
-		IL_0895: newarr [System.Runtime]System.Object
-		IL_089a: dup
-		IL_089b: ldc.i4.0
-		IL_089c: ldloc.0
-		IL_089d: stelem.ref
-		IL_089e: stloc.s 19
-		IL_08a0: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject::.ctor()
-		IL_08a5: ldc.i4.0
-		IL_08a6: conv.r8
-		IL_08a7: ldstr ""
-		IL_08ac: ldc.i4.0
-		IL_08ad: ldc.i4.1
-		IL_08ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08b3: stloc.s 34
-		IL_08b5: ldloc.s 21
-		IL_08b7: ldstr "on"
-		IL_08bc: ldstr "copy"
-		IL_08c1: ldloc.s 34
-		IL_08c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_08c8: pop
-		IL_08c9: ldloc.s 16
-		IL_08cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08d0: ldstr "listeners"
-		IL_08d5: ldstr "copy"
-		IL_08da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_08df: stloc.s 17
-		IL_08e1: ldloc.s 16
-		IL_08e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08e8: ldstr "listeners"
-		IL_08ed: ldstr "copy"
-		IL_08f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_08f7: stloc.s 18
-		IL_08f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08fe: stloc.s 20
-		IL_0900: ldloc.s 17
-		IL_0902: ldloc.s 18
-		IL_0904: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0909: stloc.s 32
-		IL_090b: ldloc.s 32
-		IL_090d: box [System.Runtime]System.Boolean
-		IL_0912: stloc.s 33
-		IL_0914: ldloc.s 20
-		IL_0916: ldloc.s 33
-		IL_0918: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_091d: pop
-		IL_091e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0923: stloc.s 20
-		IL_0925: volatile.
-		IL_0927: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_092c: brfalse IL_0942
+		IL_0928: stloc.s 15
+		IL_092a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_092f: stloc.s 20
+		IL_0931: ldloc.s 15
+		IL_0933: ldloc.s 14
+		IL_0935: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_093a: stloc.s 32
+		IL_093c: ldloc.s 32
+		IL_093e: box [System.Runtime]System.Boolean
+		IL_0943: stloc.s 33
+		IL_0945: ldloc.s 20
+		IL_0947: ldloc.s 33
+		IL_0949: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_094e: pop
+		IL_094f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0954: stloc.s 20
+		IL_0956: ldloc.s 14
+		IL_0958: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_095d: volatile.
+		IL_095f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0964: brfalse IL_0978
 
-		IL_0931: ldloc.s 17
-		IL_0933: ldstr "length"
-		IL_0938: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_093d: br IL_0958
+		IL_0969: ldstr "eventNames"
+		IL_096e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0973: br IL_098c
 
-		IL_0942: ldloc.s 17
-		IL_0944: ldstr "length"
-		IL_0949: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:257"
-		IL_094e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0953: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0978: ldstr "eventNames"
+		IL_097d: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:221"
+		IL_0982: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0987: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0958: stloc.s 21
-		IL_095a: ldloc.s 20
-		IL_095c: ldloc.s 21
-		IL_095e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0963: pop
-		IL_0964: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0969: stloc.s 20
-		IL_096b: volatile.
-		IL_096d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0972: brfalse IL_0988
+		IL_098c: stloc.s 21
+		IL_098e: volatile.
+		IL_0990: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0995: brfalse IL_09ab
 
-		IL_0977: ldloc.s 18
-		IL_0979: ldstr "length"
-		IL_097e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0983: br IL_099e
+		IL_099a: ldloc.s 21
+		IL_099c: ldstr "length"
+		IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09a6: br IL_09c1
 
-		IL_0988: ldloc.s 18
-		IL_098a: ldstr "length"
-		IL_098f: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:262"
-		IL_0994: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0999: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09ab: ldloc.s 21
+		IL_09ad: ldstr "length"
+		IL_09b2: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:223"
+		IL_09b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_09bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_099e: stloc.s 21
-		IL_09a0: ldloc.s 20
-		IL_09a2: ldloc.s 21
-		IL_09a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_09a9: pop
-		IL_09aa: ret
+		IL_09c1: stloc.s 21
+		IL_09c3: ldloc.s 20
+		IL_09c5: ldloc.s 21
+		IL_09c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_09cc: pop
+		IL_09cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_09d2: stloc.s 20
+		IL_09d4: ldloc.s 14
+		IL_09d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_09db: volatile.
+		IL_09dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_09e2: brfalse IL_09f6
+
+		IL_09e7: ldstr "getMaxListeners"
+		IL_09ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_09f1: br IL_0a0a
+
+		IL_09f6: ldstr "getMaxListeners"
+		IL_09fb: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:228"
+		IL_0a00: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0a05: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0a0a: stloc.s 21
+		IL_0a0c: ldloc.s 20
+		IL_0a0e: ldloc.s 21
+		IL_0a10: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0a15: pop
+		IL_0a16: ldloc.s 4
+		IL_0a18: dup
+		IL_0a19: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0a1e: stloc.s 16
+		IL_0a20: ldloc.s 16
+		IL_0a22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a27: stloc.s 21
+		IL_0a29: ldc.i4.1
+		IL_0a2a: newarr [System.Runtime]System.Object
+		IL_0a2f: dup
+		IL_0a30: ldc.i4.0
+		IL_0a31: ldloc.0
+		IL_0a32: stelem.ref
+		IL_0a33: stloc.s 19
+		IL_0a35: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject::.ctor()
+		IL_0a3a: ldc.i4.0
+		IL_0a3b: conv.r8
+		IL_0a3c: ldstr ""
+		IL_0a41: ldc.i4.0
+		IL_0a42: ldc.i4.1
+		IL_0a43: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a48: stloc.s 34
+		IL_0a4a: ldloc.s 21
+		IL_0a4c: ldstr "on"
+		IL_0a51: ldstr "copy"
+		IL_0a56: ldloc.s 34
+		IL_0a58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0a5d: pop
+		IL_0a5e: ldloc.s 16
+		IL_0a60: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a65: volatile.
+		IL_0a67: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0a6c: brfalse IL_0a85
+
+		IL_0a71: ldstr "listeners"
+		IL_0a76: ldstr "copy"
+		IL_0a7b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a80: br IL_0a9e
+
+		IL_0a85: ldstr "listeners"
+		IL_0a8a: ldstr "copy"
+		IL_0a8f: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:242"
+		IL_0a94: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0a99: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0a9e: stloc.s 17
+		IL_0aa0: ldloc.s 16
+		IL_0aa2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0aa7: volatile.
+		IL_0aa9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0aae: brfalse IL_0ac7
+
+		IL_0ab3: ldstr "listeners"
+		IL_0ab8: ldstr "copy"
+		IL_0abd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0ac2: br IL_0ae0
+
+		IL_0ac7: ldstr "listeners"
+		IL_0acc: ldstr "copy"
+		IL_0ad1: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:247"
+		IL_0ad6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0adb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0ae0: stloc.s 18
+		IL_0ae2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ae7: stloc.s 20
+		IL_0ae9: ldloc.s 17
+		IL_0aeb: ldloc.s 18
+		IL_0aed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0af2: stloc.s 32
+		IL_0af4: ldloc.s 32
+		IL_0af6: box [System.Runtime]System.Boolean
+		IL_0afb: stloc.s 33
+		IL_0afd: ldloc.s 20
+		IL_0aff: ldloc.s 33
+		IL_0b01: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b06: pop
+		IL_0b07: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b0c: stloc.s 20
+		IL_0b0e: volatile.
+		IL_0b10: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0b15: brfalse IL_0b2b
+
+		IL_0b1a: ldloc.s 17
+		IL_0b1c: ldstr "length"
+		IL_0b21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b26: br IL_0b41
+
+		IL_0b2b: ldloc.s 17
+		IL_0b2d: ldstr "length"
+		IL_0b32: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:257"
+		IL_0b37: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0b3c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0b41: stloc.s 21
+		IL_0b43: ldloc.s 20
+		IL_0b45: ldloc.s 21
+		IL_0b47: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b4c: pop
+		IL_0b4d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0b52: stloc.s 20
+		IL_0b54: volatile.
+		IL_0b56: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0b5b: brfalse IL_0b71
+
+		IL_0b60: ldloc.s 18
+		IL_0b62: ldstr "length"
+		IL_0b67: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b6c: br IL_0b87
+
+		IL_0b71: ldloc.s 18
+		IL_0b73: ldstr "length"
+		IL_0b78: ldstr "Events_EventEmitter_Complete:Modules.Events_EventEmitter_Complete:__js_module_init__:262"
+		IL_0b7d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0b82: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0b87: stloc.s 21
+		IL_0b89: ldloc.s 20
+		IL_0b8b: ldloc.s 21
+		IL_0b8d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b92: pop
+		IL_0b93: ret
 	} // end of method Events_EventEmitter_Complete::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_Complete
@@ -2860,6 +2995,17 @@
 	.field assembly static int32 __jroc_dynamicLookup_22
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
+	.field assembly static int32 __jroc_dynamicLookup_35
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
@@ -700,7 +700,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 883 (0x373)
+		// Code size: 1303 (0x517)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_On_Off_Once/Scope,
@@ -758,254 +758,374 @@
 		IL_0066: stloc.s 6
 		IL_0068: ldloc.s 4
 		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: ldstr "emit"
-		IL_0074: ldstr "data"
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007e: stloc.s 7
-		IL_0080: ldloc.s 6
-		IL_0082: ldloc.s 7
-		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0089: pop
-		IL_008a: ldloc.s 4
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0091: ldstr "on"
-		IL_0096: ldstr "data"
-		IL_009b: ldloc.1
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00a1: pop
-		IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a7: stloc.s 6
-		IL_00a9: ldloc.s 4
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b0: ldstr "emit"
-		IL_00b5: ldstr "data"
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: stloc.s 7
-		IL_00c1: ldloc.s 6
-		IL_00c3: ldloc.s 7
-		IL_00c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ca: pop
-		IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d0: stloc.s 6
-		IL_00d2: ldloc.0
-		IL_00d3: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
-		IL_00d8: stloc.s 7
-		IL_00da: ldloc.s 6
-		IL_00dc: ldloc.s 7
-		IL_00de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e3: pop
-		IL_00e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e9: stloc.s 6
-		IL_00eb: ldloc.s 4
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f2: ldstr "listenerCount"
-		IL_00f7: ldstr "data"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0101: stloc.s 7
-		IL_0103: ldloc.s 6
-		IL_0105: ldloc.s 7
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010c: pop
-		IL_010d: ldloc.s 4
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0114: ldstr "off"
-		IL_0119: ldstr "data"
-		IL_011e: ldloc.1
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0124: pop
-		IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012a: stloc.s 6
-		IL_012c: ldloc.s 4
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0133: ldstr "emit"
-		IL_0138: ldstr "data"
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0142: stloc.s 7
-		IL_0144: ldloc.s 6
-		IL_0146: ldloc.s 7
-		IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_014d: pop
-		IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0153: stloc.s 6
-		IL_0155: ldloc.0
-		IL_0156: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
-		IL_015b: stloc.s 7
-		IL_015d: ldloc.s 6
-		IL_015f: ldloc.s 7
-		IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0166: pop
-		IL_0167: ldloc.0
-		IL_0168: ldc.r8 0.0
-		IL_0171: box [System.Runtime]System.Double
-		IL_0176: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
-		IL_017b: ldloc.s 4
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0182: stloc.s 7
-		IL_0184: ldc.i4.1
-		IL_0185: newarr [System.Runtime]System.Object
-		IL_018a: dup
-		IL_018b: ldc.i4.0
-		IL_018c: ldloc.0
-		IL_018d: stelem.ref
-		IL_018e: stloc.s 5
-		IL_0190: ldloc.s 5
-		IL_0192: ldc.i4.0
-		IL_0193: ldelem.ref
-		IL_0194: castclass Modules.Events_EventEmitter_On_Off_Once/Scope
-		IL_0199: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
-		IL_019e: ldc.i4.0
-		IL_019f: conv.r8
-		IL_01a0: ldstr ""
-		IL_01a5: ldc.i4.0
-		IL_01a6: ldc.i4.1
-		IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ac: stloc.s 8
-		IL_01ae: ldloc.s 7
-		IL_01b0: ldstr "once"
-		IL_01b5: ldstr "tick"
-		IL_01ba: ldloc.s 8
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01c1: pop
-		IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c7: stloc.s 6
-		IL_01c9: ldloc.s 4
-		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d0: ldstr "listenerCount"
-		IL_01d5: ldstr "tick"
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01df: stloc.s 7
-		IL_01e1: ldloc.s 6
-		IL_01e3: ldloc.s 7
-		IL_01e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ea: pop
-		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f0: stloc.s 6
-		IL_01f2: ldloc.s 4
-		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f9: ldstr "emit"
-		IL_01fe: ldstr "tick"
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0208: stloc.s 7
-		IL_020a: ldloc.s 6
-		IL_020c: ldloc.s 7
-		IL_020e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0213: pop
-		IL_0214: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0219: stloc.s 6
-		IL_021b: ldloc.s 4
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0222: ldstr "emit"
-		IL_0227: ldstr "tick"
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0231: stloc.s 7
-		IL_0233: ldloc.s 6
-		IL_0235: ldloc.s 7
-		IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023c: pop
-		IL_023d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0242: stloc.s 6
-		IL_0244: ldloc.0
-		IL_0245: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
-		IL_024a: stloc.s 7
-		IL_024c: ldloc.s 6
-		IL_024e: ldloc.s 7
-		IL_0250: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0255: pop
-		IL_0256: ldloc.s 4
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025d: stloc.s 7
-		IL_025f: ldc.i4.1
-		IL_0260: newarr [System.Runtime]System.Object
-		IL_0265: dup
-		IL_0266: ldc.i4.0
-		IL_0267: ldloc.0
-		IL_0268: stelem.ref
-		IL_0269: stloc.s 5
-		IL_026b: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject::.ctor()
-		IL_0270: ldc.i4.0
-		IL_0271: conv.r8
-		IL_0272: ldstr ""
-		IL_0277: ldc.i4.0
-		IL_0278: ldc.i4.1
-		IL_0279: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_027e: stloc.s 9
-		IL_0280: ldloc.s 7
-		IL_0282: ldstr "on"
-		IL_0287: ldstr "alpha"
-		IL_028c: ldloc.s 9
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0293: pop
-		IL_0294: ldloc.s 4
-		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_029b: stloc.s 7
-		IL_029d: ldc.i4.1
-		IL_029e: newarr [System.Runtime]System.Object
-		IL_02a3: dup
-		IL_02a4: ldc.i4.0
-		IL_02a5: ldloc.0
-		IL_02a6: stelem.ref
-		IL_02a7: stloc.s 5
-		IL_02a9: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject::.ctor()
-		IL_02ae: ldc.i4.0
-		IL_02af: conv.r8
-		IL_02b0: ldstr ""
-		IL_02b5: ldc.i4.0
-		IL_02b6: ldc.i4.1
-		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02bc: stloc.s 10
-		IL_02be: ldloc.s 7
-		IL_02c0: ldstr "on"
-		IL_02c5: ldstr "beta"
-		IL_02ca: ldloc.s 10
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02d1: pop
-		IL_02d2: ldloc.s 4
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d9: ldstr "removeAllListeners"
-		IL_02de: ldstr "alpha"
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e8: pop
-		IL_02e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ee: stloc.s 6
-		IL_02f0: ldloc.s 4
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f7: ldstr "listenerCount"
-		IL_02fc: ldstr "alpha"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0306: stloc.s 7
-		IL_0308: ldloc.s 6
-		IL_030a: ldloc.s 7
-		IL_030c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0311: pop
-		IL_0312: ldloc.s 4
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0319: volatile.
-		IL_031b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0320: brfalse IL_0334
+		IL_006f: volatile.
+		IL_0071: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0076: brfalse IL_008f
 
-		IL_0325: ldstr "removeAllListeners"
-		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_032f: br IL_0348
+		IL_007b: ldstr "emit"
+		IL_0080: ldstr "data"
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008a: br IL_00a8
 
-		IL_0334: ldstr "removeAllListeners"
-		IL_0339: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:118"
-		IL_033e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_008f: ldstr "emit"
+		IL_0094: ldstr "data"
+		IL_0099: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:26"
+		IL_009e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0348: pop
-		IL_0349: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_034e: stloc.s 6
-		IL_0350: ldloc.s 4
-		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0357: ldstr "listenerCount"
-		IL_035c: ldstr "beta"
-		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0366: stloc.s 7
-		IL_0368: ldloc.s 6
-		IL_036a: ldloc.s 7
-		IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0371: pop
-		IL_0372: ret
+		IL_00a8: stloc.s 7
+		IL_00aa: ldloc.s 6
+		IL_00ac: ldloc.s 7
+		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b3: pop
+		IL_00b4: ldloc.s 4
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00bb: ldstr "on"
+		IL_00c0: ldstr "data"
+		IL_00c5: ldloc.1
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00cb: pop
+		IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d1: stloc.s 6
+		IL_00d3: ldloc.s 4
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00da: volatile.
+		IL_00dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00e1: brfalse IL_00fa
+
+		IL_00e6: ldstr "emit"
+		IL_00eb: ldstr "data"
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f5: br IL_0113
+
+		IL_00fa: ldstr "emit"
+		IL_00ff: ldstr "data"
+		IL_0104: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:36"
+		IL_0109: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0113: stloc.s 7
+		IL_0115: ldloc.s 6
+		IL_0117: ldloc.s 7
+		IL_0119: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011e: pop
+		IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0124: stloc.s 6
+		IL_0126: ldloc.0
+		IL_0127: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
+		IL_012c: stloc.s 7
+		IL_012e: ldloc.s 6
+		IL_0130: ldloc.s 7
+		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0137: pop
+		IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013d: stloc.s 6
+		IL_013f: ldloc.s 4
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0146: volatile.
+		IL_0148: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_014d: brfalse IL_0166
+
+		IL_0152: ldstr "listenerCount"
+		IL_0157: ldstr "data"
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0161: br IL_017f
+
+		IL_0166: ldstr "listenerCount"
+		IL_016b: ldstr "data"
+		IL_0170: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:46"
+		IL_0175: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_017f: stloc.s 7
+		IL_0181: ldloc.s 6
+		IL_0183: ldloc.s 7
+		IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_018a: pop
+		IL_018b: ldloc.s 4
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0192: ldstr "off"
+		IL_0197: ldstr "data"
+		IL_019c: ldloc.1
+		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01a2: pop
+		IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a8: stloc.s 6
+		IL_01aa: ldloc.s 4
+		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b1: volatile.
+		IL_01b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01b8: brfalse IL_01d1
+
+		IL_01bd: ldstr "emit"
+		IL_01c2: ldstr "data"
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01cc: br IL_01ea
+
+		IL_01d1: ldstr "emit"
+		IL_01d6: ldstr "data"
+		IL_01db: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:56"
+		IL_01e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01ea: stloc.s 7
+		IL_01ec: ldloc.s 6
+		IL_01ee: ldloc.s 7
+		IL_01f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f5: pop
+		IL_01f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01fb: stloc.s 6
+		IL_01fd: ldloc.0
+		IL_01fe: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::sum
+		IL_0203: stloc.s 7
+		IL_0205: ldloc.s 6
+		IL_0207: ldloc.s 7
+		IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_020e: pop
+		IL_020f: ldloc.0
+		IL_0210: ldc.r8 0.0
+		IL_0219: box [System.Runtime]System.Double
+		IL_021e: stfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
+		IL_0223: ldloc.s 4
+		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_022a: stloc.s 7
+		IL_022c: ldc.i4.1
+		IL_022d: newarr [System.Runtime]System.Object
+		IL_0232: dup
+		IL_0233: ldc.i4.0
+		IL_0234: ldloc.0
+		IL_0235: stelem.ref
+		IL_0236: stloc.s 5
+		IL_0238: ldloc.s 5
+		IL_023a: ldc.i4.0
+		IL_023b: ldelem.ref
+		IL_023c: castclass Modules.Events_EventEmitter_On_Off_Once/Scope
+		IL_0241: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
+		IL_0246: ldc.i4.0
+		IL_0247: conv.r8
+		IL_0248: ldstr ""
+		IL_024d: ldc.i4.0
+		IL_024e: ldc.i4.1
+		IL_024f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0254: stloc.s 8
+		IL_0256: ldloc.s 7
+		IL_0258: ldstr "once"
+		IL_025d: ldstr "tick"
+		IL_0262: ldloc.s 8
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0269: pop
+		IL_026a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_026f: stloc.s 6
+		IL_0271: ldloc.s 4
+		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0278: volatile.
+		IL_027a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_027f: brfalse IL_0298
+
+		IL_0284: ldstr "listenerCount"
+		IL_0289: ldstr "tick"
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0293: br IL_02b1
+
+		IL_0298: ldstr "listenerCount"
+		IL_029d: ldstr "tick"
+		IL_02a2: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:76"
+		IL_02a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02b1: stloc.s 7
+		IL_02b3: ldloc.s 6
+		IL_02b5: ldloc.s 7
+		IL_02b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02bc: pop
+		IL_02bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c2: stloc.s 6
+		IL_02c4: ldloc.s 4
+		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02cb: volatile.
+		IL_02cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02d2: brfalse IL_02eb
+
+		IL_02d7: ldstr "emit"
+		IL_02dc: ldstr "tick"
+		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e6: br IL_0304
+
+		IL_02eb: ldstr "emit"
+		IL_02f0: ldstr "tick"
+		IL_02f5: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:82"
+		IL_02fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0304: stloc.s 7
+		IL_0306: ldloc.s 6
+		IL_0308: ldloc.s 7
+		IL_030a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_030f: pop
+		IL_0310: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0315: stloc.s 6
+		IL_0317: ldloc.s 4
+		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_031e: volatile.
+		IL_0320: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0325: brfalse IL_033e
+
+		IL_032a: ldstr "emit"
+		IL_032f: ldstr "tick"
+		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0339: br IL_0357
+
+		IL_033e: ldstr "emit"
+		IL_0343: ldstr "tick"
+		IL_0348: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:88"
+		IL_034d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0357: stloc.s 7
+		IL_0359: ldloc.s 6
+		IL_035b: ldloc.s 7
+		IL_035d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0362: pop
+		IL_0363: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0368: stloc.s 6
+		IL_036a: ldloc.0
+		IL_036b: ldfld object Modules.Events_EventEmitter_On_Off_Once/Scope::onceTotal
+		IL_0370: stloc.s 7
+		IL_0372: ldloc.s 6
+		IL_0374: ldloc.s 7
+		IL_0376: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_037b: pop
+		IL_037c: ldloc.s 4
+		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0383: stloc.s 7
+		IL_0385: ldc.i4.1
+		IL_0386: newarr [System.Runtime]System.Object
+		IL_038b: dup
+		IL_038c: ldc.i4.0
+		IL_038d: ldloc.0
+		IL_038e: stelem.ref
+		IL_038f: stloc.s 5
+		IL_0391: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject::.ctor()
+		IL_0396: ldc.i4.0
+		IL_0397: conv.r8
+		IL_0398: ldstr ""
+		IL_039d: ldc.i4.0
+		IL_039e: ldc.i4.1
+		IL_039f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03a4: stloc.s 9
+		IL_03a6: ldloc.s 7
+		IL_03a8: ldstr "on"
+		IL_03ad: ldstr "alpha"
+		IL_03b2: ldloc.s 9
+		IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03b9: pop
+		IL_03ba: ldloc.s 4
+		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c1: stloc.s 7
+		IL_03c3: ldc.i4.1
+		IL_03c4: newarr [System.Runtime]System.Object
+		IL_03c9: dup
+		IL_03ca: ldc.i4.0
+		IL_03cb: ldloc.0
+		IL_03cc: stelem.ref
+		IL_03cd: stloc.s 5
+		IL_03cf: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject::.ctor()
+		IL_03d4: ldc.i4.0
+		IL_03d5: conv.r8
+		IL_03d6: ldstr ""
+		IL_03db: ldc.i4.0
+		IL_03dc: ldc.i4.1
+		IL_03dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03e2: stloc.s 10
+		IL_03e4: ldloc.s 7
+		IL_03e6: ldstr "on"
+		IL_03eb: ldstr "beta"
+		IL_03f0: ldloc.s 10
+		IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03f7: pop
+		IL_03f8: ldloc.s 4
+		IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ff: volatile.
+		IL_0401: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0406: brfalse IL_041f
+
+		IL_040b: ldstr "removeAllListeners"
+		IL_0410: ldstr "alpha"
+		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_041a: br IL_0438
+
+		IL_041f: ldstr "removeAllListeners"
+		IL_0424: ldstr "alpha"
+		IL_0429: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:109"
+		IL_042e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0438: pop
+		IL_0439: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_043e: stloc.s 6
+		IL_0440: ldloc.s 4
+		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0447: volatile.
+		IL_0449: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_044e: brfalse IL_0467
+
+		IL_0453: ldstr "listenerCount"
+		IL_0458: ldstr "alpha"
+		IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0462: br IL_0480
+
+		IL_0467: ldstr "listenerCount"
+		IL_046c: ldstr "alpha"
+		IL_0471: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:114"
+		IL_0476: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0480: stloc.s 7
+		IL_0482: ldloc.s 6
+		IL_0484: ldloc.s 7
+		IL_0486: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_048b: pop
+		IL_048c: ldloc.s 4
+		IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0493: volatile.
+		IL_0495: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_049a: brfalse IL_04ae
+
+		IL_049f: ldstr "removeAllListeners"
+		IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_04a9: br IL_04c2
+
+		IL_04ae: ldstr "removeAllListeners"
+		IL_04b3: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:118"
+		IL_04b8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_04c2: pop
+		IL_04c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04c8: stloc.s 6
+		IL_04ca: ldloc.s 4
+		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d1: volatile.
+		IL_04d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_04d8: brfalse IL_04f1
+
+		IL_04dd: ldstr "listenerCount"
+		IL_04e2: ldstr "beta"
+		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04ec: br IL_050a
+
+		IL_04f1: ldstr "listenerCount"
+		IL_04f6: ldstr "beta"
+		IL_04fb: ldstr "Events_EventEmitter_On_Off_Once:Modules.Events_EventEmitter_On_Off_Once:__js_module_init__:123"
+		IL_0500: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_050a: stloc.s 7
+		IL_050c: ldloc.s 6
+		IL_050e: ldloc.s 7
+		IL_0510: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0515: pop
+		IL_0516: ret
 	} // end of method Events_EventEmitter_On_Off_Once::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_On_Off_Once
@@ -1036,6 +1156,16 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_SetMaxListeners_Validation.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_SetMaxListeners_Validation.verified.txt
@@ -181,7 +181,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 705 (0x2c1)
+		// Code size: 930 (0x3a2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_SetMaxListeners_Validation/Scope,
@@ -242,213 +242,275 @@
 		IL_0069: pop
 		IL_006a: ldloc.3
 		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0070: ldstr "setMaxListeners"
-		IL_0075: ldc.r8 20
-		IL_007e: box [System.Runtime]System.Double
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0088: pop
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008e: stloc.s 14
-		IL_0090: ldloc.3
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0096: volatile.
-		IL_0098: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_009d: brfalse IL_00b1
+		IL_0070: volatile.
+		IL_0072: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0077: brfalse IL_0099
 
-		IL_00a2: ldstr "getMaxListeners"
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00ac: br IL_00c5
+		IL_007c: ldstr "setMaxListeners"
+		IL_0081: ldc.r8 20
+		IL_008a: box [System.Runtime]System.Double
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0094: br IL_00bb
 
-		IL_00b1: ldstr "getMaxListeners"
-		IL_00b6: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:27"
-		IL_00bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0099: ldstr "setMaxListeners"
+		IL_009e: ldc.r8 20
+		IL_00a7: box [System.Runtime]System.Double
+		IL_00ac: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:23"
+		IL_00b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00c5: stloc.s 15
-		IL_00c7: ldloc.s 14
-		IL_00c9: ldloc.s 15
-		IL_00cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d0: pop
-		IL_00d1: ldloc.3
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d7: ldstr "setMaxListeners"
-		IL_00dc: ldc.r8 0.0
-		IL_00e5: box [System.Runtime]System.Double
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ef: pop
-		IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f5: stloc.s 14
-		IL_00f7: ldloc.3
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fd: volatile.
-		IL_00ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0104: brfalse IL_0118
+		IL_00bb: pop
+		IL_00bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c1: stloc.s 14
+		IL_00c3: ldloc.3
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c9: volatile.
+		IL_00cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d0: brfalse IL_00e4
 
-		IL_0109: ldstr "getMaxListeners"
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0113: br IL_012c
+		IL_00d5: ldstr "getMaxListeners"
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00df: br IL_00f8
 
-		IL_0118: ldstr "getMaxListeners"
-		IL_011d: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:37"
-		IL_0122: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_00e4: ldstr "getMaxListeners"
+		IL_00e9: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:27"
+		IL_00ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_012c: stloc.s 15
-		IL_012e: ldloc.s 14
-		IL_0130: ldloc.s 15
-		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0137: pop
-		IL_0138: ldloc.2
-		IL_0139: dup
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_013f: stloc.s 4
-		IL_0141: ldloc.s 4
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0148: ldstr "setMaxListeners"
-		IL_014d: ldstr "15"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0157: pop
-		IL_0158: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015d: stloc.s 14
-		IL_015f: ldloc.s 4
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0166: volatile.
-		IL_0168: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_016d: brfalse IL_0181
+		IL_00f8: stloc.s 15
+		IL_00fa: ldloc.s 14
+		IL_00fc: ldloc.s 15
+		IL_00fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0103: pop
+		IL_0104: ldloc.3
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010a: volatile.
+		IL_010c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0111: brfalse IL_0133
 
-		IL_0172: ldstr "getMaxListeners"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_017c: br IL_0195
+		IL_0116: ldstr "setMaxListeners"
+		IL_011b: ldc.r8 0.0
+		IL_0124: box [System.Runtime]System.Double
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012e: br IL_0155
 
-		IL_0181: ldstr "getMaxListeners"
-		IL_0186: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:49"
-		IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0133: ldstr "setMaxListeners"
+		IL_0138: ldc.r8 0.0
+		IL_0141: box [System.Runtime]System.Double
+		IL_0146: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:33"
+		IL_014b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0195: stloc.s 15
-		IL_0197: ldloc.s 14
-		IL_0199: ldloc.s 15
-		IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a0: pop
-		IL_01a1: ldloc.2
-		IL_01a2: dup
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_01a8: stloc.s 5
+		IL_0155: pop
+		IL_0156: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_015b: stloc.s 14
+		IL_015d: ldloc.3
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0163: volatile.
+		IL_0165: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_016a: brfalse IL_017e
+
+		IL_016f: ldstr "getMaxListeners"
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0179: br IL_0192
+
+		IL_017e: ldstr "getMaxListeners"
+		IL_0183: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:37"
+		IL_0188: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0192: stloc.s 15
+		IL_0194: ldloc.s 14
+		IL_0196: ldloc.s 15
+		IL_0198: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019d: pop
+		IL_019e: ldloc.2
+		IL_019f: dup
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_01a5: stloc.s 4
+		IL_01a7: ldloc.s 4
+		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ae: volatile.
+		IL_01b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01b5: brfalse IL_01ce
+
+		IL_01ba: ldstr "setMaxListeners"
+		IL_01bf: ldstr "15"
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c9: br IL_01e7
+
+		IL_01ce: ldstr "setMaxListeners"
+		IL_01d3: ldstr "15"
+		IL_01d8: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:45"
+		IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01e7: pop
+		IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ed: stloc.s 14
+		IL_01ef: ldloc.s 4
+		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f6: volatile.
+		IL_01f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01fd: brfalse IL_0211
+
+		IL_0202: ldstr "getMaxListeners"
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_020c: br IL_0225
+
+		IL_0211: ldstr "getMaxListeners"
+		IL_0216: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:49"
+		IL_021b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0225: stloc.s 15
+		IL_0227: ldloc.s 14
+		IL_0229: ldloc.s 15
+		IL_022b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0230: pop
+		IL_0231: ldloc.2
+		IL_0232: dup
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0238: stloc.s 5
 		.try
 		{
-			IL_01aa: nop
-			IL_01ab: ldloc.s 5
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b2: ldc.r8 5
-			IL_01bb: neg
-			IL_01bc: stloc.s 16
-			IL_01be: ldloc.s 16
-			IL_01c0: box [System.Runtime]System.Double
-			IL_01c5: stloc.s 17
-			IL_01c7: ldstr "setMaxListeners"
-			IL_01cc: ldloc.s 17
-			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01d3: pop
-			IL_01d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01d9: stloc.s 14
-			IL_01db: ldloc.s 14
-			IL_01dd: ldstr "SHOULD NOT REACH HERE"
-			IL_01e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01e7: pop
-			IL_01e8: leave IL_0238
+			IL_023a: nop
+			IL_023b: ldloc.s 5
+			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0242: ldc.r8 5
+			IL_024b: neg
+			IL_024c: stloc.s 16
+			IL_024e: ldloc.s 16
+			IL_0250: box [System.Runtime]System.Double
+			IL_0255: stloc.s 17
+			IL_0257: volatile.
+			IL_0259: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_025e: brfalse IL_0274
+
+			IL_0263: ldstr "setMaxListeners"
+			IL_0268: ldloc.s 17
+			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_026f: br IL_028a
+
+			IL_0274: ldstr "setMaxListeners"
+			IL_0279: ldloc.s 17
+			IL_027b: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:62"
+			IL_0280: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_028a: pop
+			IL_028b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0290: stloc.s 14
+			IL_0292: ldloc.s 14
+			IL_0294: ldstr "SHOULD NOT REACH HERE"
+			IL_0299: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_029e: pop
+			IL_029f: leave IL_02ef
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01ed: stloc.s 6
-			IL_01ef: ldloc.s 6
-			IL_01f1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01f6: dup
-			IL_01f7: brtrue IL_020d
+			IL_02a4: stloc.s 6
+			IL_02a6: ldloc.s 6
+			IL_02a8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02ad: dup
+			IL_02ae: brtrue IL_02c4
 
-			IL_01fc: pop
-			IL_01fd: ldloc.s 6
-			IL_01ff: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0204: dup
-			IL_0205: brtrue IL_0219
+			IL_02b3: pop
+			IL_02b4: ldloc.s 6
+			IL_02b6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02bb: dup
+			IL_02bc: brtrue IL_02d0
 
-			IL_020a: pop
-			IL_020b: rethrow
+			IL_02c1: pop
+			IL_02c2: rethrow
 
-			IL_020d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0212: stloc.s 7
-			IL_0214: br IL_021b
+			IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02c9: stloc.s 7
+			IL_02cb: br IL_02d2
 
-			IL_0219: stloc.s 7
+			IL_02d0: stloc.s 7
 
-			IL_021b: ldloc.s 7
-			IL_021d: stloc.s 8
-			IL_021f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0224: stloc.s 14
-			IL_0226: ldloc.s 14
-			IL_0228: ldstr "Caught error for negative value"
-			IL_022d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0232: pop
-			IL_0233: leave IL_0238
+			IL_02d2: ldloc.s 7
+			IL_02d4: stloc.s 8
+			IL_02d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02db: stloc.s 14
+			IL_02dd: ldloc.s 14
+			IL_02df: ldstr "Caught error for negative value"
+			IL_02e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02e9: pop
+			IL_02ea: leave IL_02ef
 		} // end handler
 
-		IL_0238: ldloc.2
-		IL_0239: dup
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_023f: stloc.s 9
+		IL_02ef: ldloc.2
+		IL_02f0: dup
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_02f6: stloc.s 9
 		.try
 		{
-			IL_0241: nop
-			IL_0242: ldloc.s 9
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0249: ldstr "setMaxListeners"
-			IL_024e: ldstr "invalid"
-			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0258: pop
-			IL_0259: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_025e: stloc.s 14
-			IL_0260: ldloc.s 14
-			IL_0262: ldstr "SHOULD NOT REACH HERE"
-			IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_026c: pop
-			IL_026d: leave IL_02bd
+			IL_02f8: nop
+			IL_02f9: ldloc.s 9
+			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0300: volatile.
+			IL_0302: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0307: brfalse IL_0320
+
+			IL_030c: ldstr "setMaxListeners"
+			IL_0311: ldstr "invalid"
+			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_031b: br IL_0339
+
+			IL_0320: ldstr "setMaxListeners"
+			IL_0325: ldstr "invalid"
+			IL_032a: ldstr "Events_EventEmitter_SetMaxListeners_Validation:Modules.Events_EventEmitter_SetMaxListeners_Validation:__js_module_init__:91"
+			IL_032f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0339: pop
+			IL_033a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_033f: stloc.s 14
+			IL_0341: ldloc.s 14
+			IL_0343: ldstr "SHOULD NOT REACH HERE"
+			IL_0348: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_034d: pop
+			IL_034e: leave IL_039e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0272: stloc.s 10
-			IL_0274: ldloc.s 10
-			IL_0276: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_027b: dup
-			IL_027c: brtrue IL_0292
+			IL_0353: stloc.s 10
+			IL_0355: ldloc.s 10
+			IL_0357: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_035c: dup
+			IL_035d: brtrue IL_0373
 
-			IL_0281: pop
-			IL_0282: ldloc.s 10
-			IL_0284: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0289: dup
-			IL_028a: brtrue IL_029e
+			IL_0362: pop
+			IL_0363: ldloc.s 10
+			IL_0365: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_036a: dup
+			IL_036b: brtrue IL_037f
 
-			IL_028f: pop
-			IL_0290: rethrow
+			IL_0370: pop
+			IL_0371: rethrow
 
-			IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0297: stloc.s 11
-			IL_0299: br IL_02a0
+			IL_0373: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0378: stloc.s 11
+			IL_037a: br IL_0381
 
-			IL_029e: stloc.s 11
+			IL_037f: stloc.s 11
 
-			IL_02a0: ldloc.s 11
-			IL_02a2: stloc.s 12
-			IL_02a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02a9: stloc.s 14
-			IL_02ab: ldloc.s 14
-			IL_02ad: ldstr "Caught error for NaN"
-			IL_02b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02b7: pop
-			IL_02b8: leave IL_02bd
+			IL_0381: ldloc.s 11
+			IL_0383: stloc.s 12
+			IL_0385: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_038a: stloc.s 14
+			IL_038c: ldloc.s 14
+			IL_038e: ldstr "Caught error for NaN"
+			IL_0393: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0398: pop
+			IL_0399: leave IL_039e
 		} // end handler
 
-		IL_02bd: ldnull
-		IL_02be: stloc.s 13
-		IL_02c0: ret
+		IL_039e: ldnull
+		IL_039f: stloc.s 13
+		IL_03a1: ret
 	} // end of method Events_EventEmitter_SetMaxListeners_Validation::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_SetMaxListeners_Validation
@@ -482,6 +544,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Append_Rename_Unlink.verified.txt
@@ -254,7 +254,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 2442 (0x98a)
+			// Code size: 2482 (0x9b2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope,
@@ -416,7 +416,7 @@
 
 			IL_0119: ldloc.0
 			IL_011a: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_011f: switch (IL_0148, IL_0849, IL_08be, IL_07b6, IL_03cb, IL_04b6, IL_0598, IL_067e, IL_0776)
+			IL_011f: switch (IL_0148, IL_0871, IL_08e6, IL_07de, IL_03cb, IL_04b6, IL_0598, IL_067e, IL_079e)
 
 			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_014d: stloc.s 8
@@ -1072,311 +1072,324 @@
 			IL_06b4: ldloc.s 8
 			IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_06bb: stloc.s 8
-			IL_06bd: ldloc.s 8
-			IL_06bf: ldstr "unlink"
-			IL_06c4: ldloc.3
-			IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06ca: stloc.s 8
-			IL_06cc: ldloc.0
-			IL_06cd: ldc.i4.8
-			IL_06ce: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06d3: ldloc.0
-			IL_06d4: ldloc.s 8
-			IL_06d6: ldarg.0
-			IL_06d7: ldc.i4.5
-			IL_06d8: ldloc.0
-			IL_06d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_06de: ldc.i4.3
-			IL_06df: ldstr "_pendingException"
-			IL_06e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
-			IL_06e9: ldloc.0
-			IL_06ea: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_06ef: dup
-			IL_06f0: ldc.i4.0
-			IL_06f1: ldloc.1
-			IL_06f2: stelem.ref
-			IL_06f3: dup
-			IL_06f4: ldc.i4.1
-			IL_06f5: ldloc.2
-			IL_06f6: stelem.ref
-			IL_06f7: dup
-			IL_06f8: ldc.i4.2
-			IL_06f9: ldloc.3
-			IL_06fa: stelem.ref
-			IL_06fb: dup
-			IL_06fc: ldc.i4.3
-			IL_06fd: ldloc.s 4
-			IL_06ff: stelem.ref
-			IL_0700: dup
-			IL_0701: ldc.i4.4
-			IL_0702: ldloc.s 5
-			IL_0704: stelem.ref
-			IL_0705: dup
-			IL_0706: ldc.i4.5
-			IL_0707: ldloc.s 6
-			IL_0709: box [System.Runtime]System.Boolean
-			IL_070e: stelem.ref
-			IL_070f: dup
-			IL_0710: ldc.i4.6
-			IL_0711: ldloc.s 7
-			IL_0713: box [System.Runtime]System.Boolean
-			IL_0718: stelem.ref
-			IL_0719: dup
-			IL_071a: ldc.i4.7
-			IL_071b: ldloc.s 8
-			IL_071d: stelem.ref
-			IL_071e: dup
-			IL_071f: ldc.i4.8
-			IL_0720: ldloc.s 9
+			IL_06bd: volatile.
+			IL_06bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_06c4: brfalse IL_06db
+
+			IL_06c9: ldloc.s 8
+			IL_06cb: ldstr "unlink"
+			IL_06d0: ldloc.3
+			IL_06d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06d6: br IL_06f2
+
+			IL_06db: ldloc.s 8
+			IL_06dd: ldstr "unlink"
+			IL_06e2: ldloc.3
+			IL_06e3: ldstr "FSPromises_Append_Rename_Unlink:<TwoPhaseDummy_M4>:__js_call__:93"
+			IL_06e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_06f2: stloc.s 8
+			IL_06f4: ldloc.0
+			IL_06f5: ldc.i4.8
+			IL_06f6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06fb: ldloc.0
+			IL_06fc: ldloc.s 8
+			IL_06fe: ldarg.0
+			IL_06ff: ldc.i4.5
+			IL_0700: ldloc.0
+			IL_0701: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0706: ldc.i4.3
+			IL_0707: ldstr "_pendingException"
+			IL_070c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
+			IL_0711: ldloc.0
+			IL_0712: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0717: dup
+			IL_0718: ldc.i4.0
+			IL_0719: ldloc.1
+			IL_071a: stelem.ref
+			IL_071b: dup
+			IL_071c: ldc.i4.1
+			IL_071d: ldloc.2
+			IL_071e: stelem.ref
+			IL_071f: dup
+			IL_0720: ldc.i4.2
+			IL_0721: ldloc.3
 			IL_0722: stelem.ref
 			IL_0723: dup
-			IL_0724: ldc.i4.s 9
-			IL_0726: ldloc.s 10
-			IL_0728: box [System.Runtime]System.Double
-			IL_072d: stelem.ref
-			IL_072e: dup
-			IL_072f: ldc.i4.s 10
-			IL_0731: ldloc.s 11
-			IL_0733: stelem.ref
-			IL_0734: dup
-			IL_0735: ldc.i4.s 11
-			IL_0737: ldloc.s 12
-			IL_0739: stelem.ref
-			IL_073a: dup
-			IL_073b: ldc.i4.s 12
-			IL_073d: ldloc.s 13
-			IL_073f: stelem.ref
-			IL_0740: dup
-			IL_0741: ldc.i4.s 13
-			IL_0743: ldloc.s 14
+			IL_0724: ldc.i4.3
+			IL_0725: ldloc.s 4
+			IL_0727: stelem.ref
+			IL_0728: dup
+			IL_0729: ldc.i4.4
+			IL_072a: ldloc.s 5
+			IL_072c: stelem.ref
+			IL_072d: dup
+			IL_072e: ldc.i4.5
+			IL_072f: ldloc.s 6
+			IL_0731: box [System.Runtime]System.Boolean
+			IL_0736: stelem.ref
+			IL_0737: dup
+			IL_0738: ldc.i4.6
+			IL_0739: ldloc.s 7
+			IL_073b: box [System.Runtime]System.Boolean
+			IL_0740: stelem.ref
+			IL_0741: dup
+			IL_0742: ldc.i4.7
+			IL_0743: ldloc.s 8
 			IL_0745: stelem.ref
 			IL_0746: dup
-			IL_0747: ldc.i4.s 14
-			IL_0749: ldloc.s 15
-			IL_074b: stelem.ref
-			IL_074c: dup
-			IL_074d: ldc.i4.s 15
-			IL_074f: ldloc.s 16
-			IL_0751: stelem.ref
-			IL_0752: dup
-			IL_0753: ldc.i4.s 16
-			IL_0755: ldloc.s 17
-			IL_0757: box [System.Runtime]System.Boolean
-			IL_075c: stelem.ref
-			IL_075d: dup
-			IL_075e: ldc.i4.s 17
-			IL_0760: ldloc.s 18
-			IL_0762: stelem.ref
-			IL_0763: dup
-			IL_0764: ldc.i4.s 18
-			IL_0766: ldloc.s 19
-			IL_0768: stelem.ref
-			IL_0769: pop
-			IL_076a: ldloc.0
-			IL_076b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0770: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0775: ret
+			IL_0747: ldc.i4.8
+			IL_0748: ldloc.s 9
+			IL_074a: stelem.ref
+			IL_074b: dup
+			IL_074c: ldc.i4.s 9
+			IL_074e: ldloc.s 10
+			IL_0750: box [System.Runtime]System.Double
+			IL_0755: stelem.ref
+			IL_0756: dup
+			IL_0757: ldc.i4.s 10
+			IL_0759: ldloc.s 11
+			IL_075b: stelem.ref
+			IL_075c: dup
+			IL_075d: ldc.i4.s 11
+			IL_075f: ldloc.s 12
+			IL_0761: stelem.ref
+			IL_0762: dup
+			IL_0763: ldc.i4.s 12
+			IL_0765: ldloc.s 13
+			IL_0767: stelem.ref
+			IL_0768: dup
+			IL_0769: ldc.i4.s 13
+			IL_076b: ldloc.s 14
+			IL_076d: stelem.ref
+			IL_076e: dup
+			IL_076f: ldc.i4.s 14
+			IL_0771: ldloc.s 15
+			IL_0773: stelem.ref
+			IL_0774: dup
+			IL_0775: ldc.i4.s 15
+			IL_0777: ldloc.s 16
+			IL_0779: stelem.ref
+			IL_077a: dup
+			IL_077b: ldc.i4.s 16
+			IL_077d: ldloc.s 17
+			IL_077f: box [System.Runtime]System.Boolean
+			IL_0784: stelem.ref
+			IL_0785: dup
+			IL_0786: ldc.i4.s 17
+			IL_0788: ldloc.s 18
+			IL_078a: stelem.ref
+			IL_078b: dup
+			IL_078c: ldc.i4.s 18
+			IL_078e: ldloc.s 19
+			IL_0790: stelem.ref
+			IL_0791: pop
+			IL_0792: ldloc.0
+			IL_0793: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0798: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_079d: ret
 
-			IL_0776: ldloc.0
-			IL_0777: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
-			IL_077c: pop
-			IL_077d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0782: stloc.s 16
-			IL_0784: ldarg.0
-			IL_0785: ldc.i4.1
-			IL_0786: ldelem.ref
-			IL_0787: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_078c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_0791: stloc.s 14
-			IL_0793: ldloc.s 14
-			IL_0795: ldloc.3
-			IL_0796: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_079b: box [System.Runtime]System.Boolean
-			IL_07a0: stloc.s 8
-			IL_07a2: ldloc.s 16
-			IL_07a4: ldstr "ExistsAfterUnlink:"
-			IL_07a9: ldloc.s 8
-			IL_07ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_07b0: pop
-			IL_07b1: br IL_085c
+			IL_079e: ldloc.0
+			IL_079f: ldfld object Modules.FSPromises_Append_Rename_Unlink/ArrowFunction_L7C2/Scope::_awaited5
+			IL_07a4: pop
+			IL_07a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07aa: stloc.s 16
+			IL_07ac: ldarg.0
+			IL_07ad: ldc.i4.1
+			IL_07ae: ldelem.ref
+			IL_07af: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_07b4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_07b9: stloc.s 14
+			IL_07bb: ldloc.s 14
+			IL_07bd: ldloc.3
+			IL_07be: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_07c3: box [System.Runtime]System.Boolean
+			IL_07c8: stloc.s 8
+			IL_07ca: ldloc.s 16
+			IL_07cc: ldstr "ExistsAfterUnlink:"
+			IL_07d1: ldloc.s 8
+			IL_07d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_07d8: pop
+			IL_07d9: br IL_0884
 
-			IL_07b6: ldloc.0
-			IL_07b7: ldc.i4.1
-			IL_07b8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07bd: ldloc.0
-			IL_07be: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07c3: stloc.s 8
-			IL_07c5: ldloc.0
-			IL_07c6: ldc.i4.0
-			IL_07c7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07cc: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07d1: ldloc.0
-			IL_07d2: ldc.i4.0
-			IL_07d3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07d8: ldloc.s 8
-			IL_07da: stloc.s 5
-			IL_07dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07e1: stloc.s 16
-			IL_07e3: ldloc.s 5
-			IL_07e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_07ea: stloc.s 17
-			IL_07ec: ldloc.s 17
-			IL_07ee: brfalse IL_0831
+			IL_07de: ldloc.0
+			IL_07df: ldc.i4.1
+			IL_07e0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_07e5: ldloc.0
+			IL_07e6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07eb: stloc.s 8
+			IL_07ed: ldloc.0
+			IL_07ee: ldc.i4.0
+			IL_07ef: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07f4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_07f9: ldloc.0
+			IL_07fa: ldc.i4.0
+			IL_07fb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0800: ldloc.s 8
+			IL_0802: stloc.s 5
+			IL_0804: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0809: stloc.s 16
+			IL_080b: ldloc.s 5
+			IL_080d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0812: stloc.s 17
+			IL_0814: ldloc.s 17
+			IL_0816: brfalse IL_0859
 
-			IL_07f3: volatile.
-			IL_07f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_07fa: brfalse IL_0810
+			IL_081b: volatile.
+			IL_081d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0822: brfalse IL_0838
 
-			IL_07ff: ldloc.s 5
-			IL_0801: ldstr "message"
-			IL_0806: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_080b: br IL_0826
+			IL_0827: ldloc.s 5
+			IL_0829: ldstr "message"
+			IL_082e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0833: br IL_084e
 
-			IL_0810: ldloc.s 5
-			IL_0812: ldstr "message"
-			IL_0817: ldstr "FSPromises_Append_Rename_Unlink:<TwoPhaseDummy_M4>:__js_call__:118"
-			IL_081c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_0821: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0838: ldloc.s 5
+			IL_083a: ldstr "message"
+			IL_083f: ldstr "FSPromises_Append_Rename_Unlink:<TwoPhaseDummy_M4>:__js_call__:118"
+			IL_0844: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0849: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0826: stloc.s 8
-			IL_0828: ldloc.s 8
-			IL_082a: stloc.s 19
-			IL_082c: br IL_0835
+			IL_084e: stloc.s 8
+			IL_0850: ldloc.s 8
+			IL_0852: stloc.s 19
+			IL_0854: br IL_085d
 
-			IL_0831: ldloc.s 5
-			IL_0833: stloc.s 19
+			IL_0859: ldloc.s 5
+			IL_085b: stloc.s 19
 
-			IL_0835: ldloc.s 16
-			IL_0837: ldstr "Error:"
-			IL_083c: ldloc.s 19
-			IL_083e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0843: pop
-			IL_0844: br IL_085c
+			IL_085d: ldloc.s 16
+			IL_085f: ldstr "Error:"
+			IL_0864: ldloc.s 19
+			IL_0866: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_086b: pop
+			IL_086c: br IL_0884
 
-			IL_0849: ldloc.0
-			IL_084a: ldc.i4.1
-			IL_084b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0850: ldloc.0
-			IL_0851: ldc.i4.0
-			IL_0852: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0857: br IL_085c
+			IL_0871: ldloc.0
+			IL_0872: ldc.i4.1
+			IL_0873: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0878: ldloc.0
+			IL_0879: ldc.i4.0
+			IL_087a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_087f: br IL_0884
 
-			IL_085c: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
-			IL_0861: ldarg.0
-			IL_0862: ldc.i4.1
-			IL_0863: ldelem.ref
-			IL_0864: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0869: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_086e: stloc.s 14
-			IL_0870: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0875: dup
-			IL_0876: ldstr "force"
-			IL_087b: ldc.i4.1
-			IL_087c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0881: stloc.s 15
-			IL_0883: ldloc.s 14
-			IL_0885: ldloc.2
-			IL_0886: ldloc.s 15
-			IL_0888: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_088d: ldarg.0
-			IL_088e: ldc.i4.1
-			IL_088f: ldelem.ref
-			IL_0890: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
-			IL_0895: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
-			IL_089a: stloc.s 14
-			IL_089c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_08a1: dup
-			IL_08a2: ldstr "force"
-			IL_08a7: ldc.i4.1
-			IL_08a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_08ad: stloc.s 15
-			IL_08af: ldloc.s 14
-			IL_08b1: ldloc.3
-			IL_08b2: ldloc.s 15
-			IL_08b4: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_08b9: br IL_08d1
+			IL_0884: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
+			IL_0889: ldarg.0
+			IL_088a: ldc.i4.1
+			IL_088b: ldelem.ref
+			IL_088c: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_0891: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_0896: stloc.s 14
+			IL_0898: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_089d: dup
+			IL_089e: ldstr "force"
+			IL_08a3: ldc.i4.1
+			IL_08a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_08a9: stloc.s 15
+			IL_08ab: ldloc.s 14
+			IL_08ad: ldloc.2
+			IL_08ae: ldloc.s 15
+			IL_08b0: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_08b5: ldarg.0
+			IL_08b6: ldc.i4.1
+			IL_08b7: ldelem.ref
+			IL_08b8: castclass Modules.FSPromises_Append_Rename_Unlink/Scope
+			IL_08bd: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Append_Rename_Unlink/Scope::fs
+			IL_08c2: stloc.s 14
+			IL_08c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_08c9: dup
+			IL_08ca: ldstr "force"
+			IL_08cf: ldc.i4.1
+			IL_08d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_08d5: stloc.s 15
+			IL_08d7: ldloc.s 14
+			IL_08d9: ldloc.3
+			IL_08da: ldloc.s 15
+			IL_08dc: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_08e1: br IL_08f9
 
-			IL_08be: ldloc.0
-			IL_08bf: ldc.i4.1
-			IL_08c0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08c5: ldloc.0
-			IL_08c6: ldc.i4.0
-			IL_08c7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_08cc: br IL_08d1
+			IL_08e6: ldloc.0
+			IL_08e7: ldc.i4.1
+			IL_08e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_08ed: ldloc.0
+			IL_08ee: ldc.i4.0
+			IL_08ef: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_08f4: br IL_08f9
 
-			IL_08d1: ldloc.0
-			IL_08d2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08d7: stloc.s 6
-			IL_08d9: ldloc.s 6
-			IL_08db: brfalse IL_0918
+			IL_08f9: ldloc.0
+			IL_08fa: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_08ff: stloc.s 6
+			IL_0901: ldloc.s 6
+			IL_0903: brfalse IL_0940
 
-			IL_08e0: ldloc.0
-			IL_08e1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_08e6: stloc.s 8
-			IL_08e8: ldloc.0
-			IL_08e9: ldc.i4.m1
-			IL_08ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08ef: ldloc.0
-			IL_08f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_08fa: ldarg.0
-			IL_08fb: ldc.i4.1
-			IL_08fc: newarr [System.Runtime]System.Object
-			IL_0901: dup
-			IL_0902: ldc.i4.0
-			IL_0903: ldloc.s 8
-			IL_0905: stelem.ref
-			IL_0906: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_090b: pop
-			IL_090c: ldloc.0
-			IL_090d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0912: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0917: ret
+			IL_0908: ldloc.0
+			IL_0909: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_090e: stloc.s 8
+			IL_0910: ldloc.0
+			IL_0911: ldc.i4.m1
+			IL_0912: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0917: ldloc.0
+			IL_0918: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_091d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0922: ldarg.0
+			IL_0923: ldc.i4.1
+			IL_0924: newarr [System.Runtime]System.Object
+			IL_0929: dup
+			IL_092a: ldc.i4.0
+			IL_092b: ldloc.s 8
+			IL_092d: stelem.ref
+			IL_092e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0933: pop
+			IL_0934: ldloc.0
+			IL_0935: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_093a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_093f: ret
 
-			IL_0918: ldloc.0
-			IL_0919: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_091e: stloc.s 7
-			IL_0920: ldloc.s 7
-			IL_0922: brfalse IL_095f
+			IL_0940: ldloc.0
+			IL_0941: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0946: stloc.s 7
+			IL_0948: ldloc.s 7
+			IL_094a: brfalse IL_0987
 
-			IL_0927: ldloc.0
-			IL_0928: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_092d: stloc.s 8
-			IL_092f: ldloc.0
-			IL_0930: ldc.i4.m1
-			IL_0931: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0936: ldloc.0
-			IL_0937: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_093c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0941: ldarg.0
-			IL_0942: ldc.i4.1
-			IL_0943: newarr [System.Runtime]System.Object
-			IL_0948: dup
-			IL_0949: ldc.i4.0
-			IL_094a: ldloc.s 8
-			IL_094c: stelem.ref
-			IL_094d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0952: pop
-			IL_0953: ldloc.0
-			IL_0954: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0959: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_095e: ret
+			IL_094f: ldloc.0
+			IL_0950: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0955: stloc.s 8
+			IL_0957: ldloc.0
+			IL_0958: ldc.i4.m1
+			IL_0959: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_095e: ldloc.0
+			IL_095f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0964: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0969: ldarg.0
+			IL_096a: ldc.i4.1
+			IL_096b: newarr [System.Runtime]System.Object
+			IL_0970: dup
+			IL_0971: ldc.i4.0
+			IL_0972: ldloc.s 8
+			IL_0974: stelem.ref
+			IL_0975: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_097a: pop
+			IL_097b: ldloc.0
+			IL_097c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0981: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0986: ret
 
-			IL_095f: ldloc.0
-			IL_0960: ldc.i4.m1
-			IL_0961: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0966: ldloc.0
-			IL_0967: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_096c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0971: ldarg.0
-			IL_0972: ldc.i4.1
-			IL_0973: newarr [System.Runtime]System.Object
-			IL_0978: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_097d: pop
-			IL_097e: ldloc.0
-			IL_097f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0984: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0989: ret
+			IL_0987: ldloc.0
+			IL_0988: ldc.i4.m1
+			IL_0989: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_098e: ldloc.0
+			IL_098f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0994: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0999: ldarg.0
+			IL_099a: ldc.i4.1
+			IL_099b: newarr [System.Runtime]System.Object
+			IL_09a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_09a5: pop
+			IL_09a6: ldloc.0
+			IL_09a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09ac: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09b1: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1513,6 +1526,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset.verified.txt
@@ -257,7 +257,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 3234 (0xca2)
+			// Code size: 3322 (0xcfa)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/ArrowFunction_L7C2/Scope,
@@ -457,7 +457,7 @@
 
 			IL_0152: ldloc.0
 			IL_0153: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0158: switch (IL_0185, IL_0b8d, IL_0bd6, IL_0afa, IL_03c3, IL_0510, IL_062c, IL_0736, IL_0838, IL_0952)
+			IL_0158: switch (IL_0185, IL_0be5, IL_0c2e, IL_0b52, IL_03c3, IL_0510, IL_062c, IL_0736, IL_0838, IL_0952)
 
 			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_018a: stloc.s 13
@@ -1462,292 +1462,318 @@
 			IL_0960: ldloc.s 4
 			IL_0962: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 			IL_0967: stloc.s 22
-			IL_0969: ldloc.s 22
-			IL_096b: ldstr "toString"
-			IL_0970: ldstr "utf8"
-			IL_0975: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_097a: stloc.s 13
-			IL_097c: volatile.
-			IL_097e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_0983: brfalse IL_0999
+			IL_0969: volatile.
+			IL_096b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0970: brfalse IL_098b
 
-			IL_0988: ldloc.s 6
-			IL_098a: ldstr "bytesRead"
-			IL_098f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0994: br IL_09af
+			IL_0975: ldloc.s 22
+			IL_0977: ldstr "toString"
+			IL_097c: ldstr "utf8"
+			IL_0981: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0986: br IL_09a6
 
-			IL_0999: ldloc.s 6
-			IL_099b: ldstr "bytesRead"
-			IL_09a0: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:113"
-			IL_09a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_09aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_098b: ldloc.s 22
+			IL_098d: ldstr "toString"
+			IL_0992: ldstr "utf8"
+			IL_0997: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:111"
+			IL_099c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_09af: stloc.s 23
-			IL_09b1: ldloc.s 21
-			IL_09b3: ldstr "ExplicitRead:"
-			IL_09b8: ldloc.s 13
-			IL_09ba: ldloc.s 23
-			IL_09bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-			IL_09c1: pop
-			IL_09c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09c7: stloc.s 21
-			IL_09c9: ldloc.s 5
-			IL_09cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
-			IL_09d0: stloc.s 22
-			IL_09d2: ldloc.s 22
-			IL_09d4: ldstr "toString"
-			IL_09d9: ldstr "utf8"
-			IL_09de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_09e3: stloc.s 23
-			IL_09e5: volatile.
-			IL_09e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_09ec: brfalse IL_0a02
+			IL_09a6: stloc.s 13
+			IL_09a8: volatile.
+			IL_09aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_09af: brfalse IL_09c5
 
-			IL_09f1: ldloc.s 7
-			IL_09f3: ldstr "bytesRead"
-			IL_09f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09fd: br IL_0a18
+			IL_09b4: ldloc.s 6
+			IL_09b6: ldstr "bytesRead"
+			IL_09bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09c0: br IL_09db
 
-			IL_0a02: ldloc.s 7
-			IL_0a04: ldstr "bytesRead"
-			IL_0a09: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:122"
-			IL_0a0e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0a13: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_09c5: ldloc.s 6
+			IL_09c7: ldstr "bytesRead"
+			IL_09cc: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:113"
+			IL_09d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_09d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0a18: stloc.s 13
-			IL_0a1a: ldloc.s 21
-			IL_0a1c: ldstr "ImplicitReadAfterExplicit:"
-			IL_0a21: ldloc.s 23
-			IL_0a23: ldloc.s 13
-			IL_0a25: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-			IL_0a2a: pop
-			IL_0a2b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a30: stloc.s 21
-			IL_0a32: volatile.
-			IL_0a34: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0a39: brfalse IL_0a4f
+			IL_09db: stloc.s 23
+			IL_09dd: ldloc.s 21
+			IL_09df: ldstr "ExplicitRead:"
+			IL_09e4: ldloc.s 13
+			IL_09e6: ldloc.s 23
+			IL_09e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+			IL_09ed: pop
+			IL_09ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09f3: stloc.s 21
+			IL_09f5: ldloc.s 5
+			IL_09f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
+			IL_09fc: stloc.s 22
+			IL_09fe: volatile.
+			IL_0a00: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0a05: brfalse IL_0a20
 
-			IL_0a3e: ldloc.s 8
-			IL_0a40: ldstr "bytesWritten"
-			IL_0a45: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a4a: br IL_0a65
+			IL_0a0a: ldloc.s 22
+			IL_0a0c: ldstr "toString"
+			IL_0a11: ldstr "utf8"
+			IL_0a16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0a1b: br IL_0a3b
 
-			IL_0a4f: ldloc.s 8
-			IL_0a51: ldstr "bytesWritten"
-			IL_0a56: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:128"
-			IL_0a5b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0a60: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0a20: ldloc.s 22
+			IL_0a22: ldstr "toString"
+			IL_0a27: ldstr "utf8"
+			IL_0a2c: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:120"
+			IL_0a31: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0a36: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0a65: stloc.s 13
-			IL_0a67: ldloc.s 21
-			IL_0a69: ldstr "ExplicitWriteBytes:"
-			IL_0a6e: ldloc.s 13
-			IL_0a70: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0a75: pop
-			IL_0a76: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a7b: stloc.s 21
-			IL_0a7d: volatile.
-			IL_0a7f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0a84: brfalse IL_0a9a
+			IL_0a3b: stloc.s 23
+			IL_0a3d: volatile.
+			IL_0a3f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0a44: brfalse IL_0a5a
 
-			IL_0a89: ldloc.s 9
-			IL_0a8b: ldstr "bytesWritten"
-			IL_0a90: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a95: br IL_0ab0
+			IL_0a49: ldloc.s 7
+			IL_0a4b: ldstr "bytesRead"
+			IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a55: br IL_0a70
 
-			IL_0a9a: ldloc.s 9
-			IL_0a9c: ldstr "bytesWritten"
-			IL_0aa1: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:134"
-			IL_0aa6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0aab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0a5a: ldloc.s 7
+			IL_0a5c: ldstr "bytesRead"
+			IL_0a61: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:122"
+			IL_0a66: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0a6b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0ab0: stloc.s 13
-			IL_0ab2: ldloc.s 21
-			IL_0ab4: ldstr "ImplicitWriteBytes:"
-			IL_0ab9: ldloc.s 13
-			IL_0abb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0ac0: pop
-			IL_0ac1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0ac6: stloc.s 21
-			IL_0ac8: ldarg.0
-			IL_0ac9: ldc.i4.1
-			IL_0aca: ldelem.ref
-			IL_0acb: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0ad0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0ad5: stloc.s 19
-			IL_0ad7: ldloc.s 19
-			IL_0ad9: ldloc.2
-			IL_0ada: ldstr "utf8"
-			IL_0adf: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0ae4: stloc.s 13
-			IL_0ae6: ldloc.s 21
-			IL_0ae8: ldstr "FinalText:"
-			IL_0aed: ldloc.s 13
-			IL_0aef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0af4: pop
-			IL_0af5: br IL_0ba0
+			IL_0a70: stloc.s 13
+			IL_0a72: ldloc.s 21
+			IL_0a74: ldstr "ImplicitReadAfterExplicit:"
+			IL_0a79: ldloc.s 23
+			IL_0a7b: ldloc.s 13
+			IL_0a7d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+			IL_0a82: pop
+			IL_0a83: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a88: stloc.s 21
+			IL_0a8a: volatile.
+			IL_0a8c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0a91: brfalse IL_0aa7
 
-			IL_0afa: ldloc.0
-			IL_0afb: ldc.i4.1
-			IL_0afc: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b01: ldloc.0
-			IL_0b02: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0b07: stloc.s 13
-			IL_0b09: ldloc.0
-			IL_0b0a: ldc.i4.0
-			IL_0b0b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0b10: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0b15: ldloc.0
-			IL_0b16: ldc.i4.0
-			IL_0b17: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b1c: ldloc.s 13
-			IL_0b1e: stloc.s 10
-			IL_0b20: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b25: stloc.s 21
-			IL_0b27: ldloc.s 10
-			IL_0b29: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0b2e: stloc.s 24
-			IL_0b30: ldloc.s 24
-			IL_0b32: brfalse IL_0b75
+			IL_0a96: ldloc.s 8
+			IL_0a98: ldstr "bytesWritten"
+			IL_0a9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aa2: br IL_0abd
 
-			IL_0b37: volatile.
-			IL_0b39: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0b3e: brfalse IL_0b54
+			IL_0aa7: ldloc.s 8
+			IL_0aa9: ldstr "bytesWritten"
+			IL_0aae: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:128"
+			IL_0ab3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0ab8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0b43: ldloc.s 10
-			IL_0b45: ldstr "message"
-			IL_0b4a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b4f: br IL_0b6a
+			IL_0abd: stloc.s 13
+			IL_0abf: ldloc.s 21
+			IL_0ac1: ldstr "ExplicitWriteBytes:"
+			IL_0ac6: ldloc.s 13
+			IL_0ac8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0acd: pop
+			IL_0ace: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0ad3: stloc.s 21
+			IL_0ad5: volatile.
+			IL_0ad7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0adc: brfalse IL_0af2
 
-			IL_0b54: ldloc.s 10
-			IL_0b56: ldstr "message"
-			IL_0b5b: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:160"
-			IL_0b60: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0b65: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0ae1: ldloc.s 9
+			IL_0ae3: ldstr "bytesWritten"
+			IL_0ae8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0aed: br IL_0b08
 
-			IL_0b6a: stloc.s 13
-			IL_0b6c: ldloc.s 13
-			IL_0b6e: stloc.s 26
-			IL_0b70: br IL_0b79
+			IL_0af2: ldloc.s 9
+			IL_0af4: ldstr "bytesWritten"
+			IL_0af9: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:134"
+			IL_0afe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0b03: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0b75: ldloc.s 10
-			IL_0b77: stloc.s 26
+			IL_0b08: stloc.s 13
+			IL_0b0a: ldloc.s 21
+			IL_0b0c: ldstr "ImplicitWriteBytes:"
+			IL_0b11: ldloc.s 13
+			IL_0b13: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0b18: pop
+			IL_0b19: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b1e: stloc.s 21
+			IL_0b20: ldarg.0
+			IL_0b21: ldc.i4.1
+			IL_0b22: ldelem.ref
+			IL_0b23: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0b28: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0b2d: stloc.s 19
+			IL_0b2f: ldloc.s 19
+			IL_0b31: ldloc.2
+			IL_0b32: ldstr "utf8"
+			IL_0b37: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0b3c: stloc.s 13
+			IL_0b3e: ldloc.s 21
+			IL_0b40: ldstr "FinalText:"
+			IL_0b45: ldloc.s 13
+			IL_0b47: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0b4c: pop
+			IL_0b4d: br IL_0bf8
 
-			IL_0b79: ldloc.s 21
-			IL_0b7b: ldstr "Error:"
-			IL_0b80: ldloc.s 26
-			IL_0b82: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0b87: pop
-			IL_0b88: br IL_0ba0
+			IL_0b52: ldloc.0
+			IL_0b53: ldc.i4.1
+			IL_0b54: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b59: ldloc.0
+			IL_0b5a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0b5f: stloc.s 13
+			IL_0b61: ldloc.0
+			IL_0b62: ldc.i4.0
+			IL_0b63: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0b68: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0b6d: ldloc.0
+			IL_0b6e: ldc.i4.0
+			IL_0b6f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0b74: ldloc.s 13
+			IL_0b76: stloc.s 10
+			IL_0b78: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b7d: stloc.s 21
+			IL_0b7f: ldloc.s 10
+			IL_0b81: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0b86: stloc.s 24
+			IL_0b88: ldloc.s 24
+			IL_0b8a: brfalse IL_0bcd
 
-			IL_0b8d: ldloc.0
-			IL_0b8e: ldc.i4.1
-			IL_0b8f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0b94: ldloc.0
-			IL_0b95: ldc.i4.0
-			IL_0b96: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0b9b: br IL_0ba0
+			IL_0b8f: volatile.
+			IL_0b91: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0b96: brfalse IL_0bac
 
-			IL_0ba0: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
-			IL_0ba5: ldarg.0
-			IL_0ba6: ldc.i4.1
-			IL_0ba7: ldelem.ref
-			IL_0ba8: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
-			IL_0bad: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
-			IL_0bb2: stloc.s 19
-			IL_0bb4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0bb9: dup
-			IL_0bba: ldstr "force"
-			IL_0bbf: ldc.i4.1
-			IL_0bc0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0bc5: stloc.s 20
-			IL_0bc7: ldloc.s 19
-			IL_0bc9: ldloc.2
-			IL_0bca: ldloc.s 20
-			IL_0bcc: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0bd1: br IL_0be9
+			IL_0b9b: ldloc.s 10
+			IL_0b9d: ldstr "message"
+			IL_0ba2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ba7: br IL_0bc2
 
-			IL_0bd6: ldloc.0
-			IL_0bd7: ldc.i4.1
-			IL_0bd8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0bdd: ldloc.0
-			IL_0bde: ldc.i4.0
-			IL_0bdf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0be4: br IL_0be9
+			IL_0bac: ldloc.s 10
+			IL_0bae: ldstr "message"
+			IL_0bb3: ldstr "FSPromises_Open_ExplicitPosition_DoesNotMoveOffset:<TwoPhaseDummy_M4>:__js_call__:160"
+			IL_0bb8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0bbd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0be9: ldloc.0
-			IL_0bea: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0bef: stloc.s 11
-			IL_0bf1: ldloc.s 11
-			IL_0bf3: brfalse IL_0c30
+			IL_0bc2: stloc.s 13
+			IL_0bc4: ldloc.s 13
+			IL_0bc6: stloc.s 26
+			IL_0bc8: br IL_0bd1
 
-			IL_0bf8: ldloc.0
-			IL_0bf9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0bfe: stloc.s 13
-			IL_0c00: ldloc.0
-			IL_0c01: ldc.i4.m1
-			IL_0c02: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c07: ldloc.0
-			IL_0c08: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c0d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0c12: ldarg.0
-			IL_0c13: ldc.i4.1
-			IL_0c14: newarr [System.Runtime]System.Object
-			IL_0c19: dup
-			IL_0c1a: ldc.i4.0
-			IL_0c1b: ldloc.s 13
-			IL_0c1d: stelem.ref
-			IL_0c1e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c23: pop
-			IL_0c24: ldloc.0
-			IL_0c25: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c2a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c2f: ret
+			IL_0bcd: ldloc.s 10
+			IL_0bcf: stloc.s 26
 
-			IL_0c30: ldloc.0
-			IL_0c31: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0c36: stloc.s 12
-			IL_0c38: ldloc.s 12
-			IL_0c3a: brfalse IL_0c77
+			IL_0bd1: ldloc.s 21
+			IL_0bd3: ldstr "Error:"
+			IL_0bd8: ldloc.s 26
+			IL_0bda: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0bdf: pop
+			IL_0be0: br IL_0bf8
 
-			IL_0c3f: ldloc.0
-			IL_0c40: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_0c45: stloc.s 13
-			IL_0c47: ldloc.0
-			IL_0c48: ldc.i4.m1
-			IL_0c49: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c4e: ldloc.0
-			IL_0c4f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c54: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c59: ldarg.0
-			IL_0c5a: ldc.i4.1
-			IL_0c5b: newarr [System.Runtime]System.Object
-			IL_0c60: dup
-			IL_0c61: ldc.i4.0
-			IL_0c62: ldloc.s 13
-			IL_0c64: stelem.ref
-			IL_0c65: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c6a: pop
-			IL_0c6b: ldloc.0
-			IL_0c6c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c71: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c76: ret
+			IL_0be5: ldloc.0
+			IL_0be6: ldc.i4.1
+			IL_0be7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0bec: ldloc.0
+			IL_0bed: ldc.i4.0
+			IL_0bee: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0bf3: br IL_0bf8
 
-			IL_0c77: ldloc.0
-			IL_0c78: ldc.i4.m1
-			IL_0c79: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c7e: ldloc.0
-			IL_0c7f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c84: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c89: ldarg.0
-			IL_0c8a: ldc.i4.1
-			IL_0c8b: newarr [System.Runtime]System.Object
-			IL_0c90: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c95: pop
-			IL_0c96: ldloc.0
-			IL_0c97: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c9c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0ca1: ret
+			IL_0bf8: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
+			IL_0bfd: ldarg.0
+			IL_0bfe: ldc.i4.1
+			IL_0bff: ldelem.ref
+			IL_0c00: castclass Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope
+			IL_0c05: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_ExplicitPosition_DoesNotMoveOffset/Scope::fs
+			IL_0c0a: stloc.s 19
+			IL_0c0c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0c11: dup
+			IL_0c12: ldstr "force"
+			IL_0c17: ldc.i4.1
+			IL_0c18: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0c1d: stloc.s 20
+			IL_0c1f: ldloc.s 19
+			IL_0c21: ldloc.2
+			IL_0c22: ldloc.s 20
+			IL_0c24: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0c29: br IL_0c41
+
+			IL_0c2e: ldloc.0
+			IL_0c2f: ldc.i4.1
+			IL_0c30: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0c35: ldloc.0
+			IL_0c36: ldc.i4.0
+			IL_0c37: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0c3c: br IL_0c41
+
+			IL_0c41: ldloc.0
+			IL_0c42: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0c47: stloc.s 11
+			IL_0c49: ldloc.s 11
+			IL_0c4b: brfalse IL_0c88
+
+			IL_0c50: ldloc.0
+			IL_0c51: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0c56: stloc.s 13
+			IL_0c58: ldloc.0
+			IL_0c59: ldc.i4.m1
+			IL_0c5a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c5f: ldloc.0
+			IL_0c60: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c65: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0c6a: ldarg.0
+			IL_0c6b: ldc.i4.1
+			IL_0c6c: newarr [System.Runtime]System.Object
+			IL_0c71: dup
+			IL_0c72: ldc.i4.0
+			IL_0c73: ldloc.s 13
+			IL_0c75: stelem.ref
+			IL_0c76: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c7b: pop
+			IL_0c7c: ldloc.0
+			IL_0c7d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c82: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c87: ret
+
+			IL_0c88: ldloc.0
+			IL_0c89: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0c8e: stloc.s 12
+			IL_0c90: ldloc.s 12
+			IL_0c92: brfalse IL_0ccf
+
+			IL_0c97: ldloc.0
+			IL_0c98: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0c9d: stloc.s 13
+			IL_0c9f: ldloc.0
+			IL_0ca0: ldc.i4.m1
+			IL_0ca1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0ca6: ldloc.0
+			IL_0ca7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0cac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0cb1: ldarg.0
+			IL_0cb2: ldc.i4.1
+			IL_0cb3: newarr [System.Runtime]System.Object
+			IL_0cb8: dup
+			IL_0cb9: ldc.i4.0
+			IL_0cba: ldloc.s 13
+			IL_0cbc: stelem.ref
+			IL_0cbd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0cc2: pop
+			IL_0cc3: ldloc.0
+			IL_0cc4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0cc9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0cce: ret
+
+			IL_0ccf: ldloc.0
+			IL_0cd0: ldc.i4.m1
+			IL_0cd1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0cd6: ldloc.0
+			IL_0cd7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0cdc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0ce1: ldarg.0
+			IL_0ce2: ldc.i4.1
+			IL_0ce3: newarr [System.Runtime]System.Object
+			IL_0ce8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0ced: pop
+			IL_0cee: ldloc.0
+			IL_0cef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0cf4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0cf9: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1889,6 +1915,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Open_Read_Write_Close.verified.txt
@@ -252,7 +252,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 2427 (0x97b)
+			// Code size: 2471 (0x9a7)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Open_Read_Write_Close/ArrowFunction_L7C2/Scope,
@@ -436,7 +436,7 @@
 
 			IL_013b: ldloc.0
 			IL_013c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0141: switch (IL_0166, IL_0866, IL_08af, IL_07d3, IL_0371, IL_0468, IL_058f, IL_0696)
+			IL_0141: switch (IL_0166, IL_0892, IL_08db, IL_07ff, IL_0371, IL_0468, IL_058f, IL_0696)
 
 			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
 			IL_016b: stloc.s 10
@@ -1165,179 +1165,192 @@
 			IL_07a3: ldloc.s 5
 			IL_07a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 			IL_07aa: stloc.s 21
-			IL_07ac: ldloc.s 21
-			IL_07ae: ldstr "toString"
-			IL_07b3: ldstr "utf8"
-			IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07bd: stloc.s 10
-			IL_07bf: ldloc.s 18
-			IL_07c1: ldstr "BufferText:"
-			IL_07c6: ldloc.s 10
-			IL_07c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_07cd: pop
-			IL_07ce: br IL_0879
+			IL_07ac: volatile.
+			IL_07ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_07b3: brfalse IL_07ce
 
-			IL_07d3: ldloc.0
-			IL_07d4: ldc.i4.1
-			IL_07d5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07da: ldloc.0
-			IL_07db: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07e0: stloc.s 10
-			IL_07e2: ldloc.0
-			IL_07e3: ldc.i4.0
-			IL_07e4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07e9: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_07ee: ldloc.0
-			IL_07ef: ldc.i4.0
-			IL_07f0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_07f5: ldloc.s 10
-			IL_07f7: stloc.s 7
-			IL_07f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07fe: stloc.s 18
-			IL_0800: ldloc.s 7
-			IL_0802: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0807: stloc.s 19
-			IL_0809: ldloc.s 19
-			IL_080b: brfalse IL_084e
+			IL_07b8: ldloc.s 21
+			IL_07ba: ldstr "toString"
+			IL_07bf: ldstr "utf8"
+			IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_07c9: br IL_07e9
 
-			IL_0810: volatile.
-			IL_0812: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0817: brfalse IL_082d
+			IL_07ce: ldloc.s 21
+			IL_07d0: ldstr "toString"
+			IL_07d5: ldstr "utf8"
+			IL_07da: ldstr "FSPromises_Open_Read_Write_Close:<TwoPhaseDummy_M4>:__js_call__:103"
+			IL_07df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_07e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_081c: ldloc.s 7
-			IL_081e: ldstr "message"
-			IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0828: br IL_0843
+			IL_07e9: stloc.s 10
+			IL_07eb: ldloc.s 18
+			IL_07ed: ldstr "BufferText:"
+			IL_07f2: ldloc.s 10
+			IL_07f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_07f9: pop
+			IL_07fa: br IL_08a5
 
-			IL_082d: ldloc.s 7
-			IL_082f: ldstr "message"
-			IL_0834: ldstr "FSPromises_Open_Read_Write_Close:<TwoPhaseDummy_M4>:__js_call__:122"
-			IL_0839: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07ff: ldloc.0
+			IL_0800: ldc.i4.1
+			IL_0801: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0806: ldloc.0
+			IL_0807: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_080c: stloc.s 10
+			IL_080e: ldloc.0
+			IL_080f: ldc.i4.0
+			IL_0810: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0815: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_081a: ldloc.0
+			IL_081b: ldc.i4.0
+			IL_081c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0821: ldloc.s 10
+			IL_0823: stloc.s 7
+			IL_0825: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_082a: stloc.s 18
+			IL_082c: ldloc.s 7
+			IL_082e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0833: stloc.s 19
+			IL_0835: ldloc.s 19
+			IL_0837: brfalse IL_087a
 
-			IL_0843: stloc.s 10
-			IL_0845: ldloc.s 10
-			IL_0847: stloc.s 23
-			IL_0849: br IL_0852
+			IL_083c: volatile.
+			IL_083e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0843: brfalse IL_0859
 
-			IL_084e: ldloc.s 7
-			IL_0850: stloc.s 23
+			IL_0848: ldloc.s 7
+			IL_084a: ldstr "message"
+			IL_084f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0854: br IL_086f
 
-			IL_0852: ldloc.s 18
-			IL_0854: ldstr "Error:"
-			IL_0859: ldloc.s 23
-			IL_085b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0860: pop
-			IL_0861: br IL_0879
+			IL_0859: ldloc.s 7
+			IL_085b: ldstr "message"
+			IL_0860: ldstr "FSPromises_Open_Read_Write_Close:<TwoPhaseDummy_M4>:__js_call__:122"
+			IL_0865: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_086a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0866: ldloc.0
-			IL_0867: ldc.i4.1
-			IL_0868: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_086d: ldloc.0
-			IL_086e: ldc.i4.0
-			IL_086f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0874: br IL_0879
+			IL_086f: stloc.s 10
+			IL_0871: ldloc.s 10
+			IL_0873: stloc.s 23
+			IL_0875: br IL_087e
 
-			IL_0879: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
-			IL_087e: ldarg.0
-			IL_087f: ldc.i4.1
-			IL_0880: ldelem.ref
-			IL_0881: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
-			IL_0886: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
-			IL_088b: stloc.s 16
-			IL_088d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0892: dup
-			IL_0893: ldstr "force"
-			IL_0898: ldc.i4.1
-			IL_0899: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_089e: stloc.s 17
-			IL_08a0: ldloc.s 16
-			IL_08a2: ldloc.2
-			IL_08a3: ldloc.s 17
-			IL_08a5: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_08aa: br IL_08c2
+			IL_087a: ldloc.s 7
+			IL_087c: stloc.s 23
 
-			IL_08af: ldloc.0
-			IL_08b0: ldc.i4.1
-			IL_08b1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08b6: ldloc.0
-			IL_08b7: ldc.i4.0
-			IL_08b8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_08bd: br IL_08c2
+			IL_087e: ldloc.s 18
+			IL_0880: ldstr "Error:"
+			IL_0885: ldloc.s 23
+			IL_0887: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_088c: pop
+			IL_088d: br IL_08a5
 
-			IL_08c2: ldloc.0
-			IL_08c3: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_08c8: stloc.s 8
-			IL_08ca: ldloc.s 8
-			IL_08cc: brfalse IL_0909
+			IL_0892: ldloc.0
+			IL_0893: ldc.i4.1
+			IL_0894: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0899: ldloc.0
+			IL_089a: ldc.i4.0
+			IL_089b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_08a0: br IL_08a5
 
-			IL_08d1: ldloc.0
-			IL_08d2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_08d7: stloc.s 10
-			IL_08d9: ldloc.0
-			IL_08da: ldc.i4.m1
-			IL_08db: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08e0: ldloc.0
-			IL_08e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_08eb: ldarg.0
-			IL_08ec: ldc.i4.1
-			IL_08ed: newarr [System.Runtime]System.Object
-			IL_08f2: dup
-			IL_08f3: ldc.i4.0
-			IL_08f4: ldloc.s 10
-			IL_08f6: stelem.ref
-			IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_08fc: pop
+			IL_08a5: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
+			IL_08aa: ldarg.0
+			IL_08ab: ldc.i4.1
+			IL_08ac: ldelem.ref
+			IL_08ad: castclass Modules.FSPromises_Open_Read_Write_Close/Scope
+			IL_08b2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.FSPromises_Open_Read_Write_Close/Scope::fs
+			IL_08b7: stloc.s 16
+			IL_08b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_08be: dup
+			IL_08bf: ldstr "force"
+			IL_08c4: ldc.i4.1
+			IL_08c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_08ca: stloc.s 17
+			IL_08cc: ldloc.s 16
+			IL_08ce: ldloc.2
+			IL_08cf: ldloc.s 17
+			IL_08d1: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_08d6: br IL_08ee
+
+			IL_08db: ldloc.0
+			IL_08dc: ldc.i4.1
+			IL_08dd: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_08e2: ldloc.0
+			IL_08e3: ldc.i4.0
+			IL_08e4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_08e9: br IL_08ee
+
+			IL_08ee: ldloc.0
+			IL_08ef: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_08f4: stloc.s 8
+			IL_08f6: ldloc.s 8
+			IL_08f8: brfalse IL_0935
+
 			IL_08fd: ldloc.0
-			IL_08fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0903: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0908: ret
+			IL_08fe: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0903: stloc.s 10
+			IL_0905: ldloc.0
+			IL_0906: ldc.i4.m1
+			IL_0907: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_090c: ldloc.0
+			IL_090d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0912: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0917: ldarg.0
+			IL_0918: ldc.i4.1
+			IL_0919: newarr [System.Runtime]System.Object
+			IL_091e: dup
+			IL_091f: ldc.i4.0
+			IL_0920: ldloc.s 10
+			IL_0922: stelem.ref
+			IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0928: pop
+			IL_0929: ldloc.0
+			IL_092a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_092f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0934: ret
 
-			IL_0909: ldloc.0
-			IL_090a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_090f: stloc.s 9
-			IL_0911: ldloc.s 9
-			IL_0913: brfalse IL_0950
+			IL_0935: ldloc.0
+			IL_0936: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_093b: stloc.s 9
+			IL_093d: ldloc.s 9
+			IL_093f: brfalse IL_097c
 
-			IL_0918: ldloc.0
-			IL_0919: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_091e: stloc.s 10
-			IL_0920: ldloc.0
-			IL_0921: ldc.i4.m1
-			IL_0922: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0927: ldloc.0
-			IL_0928: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_092d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0932: ldarg.0
-			IL_0933: ldc.i4.1
-			IL_0934: newarr [System.Runtime]System.Object
-			IL_0939: dup
-			IL_093a: ldc.i4.0
-			IL_093b: ldloc.s 10
-			IL_093d: stelem.ref
-			IL_093e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0943: pop
 			IL_0944: ldloc.0
-			IL_0945: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_094a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_094f: ret
+			IL_0945: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_094a: stloc.s 10
+			IL_094c: ldloc.0
+			IL_094d: ldc.i4.m1
+			IL_094e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0953: ldloc.0
+			IL_0954: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0959: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_095e: ldarg.0
+			IL_095f: ldc.i4.1
+			IL_0960: newarr [System.Runtime]System.Object
+			IL_0965: dup
+			IL_0966: ldc.i4.0
+			IL_0967: ldloc.s 10
+			IL_0969: stelem.ref
+			IL_096a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_096f: pop
+			IL_0970: ldloc.0
+			IL_0971: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0976: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_097b: ret
 
-			IL_0950: ldloc.0
-			IL_0951: ldc.i4.m1
-			IL_0952: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0957: ldloc.0
-			IL_0958: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_095d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0962: ldarg.0
-			IL_0963: ldc.i4.1
-			IL_0964: newarr [System.Runtime]System.Object
-			IL_0969: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_096e: pop
-			IL_096f: ldloc.0
-			IL_0970: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0975: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_097a: ret
+			IL_097c: ldloc.0
+			IL_097d: ldc.i4.m1
+			IL_097e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0983: ldloc.0
+			IL_0984: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0989: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_098e: ldarg.0
+			IL_098f: ldc.i4.1
+			IL_0990: newarr [System.Runtime]System.Object
+			IL_0995: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_099a: pop
+			IL_099b: ldloc.0
+			IL_099c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09a1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09a6: ret
 		} // end of method ArrowFunction_L7C2::__js_call__
 
 	} // end of class ArrowFunction_L7C2
@@ -1478,6 +1491,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Buffer.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Buffer.verified.txt
@@ -209,7 +209,7 @@
 			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0024: stloc.0
 			IL_0025: volatile.
-			IL_0027: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0027: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_002c: brfalse IL_0041
 
 			IL_0031: ldarg.2
@@ -220,7 +220,7 @@
 			IL_0041: ldarg.2
 			IL_0042: ldstr "length"
 			IL_0047: ldstr "FSPromises_ReadFile_Buffer:<TwoPhaseDummy_M4>:__js_call__:12"
-			IL_004c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_004c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0056: stloc.2
@@ -378,7 +378,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.1
@@ -389,7 +389,7 @@
 			IL_002c: ldarg.1
 			IL_002d: ldstr "message"
 			IL_0032: ldstr "FSPromises_ReadFile_Buffer:<TwoPhaseDummy_M5>:__js_call__:7"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
@@ -445,7 +445,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 425 (0x1a9)
+		// Code size: 507 (0x1fb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_ReadFile_Buffer/Scope,
@@ -592,36 +592,62 @@
 		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L8C28/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0153: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L8C28/FunctionObject>(!!0)
 		IL_0158: stloc.s 8
-		IL_015a: ldloc.s 5
-		IL_015c: ldstr "then"
-		IL_0161: ldloc.s 8
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0168: stloc.s 5
-		IL_016a: ldloc.s 5
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0171: stloc.s 5
-		IL_0173: ldc.i4.1
-		IL_0174: newarr [System.Runtime]System.Object
-		IL_0179: dup
-		IL_017a: ldc.i4.0
-		IL_017b: ldloc.0
-		IL_017c: stelem.ref
-		IL_017d: stloc.s 7
-		IL_017f: newobj instance void Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10/FunctionObject::.ctor()
-		IL_0184: ldc.i4.1
-		IL_0185: conv.r8
-		IL_0186: ldstr ""
-		IL_018b: ldc.i4.0
-		IL_018c: ldc.i4.0
-		IL_018d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10/FunctionObject>(!!0)
-		IL_0197: stloc.s 9
-		IL_0199: ldloc.s 5
-		IL_019b: ldstr "catch"
-		IL_01a0: ldloc.s 9
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a7: pop
-		IL_01a8: ret
+		IL_015a: volatile.
+		IL_015c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0161: brfalse IL_0179
+
+		IL_0166: ldloc.s 5
+		IL_0168: ldstr "then"
+		IL_016d: ldloc.s 8
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0174: br IL_0191
+
+		IL_0179: ldloc.s 5
+		IL_017b: ldstr "then"
+		IL_0180: ldloc.s 8
+		IL_0182: ldstr "FSPromises_ReadFile_Buffer:Modules.FSPromises_ReadFile_Buffer:__js_module_init__:35"
+		IL_0187: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0191: stloc.s 5
+		IL_0193: ldloc.s 5
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019a: stloc.s 5
+		IL_019c: ldc.i4.1
+		IL_019d: newarr [System.Runtime]System.Object
+		IL_01a2: dup
+		IL_01a3: ldc.i4.0
+		IL_01a4: ldloc.0
+		IL_01a5: stelem.ref
+		IL_01a6: stloc.s 7
+		IL_01a8: newobj instance void Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10/FunctionObject::.ctor()
+		IL_01ad: ldc.i4.1
+		IL_01ae: conv.r8
+		IL_01af: ldstr ""
+		IL_01b4: ldc.i4.0
+		IL_01b5: ldc.i4.0
+		IL_01b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_ReadFile_Buffer/ArrowFunction_L12C10/FunctionObject>(!!0)
+		IL_01c0: stloc.s 9
+		IL_01c2: volatile.
+		IL_01c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01c9: brfalse IL_01e1
+
+		IL_01ce: ldloc.s 5
+		IL_01d0: ldstr "catch"
+		IL_01d5: ldloc.s 9
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01dc: br IL_01f9
+
+		IL_01e1: ldloc.s 5
+		IL_01e3: ldstr "catch"
+		IL_01e8: ldloc.s 9
+		IL_01ea: ldstr "FSPromises_ReadFile_Buffer:Modules.FSPromises_ReadFile_Buffer:__js_module_init__:39"
+		IL_01ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01f9: pop
+		IL_01fa: ret
 	} // end of method FSPromises_ReadFile_Buffer::__js_module_init__
 
 } // end of class Modules.FSPromises_ReadFile_Buffer
@@ -653,6 +679,8 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_ReadFile_Utf8.verified.txt
@@ -350,7 +350,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.1
@@ -361,7 +361,7 @@
 			IL_002c: ldarg.1
 			IL_002d: ldstr "message"
 			IL_0032: ldstr "FSPromises_ReadFile_Utf8:<TwoPhaseDummy_M5>:__js_call__:7"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
@@ -417,7 +417,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 430 (0x1ae)
+		// Code size: 512 (0x200)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_ReadFile_Utf8/Scope,
@@ -565,36 +565,62 @@
 		IL_0153: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L8C36/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L8C36/FunctionObject>(!!0)
 		IL_015d: stloc.s 8
-		IL_015f: ldloc.s 5
-		IL_0161: ldstr "then"
-		IL_0166: ldloc.s 8
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016d: stloc.s 5
-		IL_016f: ldloc.s 5
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0176: stloc.s 5
-		IL_0178: ldc.i4.1
-		IL_0179: newarr [System.Runtime]System.Object
-		IL_017e: dup
-		IL_017f: ldc.i4.0
-		IL_0180: ldloc.0
-		IL_0181: stelem.ref
-		IL_0182: stloc.s 7
-		IL_0184: newobj instance void Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10/FunctionObject::.ctor()
-		IL_0189: ldc.i4.1
-		IL_018a: conv.r8
-		IL_018b: ldstr ""
-		IL_0190: ldc.i4.0
-		IL_0191: ldc.i4.0
-		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0197: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10/FunctionObject>(!!0)
-		IL_019c: stloc.s 9
-		IL_019e: ldloc.s 5
-		IL_01a0: ldstr "catch"
-		IL_01a5: ldloc.s 9
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ac: pop
-		IL_01ad: ret
+		IL_015f: volatile.
+		IL_0161: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0166: brfalse IL_017e
+
+		IL_016b: ldloc.s 5
+		IL_016d: ldstr "then"
+		IL_0172: ldloc.s 8
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0179: br IL_0196
+
+		IL_017e: ldloc.s 5
+		IL_0180: ldstr "then"
+		IL_0185: ldloc.s 8
+		IL_0187: ldstr "FSPromises_ReadFile_Utf8:Modules.FSPromises_ReadFile_Utf8:__js_module_init__:36"
+		IL_018c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0196: stloc.s 5
+		IL_0198: ldloc.s 5
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019f: stloc.s 5
+		IL_01a1: ldc.i4.1
+		IL_01a2: newarr [System.Runtime]System.Object
+		IL_01a7: dup
+		IL_01a8: ldc.i4.0
+		IL_01a9: ldloc.0
+		IL_01aa: stelem.ref
+		IL_01ab: stloc.s 7
+		IL_01ad: newobj instance void Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10/FunctionObject::.ctor()
+		IL_01b2: ldc.i4.1
+		IL_01b3: conv.r8
+		IL_01b4: ldstr ""
+		IL_01b9: ldc.i4.0
+		IL_01ba: ldc.i4.0
+		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_ReadFile_Utf8/ArrowFunction_L11C10/FunctionObject>(!!0)
+		IL_01c5: stloc.s 9
+		IL_01c7: volatile.
+		IL_01c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01ce: brfalse IL_01e6
+
+		IL_01d3: ldloc.s 5
+		IL_01d5: ldstr "catch"
+		IL_01da: ldloc.s 9
+		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e1: br IL_01fe
+
+		IL_01e6: ldloc.s 5
+		IL_01e8: ldstr "catch"
+		IL_01ed: ldloc.s 9
+		IL_01ef: ldstr "FSPromises_ReadFile_Utf8:Modules.FSPromises_ReadFile_Utf8:__js_module_init__:40"
+		IL_01f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01fe: pop
+		IL_01ff: ret
 	} // end of method FSPromises_ReadFile_Utf8::__js_module_init__
 
 } // end of class Modules.FSPromises_ReadFile_Utf8
@@ -625,6 +651,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
@@ -290,7 +290,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -301,7 +301,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "message"
 			IL_0028: ldstr "FSPromises_Readdir_MissingDir_Rejects:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -370,7 +370,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 232 (0xe8)
+		// Code size: 314 (0x13a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_MissingDir_Rejects/Scope,
@@ -446,36 +446,62 @@
 		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L9C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L9C11/FunctionObject>(!!0)
 		IL_0097: stloc.s 9
-		IL_0099: ldloc.s 5
-		IL_009b: ldstr "then"
-		IL_00a0: ldloc.s 9
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a7: stloc.s 5
-		IL_00a9: ldloc.s 5
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00b0: stloc.s 5
-		IL_00b2: ldc.i4.1
-		IL_00b3: newarr [System.Runtime]System.Object
-		IL_00b8: dup
-		IL_00b9: ldc.i4.0
-		IL_00ba: ldloc.0
-		IL_00bb: stelem.ref
-		IL_00bc: stloc.s 8
-		IL_00be: newobj instance void Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L12C12/FunctionObject::.ctor()
-		IL_00c3: ldc.i4.1
-		IL_00c4: conv.r8
-		IL_00c5: ldstr ""
-		IL_00ca: ldc.i4.0
-		IL_00cb: ldc.i4.0
-		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L12C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L12C12/FunctionObject>(!!0)
-		IL_00d6: stloc.s 10
-		IL_00d8: ldloc.s 5
-		IL_00da: ldstr "catch"
-		IL_00df: ldloc.s 10
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e6: pop
-		IL_00e7: ret
+		IL_0099: volatile.
+		IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a0: brfalse IL_00b8
+
+		IL_00a5: ldloc.s 5
+		IL_00a7: ldstr "then"
+		IL_00ac: ldloc.s 9
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b3: br IL_00d0
+
+		IL_00b8: ldloc.s 5
+		IL_00ba: ldstr "then"
+		IL_00bf: ldloc.s 9
+		IL_00c1: ldstr "FSPromises_Readdir_MissingDir_Rejects:Modules.FSPromises_Readdir_MissingDir_Rejects:__js_module_init__:30"
+		IL_00c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d0: stloc.s 5
+		IL_00d2: ldloc.s 5
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d9: stloc.s 5
+		IL_00db: ldc.i4.1
+		IL_00dc: newarr [System.Runtime]System.Object
+		IL_00e1: dup
+		IL_00e2: ldc.i4.0
+		IL_00e3: ldloc.0
+		IL_00e4: stelem.ref
+		IL_00e5: stloc.s 8
+		IL_00e7: newobj instance void Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L12C12/FunctionObject::.ctor()
+		IL_00ec: ldc.i4.1
+		IL_00ed: conv.r8
+		IL_00ee: ldstr ""
+		IL_00f3: ldc.i4.0
+		IL_00f4: ldc.i4.0
+		IL_00f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L12C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_MissingDir_Rejects/ArrowFunction_L12C12/FunctionObject>(!!0)
+		IL_00ff: stloc.s 10
+		IL_0101: volatile.
+		IL_0103: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0108: brfalse IL_0120
+
+		IL_010d: ldloc.s 5
+		IL_010f: ldstr "catch"
+		IL_0114: ldloc.s 10
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011b: br IL_0138
+
+		IL_0120: ldloc.s 5
+		IL_0122: ldstr "catch"
+		IL_0127: ldloc.s 10
+		IL_0129: ldstr "FSPromises_Readdir_MissingDir_Rejects:Modules.FSPromises_Readdir_MissingDir_Rejects:__js_module_init__:34"
+		IL_012e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0138: pop
+		IL_0139: ret
 	} // end of method FSPromises_Readdir_MissingDir_Rejects::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_MissingDir_Rejects
@@ -506,6 +532,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_Names.verified.txt
@@ -290,7 +290,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 169 (0xa9)
+			// Code size: 209 (0xd1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11/Scope,
@@ -305,7 +305,7 @@
 			IL_0006: ldarg.1
 			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000c: volatile.
-			IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 			IL_0013: brfalse IL_0027
 
 			IL_0018: ldstr "slice"
@@ -314,14 +314,14 @@
 
 			IL_0027: ldstr "slice"
 			IL_002c: ldstr "FSPromises_Readdir_Names:<TwoPhaseDummy_M4>:__js_call__:4"
-			IL_0031: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0031: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_003b: stloc.2
 			IL_003c: ldloc.2
 			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0042: volatile.
-			IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_0049: brfalse IL_005d
 
 			IL_004e: ldstr "sort"
@@ -330,7 +330,7 @@
 
 			IL_005d: ldstr "sort"
 			IL_0062: ldstr "FSPromises_Readdir_Names:<TwoPhaseDummy_M4>:__js_call__:6"
-			IL_0067: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0067: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0071: stloc.1
@@ -348,13 +348,26 @@
 			IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11/ArrowFunction_L16C24/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11/ArrowFunction_L16C24/FunctionObject>(!!0)
 			IL_0097: stloc.s 4
-			IL_0099: ldloc.2
-			IL_009a: ldstr "forEach"
-			IL_009f: ldloc.s 4
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a6: pop
-			IL_00a7: ldnull
-			IL_00a8: ret
+			IL_0099: volatile.
+			IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_00a0: brfalse IL_00b7
+
+			IL_00a5: ldloc.2
+			IL_00a6: ldstr "forEach"
+			IL_00ab: ldloc.s 4
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b2: br IL_00ce
+
+			IL_00b7: ldloc.2
+			IL_00b8: ldstr "forEach"
+			IL_00bd: ldloc.s 4
+			IL_00bf: ldstr "FSPromises_Readdir_Names:<TwoPhaseDummy_M4>:__js_call__:12"
+			IL_00c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00ce: pop
+			IL_00cf: ldnull
+			IL_00d0: ret
 		} // end of method ArrowFunction_L14C11::__js_call__
 
 	} // end of class ArrowFunction_L14C11
@@ -471,7 +484,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.1
@@ -482,7 +495,7 @@
 			IL_002c: ldarg.1
 			IL_002d: ldstr "message"
 			IL_0032: ldstr "FSPromises_Readdir_Names:<TwoPhaseDummy_M5>:__js_call__:7"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
@@ -674,7 +687,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 565 (0x235)
+		// Code size: 688 (0x2b0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_Names/Scope,
@@ -853,64 +866,103 @@
 		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0197: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_Names/ArrowFunction_L14C11/FunctionObject>(!!0)
 		IL_019c: stloc.s 10
-		IL_019e: ldloc.s 5
-		IL_01a0: ldstr "then"
-		IL_01a5: ldloc.s 10
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ac: stloc.s 5
-		IL_01ae: ldloc.s 5
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b5: stloc.s 5
-		IL_01b7: ldc.i4.1
-		IL_01b8: newarr [System.Runtime]System.Object
-		IL_01bd: dup
-		IL_01be: ldc.i4.0
-		IL_01bf: ldloc.0
-		IL_01c0: stelem.ref
-		IL_01c1: stloc.s 9
-		IL_01c3: newobj instance void Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12/FunctionObject::.ctor()
-		IL_01c8: ldc.i4.1
-		IL_01c9: conv.r8
-		IL_01ca: ldstr ""
-		IL_01cf: ldc.i4.0
-		IL_01d0: ldc.i4.0
-		IL_01d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12/FunctionObject>(!!0)
-		IL_01db: stloc.s 11
-		IL_01dd: ldloc.s 5
-		IL_01df: ldstr "catch"
-		IL_01e4: ldloc.s 11
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01eb: stloc.s 5
-		IL_01ed: ldloc.s 5
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f4: stloc.s 5
-		IL_01f6: ldc.i4.1
-		IL_01f7: newarr [System.Runtime]System.Object
-		IL_01fc: dup
-		IL_01fd: ldc.i4.0
-		IL_01fe: ldloc.0
-		IL_01ff: stelem.ref
-		IL_0200: stloc.s 9
-		IL_0202: ldloc.s 9
-		IL_0204: ldc.i4.0
-		IL_0205: ldelem.ref
-		IL_0206: castclass Modules.FSPromises_Readdir_Names/Scope
-		IL_020b: newobj instance void Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14/FunctionObject::.ctor(class Modules.FSPromises_Readdir_Names/Scope)
-		IL_0210: ldc.i4.0
-		IL_0211: conv.r8
-		IL_0212: ldstr ""
-		IL_0217: ldc.i4.0
-		IL_0218: ldc.i4.0
-		IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_021e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14/FunctionObject>(!!0)
-		IL_0223: stloc.s 12
+		IL_019e: volatile.
+		IL_01a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01a5: brfalse IL_01bd
+
+		IL_01aa: ldloc.s 5
+		IL_01ac: ldstr "then"
+		IL_01b1: ldloc.s 10
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b8: br IL_01d5
+
+		IL_01bd: ldloc.s 5
+		IL_01bf: ldstr "then"
+		IL_01c4: ldloc.s 10
+		IL_01c6: ldstr "FSPromises_Readdir_Names:Modules.FSPromises_Readdir_Names:__js_module_init__:64"
+		IL_01cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01d5: stloc.s 5
+		IL_01d7: ldloc.s 5
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01de: stloc.s 5
+		IL_01e0: ldc.i4.1
+		IL_01e1: newarr [System.Runtime]System.Object
+		IL_01e6: dup
+		IL_01e7: ldc.i4.0
+		IL_01e8: ldloc.0
+		IL_01e9: stelem.ref
+		IL_01ea: stloc.s 9
+		IL_01ec: newobj instance void Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12/FunctionObject::.ctor()
+		IL_01f1: ldc.i4.1
+		IL_01f2: conv.r8
+		IL_01f3: ldstr ""
+		IL_01f8: ldc.i4.0
+		IL_01f9: ldc.i4.0
+		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_Names/ArrowFunction_L18C12/FunctionObject>(!!0)
+		IL_0204: stloc.s 11
+		IL_0206: volatile.
+		IL_0208: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_020d: brfalse IL_0225
+
+		IL_0212: ldloc.s 5
+		IL_0214: ldstr "catch"
+		IL_0219: ldloc.s 11
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0220: br IL_023d
+
 		IL_0225: ldloc.s 5
-		IL_0227: ldstr "finally"
-		IL_022c: ldloc.s 12
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0233: pop
-		IL_0234: ret
+		IL_0227: ldstr "catch"
+		IL_022c: ldloc.s 11
+		IL_022e: ldstr "FSPromises_Readdir_Names:Modules.FSPromises_Readdir_Names:__js_module_init__:68"
+		IL_0233: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_023d: stloc.s 5
+		IL_023f: ldloc.s 5
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0246: stloc.s 5
+		IL_0248: ldc.i4.1
+		IL_0249: newarr [System.Runtime]System.Object
+		IL_024e: dup
+		IL_024f: ldc.i4.0
+		IL_0250: ldloc.0
+		IL_0251: stelem.ref
+		IL_0252: stloc.s 9
+		IL_0254: ldloc.s 9
+		IL_0256: ldc.i4.0
+		IL_0257: ldelem.ref
+		IL_0258: castclass Modules.FSPromises_Readdir_Names/Scope
+		IL_025d: newobj instance void Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14/FunctionObject::.ctor(class Modules.FSPromises_Readdir_Names/Scope)
+		IL_0262: ldc.i4.0
+		IL_0263: conv.r8
+		IL_0264: ldstr ""
+		IL_0269: ldc.i4.0
+		IL_026a: ldc.i4.0
+		IL_026b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0270: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_Names/ArrowFunction_L21C14/FunctionObject>(!!0)
+		IL_0275: stloc.s 12
+		IL_0277: volatile.
+		IL_0279: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_027e: brfalse IL_0296
+
+		IL_0283: ldloc.s 5
+		IL_0285: ldstr "finally"
+		IL_028a: ldloc.s 12
+		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0291: br IL_02ae
+
+		IL_0296: ldloc.s 5
+		IL_0298: ldstr "finally"
+		IL_029d: ldloc.s 12
+		IL_029f: ldstr "FSPromises_Readdir_Names:Modules.FSPromises_Readdir_Names:__js_module_init__:72"
+		IL_02a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02ae: pop
+		IL_02af: ret
 	} // end of method FSPromises_Readdir_Names::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_Names
@@ -943,6 +995,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_WithFileTypes.verified.txt
@@ -185,7 +185,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 				IL_0007: brfalse IL_001c
 
 				IL_000c: ldarg.1
@@ -196,7 +196,7 @@
 				IL_001c: ldarg.1
 				IL_001d: ldstr "name"
 				IL_0022: ldstr "FSPromises_Readdir_WithFileTypes:<TwoPhaseDummy_M7>:__js_call__:2"
-				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0031: stloc.1
@@ -207,7 +207,7 @@
 				IL_003e: ldarg.1
 				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0044: volatile.
-				IL_0046: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+				IL_0046: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 				IL_004b: brfalse IL_005f
 
 				IL_0050: ldstr "isDirectory"
@@ -216,7 +216,7 @@
 
 				IL_005f: ldstr "isDirectory"
 				IL_0064: ldstr "FSPromises_Readdir_WithFileTypes:<TwoPhaseDummy_M7>:__js_call__:7"
-				IL_0069: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+				IL_0069: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0073: stloc.1
@@ -457,7 +457,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 168 (0xa8)
+			// Code size: 248 (0xf8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/Scope,
@@ -484,48 +484,74 @@
 			IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/ArrowFunction_L14C35/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0026: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/ArrowFunction_L14C35/FunctionObject>(!!0)
 			IL_002b: stloc.s 4
-			IL_002d: ldloc.2
-			IL_002e: ldstr "map"
-			IL_0033: ldloc.s 4
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_003a: stloc.1
-			IL_003b: ldloc.1
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0041: volatile.
-			IL_0043: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_0048: brfalse IL_005c
+			IL_002d: volatile.
+			IL_002f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0034: brfalse IL_004b
 
-			IL_004d: ldstr "sort"
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0057: br IL_0070
+			IL_0039: ldloc.2
+			IL_003a: ldstr "map"
+			IL_003f: ldloc.s 4
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0046: br IL_0062
 
-			IL_005c: ldstr "sort"
-			IL_0061: ldstr "FSPromises_Readdir_WithFileTypes:<TwoPhaseDummy_M4>:__js_call__:10"
-			IL_0066: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_004b: ldloc.2
+			IL_004c: ldstr "map"
+			IL_0051: ldloc.s 4
+			IL_0053: ldstr "FSPromises_Readdir_WithFileTypes:<TwoPhaseDummy_M4>:__js_call__:6"
+			IL_0058: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0070: pop
-			IL_0071: ldloc.1
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0077: stloc.2
-			IL_0078: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_007d: stloc.3
-			IL_007e: newobj instance void Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/ArrowFunction_L16C23/FunctionObject::.ctor()
-			IL_0083: ldc.i4.1
-			IL_0084: conv.r8
-			IL_0085: ldstr ""
-			IL_008a: ldc.i4.0
-			IL_008b: ldc.i4.0
-			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/ArrowFunction_L16C23/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/ArrowFunction_L16C23/FunctionObject>(!!0)
-			IL_0096: stloc.s 5
-			IL_0098: ldloc.2
-			IL_0099: ldstr "forEach"
-			IL_009e: ldloc.s 5
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a5: pop
-			IL_00a6: ldnull
-			IL_00a7: ret
+			IL_0062: stloc.1
+			IL_0063: ldloc.1
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0069: volatile.
+			IL_006b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0070: brfalse IL_0084
+
+			IL_0075: ldstr "sort"
+			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_007f: br IL_0098
+
+			IL_0084: ldstr "sort"
+			IL_0089: ldstr "FSPromises_Readdir_WithFileTypes:<TwoPhaseDummy_M4>:__js_call__:10"
+			IL_008e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+			IL_0098: pop
+			IL_0099: ldloc.1
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009f: stloc.2
+			IL_00a0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_00a5: stloc.3
+			IL_00a6: newobj instance void Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/ArrowFunction_L16C23/FunctionObject::.ctor()
+			IL_00ab: ldc.i4.1
+			IL_00ac: conv.r8
+			IL_00ad: ldstr ""
+			IL_00b2: ldc.i4.0
+			IL_00b3: ldc.i4.0
+			IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/ArrowFunction_L16C23/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/ArrowFunction_L16C23/FunctionObject>(!!0)
+			IL_00be: stloc.s 5
+			IL_00c0: volatile.
+			IL_00c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_00c7: brfalse IL_00de
+
+			IL_00cc: ldloc.2
+			IL_00cd: ldstr "forEach"
+			IL_00d2: ldloc.s 5
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d9: br IL_00f5
+
+			IL_00de: ldloc.2
+			IL_00df: ldstr "forEach"
+			IL_00e4: ldloc.s 5
+			IL_00e6: ldstr "FSPromises_Readdir_WithFileTypes:<TwoPhaseDummy_M4>:__js_call__:15"
+			IL_00eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00f5: pop
+			IL_00f6: ldnull
+			IL_00f7: ret
 		} // end of method ArrowFunction_L13C11::__js_call__
 
 	} // end of class ArrowFunction_L13C11
@@ -642,7 +668,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.1
@@ -653,7 +679,7 @@
 			IL_002c: ldarg.1
 			IL_002d: ldstr "message"
 			IL_0032: ldstr "FSPromises_Readdir_WithFileTypes:<TwoPhaseDummy_M5>:__js_call__:7"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
@@ -845,7 +871,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 524 (0x20c)
+		// Code size: 647 (0x287)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Readdir_WithFileTypes/Scope,
@@ -1007,64 +1033,103 @@
 		IL_0169: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_016e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L13C11/FunctionObject>(!!0)
 		IL_0173: stloc.s 10
-		IL_0175: ldloc.s 5
-		IL_0177: ldstr "then"
-		IL_017c: ldloc.s 10
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0183: stloc.s 5
-		IL_0185: ldloc.s 5
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018c: stloc.s 5
-		IL_018e: ldc.i4.1
-		IL_018f: newarr [System.Runtime]System.Object
-		IL_0194: dup
-		IL_0195: ldc.i4.0
-		IL_0196: ldloc.0
-		IL_0197: stelem.ref
-		IL_0198: stloc.s 9
-		IL_019a: newobj instance void Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12/FunctionObject::.ctor()
-		IL_019f: ldc.i4.1
-		IL_01a0: conv.r8
-		IL_01a1: ldstr ""
-		IL_01a6: ldc.i4.0
-		IL_01a7: ldc.i4.0
-		IL_01a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12/FunctionObject>(!!0)
-		IL_01b2: stloc.s 11
-		IL_01b4: ldloc.s 5
-		IL_01b6: ldstr "catch"
-		IL_01bb: ldloc.s 11
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c2: stloc.s 5
-		IL_01c4: ldloc.s 5
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cb: stloc.s 5
-		IL_01cd: ldc.i4.1
-		IL_01ce: newarr [System.Runtime]System.Object
-		IL_01d3: dup
-		IL_01d4: ldc.i4.0
-		IL_01d5: ldloc.0
-		IL_01d6: stelem.ref
-		IL_01d7: stloc.s 9
-		IL_01d9: ldloc.s 9
-		IL_01db: ldc.i4.0
-		IL_01dc: ldelem.ref
-		IL_01dd: castclass Modules.FSPromises_Readdir_WithFileTypes/Scope
-		IL_01e2: newobj instance void Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14/FunctionObject::.ctor(class Modules.FSPromises_Readdir_WithFileTypes/Scope)
-		IL_01e7: ldc.i4.0
-		IL_01e8: conv.r8
-		IL_01e9: ldstr ""
-		IL_01ee: ldc.i4.0
-		IL_01ef: ldc.i4.0
-		IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14/FunctionObject>(!!0)
-		IL_01fa: stloc.s 12
+		IL_0175: volatile.
+		IL_0177: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_017c: brfalse IL_0194
+
+		IL_0181: ldloc.s 5
+		IL_0183: ldstr "then"
+		IL_0188: ldloc.s 10
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018f: br IL_01ac
+
+		IL_0194: ldloc.s 5
+		IL_0196: ldstr "then"
+		IL_019b: ldloc.s 10
+		IL_019d: ldstr "FSPromises_Readdir_WithFileTypes:Modules.FSPromises_Readdir_WithFileTypes:__js_module_init__:58"
+		IL_01a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01ac: stloc.s 5
+		IL_01ae: ldloc.s 5
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b5: stloc.s 5
+		IL_01b7: ldc.i4.1
+		IL_01b8: newarr [System.Runtime]System.Object
+		IL_01bd: dup
+		IL_01be: ldc.i4.0
+		IL_01bf: ldloc.0
+		IL_01c0: stelem.ref
+		IL_01c1: stloc.s 9
+		IL_01c3: newobj instance void Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12/FunctionObject::.ctor()
+		IL_01c8: ldc.i4.1
+		IL_01c9: conv.r8
+		IL_01ca: ldstr ""
+		IL_01cf: ldc.i4.0
+		IL_01d0: ldc.i4.0
+		IL_01d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L18C12/FunctionObject>(!!0)
+		IL_01db: stloc.s 11
+		IL_01dd: volatile.
+		IL_01df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01e4: brfalse IL_01fc
+
+		IL_01e9: ldloc.s 5
+		IL_01eb: ldstr "catch"
+		IL_01f0: ldloc.s 11
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f7: br IL_0214
+
 		IL_01fc: ldloc.s 5
-		IL_01fe: ldstr "finally"
-		IL_0203: ldloc.s 12
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020a: pop
-		IL_020b: ret
+		IL_01fe: ldstr "catch"
+		IL_0203: ldloc.s 11
+		IL_0205: ldstr "FSPromises_Readdir_WithFileTypes:Modules.FSPromises_Readdir_WithFileTypes:__js_module_init__:62"
+		IL_020a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0214: stloc.s 5
+		IL_0216: ldloc.s 5
+		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021d: stloc.s 5
+		IL_021f: ldc.i4.1
+		IL_0220: newarr [System.Runtime]System.Object
+		IL_0225: dup
+		IL_0226: ldc.i4.0
+		IL_0227: ldloc.0
+		IL_0228: stelem.ref
+		IL_0229: stloc.s 9
+		IL_022b: ldloc.s 9
+		IL_022d: ldc.i4.0
+		IL_022e: ldelem.ref
+		IL_022f: castclass Modules.FSPromises_Readdir_WithFileTypes/Scope
+		IL_0234: newobj instance void Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14/FunctionObject::.ctor(class Modules.FSPromises_Readdir_WithFileTypes/Scope)
+		IL_0239: ldc.i4.0
+		IL_023a: conv.r8
+		IL_023b: ldstr ""
+		IL_0240: ldc.i4.0
+		IL_0241: ldc.i4.0
+		IL_0242: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0247: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Readdir_WithFileTypes/ArrowFunction_L21C14/FunctionObject>(!!0)
+		IL_024c: stloc.s 12
+		IL_024e: volatile.
+		IL_0250: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0255: brfalse IL_026d
+
+		IL_025a: ldloc.s 5
+		IL_025c: ldstr "finally"
+		IL_0261: ldloc.s 12
+		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0268: br IL_0285
+
+		IL_026d: ldloc.s 5
+		IL_026f: ldstr "finally"
+		IL_0274: ldloc.s 12
+		IL_0276: ldstr "FSPromises_Readdir_WithFileTypes:Modules.FSPromises_Readdir_WithFileTypes:__js_module_init__:66"
+		IL_027b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0285: pop
+		IL_0286: ret
 	} // end of method FSPromises_Readdir_WithFileTypes::__js_module_init__
 
 } // end of class Modules.FSPromises_Readdir_WithFileTypes
@@ -1098,6 +1163,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
@@ -199,7 +199,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.2
@@ -210,7 +210,7 @@
 			IL_0022: ldarg.2
 			IL_0023: ldstr "length"
 			IL_0028: ldstr "FSPromises_Realpath:<TwoPhaseDummy_M4>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -416,7 +416,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.1
@@ -427,7 +427,7 @@
 			IL_002c: ldarg.1
 			IL_002d: ldstr "message"
 			IL_0032: ldstr "FSPromises_Realpath:<TwoPhaseDummy_M5>:__js_call__:7"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
@@ -483,7 +483,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 425 (0x1a9)
+		// Code size: 507 (0x1fb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Realpath/Scope,
@@ -630,36 +630,62 @@
 		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Realpath/ArrowFunction_L8C28/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0153: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Realpath/ArrowFunction_L8C28/FunctionObject>(!!0)
 		IL_0158: stloc.s 8
-		IL_015a: ldloc.s 5
-		IL_015c: ldstr "then"
-		IL_0161: ldloc.s 8
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0168: stloc.s 5
-		IL_016a: ldloc.s 5
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0171: stloc.s 5
-		IL_0173: ldc.i4.1
-		IL_0174: newarr [System.Runtime]System.Object
-		IL_0179: dup
-		IL_017a: ldc.i4.0
-		IL_017b: ldloc.0
-		IL_017c: stelem.ref
-		IL_017d: stloc.s 7
-		IL_017f: newobj instance void Modules.FSPromises_Realpath/ArrowFunction_L12C10/FunctionObject::.ctor()
-		IL_0184: ldc.i4.1
-		IL_0185: conv.r8
-		IL_0186: ldstr ""
-		IL_018b: ldc.i4.0
-		IL_018c: ldc.i4.0
-		IL_018d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Realpath/ArrowFunction_L12C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0192: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Realpath/ArrowFunction_L12C10/FunctionObject>(!!0)
-		IL_0197: stloc.s 9
-		IL_0199: ldloc.s 5
-		IL_019b: ldstr "catch"
-		IL_01a0: ldloc.s 9
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a7: pop
-		IL_01a8: ret
+		IL_015a: volatile.
+		IL_015c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0161: brfalse IL_0179
+
+		IL_0166: ldloc.s 5
+		IL_0168: ldstr "then"
+		IL_016d: ldloc.s 8
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0174: br IL_0191
+
+		IL_0179: ldloc.s 5
+		IL_017b: ldstr "then"
+		IL_0180: ldloc.s 8
+		IL_0182: ldstr "FSPromises_Realpath:Modules.FSPromises_Realpath:__js_module_init__:35"
+		IL_0187: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0191: stloc.s 5
+		IL_0193: ldloc.s 5
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019a: stloc.s 5
+		IL_019c: ldc.i4.1
+		IL_019d: newarr [System.Runtime]System.Object
+		IL_01a2: dup
+		IL_01a3: ldc.i4.0
+		IL_01a4: ldloc.0
+		IL_01a5: stelem.ref
+		IL_01a6: stloc.s 7
+		IL_01a8: newobj instance void Modules.FSPromises_Realpath/ArrowFunction_L12C10/FunctionObject::.ctor()
+		IL_01ad: ldc.i4.1
+		IL_01ae: conv.r8
+		IL_01af: ldstr ""
+		IL_01b4: ldc.i4.0
+		IL_01b5: ldc.i4.0
+		IL_01b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Realpath/ArrowFunction_L12C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Realpath/ArrowFunction_L12C10/FunctionObject>(!!0)
+		IL_01c0: stloc.s 9
+		IL_01c2: volatile.
+		IL_01c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01c9: brfalse IL_01e1
+
+		IL_01ce: ldloc.s 5
+		IL_01d0: ldstr "catch"
+		IL_01d5: ldloc.s 9
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01dc: br IL_01f9
+
+		IL_01e1: ldloc.s 5
+		IL_01e3: ldstr "catch"
+		IL_01e8: ldloc.s 9
+		IL_01ea: ldstr "FSPromises_Realpath:Modules.FSPromises_Realpath:__js_module_init__:39"
+		IL_01ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01f9: pop
+		IL_01fa: ret
 	} // end of method FSPromises_Realpath::__js_module_init__
 
 } // end of class Modules.FSPromises_Realpath
@@ -691,6 +717,8 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_FileSize.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_FileSize.verified.txt
@@ -197,7 +197,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.2
@@ -208,7 +208,7 @@
 			IL_0022: ldarg.2
 			IL_0023: ldstr "size"
 			IL_0028: ldstr "FSPromises_Stat_FileSize:<TwoPhaseDummy_M4>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -366,7 +366,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.1
@@ -377,7 +377,7 @@
 			IL_002c: ldarg.1
 			IL_002d: ldstr "message"
 			IL_0032: ldstr "FSPromises_Stat_FileSize:<TwoPhaseDummy_M5>:__js_call__:7"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
@@ -433,7 +433,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 431 (0x1af)
+		// Code size: 513 (0x201)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Stat_FileSize/Scope,
@@ -583,36 +583,62 @@
 		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Stat_FileSize/ArrowFunction_L9C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0159: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Stat_FileSize/ArrowFunction_L9C24/FunctionObject>(!!0)
 		IL_015e: stloc.s 9
-		IL_0160: ldloc.s 6
-		IL_0162: ldstr "then"
-		IL_0167: ldloc.s 9
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016e: stloc.s 6
-		IL_0170: ldloc.s 6
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0177: stloc.s 6
-		IL_0179: ldc.i4.1
-		IL_017a: newarr [System.Runtime]System.Object
-		IL_017f: dup
-		IL_0180: ldc.i4.0
-		IL_0181: ldloc.0
-		IL_0182: stelem.ref
-		IL_0183: stloc.s 8
-		IL_0185: newobj instance void Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10/FunctionObject::.ctor()
-		IL_018a: ldc.i4.1
-		IL_018b: conv.r8
-		IL_018c: ldstr ""
-		IL_0191: ldc.i4.0
-		IL_0192: ldc.i4.0
-		IL_0193: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0198: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10/FunctionObject>(!!0)
-		IL_019d: stloc.s 10
-		IL_019f: ldloc.s 6
-		IL_01a1: ldstr "catch"
-		IL_01a6: ldloc.s 10
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ad: pop
-		IL_01ae: ret
+		IL_0160: volatile.
+		IL_0162: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0167: brfalse IL_017f
+
+		IL_016c: ldloc.s 6
+		IL_016e: ldstr "then"
+		IL_0173: ldloc.s 9
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017a: br IL_0197
+
+		IL_017f: ldloc.s 6
+		IL_0181: ldstr "then"
+		IL_0186: ldloc.s 9
+		IL_0188: ldstr "FSPromises_Stat_FileSize:Modules.FSPromises_Stat_FileSize:__js_module_init__:37"
+		IL_018d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0197: stloc.s 6
+		IL_0199: ldloc.s 6
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a0: stloc.s 6
+		IL_01a2: ldc.i4.1
+		IL_01a3: newarr [System.Runtime]System.Object
+		IL_01a8: dup
+		IL_01a9: ldc.i4.0
+		IL_01aa: ldloc.0
+		IL_01ab: stelem.ref
+		IL_01ac: stloc.s 8
+		IL_01ae: newobj instance void Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10/FunctionObject::.ctor()
+		IL_01b3: ldc.i4.1
+		IL_01b4: conv.r8
+		IL_01b5: ldstr ""
+		IL_01ba: ldc.i4.0
+		IL_01bb: ldc.i4.0
+		IL_01bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Stat_FileSize/ArrowFunction_L12C10/FunctionObject>(!!0)
+		IL_01c6: stloc.s 10
+		IL_01c8: volatile.
+		IL_01ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01cf: brfalse IL_01e7
+
+		IL_01d4: ldloc.s 6
+		IL_01d6: ldstr "catch"
+		IL_01db: ldloc.s 10
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e2: br IL_01ff
+
+		IL_01e7: ldloc.s 6
+		IL_01e9: ldstr "catch"
+		IL_01ee: ldloc.s 10
+		IL_01f0: ldstr "FSPromises_Stat_FileSize:Modules.FSPromises_Stat_FileSize:__js_module_init__:41"
+		IL_01f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01ff: pop
+		IL_0200: ret
 	} // end of method FSPromises_Stat_FileSize::__js_module_init__
 
 } // end of class Modules.FSPromises_Stat_FileSize
@@ -644,6 +670,8 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_RichMetadata.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Stat_RichMetadata.verified.txt
@@ -346,7 +346,7 @@
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_000c: volatile.
-			IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_0013: brfalse IL_0027
 
 			IL_0018: ldstr "size"
@@ -355,7 +355,7 @@
 
 			IL_0027: ldstr "size"
 			IL_002c: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_0031: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0031: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_003b: stloc.1
@@ -369,7 +369,7 @@
 			IL_004f: ldarg.0
 			IL_0050: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_0055: volatile.
-			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_005c: brfalse IL_0070
 
 			IL_0061: ldstr "mode"
@@ -378,7 +378,7 @@
 
 			IL_0070: ldstr "mode"
 			IL_0075: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:12"
-			IL_007a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_007a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0084: stloc.1
@@ -410,7 +410,7 @@
 			IL_00c5: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00cf: volatile.
-			IL_00d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_00d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_00d6: brfalse IL_00ea
 
 			IL_00db: ldstr "isFile"
@@ -419,7 +419,7 @@
 
 			IL_00ea: ldstr "isFile"
 			IL_00ef: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:25"
-			IL_00f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_00f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_00fe: stloc.1
@@ -433,7 +433,7 @@
 			IL_0112: ldarg.0
 			IL_0113: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_0118: volatile.
-			IL_011a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_011a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_011f: brfalse IL_0133
 
 			IL_0124: ldstr "birthtimeMs"
@@ -442,7 +442,7 @@
 
 			IL_0133: ldstr "birthtimeMs"
 			IL_0138: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:32"
-			IL_013d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_013d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0147: stloc.1
@@ -465,7 +465,7 @@
 			IL_0173: ldarg.0
 			IL_0174: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_0179: volatile.
-			IL_017b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_017b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_0180: brfalse IL_0194
 
 			IL_0185: ldstr "birthtimeMs"
@@ -474,7 +474,7 @@
 
 			IL_0194: ldstr "birthtimeMs"
 			IL_0199: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:41"
-			IL_019e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_019e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01a8: stloc.1
@@ -503,7 +503,7 @@
 			IL_01e4: ldarg.0
 			IL_01e5: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_01ea: volatile.
-			IL_01ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_01ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_01f1: brfalse IL_0205
 
 			IL_01f6: ldstr "birthtime"
@@ -512,14 +512,14 @@
 
 			IL_0205: ldstr "birthtime"
 			IL_020a: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:57"
-			IL_020f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_020f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0219: stloc.1
 			IL_021a: ldloc.1
 			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0220: volatile.
-			IL_0222: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0222: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_0227: brfalse IL_023b
 
 			IL_022c: ldstr "toISOString"
@@ -528,12 +528,12 @@
 
 			IL_023b: ldstr "toISOString"
 			IL_0240: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:59"
-			IL_0245: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0245: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_024f: stloc.1
 			IL_0250: volatile.
-			IL_0252: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0252: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_0257: brfalse IL_026c
 
 			IL_025c: ldloc.1
@@ -544,7 +544,7 @@
 			IL_026c: ldloc.1
 			IL_026d: ldstr "length"
 			IL_0272: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:61"
-			IL_0277: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0277: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0281: stloc.1
@@ -559,7 +559,7 @@
 			IL_0296: ldfld object Modules.FSPromises_Stat_RichMetadata/Scope::fileStats
 			IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_02a0: volatile.
-			IL_02a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_02a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_02a7: brfalse IL_02bb
 
 			IL_02ac: ldstr "isCharacterDevice"
@@ -568,7 +568,7 @@
 
 			IL_02bb: ldstr "isCharacterDevice"
 			IL_02c0: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:68"
-			IL_02c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_02c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_02cf: stloc.1
@@ -580,7 +580,7 @@
 			IL_02dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_02e2: stloc.0
 			IL_02e3: volatile.
-			IL_02e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_02e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_02ea: brfalse IL_02ff
 
 			IL_02ef: ldarg.2
@@ -591,7 +591,7 @@
 			IL_02ff: ldarg.2
 			IL_0300: ldstr "mode"
 			IL_0305: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:75"
-			IL_030a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_030a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0314: stloc.1
@@ -622,7 +622,7 @@
 			IL_0354: ldarg.2
 			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_035a: volatile.
-			IL_035c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_035c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_0361: brfalse IL_0375
 
 			IL_0366: ldstr "isDirectory"
@@ -631,7 +631,7 @@
 
 			IL_0375: ldstr "isDirectory"
 			IL_037a: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:88"
-			IL_037f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_037f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0389: stloc.1
@@ -643,7 +643,7 @@
 			IL_0397: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_039c: stloc.0
 			IL_039d: volatile.
-			IL_039f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_039f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_03a4: brfalse IL_03b9
 
 			IL_03a9: ldarg.2
@@ -654,7 +654,7 @@
 			IL_03b9: ldarg.2
 			IL_03ba: ldstr "ctimeMs"
 			IL_03bf: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:95"
-			IL_03c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_03c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_03ce: stloc.1
@@ -675,7 +675,7 @@
 			IL_03f5: brfalse IL_044f
 
 			IL_03fa: volatile.
-			IL_03fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_03fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0401: brfalse IL_0416
 
 			IL_0406: ldarg.2
@@ -686,7 +686,7 @@
 			IL_0416: ldarg.2
 			IL_0417: ldstr "ctimeMs"
 			IL_041c: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:104"
-			IL_0421: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0421: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_042b: stloc.1
@@ -715,7 +715,7 @@
 			IL_0467: ldarg.2
 			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_046d: volatile.
-			IL_046f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_046f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0474: brfalse IL_0488
 
 			IL_0479: ldstr "isFIFO"
@@ -724,7 +724,7 @@
 
 			IL_0488: ldstr "isFIFO"
 			IL_048d: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M5>:__js_call__:120"
-			IL_0492: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0492: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_049c: stloc.1
@@ -909,7 +909,7 @@
 			IL_000e: brfalse IL_004d
 
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldarg.2
@@ -920,7 +920,7 @@
 			IL_002f: ldarg.2
 			IL_0030: ldstr "message"
 			IL_0035: ldstr "FSPromises_Stat_RichMetadata:<TwoPhaseDummy_M6>:__js_call__:8"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0044: stloc.2
@@ -1024,7 +1024,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 730 (0x2da)
+		// Code size: 853 (0x355)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_Stat_RichMetadata/Scope,
@@ -1245,68 +1245,107 @@
 		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L18C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L18C20/FunctionObject>(!!0)
 		IL_0238: stloc.s 11
-		IL_023a: ldloc.s 6
-		IL_023c: ldstr "then"
-		IL_0241: ldloc.s 11
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0248: stloc.s 6
-		IL_024a: ldloc.s 6
-		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0251: stloc.s 6
-		IL_0253: ldc.i4.1
-		IL_0254: newarr [System.Runtime]System.Object
-		IL_0259: dup
-		IL_025a: ldc.i4.0
-		IL_025b: ldloc.0
-		IL_025c: stelem.ref
-		IL_025d: stloc.s 10
-		IL_025f: ldloc.s 10
-		IL_0261: ldc.i4.0
-		IL_0262: ldelem.ref
-		IL_0263: castclass Modules.FSPromises_Stat_RichMetadata/Scope
-		IL_0268: newobj instance void Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9/FunctionObject::.ctor(class Modules.FSPromises_Stat_RichMetadata/Scope)
-		IL_026d: ldc.i4.1
-		IL_026e: conv.r8
-		IL_026f: ldstr ""
-		IL_0274: ldc.i4.0
-		IL_0275: ldc.i4.0
-		IL_0276: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_027b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9/FunctionObject>(!!0)
-		IL_0280: stloc.s 12
-		IL_0282: ldloc.s 6
-		IL_0284: ldstr "then"
-		IL_0289: ldloc.s 12
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0290: stloc.s 6
-		IL_0292: ldloc.s 6
-		IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0299: stloc.s 6
-		IL_029b: ldc.i4.1
-		IL_029c: newarr [System.Runtime]System.Object
-		IL_02a1: dup
-		IL_02a2: ldc.i4.0
-		IL_02a3: ldloc.0
-		IL_02a4: stelem.ref
-		IL_02a5: stloc.s 10
-		IL_02a7: ldloc.s 10
-		IL_02a9: ldc.i4.0
-		IL_02aa: ldelem.ref
-		IL_02ab: castclass Modules.FSPromises_Stat_RichMetadata/Scope
-		IL_02b0: newobj instance void Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10/FunctionObject::.ctor(class Modules.FSPromises_Stat_RichMetadata/Scope)
-		IL_02b5: ldc.i4.1
-		IL_02b6: conv.r8
-		IL_02b7: ldstr ""
-		IL_02bc: ldc.i4.0
-		IL_02bd: ldc.i4.0
-		IL_02be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10/FunctionObject>(!!0)
-		IL_02c8: stloc.s 13
+		IL_023a: volatile.
+		IL_023c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0241: brfalse IL_0259
+
+		IL_0246: ldloc.s 6
+		IL_0248: ldstr "then"
+		IL_024d: ldloc.s 11
+		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0254: br IL_0271
+
+		IL_0259: ldloc.s 6
+		IL_025b: ldstr "then"
+		IL_0260: ldloc.s 11
+		IL_0262: ldstr "FSPromises_Stat_RichMetadata:Modules.FSPromises_Stat_RichMetadata:__js_module_init__:89"
+		IL_0267: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0271: stloc.s 6
+		IL_0273: ldloc.s 6
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027a: stloc.s 6
+		IL_027c: ldc.i4.1
+		IL_027d: newarr [System.Runtime]System.Object
+		IL_0282: dup
+		IL_0283: ldc.i4.0
+		IL_0284: ldloc.0
+		IL_0285: stelem.ref
+		IL_0286: stloc.s 10
+		IL_0288: ldloc.s 10
+		IL_028a: ldc.i4.0
+		IL_028b: ldelem.ref
+		IL_028c: castclass Modules.FSPromises_Stat_RichMetadata/Scope
+		IL_0291: newobj instance void Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9/FunctionObject::.ctor(class Modules.FSPromises_Stat_RichMetadata/Scope)
+		IL_0296: ldc.i4.1
+		IL_0297: conv.r8
+		IL_0298: ldstr ""
+		IL_029d: ldc.i4.0
+		IL_029e: ldc.i4.0
+		IL_029f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L21C9/FunctionObject>(!!0)
+		IL_02a9: stloc.s 12
+		IL_02ab: volatile.
+		IL_02ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02b2: brfalse IL_02ca
+
+		IL_02b7: ldloc.s 6
+		IL_02b9: ldstr "then"
+		IL_02be: ldloc.s 12
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c5: br IL_02e2
+
 		IL_02ca: ldloc.s 6
-		IL_02cc: ldstr "catch"
-		IL_02d1: ldloc.s 13
-		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d8: pop
-		IL_02d9: ret
+		IL_02cc: ldstr "then"
+		IL_02d1: ldloc.s 12
+		IL_02d3: ldstr "FSPromises_Stat_RichMetadata:Modules.FSPromises_Stat_RichMetadata:__js_module_init__:93"
+		IL_02d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02e2: stloc.s 6
+		IL_02e4: ldloc.s 6
+		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02eb: stloc.s 6
+		IL_02ed: ldc.i4.1
+		IL_02ee: newarr [System.Runtime]System.Object
+		IL_02f3: dup
+		IL_02f4: ldc.i4.0
+		IL_02f5: ldloc.0
+		IL_02f6: stelem.ref
+		IL_02f7: stloc.s 10
+		IL_02f9: ldloc.s 10
+		IL_02fb: ldc.i4.0
+		IL_02fc: ldelem.ref
+		IL_02fd: castclass Modules.FSPromises_Stat_RichMetadata/Scope
+		IL_0302: newobj instance void Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10/FunctionObject::.ctor(class Modules.FSPromises_Stat_RichMetadata/Scope)
+		IL_0307: ldc.i4.1
+		IL_0308: conv.r8
+		IL_0309: ldstr ""
+		IL_030e: ldc.i4.0
+		IL_030f: ldc.i4.0
+		IL_0310: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0315: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_Stat_RichMetadata/ArrowFunction_L36C10/FunctionObject>(!!0)
+		IL_031a: stloc.s 13
+		IL_031c: volatile.
+		IL_031e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0323: brfalse IL_033b
+
+		IL_0328: ldloc.s 6
+		IL_032a: ldstr "catch"
+		IL_032f: ldloc.s 13
+		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0336: br IL_0353
+
+		IL_033b: ldloc.s 6
+		IL_033d: ldstr "catch"
+		IL_0342: ldloc.s 13
+		IL_0344: ldstr "FSPromises_Stat_RichMetadata:Modules.FSPromises_Stat_RichMetadata:__js_module_init__:97"
+		IL_0349: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0353: pop
+		IL_0354: ret
 	} // end of method FSPromises_Stat_RichMetadata::__js_module_init__
 
 } // end of class Modules.FSPromises_Stat_RichMetadata
@@ -1351,6 +1390,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_24
 	.field assembly static int32 __jroc_dynamicLookup_25
 	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_WriteFile_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_WriteFile_Utf8.verified.txt
@@ -377,7 +377,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.1
@@ -388,7 +388,7 @@
 			IL_002c: ldarg.1
 			IL_002d: ldstr "message"
 			IL_0032: ldstr "FSPromises_WriteFile_Utf8:<TwoPhaseDummy_M5>:__js_call__:7"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
@@ -444,7 +444,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 326 (0x146)
+		// Code size: 408 (0x198)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FSPromises_WriteFile_Utf8/Scope,
@@ -551,36 +551,62 @@
 		IL_00eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L7C63/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L7C63/FunctionObject>(!!0)
 		IL_00f5: stloc.s 7
-		IL_00f7: ldloc.s 5
-		IL_00f9: ldstr "then"
-		IL_00fe: ldloc.s 7
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0105: stloc.s 5
-		IL_0107: ldloc.s 5
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010e: stloc.s 5
-		IL_0110: ldc.i4.1
-		IL_0111: newarr [System.Runtime]System.Object
-		IL_0116: dup
-		IL_0117: ldc.i4.0
-		IL_0118: ldloc.0
-		IL_0119: stelem.ref
-		IL_011a: stloc.s 6
-		IL_011c: newobj instance void Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10/FunctionObject::.ctor()
-		IL_0121: ldc.i4.1
-		IL_0122: conv.r8
-		IL_0123: ldstr ""
-		IL_0128: ldc.i4.0
-		IL_0129: ldc.i4.0
-		IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10/FunctionObject>(!!0)
-		IL_0134: stloc.s 8
-		IL_0136: ldloc.s 5
-		IL_0138: ldstr "catch"
-		IL_013d: ldloc.s 8
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0144: pop
-		IL_0145: ret
+		IL_00f7: volatile.
+		IL_00f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00fe: brfalse IL_0116
+
+		IL_0103: ldloc.s 5
+		IL_0105: ldstr "then"
+		IL_010a: ldloc.s 7
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0111: br IL_012e
+
+		IL_0116: ldloc.s 5
+		IL_0118: ldstr "then"
+		IL_011d: ldloc.s 7
+		IL_011f: ldstr "FSPromises_WriteFile_Utf8:Modules.FSPromises_WriteFile_Utf8:__js_module_init__:29"
+		IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_012e: stloc.s 5
+		IL_0130: ldloc.s 5
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0137: stloc.s 5
+		IL_0139: ldc.i4.1
+		IL_013a: newarr [System.Runtime]System.Object
+		IL_013f: dup
+		IL_0140: ldc.i4.0
+		IL_0141: ldloc.0
+		IL_0142: stelem.ref
+		IL_0143: stloc.s 6
+		IL_0145: newobj instance void Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10/FunctionObject::.ctor()
+		IL_014a: ldc.i4.1
+		IL_014b: conv.r8
+		IL_014c: ldstr ""
+		IL_0151: ldc.i4.0
+		IL_0152: ldc.i4.0
+		IL_0153: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FSPromises_WriteFile_Utf8/ArrowFunction_L11C10/FunctionObject>(!!0)
+		IL_015d: stloc.s 8
+		IL_015f: volatile.
+		IL_0161: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0166: brfalse IL_017e
+
+		IL_016b: ldloc.s 5
+		IL_016d: ldstr "catch"
+		IL_0172: ldloc.s 8
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0179: br IL_0196
+
+		IL_017e: ldloc.s 5
+		IL_0180: ldstr "catch"
+		IL_0185: ldloc.s 8
+		IL_0187: ldstr "FSPromises_WriteFile_Utf8:Modules.FSPromises_WriteFile_Utf8:__js_module_init__:33"
+		IL_018c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0196: pop
+		IL_0197: ret
 	} // end of method FSPromises_WriteFile_Utf8::__js_module_init__
 
 } // end of class Modules.FSPromises_WriteFile_Utf8
@@ -611,6 +637,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Basic.verified.txt
@@ -466,7 +466,7 @@
 			IL_000e: brfalse IL_004d
 
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldarg.2
@@ -477,7 +477,7 @@
 			IL_002f: ldarg.2
 			IL_0030: ldstr "message"
 			IL_0035: ldstr "FS_CreateWriteStream_Basic:<TwoPhaseDummy_M6>:__js_call__:8"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0044: stloc.2
@@ -554,7 +554,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 575 (0x23f)
+		// Code size: 659 (0x293)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_CreateWriteStream_Basic/Scope,
@@ -760,17 +760,41 @@
 		IL_020f: pop
 		IL_0210: ldloc.s 4
 		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0217: ldstr "write"
-		IL_021c: ldstr "hello "
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0226: pop
-		IL_0227: ldloc.s 4
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022e: ldstr "end"
-		IL_0233: ldstr "world"
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023d: pop
-		IL_023e: ret
+		IL_0217: volatile.
+		IL_0219: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_021e: brfalse IL_0237
+
+		IL_0223: ldstr "write"
+		IL_0228: ldstr "hello "
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0232: br IL_0250
+
+		IL_0237: ldstr "write"
+		IL_023c: ldstr "hello "
+		IL_0241: ldstr "FS_CreateWriteStream_Basic:Modules.FS_CreateWriteStream_Basic:__js_module_init__:76"
+		IL_0246: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0250: pop
+		IL_0251: ldloc.s 4
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0258: volatile.
+		IL_025a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_025f: brfalse IL_0278
+
+		IL_0264: ldstr "end"
+		IL_0269: ldstr "world"
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0273: br IL_0291
+
+		IL_0278: ldstr "end"
+		IL_027d: ldstr "world"
+		IL_0282: ldstr "FS_CreateWriteStream_Basic:Modules.FS_CreateWriteStream_Basic:__js_module_init__:80"
+		IL_0287: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0291: pop
+		IL_0292: ret
 	} // end of method FS_CreateWriteStream_Basic::__js_module_init__
 
 } // end of class Modules.FS_CreateWriteStream_Basic
@@ -801,6 +825,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Missing_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_CreateWriteStream_Missing_Error.verified.txt
@@ -196,7 +196,7 @@
 			IL_001e: brfalse IL_005d
 
 			IL_0023: volatile.
-			IL_0025: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0025: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_002a: brfalse IL_003f
 
 			IL_002f: ldarg.1
@@ -207,7 +207,7 @@
 			IL_003f: ldarg.1
 			IL_0040: ldstr "message"
 			IL_0045: ldstr "FS_CreateWriteStream_Missing_Error:<TwoPhaseDummy_M4>:__js_call__:11"
-			IL_004a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_004a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0054: stloc.3
@@ -373,7 +373,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 510 (0x1fe)
+		// Code size: 552 (0x228)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_CreateWriteStream_Missing_Error/Scope,
@@ -571,11 +571,23 @@
 		IL_01e5: pop
 		IL_01e6: ldloc.s 7
 		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ed: ldstr "write"
-		IL_01f2: ldstr "nope"
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fc: pop
-		IL_01fd: ret
+		IL_01ed: volatile.
+		IL_01ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_01f4: brfalse IL_020d
+
+		IL_01f9: ldstr "write"
+		IL_01fe: ldstr "nope"
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0208: br IL_0226
+
+		IL_020d: ldstr "write"
+		IL_0212: ldstr "nope"
+		IL_0217: ldstr "FS_CreateWriteStream_Missing_Error:Modules.FS_CreateWriteStream_Missing_Error:__js_module_init__:75"
+		IL_021c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0226: pop
+		IL_0227: ret
 	} // end of method FS_CreateWriteStream_Missing_Error::__js_module_init__
 
 } // end of class Modules.FS_CreateWriteStream_Missing_Error
@@ -606,6 +618,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Open_Callback_FileHandle.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_Open_Callback_FileHandle.verified.txt
@@ -199,7 +199,7 @@
 				IL_0008: ldfld object Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope::handle
 				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0012: volatile.
-				IL_0014: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_0014: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 				IL_0019: brfalse IL_002d
 
 				IL_001e: ldstr "close"
@@ -208,7 +208,7 @@
 
 				IL_002d: ldstr "close"
 				IL_0032: ldstr "FS_Open_Callback_FileHandle:<TwoPhaseDummy_M5>:__js_call__:2"
-				IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0041: stloc.0
@@ -531,7 +531,7 @@
 				IL_000e: brfalse IL_004d
 
 				IL_0013: volatile.
-				IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 				IL_001a: brfalse IL_002f
 
 				IL_001f: ldarg.2
@@ -542,7 +542,7 @@
 				IL_002f: ldarg.2
 				IL_0030: ldstr "message"
 				IL_0035: ldstr "FS_Open_Callback_FileHandle:<TwoPhaseDummy_M7>:__js_call__:8"
-				IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 				IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0044: stloc.2
@@ -722,7 +722,7 @@
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 522 (0x20a)
+			// Code size: 562 (0x232)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope,
@@ -867,80 +867,93 @@
 			IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C40/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0160: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C40/FunctionObject>(!!0)
 			IL_0165: stloc.s 9
-			IL_0167: ldloc.3
-			IL_0168: ldstr "then"
-			IL_016d: ldloc.s 9
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0174: stloc.3
-			IL_0175: ldloc.3
-			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017b: stloc.3
-			IL_017c: ldc.i4.2
-			IL_017d: newarr [System.Runtime]System.Object
-			IL_0182: dup
-			IL_0183: ldc.i4.0
-			IL_0184: ldarg.0
-			IL_0185: stelem.ref
-			IL_0186: dup
-			IL_0187: ldc.i4.1
-			IL_0188: ldloc.0
-			IL_0189: stelem.ref
-			IL_018a: stloc.s 8
-			IL_018c: ldloc.s 8
-			IL_018e: ldc.i4.0
-			IL_018f: ldelem.ref
-			IL_0190: castclass Modules.FS_Open_Callback_FileHandle/Scope
-			IL_0195: ldloc.s 8
-			IL_0197: ldc.i4.1
-			IL_0198: ldelem.ref
-			IL_0199: castclass Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope
-			IL_019e: ldloc.s 8
-			IL_01a0: newobj instance void Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67/FunctionObject::.ctor(class Modules.FS_Open_Callback_FileHandle/Scope, class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope, object[])
-			IL_01a5: ldc.i4.0
-			IL_01a6: conv.r8
-			IL_01a7: ldstr ""
-			IL_01ac: ldc.i4.0
-			IL_01ad: ldc.i4.0
-			IL_01ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_01b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67/FunctionObject>(!!0)
-			IL_01b8: stloc.s 10
-			IL_01ba: ldc.i4.2
-			IL_01bb: newarr [System.Runtime]System.Object
-			IL_01c0: dup
-			IL_01c1: ldc.i4.0
-			IL_01c2: ldarg.0
-			IL_01c3: stelem.ref
-			IL_01c4: dup
-			IL_01c5: ldc.i4.1
-			IL_01c6: ldloc.0
-			IL_01c7: stelem.ref
-			IL_01c8: stloc.s 8
-			IL_01ca: ldloc.s 8
-			IL_01cc: ldc.i4.0
-			IL_01cd: ldelem.ref
-			IL_01ce: castclass Modules.FS_Open_Callback_FileHandle/Scope
-			IL_01d3: ldloc.s 8
-			IL_01d5: ldc.i4.1
-			IL_01d6: ldelem.ref
-			IL_01d7: castclass Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope
-			IL_01dc: ldloc.s 8
-			IL_01de: newobj instance void Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8/FunctionObject::.ctor(class Modules.FS_Open_Callback_FileHandle/Scope, class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope, object[])
-			IL_01e3: ldc.i4.1
-			IL_01e4: conv.r8
-			IL_01e5: ldstr ""
-			IL_01ea: ldc.i4.0
-			IL_01eb: ldc.i4.0
-			IL_01ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_01f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8/FunctionObject>(!!0)
-			IL_01f6: stloc.s 11
-			IL_01f8: ldloc.3
-			IL_01f9: ldstr "then"
-			IL_01fe: ldloc.s 10
-			IL_0200: ldloc.s 11
-			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0207: pop
-			IL_0208: ldnull
-			IL_0209: ret
+			IL_0167: volatile.
+			IL_0169: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_016e: brfalse IL_0185
+
+			IL_0173: ldloc.3
+			IL_0174: ldstr "then"
+			IL_0179: ldloc.s 9
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0180: br IL_019c
+
+			IL_0185: ldloc.3
+			IL_0186: ldstr "then"
+			IL_018b: ldloc.s 9
+			IL_018d: ldstr "FS_Open_Callback_FileHandle:<TwoPhaseDummy_M4>:__js_call__:46"
+			IL_0192: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_019c: stloc.3
+			IL_019d: ldloc.3
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a3: stloc.3
+			IL_01a4: ldc.i4.2
+			IL_01a5: newarr [System.Runtime]System.Object
+			IL_01aa: dup
+			IL_01ab: ldc.i4.0
+			IL_01ac: ldarg.0
+			IL_01ad: stelem.ref
+			IL_01ae: dup
+			IL_01af: ldc.i4.1
+			IL_01b0: ldloc.0
+			IL_01b1: stelem.ref
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
+			IL_01b6: ldc.i4.0
+			IL_01b7: ldelem.ref
+			IL_01b8: castclass Modules.FS_Open_Callback_FileHandle/Scope
+			IL_01bd: ldloc.s 8
+			IL_01bf: ldc.i4.1
+			IL_01c0: ldelem.ref
+			IL_01c1: castclass Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope
+			IL_01c6: ldloc.s 8
+			IL_01c8: newobj instance void Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67/FunctionObject::.ctor(class Modules.FS_Open_Callback_FileHandle/Scope, class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope, object[])
+			IL_01cd: ldc.i4.0
+			IL_01ce: conv.r8
+			IL_01cf: ldstr ""
+			IL_01d4: ldc.i4.0
+			IL_01d5: ldc.i4.0
+			IL_01d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L20C67/FunctionObject>(!!0)
+			IL_01e0: stloc.s 10
+			IL_01e2: ldc.i4.2
+			IL_01e3: newarr [System.Runtime]System.Object
+			IL_01e8: dup
+			IL_01e9: ldc.i4.0
+			IL_01ea: ldarg.0
+			IL_01eb: stelem.ref
+			IL_01ec: dup
+			IL_01ed: ldc.i4.1
+			IL_01ee: ldloc.0
+			IL_01ef: stelem.ref
+			IL_01f0: stloc.s 8
+			IL_01f2: ldloc.s 8
+			IL_01f4: ldc.i4.0
+			IL_01f5: ldelem.ref
+			IL_01f6: castclass Modules.FS_Open_Callback_FileHandle/Scope
+			IL_01fb: ldloc.s 8
+			IL_01fd: ldc.i4.1
+			IL_01fe: ldelem.ref
+			IL_01ff: castclass Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope
+			IL_0204: ldloc.s 8
+			IL_0206: newobj instance void Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8/FunctionObject::.ctor(class Modules.FS_Open_Callback_FileHandle/Scope, class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/Scope, object[])
+			IL_020b: ldc.i4.1
+			IL_020c: conv.r8
+			IL_020d: ldstr ""
+			IL_0212: ldc.i4.0
+			IL_0213: ldc.i4.0
+			IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.FS_Open_Callback_FileHandle/ArrowFunction_L11C21/ArrowFunction_L23C8/FunctionObject>(!!0)
+			IL_021e: stloc.s 11
+			IL_0220: ldloc.3
+			IL_0221: ldstr "then"
+			IL_0226: ldloc.s 10
+			IL_0228: ldloc.s 11
+			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_022f: pop
+			IL_0230: ldnull
+			IL_0231: ret
 		} // end of method ArrowFunction_L11C21::__js_call__
 
 	} // end of class ArrowFunction_L11C21
@@ -1152,6 +1165,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
 	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
@@ -224,7 +224,7 @@
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
 			// Header size: 12
-			// Code size: 98 (0x62)
+			// Code size: 137 (0x89)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -259,13 +259,26 @@
 			IL_004c: ldloc.2
 			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0052: stloc.1
-			IL_0053: ldloc.0
-			IL_0054: ldstr "end"
-			IL_0059: ldloc.1
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_005f: pop
-			IL_0060: ldnull
-			IL_0061: ret
+			IL_0053: volatile.
+			IL_0055: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_005a: brfalse IL_0070
+
+			IL_005f: ldloc.0
+			IL_0060: ldstr "end"
+			IL_0065: ldloc.1
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_006b: br IL_0086
+
+			IL_0070: ldloc.0
+			IL_0071: ldstr "end"
+			IL_0076: ldloc.1
+			IL_0077: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M4>:__js_call__:17"
+			IL_007c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0086: pop
+			IL_0087: ldnull
+			IL_0088: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server
@@ -1123,7 +1136,7 @@
 								01 00 02 00 00 00 00 00
 							)
 							// Header size: 12
-							// Code size: 222 (0xde)
+							// Code size: 262 (0x106)
 							.maxstack 8
 							.locals init (
 								[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/Scope,
@@ -1175,7 +1188,7 @@
 							IL_005e: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::agent
 							IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 							IL_0068: volatile.
-							IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+							IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 							IL_006f: brfalse IL_0083
 
 							IL_0074: ldstr "destroy"
@@ -1184,7 +1197,7 @@
 
 							IL_0083: ldstr "destroy"
 							IL_0088: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M12>:__js_call__:16"
-							IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+							IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 							IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 							IL_0097: pop
@@ -1212,13 +1225,26 @@
 							IL_00c6: ldc.i4.1
 							IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject>(!!0, float64, string, bool, bool)
 							IL_00cc: stloc.s 5
-							IL_00ce: ldloc.2
-							IL_00cf: ldstr "close"
-							IL_00d4: ldloc.s 5
-							IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-							IL_00db: pop
-							IL_00dc: ldnull
-							IL_00dd: ret
+							IL_00ce: volatile.
+							IL_00d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+							IL_00d5: brfalse IL_00ec
+
+							IL_00da: ldloc.2
+							IL_00db: ldstr "close"
+							IL_00e0: ldloc.s 5
+							IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+							IL_00e7: br IL_0103
+
+							IL_00ec: ldloc.2
+							IL_00ed: ldstr "close"
+							IL_00f2: ldloc.s 5
+							IL_00f4: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M12>:__js_call__:22"
+							IL_00f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+							IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+							IL_0103: pop
+							IL_0104: ldnull
+							IL_0105: ret
 						} // end of method FunctionExpression_L57C30::__js_call__
 
 					} // end of class FunctionExpression_L57C30
@@ -1384,7 +1410,7 @@
 							01 00 02 00 00 00 00 00
 						)
 						// Header size: 12
-						// Code size: 409 (0x199)
+						// Code size: 451 (0x1c3)
 						.maxstack 8
 						.locals init (
 							[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope,
@@ -1400,187 +1426,199 @@
 						IL_0005: stloc.0
 						IL_0006: ldarg.2
 						IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-						IL_000c: ldstr "setEncoding"
-						IL_0011: ldstr "utf8"
-						IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-						IL_001b: pop
-						IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-						IL_0021: stloc.1
-						IL_0022: volatile.
-						IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-						IL_0029: brfalse IL_003e
+						IL_000c: volatile.
+						IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+						IL_0013: brfalse IL_002c
 
-						IL_002e: ldarg.2
-						IL_002f: ldstr "headers"
-						IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-						IL_0039: br IL_0053
+						IL_0018: ldstr "setEncoding"
+						IL_001d: ldstr "utf8"
+						IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+						IL_0027: br IL_0045
 
-						IL_003e: ldarg.2
-						IL_003f: ldstr "headers"
-						IL_0044: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M10>:__js_call__:11"
-						IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-						IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+						IL_002c: ldstr "setEncoding"
+						IL_0031: ldstr "utf8"
+						IL_0036: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M10>:__js_call__:5"
+						IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+						IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-						IL_0053: stloc.2
-						IL_0054: volatile.
-						IL_0056: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-						IL_005b: brfalse IL_0070
+						IL_0045: pop
+						IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+						IL_004b: stloc.1
+						IL_004c: volatile.
+						IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+						IL_0053: brfalse IL_0068
 
-						IL_0060: ldloc.2
-						IL_0061: ldstr "connection"
-						IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-						IL_006b: br IL_0085
+						IL_0058: ldarg.2
+						IL_0059: ldstr "headers"
+						IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+						IL_0063: br IL_007d
 
-						IL_0070: ldloc.2
-						IL_0071: ldstr "connection"
-						IL_0076: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M10>:__js_call__:13"
-						IL_007b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-						IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+						IL_0068: ldarg.2
+						IL_0069: ldstr "headers"
+						IL_006e: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M10>:__js_call__:11"
+						IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+						IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-						IL_0085: stloc.2
-						IL_0086: ldstr "second connection:"
-						IL_008b: ldloc.2
-						IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-						IL_0091: stloc.3
-						IL_0092: ldloc.1
-						IL_0093: ldloc.3
-						IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-						IL_0099: pop
-						IL_009a: ldloc.0
-						IL_009b: ldstr ""
-						IL_00a0: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope::nextBody
-						IL_00a5: ldarg.2
-						IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-						IL_00ab: stloc.2
-						IL_00ac: ldc.i4.5
-						IL_00ad: newarr [System.Runtime]System.Object
-						IL_00b2: dup
-						IL_00b3: ldc.i4.0
-						IL_00b4: ldarg.0
-						IL_00b5: ldc.i4.0
-						IL_00b6: ldelem.ref
-						IL_00b7: stelem.ref
-						IL_00b8: dup
-						IL_00b9: ldc.i4.1
-						IL_00ba: ldarg.0
-						IL_00bb: ldc.i4.1
-						IL_00bc: ldelem.ref
-						IL_00bd: stelem.ref
-						IL_00be: dup
-						IL_00bf: ldc.i4.2
-						IL_00c0: ldarg.0
-						IL_00c1: ldc.i4.2
-						IL_00c2: ldelem.ref
-						IL_00c3: stelem.ref
-						IL_00c4: dup
-						IL_00c5: ldc.i4.3
-						IL_00c6: ldarg.0
-						IL_00c7: ldc.i4.3
-						IL_00c8: ldelem.ref
-						IL_00c9: stelem.ref
-						IL_00ca: dup
-						IL_00cb: ldc.i4.4
-						IL_00cc: ldloc.0
-						IL_00cd: stelem.ref
-						IL_00ce: stloc.s 4
-						IL_00d0: ldloc.s 4
-						IL_00d2: ldc.i4.0
-						IL_00d3: ldelem.ref
-						IL_00d4: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-						IL_00d9: ldloc.s 4
-						IL_00db: ldc.i4.1
-						IL_00dc: ldelem.ref
-						IL_00dd: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-						IL_00e2: ldloc.s 4
-						IL_00e4: ldc.i4.2
-						IL_00e5: ldelem.ref
-						IL_00e6: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
-						IL_00eb: ldloc.s 4
-						IL_00ed: ldc.i4.4
-						IL_00ee: ldelem.ref
-						IL_00ef: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
-						IL_00f4: ldloc.s 4
-						IL_00f6: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
-						IL_00fb: ldc.i4.1
-						IL_00fc: conv.r8
-						IL_00fd: ldstr ""
-						IL_0102: ldc.i4.0
-						IL_0103: ldc.i4.1
-						IL_0104: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject>(!!0, float64, string, bool, bool)
-						IL_0109: stloc.s 5
-						IL_010b: ldloc.2
-						IL_010c: ldstr "on"
-						IL_0111: ldstr "data"
-						IL_0116: ldloc.s 5
-						IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-						IL_011d: pop
-						IL_011e: ldarg.2
-						IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-						IL_0124: stloc.2
-						IL_0125: ldc.i4.5
-						IL_0126: newarr [System.Runtime]System.Object
-						IL_012b: dup
+						IL_007d: stloc.2
+						IL_007e: volatile.
+						IL_0080: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+						IL_0085: brfalse IL_009a
+
+						IL_008a: ldloc.2
+						IL_008b: ldstr "connection"
+						IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+						IL_0095: br IL_00af
+
+						IL_009a: ldloc.2
+						IL_009b: ldstr "connection"
+						IL_00a0: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M10>:__js_call__:13"
+						IL_00a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+						IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+						IL_00af: stloc.2
+						IL_00b0: ldstr "second connection:"
+						IL_00b5: ldloc.2
+						IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+						IL_00bb: stloc.3
+						IL_00bc: ldloc.1
+						IL_00bd: ldloc.3
+						IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+						IL_00c3: pop
+						IL_00c4: ldloc.0
+						IL_00c5: ldstr ""
+						IL_00ca: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope::nextBody
+						IL_00cf: ldarg.2
+						IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+						IL_00d5: stloc.2
+						IL_00d6: ldc.i4.5
+						IL_00d7: newarr [System.Runtime]System.Object
+						IL_00dc: dup
+						IL_00dd: ldc.i4.0
+						IL_00de: ldarg.0
+						IL_00df: ldc.i4.0
+						IL_00e0: ldelem.ref
+						IL_00e1: stelem.ref
+						IL_00e2: dup
+						IL_00e3: ldc.i4.1
+						IL_00e4: ldarg.0
+						IL_00e5: ldc.i4.1
+						IL_00e6: ldelem.ref
+						IL_00e7: stelem.ref
+						IL_00e8: dup
+						IL_00e9: ldc.i4.2
+						IL_00ea: ldarg.0
+						IL_00eb: ldc.i4.2
+						IL_00ec: ldelem.ref
+						IL_00ed: stelem.ref
+						IL_00ee: dup
+						IL_00ef: ldc.i4.3
+						IL_00f0: ldarg.0
+						IL_00f1: ldc.i4.3
+						IL_00f2: ldelem.ref
+						IL_00f3: stelem.ref
+						IL_00f4: dup
+						IL_00f5: ldc.i4.4
+						IL_00f6: ldloc.0
+						IL_00f7: stelem.ref
+						IL_00f8: stloc.s 4
+						IL_00fa: ldloc.s 4
+						IL_00fc: ldc.i4.0
+						IL_00fd: ldelem.ref
+						IL_00fe: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+						IL_0103: ldloc.s 4
+						IL_0105: ldc.i4.1
+						IL_0106: ldelem.ref
+						IL_0107: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+						IL_010c: ldloc.s 4
+						IL_010e: ldc.i4.2
+						IL_010f: ldelem.ref
+						IL_0110: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
+						IL_0115: ldloc.s 4
+						IL_0117: ldc.i4.4
+						IL_0118: ldelem.ref
+						IL_0119: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
+						IL_011e: ldloc.s 4
+						IL_0120: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
+						IL_0125: ldc.i4.1
+						IL_0126: conv.r8
+						IL_0127: ldstr ""
 						IL_012c: ldc.i4.0
-						IL_012d: ldarg.0
-						IL_012e: ldc.i4.0
-						IL_012f: ldelem.ref
-						IL_0130: stelem.ref
-						IL_0131: dup
-						IL_0132: ldc.i4.1
-						IL_0133: ldarg.0
-						IL_0134: ldc.i4.1
-						IL_0135: ldelem.ref
-						IL_0136: stelem.ref
-						IL_0137: dup
-						IL_0138: ldc.i4.2
-						IL_0139: ldarg.0
-						IL_013a: ldc.i4.2
-						IL_013b: ldelem.ref
-						IL_013c: stelem.ref
-						IL_013d: dup
-						IL_013e: ldc.i4.3
-						IL_013f: ldarg.0
-						IL_0140: ldc.i4.3
-						IL_0141: ldelem.ref
-						IL_0142: stelem.ref
-						IL_0143: dup
-						IL_0144: ldc.i4.4
-						IL_0145: ldloc.0
-						IL_0146: stelem.ref
-						IL_0147: stloc.s 4
-						IL_0149: ldloc.s 4
-						IL_014b: ldc.i4.0
-						IL_014c: ldelem.ref
-						IL_014d: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-						IL_0152: ldloc.s 4
-						IL_0154: ldc.i4.1
-						IL_0155: ldelem.ref
-						IL_0156: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-						IL_015b: ldloc.s 4
-						IL_015d: ldc.i4.2
-						IL_015e: ldelem.ref
-						IL_015f: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
-						IL_0164: ldloc.s 4
-						IL_0166: ldc.i4.4
-						IL_0167: ldelem.ref
-						IL_0168: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
-						IL_016d: ldloc.s 4
-						IL_016f: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
-						IL_0174: ldc.i4.0
-						IL_0175: conv.r8
-						IL_0176: ldstr ""
-						IL_017b: ldc.i4.0
-						IL_017c: ldc.i4.1
-						IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject>(!!0, float64, string, bool, bool)
-						IL_0182: stloc.s 6
-						IL_0184: ldloc.2
-						IL_0185: ldstr "on"
-						IL_018a: ldstr "end"
-						IL_018f: ldloc.s 6
-						IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-						IL_0196: pop
-						IL_0197: ldnull
-						IL_0198: ret
+						IL_012d: ldc.i4.1
+						IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject>(!!0, float64, string, bool, bool)
+						IL_0133: stloc.s 5
+						IL_0135: ldloc.2
+						IL_0136: ldstr "on"
+						IL_013b: ldstr "data"
+						IL_0140: ldloc.s 5
+						IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+						IL_0147: pop
+						IL_0148: ldarg.2
+						IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+						IL_014e: stloc.2
+						IL_014f: ldc.i4.5
+						IL_0150: newarr [System.Runtime]System.Object
+						IL_0155: dup
+						IL_0156: ldc.i4.0
+						IL_0157: ldarg.0
+						IL_0158: ldc.i4.0
+						IL_0159: ldelem.ref
+						IL_015a: stelem.ref
+						IL_015b: dup
+						IL_015c: ldc.i4.1
+						IL_015d: ldarg.0
+						IL_015e: ldc.i4.1
+						IL_015f: ldelem.ref
+						IL_0160: stelem.ref
+						IL_0161: dup
+						IL_0162: ldc.i4.2
+						IL_0163: ldarg.0
+						IL_0164: ldc.i4.2
+						IL_0165: ldelem.ref
+						IL_0166: stelem.ref
+						IL_0167: dup
+						IL_0168: ldc.i4.3
+						IL_0169: ldarg.0
+						IL_016a: ldc.i4.3
+						IL_016b: ldelem.ref
+						IL_016c: stelem.ref
+						IL_016d: dup
+						IL_016e: ldc.i4.4
+						IL_016f: ldloc.0
+						IL_0170: stelem.ref
+						IL_0171: stloc.s 4
+						IL_0173: ldloc.s 4
+						IL_0175: ldc.i4.0
+						IL_0176: ldelem.ref
+						IL_0177: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+						IL_017c: ldloc.s 4
+						IL_017e: ldc.i4.1
+						IL_017f: ldelem.ref
+						IL_0180: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+						IL_0185: ldloc.s 4
+						IL_0187: ldc.i4.2
+						IL_0188: ldelem.ref
+						IL_0189: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
+						IL_018e: ldloc.s 4
+						IL_0190: ldc.i4.4
+						IL_0191: ldelem.ref
+						IL_0192: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
+						IL_0197: ldloc.s 4
+						IL_0199: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
+						IL_019e: ldc.i4.0
+						IL_019f: conv.r8
+						IL_01a0: ldstr ""
+						IL_01a5: ldc.i4.0
+						IL_01a6: ldc.i4.1
+						IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject>(!!0, float64, string, bool, bool)
+						IL_01ac: stloc.s 6
+						IL_01ae: ldloc.2
+						IL_01af: ldstr "on"
+						IL_01b4: ldstr "end"
+						IL_01b9: ldloc.s 6
+						IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+						IL_01c0: pop
+						IL_01c1: ldnull
+						IL_01c2: ret
 					} // end of method FunctionExpression_L48C10::__js_call__
 
 				} // end of class FunctionExpression_L48C10
@@ -1777,7 +1815,7 @@
 					IL_0040: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
 					IL_0045: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
 					IL_004a: volatile.
-					IL_004c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+					IL_004c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 					IL_0051: brfalse IL_0065
 
 					IL_0056: ldstr "address"
@@ -1786,7 +1824,7 @@
 
 					IL_0065: ldstr "address"
 					IL_006a: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M9>:__js_call__:11"
-					IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+					IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 					IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0079: stloc.2
@@ -1796,7 +1834,7 @@
 					IL_007d: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
 					IL_0082: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
 					IL_0087: volatile.
-					IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+					IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 					IL_008e: brfalse IL_00a2
 
 					IL_0093: ldstr "port"
@@ -1805,7 +1843,7 @@
 
 					IL_00a2: ldstr "port"
 					IL_00a7: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M9>:__js_call__:14"
-					IL_00ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+					IL_00ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 					IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_00b6: stloc.s 5
@@ -2047,7 +2085,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 367 (0x16f)
+				// Code size: 409 (0x199)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope,
@@ -2063,155 +2101,167 @@
 				IL_0005: stloc.0
 				IL_0006: ldarg.2
 				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000c: ldstr "setEncoding"
-				IL_0011: ldstr "utf8"
-				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001b: pop
-				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0021: stloc.1
-				IL_0022: volatile.
-				IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-				IL_0029: brfalse IL_003e
+				IL_000c: volatile.
+				IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+				IL_0013: brfalse IL_002c
 
-				IL_002e: ldarg.2
-				IL_002f: ldstr "headers"
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0039: br IL_0053
+				IL_0018: ldstr "setEncoding"
+				IL_001d: ldstr "utf8"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0027: br IL_0045
 
-				IL_003e: ldarg.2
-				IL_003f: ldstr "headers"
-				IL_0044: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M7>:__js_call__:11"
-				IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_002c: ldstr "setEncoding"
+				IL_0031: ldstr "utf8"
+				IL_0036: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M7>:__js_call__:5"
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0053: stloc.2
-				IL_0054: volatile.
-				IL_0056: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-				IL_005b: brfalse IL_0070
+				IL_0045: pop
+				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_004b: stloc.1
+				IL_004c: volatile.
+				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+				IL_0053: brfalse IL_0068
 
-				IL_0060: ldloc.2
-				IL_0061: ldstr "connection"
-				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_006b: br IL_0085
+				IL_0058: ldarg.2
+				IL_0059: ldstr "headers"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0063: br IL_007d
 
-				IL_0070: ldloc.2
-				IL_0071: ldstr "connection"
-				IL_0076: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M7>:__js_call__:13"
-				IL_007b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0068: ldarg.2
+				IL_0069: ldstr "headers"
+				IL_006e: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M7>:__js_call__:11"
+				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0085: stloc.2
-				IL_0086: ldstr "first connection:"
-				IL_008b: ldloc.2
-				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0091: stloc.3
-				IL_0092: ldloc.1
-				IL_0093: ldloc.3
-				IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0099: pop
-				IL_009a: ldloc.0
-				IL_009b: ldstr ""
-				IL_00a0: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope::body
-				IL_00a5: ldarg.2
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ab: stloc.2
-				IL_00ac: ldc.i4.3
-				IL_00ad: newarr [System.Runtime]System.Object
-				IL_00b2: dup
-				IL_00b3: ldc.i4.0
-				IL_00b4: ldarg.0
-				IL_00b5: ldc.i4.0
-				IL_00b6: ldelem.ref
-				IL_00b7: stelem.ref
-				IL_00b8: dup
-				IL_00b9: ldc.i4.1
-				IL_00ba: ldarg.0
-				IL_00bb: ldc.i4.1
-				IL_00bc: ldelem.ref
-				IL_00bd: stelem.ref
-				IL_00be: dup
-				IL_00bf: ldc.i4.2
-				IL_00c0: ldloc.0
-				IL_00c1: stelem.ref
-				IL_00c2: stloc.s 4
-				IL_00c4: ldloc.s 4
-				IL_00c6: ldc.i4.0
-				IL_00c7: ldelem.ref
-				IL_00c8: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-				IL_00cd: ldloc.s 4
-				IL_00cf: ldc.i4.1
-				IL_00d0: ldelem.ref
-				IL_00d1: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-				IL_00d6: ldloc.s 4
-				IL_00d8: ldc.i4.2
-				IL_00d9: ldelem.ref
-				IL_00da: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
-				IL_00df: ldloc.s 4
-				IL_00e1: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
-				IL_00e6: ldc.i4.1
-				IL_00e7: conv.r8
-				IL_00e8: ldstr ""
-				IL_00ed: ldc.i4.0
-				IL_00ee: ldc.i4.1
-				IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_00f4: stloc.s 5
-				IL_00f6: ldloc.2
-				IL_00f7: ldstr "on"
-				IL_00fc: ldstr "data"
-				IL_0101: ldloc.s 5
-				IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0108: pop
-				IL_0109: ldarg.2
-				IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_010f: stloc.2
-				IL_0110: ldc.i4.3
-				IL_0111: newarr [System.Runtime]System.Object
-				IL_0116: dup
+				IL_007d: stloc.2
+				IL_007e: volatile.
+				IL_0080: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+				IL_0085: brfalse IL_009a
+
+				IL_008a: ldloc.2
+				IL_008b: ldstr "connection"
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0095: br IL_00af
+
+				IL_009a: ldloc.2
+				IL_009b: ldstr "connection"
+				IL_00a0: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M7>:__js_call__:13"
+				IL_00a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_00af: stloc.2
+				IL_00b0: ldstr "first connection:"
+				IL_00b5: ldloc.2
+				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00bb: stloc.3
+				IL_00bc: ldloc.1
+				IL_00bd: ldloc.3
+				IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_00c3: pop
+				IL_00c4: ldloc.0
+				IL_00c5: ldstr ""
+				IL_00ca: stfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope::body
+				IL_00cf: ldarg.2
+				IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00d5: stloc.2
+				IL_00d6: ldc.i4.3
+				IL_00d7: newarr [System.Runtime]System.Object
+				IL_00dc: dup
+				IL_00dd: ldc.i4.0
+				IL_00de: ldarg.0
+				IL_00df: ldc.i4.0
+				IL_00e0: ldelem.ref
+				IL_00e1: stelem.ref
+				IL_00e2: dup
+				IL_00e3: ldc.i4.1
+				IL_00e4: ldarg.0
+				IL_00e5: ldc.i4.1
+				IL_00e6: ldelem.ref
+				IL_00e7: stelem.ref
+				IL_00e8: dup
+				IL_00e9: ldc.i4.2
+				IL_00ea: ldloc.0
+				IL_00eb: stelem.ref
+				IL_00ec: stloc.s 4
+				IL_00ee: ldloc.s 4
+				IL_00f0: ldc.i4.0
+				IL_00f1: ldelem.ref
+				IL_00f2: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+				IL_00f7: ldloc.s 4
+				IL_00f9: ldc.i4.1
+				IL_00fa: ldelem.ref
+				IL_00fb: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+				IL_0100: ldloc.s 4
+				IL_0102: ldc.i4.2
+				IL_0103: ldelem.ref
+				IL_0104: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
+				IL_0109: ldloc.s 4
+				IL_010b: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
+				IL_0110: ldc.i4.1
+				IL_0111: conv.r8
+				IL_0112: ldstr ""
 				IL_0117: ldc.i4.0
-				IL_0118: ldarg.0
-				IL_0119: ldc.i4.0
-				IL_011a: ldelem.ref
-				IL_011b: stelem.ref
-				IL_011c: dup
-				IL_011d: ldc.i4.1
-				IL_011e: ldarg.0
-				IL_011f: ldc.i4.1
-				IL_0120: ldelem.ref
-				IL_0121: stelem.ref
-				IL_0122: dup
-				IL_0123: ldc.i4.2
-				IL_0124: ldloc.0
-				IL_0125: stelem.ref
-				IL_0126: stloc.s 4
-				IL_0128: ldloc.s 4
-				IL_012a: ldc.i4.0
-				IL_012b: ldelem.ref
-				IL_012c: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-				IL_0131: ldloc.s 4
-				IL_0133: ldc.i4.1
-				IL_0134: ldelem.ref
-				IL_0135: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
-				IL_013a: ldloc.s 4
-				IL_013c: ldc.i4.2
-				IL_013d: ldelem.ref
-				IL_013e: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
-				IL_0143: ldloc.s 4
-				IL_0145: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
-				IL_014a: ldc.i4.0
-				IL_014b: conv.r8
-				IL_014c: ldstr ""
-				IL_0151: ldc.i4.0
-				IL_0152: ldc.i4.1
-				IL_0153: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0158: stloc.s 6
-				IL_015a: ldloc.2
-				IL_015b: ldstr "on"
-				IL_0160: ldstr "end"
-				IL_0165: ldloc.s 6
-				IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_016c: pop
-				IL_016d: ldnull
-				IL_016e: ret
+				IL_0118: ldc.i4.1
+				IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_011e: stloc.s 5
+				IL_0120: ldloc.2
+				IL_0121: ldstr "on"
+				IL_0126: ldstr "data"
+				IL_012b: ldloc.s 5
+				IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0132: pop
+				IL_0133: ldarg.2
+				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0139: stloc.2
+				IL_013a: ldc.i4.3
+				IL_013b: newarr [System.Runtime]System.Object
+				IL_0140: dup
+				IL_0141: ldc.i4.0
+				IL_0142: ldarg.0
+				IL_0143: ldc.i4.0
+				IL_0144: ldelem.ref
+				IL_0145: stelem.ref
+				IL_0146: dup
+				IL_0147: ldc.i4.1
+				IL_0148: ldarg.0
+				IL_0149: ldc.i4.1
+				IL_014a: ldelem.ref
+				IL_014b: stelem.ref
+				IL_014c: dup
+				IL_014d: ldc.i4.2
+				IL_014e: ldloc.0
+				IL_014f: stelem.ref
+				IL_0150: stloc.s 4
+				IL_0152: ldloc.s 4
+				IL_0154: ldc.i4.0
+				IL_0155: ldelem.ref
+				IL_0156: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
+				IL_015b: ldloc.s 4
+				IL_015d: ldc.i4.1
+				IL_015e: ldelem.ref
+				IL_015f: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
+				IL_0164: ldloc.s 4
+				IL_0166: ldc.i4.2
+				IL_0167: ldelem.ref
+				IL_0168: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
+				IL_016d: ldloc.s 4
+				IL_016f: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
+				IL_0174: ldc.i4.0
+				IL_0175: conv.r8
+				IL_0176: ldstr ""
+				IL_017b: ldc.i4.0
+				IL_017c: ldc.i4.1
+				IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0182: stloc.s 6
+				IL_0184: ldloc.2
+				IL_0185: ldstr "on"
+				IL_018a: ldstr "end"
+				IL_018f: ldloc.s 6
+				IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0196: pop
+				IL_0197: ldnull
+				IL_0198: ret
 			} // end of method FunctionExpression_L29C4::__js_call__
 
 		} // end of class FunctionExpression_L29C4
@@ -2376,7 +2426,7 @@
 			IL_0007: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -2385,7 +2435,7 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M6>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
@@ -2398,7 +2448,7 @@
 			IL_004f: ldloc.0
 			IL_0050: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
 			IL_0055: volatile.
-			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 			IL_005c: brfalse IL_0070
 
 			IL_0061: ldstr "address"
@@ -2407,14 +2457,14 @@
 
 			IL_0070: ldstr "address"
 			IL_0075: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M6>:__js_call__:10"
-			IL_007a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_007a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0084: stloc.1
 			IL_0085: ldloc.0
 			IL_0086: ldfld object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::info
 			IL_008b: volatile.
-			IL_008d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_008d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
 			IL_0092: brfalse IL_00a6
 
 			IL_0097: ldstr "port"
@@ -2423,7 +2473,7 @@
 
 			IL_00a6: ldstr "port"
 			IL_00ab: ldstr "Http_Agent_KeepAlive_Reuses_Connection:<TwoPhaseDummy_M6>:__js_call__:13"
-			IL_00b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+			IL_00b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
 			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00ba: stloc.3
@@ -2715,6 +2765,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_44
 	.field assembly static int32 __jroc_dynamicLookup_45
 	.field assembly static int32 __jroc_dynamicLookup_46
+	.field assembly static int32 __jroc_dynamicLookup_47
+	.field assembly static int32 __jroc_dynamicLookup_48
+	.field assembly static int32 __jroc_dynamicLookup_49
+	.field assembly static int32 __jroc_dynamicLookup_50
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
@@ -209,7 +209,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 530 (0x212)
+			// Code size: 569 (0x239)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -391,13 +391,26 @@
 			IL_01fb: ldloc.s 5
 			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0202: stloc.2
-			IL_0203: ldloc.1
-			IL_0204: ldstr "end"
-			IL_0209: ldloc.2
-			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_020f: pop
-			IL_0210: ldnull
-			IL_0211: ret
+			IL_0203: volatile.
+			IL_0205: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_020a: brfalse IL_0220
+
+			IL_020f: ldloc.1
+			IL_0210: ldstr "end"
+			IL_0215: ldloc.2
+			IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_021b: br IL_0236
+
+			IL_0220: ldloc.1
+			IL_0221: ldstr "end"
+			IL_0226: ldloc.2
+			IL_0227: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M4>:__js_call__:52"
+			IL_022c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0236: pop
+			IL_0237: ldnull
+			IL_0238: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server
@@ -879,7 +892,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 116 (0x74)
+					// Code size: 156 (0x9c)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/Scope,
@@ -932,13 +945,26 @@
 					IL_005c: ldc.i4.1
 					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0062: stloc.s 5
-					IL_0064: ldloc.2
-					IL_0065: ldstr "close"
-					IL_006a: ldloc.s 5
-					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0071: pop
-					IL_0072: ldnull
-					IL_0073: ret
+					IL_0064: volatile.
+					IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+					IL_006b: brfalse IL_0082
+
+					IL_0070: ldloc.2
+					IL_0071: ldstr "close"
+					IL_0076: ldloc.s 5
+					IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_007d: br IL_0099
+
+					IL_0082: ldloc.2
+					IL_0083: ldstr "close"
+					IL_0088: ldloc.s 5
+					IL_008a: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M8>:__js_call__:12"
+					IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+					IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_0099: pop
+					IL_009a: ldnull
+					IL_009b: ret
 				} // end of method FunctionExpression_L29C18::__js_call__
 
 			} // end of class FunctionExpression_L29C18
@@ -1094,7 +1120,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 425 (0x1a9)
+				// Code size: 467 (0x1d3)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope,
@@ -1110,173 +1136,185 @@
 				IL_0005: stloc.0
 				IL_0006: ldarg.2
 				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000c: ldstr "setEncoding"
-				IL_0011: ldstr "utf8"
-				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001b: pop
-				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0021: stloc.1
-				IL_0022: volatile.
-				IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-				IL_0029: brfalse IL_003e
+				IL_000c: volatile.
+				IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_0013: brfalse IL_002c
 
-				IL_002e: ldarg.2
-				IL_002f: ldstr "statusCode"
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0039: br IL_0053
+				IL_0018: ldstr "setEncoding"
+				IL_001d: ldstr "utf8"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0027: br IL_0045
 
-				IL_003e: ldarg.2
-				IL_003f: ldstr "statusCode"
-				IL_0044: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M6>:__js_call__:11"
-				IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_002c: ldstr "setEncoding"
+				IL_0031: ldstr "utf8"
+				IL_0036: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M6>:__js_call__:5"
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0053: stloc.2
-				IL_0054: ldstr "status:"
-				IL_0059: ldloc.2
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005f: stloc.3
-				IL_0060: ldloc.1
-				IL_0061: ldloc.3
-				IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0067: pop
-				IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_006d: stloc.1
-				IL_006e: volatile.
-				IL_0070: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-				IL_0075: brfalse IL_008a
+				IL_0045: pop
+				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_004b: stloc.1
+				IL_004c: volatile.
+				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_0053: brfalse IL_0068
 
-				IL_007a: ldarg.2
-				IL_007b: ldstr "headers"
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0085: br IL_009f
+				IL_0058: ldarg.2
+				IL_0059: ldstr "statusCode"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0063: br IL_007d
 
-				IL_008a: ldarg.2
-				IL_008b: ldstr "headers"
-				IL_0090: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M6>:__js_call__:19"
-				IL_0095: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0068: ldarg.2
+				IL_0069: ldstr "statusCode"
+				IL_006e: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M6>:__js_call__:11"
+				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_009f: stloc.2
-				IL_00a0: volatile.
-				IL_00a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-				IL_00a7: brfalse IL_00bc
+				IL_007d: stloc.2
+				IL_007e: ldstr "status:"
+				IL_0083: ldloc.2
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0089: stloc.3
+				IL_008a: ldloc.1
+				IL_008b: ldloc.3
+				IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0091: pop
+				IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0097: stloc.1
+				IL_0098: volatile.
+				IL_009a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_009f: brfalse IL_00b4
 
-				IL_00ac: ldloc.2
-				IL_00ad: ldstr "x-answer"
-				IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00b7: br IL_00d1
+				IL_00a4: ldarg.2
+				IL_00a5: ldstr "headers"
+				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00af: br IL_00c9
 
-				IL_00bc: ldloc.2
-				IL_00bd: ldstr "x-answer"
-				IL_00c2: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M6>:__js_call__:21"
-				IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-				IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_00b4: ldarg.2
+				IL_00b5: ldstr "headers"
+				IL_00ba: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M6>:__js_call__:19"
+				IL_00bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_00d1: stloc.2
-				IL_00d2: ldstr "answer:"
-				IL_00d7: ldloc.2
-				IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00dd: stloc.3
-				IL_00de: ldloc.1
-				IL_00df: ldloc.3
-				IL_00e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_00e5: pop
-				IL_00e6: ldloc.0
-				IL_00e7: ldstr ""
-				IL_00ec: stfld object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope::body
-				IL_00f1: ldarg.2
-				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00f7: stloc.2
-				IL_00f8: ldc.i4.3
-				IL_00f9: newarr [System.Runtime]System.Object
-				IL_00fe: dup
-				IL_00ff: ldc.i4.0
-				IL_0100: ldarg.0
-				IL_0101: ldc.i4.0
-				IL_0102: ldelem.ref
-				IL_0103: stelem.ref
-				IL_0104: dup
-				IL_0105: ldc.i4.1
-				IL_0106: ldarg.0
-				IL_0107: ldc.i4.1
-				IL_0108: ldelem.ref
-				IL_0109: stelem.ref
-				IL_010a: dup
-				IL_010b: ldc.i4.2
-				IL_010c: ldloc.0
-				IL_010d: stelem.ref
-				IL_010e: stloc.s 4
-				IL_0110: ldloc.s 4
-				IL_0112: ldc.i4.0
-				IL_0113: ldelem.ref
-				IL_0114: castclass Modules.Http_CreateServer_Get_Loopback/Scope
-				IL_0119: ldloc.s 4
-				IL_011b: ldc.i4.2
-				IL_011c: ldelem.ref
-				IL_011d: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
-				IL_0122: ldloc.s 4
-				IL_0124: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
-				IL_0129: ldc.i4.1
-				IL_012a: conv.r8
-				IL_012b: ldstr ""
-				IL_0130: ldc.i4.0
+				IL_00c9: stloc.2
+				IL_00ca: volatile.
+				IL_00cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_00d1: brfalse IL_00e6
+
+				IL_00d6: ldloc.2
+				IL_00d7: ldstr "x-answer"
+				IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00e1: br IL_00fb
+
+				IL_00e6: ldloc.2
+				IL_00e7: ldstr "x-answer"
+				IL_00ec: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M6>:__js_call__:21"
+				IL_00f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_00fb: stloc.2
+				IL_00fc: ldstr "answer:"
+				IL_0101: ldloc.2
+				IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0107: stloc.3
+				IL_0108: ldloc.1
+				IL_0109: ldloc.3
+				IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_010f: pop
+				IL_0110: ldloc.0
+				IL_0111: ldstr ""
+				IL_0116: stfld object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope::body
+				IL_011b: ldarg.2
+				IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0121: stloc.2
+				IL_0122: ldc.i4.3
+				IL_0123: newarr [System.Runtime]System.Object
+				IL_0128: dup
+				IL_0129: ldc.i4.0
+				IL_012a: ldarg.0
+				IL_012b: ldc.i4.0
+				IL_012c: ldelem.ref
+				IL_012d: stelem.ref
+				IL_012e: dup
+				IL_012f: ldc.i4.1
+				IL_0130: ldarg.0
 				IL_0131: ldc.i4.1
-				IL_0132: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0137: stloc.s 5
-				IL_0139: ldloc.2
-				IL_013a: ldstr "on"
-				IL_013f: ldstr "data"
-				IL_0144: ldloc.s 5
-				IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_014b: pop
-				IL_014c: ldarg.2
-				IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0152: stloc.2
-				IL_0153: ldc.i4.3
-				IL_0154: newarr [System.Runtime]System.Object
-				IL_0159: dup
+				IL_0132: ldelem.ref
+				IL_0133: stelem.ref
+				IL_0134: dup
+				IL_0135: ldc.i4.2
+				IL_0136: ldloc.0
+				IL_0137: stelem.ref
+				IL_0138: stloc.s 4
+				IL_013a: ldloc.s 4
+				IL_013c: ldc.i4.0
+				IL_013d: ldelem.ref
+				IL_013e: castclass Modules.Http_CreateServer_Get_Loopback/Scope
+				IL_0143: ldloc.s 4
+				IL_0145: ldc.i4.2
+				IL_0146: ldelem.ref
+				IL_0147: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
+				IL_014c: ldloc.s 4
+				IL_014e: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
+				IL_0153: ldc.i4.1
+				IL_0154: conv.r8
+				IL_0155: ldstr ""
 				IL_015a: ldc.i4.0
-				IL_015b: ldarg.0
-				IL_015c: ldc.i4.0
-				IL_015d: ldelem.ref
-				IL_015e: stelem.ref
-				IL_015f: dup
-				IL_0160: ldc.i4.1
-				IL_0161: ldarg.0
-				IL_0162: ldc.i4.1
-				IL_0163: ldelem.ref
-				IL_0164: stelem.ref
-				IL_0165: dup
-				IL_0166: ldc.i4.2
-				IL_0167: ldloc.0
-				IL_0168: stelem.ref
-				IL_0169: stloc.s 4
-				IL_016b: ldloc.s 4
-				IL_016d: ldc.i4.0
-				IL_016e: ldelem.ref
-				IL_016f: castclass Modules.Http_CreateServer_Get_Loopback/Scope
-				IL_0174: ldloc.s 4
-				IL_0176: ldc.i4.2
-				IL_0177: ldelem.ref
-				IL_0178: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
-				IL_017d: ldloc.s 4
-				IL_017f: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
+				IL_015b: ldc.i4.1
+				IL_015c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0161: stloc.s 5
+				IL_0163: ldloc.2
+				IL_0164: ldstr "on"
+				IL_0169: ldstr "data"
+				IL_016e: ldloc.s 5
+				IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0175: pop
+				IL_0176: ldarg.2
+				IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_017c: stloc.2
+				IL_017d: ldc.i4.3
+				IL_017e: newarr [System.Runtime]System.Object
+				IL_0183: dup
 				IL_0184: ldc.i4.0
-				IL_0185: conv.r8
-				IL_0186: ldstr ""
-				IL_018b: ldc.i4.0
+				IL_0185: ldarg.0
+				IL_0186: ldc.i4.0
+				IL_0187: ldelem.ref
+				IL_0188: stelem.ref
+				IL_0189: dup
+				IL_018a: ldc.i4.1
+				IL_018b: ldarg.0
 				IL_018c: ldc.i4.1
-				IL_018d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0192: stloc.s 6
-				IL_0194: ldloc.2
-				IL_0195: ldstr "on"
-				IL_019a: ldstr "end"
-				IL_019f: ldloc.s 6
-				IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01a6: pop
-				IL_01a7: ldnull
-				IL_01a8: ret
+				IL_018d: ldelem.ref
+				IL_018e: stelem.ref
+				IL_018f: dup
+				IL_0190: ldc.i4.2
+				IL_0191: ldloc.0
+				IL_0192: stelem.ref
+				IL_0193: stloc.s 4
+				IL_0195: ldloc.s 4
+				IL_0197: ldc.i4.0
+				IL_0198: ldelem.ref
+				IL_0199: castclass Modules.Http_CreateServer_Get_Loopback/Scope
+				IL_019e: ldloc.s 4
+				IL_01a0: ldc.i4.2
+				IL_01a1: ldelem.ref
+				IL_01a2: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
+				IL_01a7: ldloc.s 4
+				IL_01a9: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
+				IL_01ae: ldc.i4.0
+				IL_01af: conv.r8
+				IL_01b0: ldstr ""
+				IL_01b5: ldc.i4.0
+				IL_01b6: ldc.i4.1
+				IL_01b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_01bc: stloc.s 6
+				IL_01be: ldloc.2
+				IL_01bf: ldstr "on"
+				IL_01c4: ldstr "end"
+				IL_01c9: ldloc.s 6
+				IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01d0: pop
+				IL_01d1: ldnull
+				IL_01d2: ret
 			} // end of method FunctionExpression_L19C76::__js_call__
 
 		} // end of class FunctionExpression_L19C76
@@ -1436,7 +1474,7 @@
 			IL_0007: ldfld object Modules.Http_CreateServer_Get_Loopback/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1445,14 +1483,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0046: stloc.2
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1463,7 +1501,7 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "address"
 			IL_0069: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M5>:__js_call__:10"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.3
@@ -1476,7 +1514,7 @@
 			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0092: stloc.s 4
 			IL_0094: volatile.
-			IL_0096: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0096: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_009b: brfalse IL_00b0
 
 			IL_00a0: ldloc.1
@@ -1487,7 +1525,7 @@
 			IL_00b0: ldloc.1
 			IL_00b1: ldstr "port"
 			IL_00b6: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M5>:__js_call__:15"
-			IL_00bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_00bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00c5: stloc.3
@@ -1511,7 +1549,7 @@
 			IL_00f7: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_CreateServer_Get_Loopback/Scope::http
 			IL_00fc: stloc.s 7
 			IL_00fe: volatile.
-			IL_0100: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0100: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_0105: brfalse IL_011a
 
 			IL_010a: ldloc.1
@@ -1522,7 +1560,7 @@
 			IL_011a: ldloc.1
 			IL_011b: ldstr "address"
 			IL_0120: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M5>:__js_call__:26"
-			IL_0125: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0125: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_012f: stloc.3
@@ -1535,7 +1573,7 @@
 			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0149: stloc.s 4
 			IL_014b: volatile.
-			IL_014d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_014d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0152: brfalse IL_0167
 
 			IL_0157: ldloc.1
@@ -1546,7 +1584,7 @@
 			IL_0167: ldloc.1
 			IL_0168: ldstr "port"
 			IL_016d: ldstr "Http_CreateServer_Get_Loopback:<TwoPhaseDummy_M5>:__js_call__:31"
-			IL_0172: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0172: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_017c: stloc.3
@@ -1754,6 +1792,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
 	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
@@ -404,7 +404,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 655 (0x28f)
+				// Code size: 736 (0x2e0)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -423,7 +423,7 @@
 				IL_0009: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 				IL_000e: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
 				IL_0013: volatile.
-				IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 				IL_001a: brfalse IL_002e
 
 				IL_001f: ldstr "method"
@@ -432,7 +432,7 @@
 
 				IL_002e: ldstr "method"
 				IL_0033: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:5"
-				IL_0038: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_0038: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0042: stloc.1
@@ -452,7 +452,7 @@
 				IL_0060: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 				IL_0065: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
 				IL_006a: volatile.
-				IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 				IL_0071: brfalse IL_0085
 
 				IL_0076: ldstr "url"
@@ -461,7 +461,7 @@
 
 				IL_0085: ldstr "url"
 				IL_008a: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:13"
-				IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0099: stloc.1
@@ -481,7 +481,7 @@
 				IL_00b7: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 				IL_00bc: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
 				IL_00c1: volatile.
-				IL_00c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+				IL_00c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 				IL_00c8: brfalse IL_00dc
 
 				IL_00cd: ldstr "headers"
@@ -490,12 +490,12 @@
 
 				IL_00dc: ldstr "headers"
 				IL_00e1: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:21"
-				IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+				IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 				IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00f0: stloc.1
 				IL_00f1: volatile.
-				IL_00f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+				IL_00f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 				IL_00f8: brfalse IL_010d
 
 				IL_00fd: ldloc.1
@@ -506,7 +506,7 @@
 				IL_010d: ldloc.1
 				IL_010e: ldstr "content-type"
 				IL_0113: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:23"
-				IL_0118: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+				IL_0118: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 				IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0122: stloc.1
@@ -547,7 +547,7 @@
 				IL_0175: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 				IL_017a: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
 				IL_017f: volatile.
-				IL_0181: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+				IL_0181: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 				IL_0186: brfalse IL_019a
 
 				IL_018b: ldstr "length"
@@ -556,7 +556,7 @@
 
 				IL_019a: ldstr "length"
 				IL_019f: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:40"
-				IL_01a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+				IL_01a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_01ae: stloc.3
@@ -586,58 +586,83 @@
 				IL_01fa: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 				IL_01ff: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::res
 				IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0209: ldstr "write"
-				IL_020e: ldstr "accepted:"
-				IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0218: pop
-				IL_0219: ldarg.0
-				IL_021a: ldc.i4.1
-				IL_021b: ldelem.ref
-				IL_021c: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_0221: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::res
-				IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_022b: stloc.1
-				IL_022c: ldarg.0
-				IL_022d: ldc.i4.1
-				IL_022e: ldelem.ref
-				IL_022f: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-				IL_0234: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
-				IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_023e: stloc.3
-				IL_023f: ldc.i4.0
-				IL_0240: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0245: brfalse IL_0274
+				IL_0209: volatile.
+				IL_020b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_0210: brfalse IL_0229
 
-				IL_024a: ldloc.3
-				IL_024b: isinst [System.Runtime]System.String
-				IL_0250: dup
-				IL_0251: brtrue IL_0268
+				IL_0215: ldstr "write"
+				IL_021a: ldstr "accepted:"
+				IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0224: br IL_0242
 
-				IL_0256: pop
-				IL_0257: ldloc.3
-				IL_0258: ldstr "toUpperCase"
-				IL_025d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_0262: dup
-				IL_0263: brfalse IL_0273
+				IL_0229: ldstr "write"
+				IL_022e: ldstr "accepted:"
+				IL_0233: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:48"
+				IL_0238: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0268: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-				IL_026d: stloc.3
-				IL_026e: br IL_0280
-
-				IL_0273: pop
+				IL_0242: pop
+				IL_0243: ldarg.0
+				IL_0244: ldc.i4.1
+				IL_0245: ldelem.ref
+				IL_0246: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_024b: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::res
+				IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0255: stloc.1
+				IL_0256: ldarg.0
+				IL_0257: ldc.i4.1
+				IL_0258: ldelem.ref
+				IL_0259: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+				IL_025e: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
+				IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0268: stloc.3
+				IL_0269: ldc.i4.0
+				IL_026a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_026f: brfalse IL_029e
 
 				IL_0274: ldloc.3
-				IL_0275: ldstr "toUpperCase"
-				IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_027f: stloc.3
+				IL_0275: isinst [System.Runtime]System.String
+				IL_027a: dup
+				IL_027b: brtrue IL_0292
 
-				IL_0280: ldloc.1
-				IL_0281: ldstr "end"
-				IL_0286: ldloc.3
-				IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_028c: pop
-				IL_028d: ldnull
-				IL_028e: ret
+				IL_0280: pop
+				IL_0281: ldloc.3
+				IL_0282: ldstr "toUpperCase"
+				IL_0287: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_028c: dup
+				IL_028d: brfalse IL_029d
+
+				IL_0292: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+				IL_0297: stloc.3
+				IL_0298: br IL_02aa
+
+				IL_029d: pop
+
+				IL_029e: ldloc.3
+				IL_029f: ldstr "toUpperCase"
+				IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_02a9: stloc.3
+
+				IL_02aa: volatile.
+				IL_02ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_02b1: brfalse IL_02c7
+
+				IL_02b6: ldloc.1
+				IL_02b7: ldstr "end"
+				IL_02bc: ldloc.3
+				IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02c2: br IL_02dd
+
+				IL_02c7: ldloc.1
+				IL_02c8: ldstr "end"
+				IL_02cd: ldloc.3
+				IL_02ce: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:55"
+				IL_02d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_02dd: pop
+				IL_02de: ldnull
+				IL_02df: ret
 			} // end of method FunctionExpression_server_L13C16::__js_call__
 
 		} // end of class FunctionExpression_server_L13C16
@@ -800,7 +825,7 @@
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 226 (0xe2)
+			// Code size: 268 (0x10c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope,
@@ -824,88 +849,100 @@
 			IL_001f: ldloc.0
 			IL_0020: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
 			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002a: ldstr "setEncoding"
-			IL_002f: ldstr "utf8"
-			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0039: pop
-			IL_003a: ldloc.0
-			IL_003b: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0045: stloc.1
-			IL_0046: ldc.i4.2
-			IL_0047: newarr [System.Runtime]System.Object
-			IL_004c: dup
-			IL_004d: ldc.i4.0
-			IL_004e: ldarg.0
-			IL_004f: stelem.ref
-			IL_0050: dup
-			IL_0051: ldc.i4.1
-			IL_0052: ldloc.0
-			IL_0053: stelem.ref
-			IL_0054: stloc.2
-			IL_0055: ldloc.2
-			IL_0056: ldc.i4.0
-			IL_0057: ldelem.ref
-			IL_0058: castclass Modules.Http_Request_Post_Basic/Scope
-			IL_005d: ldloc.2
-			IL_005e: ldc.i4.1
-			IL_005f: ldelem.ref
-			IL_0060: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-			IL_0065: ldloc.2
-			IL_0066: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
-			IL_006b: ldc.i4.1
-			IL_006c: conv.r8
-			IL_006d: ldstr ""
-			IL_0072: ldc.i4.0
-			IL_0073: ldc.i4.1
-			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0079: stloc.3
-			IL_007a: ldloc.1
-			IL_007b: ldstr "on"
-			IL_0080: ldstr "data"
-			IL_0085: ldloc.3
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_008b: pop
-			IL_008c: ldloc.0
-			IL_008d: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
-			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0097: stloc.1
-			IL_0098: ldc.i4.2
-			IL_0099: newarr [System.Runtime]System.Object
-			IL_009e: dup
-			IL_009f: ldc.i4.0
-			IL_00a0: ldarg.0
-			IL_00a1: stelem.ref
-			IL_00a2: dup
-			IL_00a3: ldc.i4.1
-			IL_00a4: ldloc.0
-			IL_00a5: stelem.ref
-			IL_00a6: stloc.2
-			IL_00a7: ldloc.2
-			IL_00a8: ldc.i4.0
-			IL_00a9: ldelem.ref
-			IL_00aa: castclass Modules.Http_Request_Post_Basic/Scope
-			IL_00af: ldloc.2
-			IL_00b0: ldc.i4.1
-			IL_00b1: ldelem.ref
-			IL_00b2: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
-			IL_00b7: ldloc.2
-			IL_00b8: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
-			IL_00bd: ldc.i4.0
-			IL_00be: conv.r8
-			IL_00bf: ldstr ""
-			IL_00c4: ldc.i4.0
-			IL_00c5: ldc.i4.1
-			IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_00cb: stloc.s 4
-			IL_00cd: ldloc.1
-			IL_00ce: ldstr "on"
-			IL_00d3: ldstr "end"
-			IL_00d8: ldloc.s 4
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00df: pop
-			IL_00e0: ldnull
-			IL_00e1: ret
+			IL_002a: volatile.
+			IL_002c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0031: brfalse IL_004a
+
+			IL_0036: ldstr "setEncoding"
+			IL_003b: ldstr "utf8"
+			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0045: br IL_0063
+
+			IL_004a: ldstr "setEncoding"
+			IL_004f: ldstr "utf8"
+			IL_0054: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M4>:__js_call__:12"
+			IL_0059: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0063: pop
+			IL_0064: ldloc.0
+			IL_0065: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006f: stloc.1
+			IL_0070: ldc.i4.2
+			IL_0071: newarr [System.Runtime]System.Object
+			IL_0076: dup
+			IL_0077: ldc.i4.0
+			IL_0078: ldarg.0
+			IL_0079: stelem.ref
+			IL_007a: dup
+			IL_007b: ldc.i4.1
+			IL_007c: ldloc.0
+			IL_007d: stelem.ref
+			IL_007e: stloc.2
+			IL_007f: ldloc.2
+			IL_0080: ldc.i4.0
+			IL_0081: ldelem.ref
+			IL_0082: castclass Modules.Http_Request_Post_Basic/Scope
+			IL_0087: ldloc.2
+			IL_0088: ldc.i4.1
+			IL_0089: ldelem.ref
+			IL_008a: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+			IL_008f: ldloc.2
+			IL_0090: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
+			IL_0095: ldc.i4.1
+			IL_0096: conv.r8
+			IL_0097: ldstr ""
+			IL_009c: ldc.i4.0
+			IL_009d: ldc.i4.1
+			IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00a3: stloc.3
+			IL_00a4: ldloc.1
+			IL_00a5: ldstr "on"
+			IL_00aa: ldstr "data"
+			IL_00af: ldloc.3
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00b5: pop
+			IL_00b6: ldloc.0
+			IL_00b7: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::req
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c1: stloc.1
+			IL_00c2: ldc.i4.2
+			IL_00c3: newarr [System.Runtime]System.Object
+			IL_00c8: dup
+			IL_00c9: ldc.i4.0
+			IL_00ca: ldarg.0
+			IL_00cb: stelem.ref
+			IL_00cc: dup
+			IL_00cd: ldc.i4.1
+			IL_00ce: ldloc.0
+			IL_00cf: stelem.ref
+			IL_00d0: stloc.2
+			IL_00d1: ldloc.2
+			IL_00d2: ldc.i4.0
+			IL_00d3: ldelem.ref
+			IL_00d4: castclass Modules.Http_Request_Post_Basic/Scope
+			IL_00d9: ldloc.2
+			IL_00da: ldc.i4.1
+			IL_00db: ldelem.ref
+			IL_00dc: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
+			IL_00e1: ldloc.2
+			IL_00e2: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
+			IL_00e7: ldc.i4.0
+			IL_00e8: conv.r8
+			IL_00e9: ldstr ""
+			IL_00ee: ldc.i4.0
+			IL_00ef: ldc.i4.1
+			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00f5: stloc.s 4
+			IL_00f7: ldloc.1
+			IL_00f8: ldstr "on"
+			IL_00fd: ldstr "end"
+			IL_0102: ldloc.s 4
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0109: pop
+			IL_010a: ldnull
+			IL_010b: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server
@@ -1387,7 +1424,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 116 (0x74)
+					// Code size: 156 (0x9c)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/Scope,
@@ -1440,13 +1477,26 @@
 					IL_005c: ldc.i4.1
 					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0062: stloc.s 5
-					IL_0064: ldloc.2
-					IL_0065: ldstr "close"
-					IL_006a: ldloc.s 5
-					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0071: pop
-					IL_0072: ldnull
-					IL_0073: ret
+					IL_0064: volatile.
+					IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+					IL_006b: brfalse IL_0082
+
+					IL_0070: ldloc.2
+					IL_0071: ldstr "close"
+					IL_0076: ldloc.s 5
+					IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_007d: br IL_0099
+
+					IL_0082: ldloc.2
+					IL_0083: ldstr "close"
+					IL_0088: ldloc.s 5
+					IL_008a: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M10>:__js_call__:12"
+					IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+					IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_0099: pop
+					IL_009a: ldnull
+					IL_009b: ret
 				} // end of method FunctionExpression_req_L51C20::__js_call__
 
 			} // end of class FunctionExpression_req_L51C20
@@ -1603,7 +1653,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 551 (0x227)
+				// Code size: 593 (0x251)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope,
@@ -1619,215 +1669,227 @@
 				IL_0005: stloc.0
 				IL_0006: ldarg.2
 				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000c: ldstr "setEncoding"
-				IL_0011: ldstr "utf8"
-				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001b: pop
-				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0021: stloc.1
-				IL_0022: volatile.
-				IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-				IL_0029: brfalse IL_003e
+				IL_000c: volatile.
+				IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_0013: brfalse IL_002c
 
-				IL_002e: ldarg.2
-				IL_002f: ldstr "statusCode"
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0039: br IL_0053
+				IL_0018: ldstr "setEncoding"
+				IL_001d: ldstr "utf8"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0027: br IL_0045
 
-				IL_003e: ldarg.2
-				IL_003f: ldstr "statusCode"
-				IL_0044: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:11"
-				IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_002c: ldstr "setEncoding"
+				IL_0031: ldstr "utf8"
+				IL_0036: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:5"
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0053: stloc.2
-				IL_0054: ldstr "client status:"
-				IL_0059: ldloc.2
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005f: stloc.3
-				IL_0060: ldloc.1
-				IL_0061: ldloc.3
-				IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0067: pop
-				IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_006d: stloc.1
-				IL_006e: volatile.
-				IL_0070: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-				IL_0075: brfalse IL_008a
+				IL_0045: pop
+				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_004b: stloc.1
+				IL_004c: volatile.
+				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+				IL_0053: brfalse IL_0068
 
-				IL_007a: ldarg.2
-				IL_007b: ldstr "headers"
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0085: br IL_009f
+				IL_0058: ldarg.2
+				IL_0059: ldstr "statusCode"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0063: br IL_007d
 
-				IL_008a: ldarg.2
-				IL_008b: ldstr "headers"
-				IL_0090: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:19"
-				IL_0095: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-				IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0068: ldarg.2
+				IL_0069: ldstr "statusCode"
+				IL_006e: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:11"
+				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_009f: stloc.2
-				IL_00a0: volatile.
-				IL_00a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-				IL_00a7: brfalse IL_00bc
+				IL_007d: stloc.2
+				IL_007e: ldstr "client status:"
+				IL_0083: ldloc.2
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0089: stloc.3
+				IL_008a: ldloc.1
+				IL_008b: ldloc.3
+				IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0091: pop
+				IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0097: stloc.1
+				IL_0098: volatile.
+				IL_009a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+				IL_009f: brfalse IL_00b4
 
-				IL_00ac: ldloc.2
-				IL_00ad: ldstr "content-type"
-				IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00b7: br IL_00d1
+				IL_00a4: ldarg.2
+				IL_00a5: ldstr "headers"
+				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00af: br IL_00c9
 
-				IL_00bc: ldloc.2
-				IL_00bd: ldstr "content-type"
-				IL_00c2: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:21"
-				IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-				IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_00b4: ldarg.2
+				IL_00b5: ldstr "headers"
+				IL_00ba: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:19"
+				IL_00bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_00d1: stloc.2
-				IL_00d2: ldstr "client type:"
-				IL_00d7: ldloc.2
-				IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00dd: stloc.3
-				IL_00de: ldloc.1
-				IL_00df: ldloc.3
-				IL_00e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_00e5: pop
-				IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_00eb: stloc.1
-				IL_00ec: volatile.
-				IL_00ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-				IL_00f3: brfalse IL_0108
+				IL_00c9: stloc.2
+				IL_00ca: volatile.
+				IL_00cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+				IL_00d1: brfalse IL_00e6
 
-				IL_00f8: ldarg.2
-				IL_00f9: ldstr "headers"
-				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0103: br IL_011d
+				IL_00d6: ldloc.2
+				IL_00d7: ldstr "content-type"
+				IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00e1: br IL_00fb
 
-				IL_0108: ldarg.2
-				IL_0109: ldstr "headers"
-				IL_010e: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:29"
-				IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-				IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_00e6: ldloc.2
+				IL_00e7: ldstr "content-type"
+				IL_00ec: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:21"
+				IL_00f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+				IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_011d: stloc.2
-				IL_011e: volatile.
-				IL_0120: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-				IL_0125: brfalse IL_013a
+				IL_00fb: stloc.2
+				IL_00fc: ldstr "client type:"
+				IL_0101: ldloc.2
+				IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0107: stloc.3
+				IL_0108: ldloc.1
+				IL_0109: ldloc.3
+				IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_010f: pop
+				IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0115: stloc.1
+				IL_0116: volatile.
+				IL_0118: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+				IL_011d: brfalse IL_0132
 
-				IL_012a: ldloc.2
-				IL_012b: ldstr "x-body-length"
-				IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0135: br IL_014f
+				IL_0122: ldarg.2
+				IL_0123: ldstr "headers"
+				IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_012d: br IL_0147
 
-				IL_013a: ldloc.2
-				IL_013b: ldstr "x-body-length"
-				IL_0140: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:31"
-				IL_0145: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-				IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0132: ldarg.2
+				IL_0133: ldstr "headers"
+				IL_0138: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:29"
+				IL_013d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+				IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_014f: stloc.2
-				IL_0150: ldstr "client length:"
-				IL_0155: ldloc.2
-				IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_015b: stloc.3
-				IL_015c: ldloc.1
-				IL_015d: ldloc.3
-				IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0163: pop
-				IL_0164: ldloc.0
-				IL_0165: ldstr ""
-				IL_016a: stfld object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope::responseBody
-				IL_016f: ldarg.2
-				IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0175: stloc.2
-				IL_0176: ldc.i4.3
-				IL_0177: newarr [System.Runtime]System.Object
-				IL_017c: dup
-				IL_017d: ldc.i4.0
-				IL_017e: ldarg.0
-				IL_017f: ldc.i4.0
-				IL_0180: ldelem.ref
-				IL_0181: stelem.ref
-				IL_0182: dup
-				IL_0183: ldc.i4.1
-				IL_0184: ldarg.0
-				IL_0185: ldc.i4.1
-				IL_0186: ldelem.ref
-				IL_0187: stelem.ref
-				IL_0188: dup
-				IL_0189: ldc.i4.2
-				IL_018a: ldloc.0
-				IL_018b: stelem.ref
-				IL_018c: stloc.s 4
-				IL_018e: ldloc.s 4
-				IL_0190: ldc.i4.0
-				IL_0191: ldelem.ref
-				IL_0192: castclass Modules.Http_Request_Post_Basic/Scope
-				IL_0197: ldloc.s 4
-				IL_0199: ldc.i4.2
-				IL_019a: ldelem.ref
-				IL_019b: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
-				IL_01a0: ldloc.s 4
-				IL_01a2: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
-				IL_01a7: ldc.i4.1
-				IL_01a8: conv.r8
-				IL_01a9: ldstr ""
-				IL_01ae: ldc.i4.0
+				IL_0147: stloc.2
+				IL_0148: volatile.
+				IL_014a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+				IL_014f: brfalse IL_0164
+
+				IL_0154: ldloc.2
+				IL_0155: ldstr "x-body-length"
+				IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_015f: br IL_0179
+
+				IL_0164: ldloc.2
+				IL_0165: ldstr "x-body-length"
+				IL_016a: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M8>:__js_call__:31"
+				IL_016f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+				IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_0179: stloc.2
+				IL_017a: ldstr "client length:"
+				IL_017f: ldloc.2
+				IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0185: stloc.3
+				IL_0186: ldloc.1
+				IL_0187: ldloc.3
+				IL_0188: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_018d: pop
+				IL_018e: ldloc.0
+				IL_018f: ldstr ""
+				IL_0194: stfld object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope::responseBody
+				IL_0199: ldarg.2
+				IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_019f: stloc.2
+				IL_01a0: ldc.i4.3
+				IL_01a1: newarr [System.Runtime]System.Object
+				IL_01a6: dup
+				IL_01a7: ldc.i4.0
+				IL_01a8: ldarg.0
+				IL_01a9: ldc.i4.0
+				IL_01aa: ldelem.ref
+				IL_01ab: stelem.ref
+				IL_01ac: dup
+				IL_01ad: ldc.i4.1
+				IL_01ae: ldarg.0
 				IL_01af: ldc.i4.1
-				IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_01b5: stloc.s 5
-				IL_01b7: ldloc.2
-				IL_01b8: ldstr "on"
-				IL_01bd: ldstr "data"
-				IL_01c2: ldloc.s 5
-				IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01c9: pop
-				IL_01ca: ldarg.2
-				IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01d0: stloc.2
-				IL_01d1: ldc.i4.3
-				IL_01d2: newarr [System.Runtime]System.Object
-				IL_01d7: dup
+				IL_01b0: ldelem.ref
+				IL_01b1: stelem.ref
+				IL_01b2: dup
+				IL_01b3: ldc.i4.2
+				IL_01b4: ldloc.0
+				IL_01b5: stelem.ref
+				IL_01b6: stloc.s 4
+				IL_01b8: ldloc.s 4
+				IL_01ba: ldc.i4.0
+				IL_01bb: ldelem.ref
+				IL_01bc: castclass Modules.Http_Request_Post_Basic/Scope
+				IL_01c1: ldloc.s 4
+				IL_01c3: ldc.i4.2
+				IL_01c4: ldelem.ref
+				IL_01c5: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
+				IL_01ca: ldloc.s 4
+				IL_01cc: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
+				IL_01d1: ldc.i4.1
+				IL_01d2: conv.r8
+				IL_01d3: ldstr ""
 				IL_01d8: ldc.i4.0
-				IL_01d9: ldarg.0
-				IL_01da: ldc.i4.0
-				IL_01db: ldelem.ref
-				IL_01dc: stelem.ref
-				IL_01dd: dup
-				IL_01de: ldc.i4.1
-				IL_01df: ldarg.0
-				IL_01e0: ldc.i4.1
-				IL_01e1: ldelem.ref
-				IL_01e2: stelem.ref
-				IL_01e3: dup
-				IL_01e4: ldc.i4.2
-				IL_01e5: ldloc.0
-				IL_01e6: stelem.ref
-				IL_01e7: stloc.s 4
-				IL_01e9: ldloc.s 4
-				IL_01eb: ldc.i4.0
-				IL_01ec: ldelem.ref
-				IL_01ed: castclass Modules.Http_Request_Post_Basic/Scope
-				IL_01f2: ldloc.s 4
-				IL_01f4: ldc.i4.2
-				IL_01f5: ldelem.ref
-				IL_01f6: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
-				IL_01fb: ldloc.s 4
-				IL_01fd: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
+				IL_01d9: ldc.i4.1
+				IL_01da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_01df: stloc.s 5
+				IL_01e1: ldloc.2
+				IL_01e2: ldstr "on"
+				IL_01e7: ldstr "data"
+				IL_01ec: ldloc.s 5
+				IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01f3: pop
+				IL_01f4: ldarg.2
+				IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01fa: stloc.2
+				IL_01fb: ldc.i4.3
+				IL_01fc: newarr [System.Runtime]System.Object
+				IL_0201: dup
 				IL_0202: ldc.i4.0
-				IL_0203: conv.r8
-				IL_0204: ldstr ""
-				IL_0209: ldc.i4.0
+				IL_0203: ldarg.0
+				IL_0204: ldc.i4.0
+				IL_0205: ldelem.ref
+				IL_0206: stelem.ref
+				IL_0207: dup
+				IL_0208: ldc.i4.1
+				IL_0209: ldarg.0
 				IL_020a: ldc.i4.1
-				IL_020b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0210: stloc.s 6
-				IL_0212: ldloc.2
-				IL_0213: ldstr "on"
-				IL_0218: ldstr "end"
-				IL_021d: ldloc.s 6
-				IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0224: pop
-				IL_0225: ldnull
-				IL_0226: ret
+				IL_020b: ldelem.ref
+				IL_020c: stelem.ref
+				IL_020d: dup
+				IL_020e: ldc.i4.2
+				IL_020f: ldloc.0
+				IL_0210: stelem.ref
+				IL_0211: stloc.s 4
+				IL_0213: ldloc.s 4
+				IL_0215: ldc.i4.0
+				IL_0216: ldelem.ref
+				IL_0217: castclass Modules.Http_Request_Post_Basic/Scope
+				IL_021c: ldloc.s 4
+				IL_021e: ldc.i4.2
+				IL_021f: ldelem.ref
+				IL_0220: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
+				IL_0225: ldloc.s 4
+				IL_0227: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
+				IL_022c: ldc.i4.0
+				IL_022d: conv.r8
+				IL_022e: ldstr ""
+				IL_0233: ldc.i4.0
+				IL_0234: ldc.i4.1
+				IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_023a: stloc.s 6
+				IL_023c: ldloc.2
+				IL_023d: ldstr "on"
+				IL_0242: ldstr "end"
+				IL_0247: ldloc.s 6
+				IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_024e: pop
+				IL_024f: ldnull
+				IL_0250: ret
 			} // end of method FunctionExpression_req::__js_call__
 
 		} // end of class FunctionExpression_req
@@ -1966,7 +2028,7 @@
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 381 (0x17d)
+			// Code size: 465 (0x1d1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/Scope,
@@ -1985,7 +2047,7 @@
 			IL_0007: ldfld object Modules.Http_Request_Post_Basic/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1994,14 +2056,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: ldarg.0
 			IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Request_Post_Basic/Scope::http
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -2012,12 +2074,12 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "address"
 			IL_0069: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M5>:__js_call__:9"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.3
 			IL_0079: volatile.
-			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_0080: brfalse IL_0095
 
 			IL_0085: ldloc.1
@@ -2028,7 +2090,7 @@
 			IL_0095: ldloc.1
 			IL_0096: ldstr "port"
 			IL_009b: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M5>:__js_call__:11"
-			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00aa: stloc.s 4
@@ -2091,18 +2153,42 @@
 			IL_014e: stloc.2
 			IL_014f: ldloc.2
 			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0155: ldstr "write"
-			IL_015a: ldstr "node "
-			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0164: pop
-			IL_0165: ldloc.2
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016b: ldstr "end"
-			IL_0170: ldstr "baseline"
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_017a: pop
-			IL_017b: ldnull
-			IL_017c: ret
+			IL_0155: volatile.
+			IL_0157: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_015c: brfalse IL_0175
+
+			IL_0161: ldstr "write"
+			IL_0166: ldstr "node "
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0170: br IL_018e
+
+			IL_0175: ldstr "write"
+			IL_017a: ldstr "node "
+			IL_017f: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M5>:__js_call__:24"
+			IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_018e: pop
+			IL_018f: ldloc.2
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0195: volatile.
+			IL_0197: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_019c: brfalse IL_01b5
+
+			IL_01a1: ldstr "end"
+			IL_01a6: ldstr "baseline"
+			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01b0: br IL_01ce
+
+			IL_01b5: ldstr "end"
+			IL_01ba: ldstr "baseline"
+			IL_01bf: ldstr "Http_Request_Post_Basic:<TwoPhaseDummy_M5>:__js_call__:28"
+			IL_01c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_01ce: pop
+			IL_01cf: ldnull
+			IL_01d0: ret
 		} // end of method FunctionExpression_L28C30::__js_call__
 
 	} // end of class FunctionExpression_L28C30
@@ -2271,6 +2357,13 @@
 	.field assembly static int32 __jroc_dynamicLookup_33
 	.field assembly static int32 __jroc_dynamicLookup_34
 	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
+	.field assembly static int32 __jroc_dynamicLookup_37
+	.field assembly static int32 __jroc_dynamicLookup_38
+	.field assembly static int32 __jroc_dynamicLookup_39
+	.field assembly static int32 __jroc_dynamicLookup_40
+	.field assembly static int32 __jroc_dynamicLookup_41
+	.field assembly static int32 __jroc_dynamicLookup_42
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
@@ -445,7 +445,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 116 (0x74)
+				// Code size: 158 (0x9e)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -491,12 +491,24 @@
 				IL_0053: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
 				IL_0058: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::res
 				IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0062: ldstr "end"
-				IL_0067: ldstr "ok"
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0071: pop
-				IL_0072: ldnull
-				IL_0073: ret
+				IL_0062: volatile.
+				IL_0064: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+				IL_0069: brfalse IL_0082
+
+				IL_006e: ldstr "end"
+				IL_0073: ldstr "ok"
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007d: br IL_009b
+
+				IL_0082: ldstr "end"
+				IL_0087: ldstr "ok"
+				IL_008c: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M7>:__js_call__:16"
+				IL_0091: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_009b: pop
+				IL_009c: ldnull
+				IL_009d: ret
 			} // end of method FunctionExpression_server_L19C16::__js_call__
 
 		} // end of class FunctionExpression_server_L19C16
@@ -660,7 +672,7 @@
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 360 (0x168)
+			// Code size: 402 (0x192)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope,
@@ -679,135 +691,147 @@
 			IL_0008: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::res
 			IL_000d: ldarg.2
 			IL_000e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0013: ldstr "setEncoding"
-			IL_0018: ldstr "utf8"
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0022: pop
-			IL_0023: ldloc.0
-			IL_0024: ldc.r8 0.0
-			IL_002d: box [System.Runtime]System.Double
-			IL_0032: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::chunkCount
-			IL_0037: ldloc.0
-			IL_0038: ldstr ""
-			IL_003d: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::body
-			IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0047: stloc.1
-			IL_0048: volatile.
-			IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_004f: brfalse IL_0064
+			IL_0013: volatile.
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_001a: brfalse IL_0033
 
-			IL_0054: ldarg.2
-			IL_0055: ldstr "headers"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005f: br IL_0079
+			IL_001f: ldstr "setEncoding"
+			IL_0024: ldstr "utf8"
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002e: br IL_004c
 
-			IL_0064: ldarg.2
-			IL_0065: ldstr "headers"
-			IL_006a: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M4>:__js_call__:20"
-			IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0033: ldstr "setEncoding"
+			IL_0038: ldstr "utf8"
+			IL_003d: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M4>:__js_call__:7"
+			IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0079: stloc.2
-			IL_007a: volatile.
-			IL_007c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0081: brfalse IL_0096
+			IL_004c: pop
+			IL_004d: ldloc.0
+			IL_004e: ldc.r8 0.0
+			IL_0057: box [System.Runtime]System.Double
+			IL_005c: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::chunkCount
+			IL_0061: ldloc.0
+			IL_0062: ldstr ""
+			IL_0067: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::body
+			IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0071: stloc.1
+			IL_0072: volatile.
+			IL_0074: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0079: brfalse IL_008e
 
-			IL_0086: ldloc.2
-			IL_0087: ldstr "transfer-encoding"
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0091: br IL_00ab
+			IL_007e: ldarg.2
+			IL_007f: ldstr "headers"
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0089: br IL_00a3
 
-			IL_0096: ldloc.2
-			IL_0097: ldstr "transfer-encoding"
-			IL_009c: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M4>:__js_call__:22"
-			IL_00a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_008e: ldarg.2
+			IL_008f: ldstr "headers"
+			IL_0094: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M4>:__js_call__:20"
+			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00ab: stloc.2
-			IL_00ac: ldstr "transfer:"
-			IL_00b1: ldloc.2
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00b7: stloc.3
-			IL_00b8: ldloc.1
-			IL_00b9: ldloc.3
-			IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00bf: pop
-			IL_00c0: ldarg.2
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c6: stloc.2
-			IL_00c7: ldc.i4.2
-			IL_00c8: newarr [System.Runtime]System.Object
-			IL_00cd: dup
-			IL_00ce: ldc.i4.0
-			IL_00cf: ldarg.0
-			IL_00d0: stelem.ref
-			IL_00d1: dup
-			IL_00d2: ldc.i4.1
-			IL_00d3: ldloc.0
-			IL_00d4: stelem.ref
-			IL_00d5: stloc.s 4
-			IL_00d7: ldloc.s 4
-			IL_00d9: ldc.i4.0
-			IL_00da: ldelem.ref
-			IL_00db: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-			IL_00e0: ldloc.s 4
-			IL_00e2: ldc.i4.1
-			IL_00e3: ldelem.ref
-			IL_00e4: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
-			IL_00e9: ldloc.s 4
-			IL_00eb: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
-			IL_00f0: ldc.i4.1
-			IL_00f1: conv.r8
-			IL_00f2: ldstr ""
-			IL_00f7: ldc.i4.0
-			IL_00f8: ldc.i4.1
-			IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_00fe: stloc.s 5
-			IL_0100: ldloc.2
-			IL_0101: ldstr "on"
-			IL_0106: ldstr "data"
-			IL_010b: ldloc.s 5
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0112: pop
-			IL_0113: ldarg.2
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0119: stloc.2
-			IL_011a: ldc.i4.2
-			IL_011b: newarr [System.Runtime]System.Object
-			IL_0120: dup
+			IL_00a3: stloc.2
+			IL_00a4: volatile.
+			IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_00ab: brfalse IL_00c0
+
+			IL_00b0: ldloc.2
+			IL_00b1: ldstr "transfer-encoding"
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bb: br IL_00d5
+
+			IL_00c0: ldloc.2
+			IL_00c1: ldstr "transfer-encoding"
+			IL_00c6: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M4>:__js_call__:22"
+			IL_00cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_00d5: stloc.2
+			IL_00d6: ldstr "transfer:"
+			IL_00db: ldloc.2
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00e1: stloc.3
+			IL_00e2: ldloc.1
+			IL_00e3: ldloc.3
+			IL_00e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00e9: pop
+			IL_00ea: ldarg.2
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f0: stloc.2
+			IL_00f1: ldc.i4.2
+			IL_00f2: newarr [System.Runtime]System.Object
+			IL_00f7: dup
+			IL_00f8: ldc.i4.0
+			IL_00f9: ldarg.0
+			IL_00fa: stelem.ref
+			IL_00fb: dup
+			IL_00fc: ldc.i4.1
+			IL_00fd: ldloc.0
+			IL_00fe: stelem.ref
+			IL_00ff: stloc.s 4
+			IL_0101: ldloc.s 4
+			IL_0103: ldc.i4.0
+			IL_0104: ldelem.ref
+			IL_0105: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+			IL_010a: ldloc.s 4
+			IL_010c: ldc.i4.1
+			IL_010d: ldelem.ref
+			IL_010e: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
+			IL_0113: ldloc.s 4
+			IL_0115: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
+			IL_011a: ldc.i4.1
+			IL_011b: conv.r8
+			IL_011c: ldstr ""
 			IL_0121: ldc.i4.0
-			IL_0122: ldarg.0
-			IL_0123: stelem.ref
-			IL_0124: dup
-			IL_0125: ldc.i4.1
-			IL_0126: ldloc.0
-			IL_0127: stelem.ref
-			IL_0128: stloc.s 4
-			IL_012a: ldloc.s 4
-			IL_012c: ldc.i4.0
-			IL_012d: ldelem.ref
-			IL_012e: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-			IL_0133: ldloc.s 4
-			IL_0135: ldc.i4.1
-			IL_0136: ldelem.ref
-			IL_0137: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
-			IL_013c: ldloc.s 4
-			IL_013e: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
-			IL_0143: ldc.i4.0
-			IL_0144: conv.r8
-			IL_0145: ldstr ""
-			IL_014a: ldc.i4.0
-			IL_014b: ldc.i4.1
-			IL_014c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0151: stloc.s 6
-			IL_0153: ldloc.2
-			IL_0154: ldstr "on"
-			IL_0159: ldstr "end"
-			IL_015e: ldloc.s 6
-			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0165: pop
-			IL_0166: ldnull
-			IL_0167: ret
+			IL_0122: ldc.i4.1
+			IL_0123: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0128: stloc.s 5
+			IL_012a: ldloc.2
+			IL_012b: ldstr "on"
+			IL_0130: ldstr "data"
+			IL_0135: ldloc.s 5
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_013c: pop
+			IL_013d: ldarg.2
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0143: stloc.2
+			IL_0144: ldc.i4.2
+			IL_0145: newarr [System.Runtime]System.Object
+			IL_014a: dup
+			IL_014b: ldc.i4.0
+			IL_014c: ldarg.0
+			IL_014d: stelem.ref
+			IL_014e: dup
+			IL_014f: ldc.i4.1
+			IL_0150: ldloc.0
+			IL_0151: stelem.ref
+			IL_0152: stloc.s 4
+			IL_0154: ldloc.s 4
+			IL_0156: ldc.i4.0
+			IL_0157: ldelem.ref
+			IL_0158: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+			IL_015d: ldloc.s 4
+			IL_015f: ldc.i4.1
+			IL_0160: ldelem.ref
+			IL_0161: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
+			IL_0166: ldloc.s 4
+			IL_0168: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
+			IL_016d: ldc.i4.0
+			IL_016e: conv.r8
+			IL_016f: ldstr ""
+			IL_0174: ldc.i4.0
+			IL_0175: ldc.i4.1
+			IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_017b: stloc.s 6
+			IL_017d: ldloc.2
+			IL_017e: ldstr "on"
+			IL_0183: ldstr "end"
+			IL_0188: ldloc.s 6
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_018f: pop
+			IL_0190: ldnull
+			IL_0191: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server
@@ -1289,7 +1313,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 116 (0x74)
+					// Code size: 156 (0x9c)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/Scope,
@@ -1342,13 +1366,26 @@
 					IL_005c: ldc.i4.1
 					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0062: stloc.s 5
-					IL_0064: ldloc.2
-					IL_0065: ldstr "close"
-					IL_006a: ldloc.s 5
-					IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0071: pop
-					IL_0072: ldnull
-					IL_0073: ret
+					IL_0064: volatile.
+					IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+					IL_006b: brfalse IL_0082
+
+					IL_0070: ldloc.2
+					IL_0071: ldstr "close"
+					IL_0076: ldloc.s 5
+					IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_007d: br IL_0099
+
+					IL_0082: ldloc.2
+					IL_0083: ldstr "close"
+					IL_0088: ldloc.s 5
+					IL_008a: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M10>:__js_call__:12"
+					IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+					IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_0099: pop
+					IL_009a: ldnull
+					IL_009b: ret
 				} // end of method FunctionExpression_req_L46C20::__js_call__
 
 			} // end of class FunctionExpression_req_L46C20
@@ -1505,7 +1542,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 213 (0xd5)
+				// Code size: 255 (0xff)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope,
@@ -1519,105 +1556,117 @@
 				IL_0005: stloc.0
 				IL_0006: ldarg.2
 				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000c: ldstr "setEncoding"
-				IL_0011: ldstr "utf8"
-				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001b: pop
-				IL_001c: ldloc.0
-				IL_001d: ldstr ""
-				IL_0022: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope::responseBody
-				IL_0027: ldarg.2
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002d: stloc.1
-				IL_002e: ldc.i4.3
-				IL_002f: newarr [System.Runtime]System.Object
-				IL_0034: dup
-				IL_0035: ldc.i4.0
-				IL_0036: ldarg.0
-				IL_0037: ldc.i4.0
-				IL_0038: ldelem.ref
-				IL_0039: stelem.ref
-				IL_003a: dup
-				IL_003b: ldc.i4.1
-				IL_003c: ldarg.0
-				IL_003d: ldc.i4.1
-				IL_003e: ldelem.ref
-				IL_003f: stelem.ref
-				IL_0040: dup
-				IL_0041: ldc.i4.2
-				IL_0042: ldloc.0
-				IL_0043: stelem.ref
-				IL_0044: stloc.2
-				IL_0045: ldloc.2
-				IL_0046: ldc.i4.0
-				IL_0047: ldelem.ref
-				IL_0048: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-				IL_004d: ldloc.2
-				IL_004e: ldc.i4.2
-				IL_004f: ldelem.ref
-				IL_0050: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
-				IL_0055: ldloc.2
-				IL_0056: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
-				IL_005b: ldc.i4.1
-				IL_005c: conv.r8
-				IL_005d: ldstr ""
-				IL_0062: ldc.i4.0
-				IL_0063: ldc.i4.1
-				IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0069: stloc.3
-				IL_006a: ldloc.1
-				IL_006b: ldstr "on"
-				IL_0070: ldstr "data"
-				IL_0075: ldloc.3
-				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_007b: pop
-				IL_007c: ldarg.2
-				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0082: stloc.1
-				IL_0083: ldc.i4.3
-				IL_0084: newarr [System.Runtime]System.Object
-				IL_0089: dup
-				IL_008a: ldc.i4.0
-				IL_008b: ldarg.0
+				IL_000c: volatile.
+				IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+				IL_0013: brfalse IL_002c
+
+				IL_0018: ldstr "setEncoding"
+				IL_001d: ldstr "utf8"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0027: br IL_0045
+
+				IL_002c: ldstr "setEncoding"
+				IL_0031: ldstr "utf8"
+				IL_0036: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M8>:__js_call__:5"
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0045: pop
+				IL_0046: ldloc.0
+				IL_0047: ldstr ""
+				IL_004c: stfld object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope::responseBody
+				IL_0051: ldarg.2
+				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0057: stloc.1
+				IL_0058: ldc.i4.3
+				IL_0059: newarr [System.Runtime]System.Object
+				IL_005e: dup
+				IL_005f: ldc.i4.0
+				IL_0060: ldarg.0
+				IL_0061: ldc.i4.0
+				IL_0062: ldelem.ref
+				IL_0063: stelem.ref
+				IL_0064: dup
+				IL_0065: ldc.i4.1
+				IL_0066: ldarg.0
+				IL_0067: ldc.i4.1
+				IL_0068: ldelem.ref
+				IL_0069: stelem.ref
+				IL_006a: dup
+				IL_006b: ldc.i4.2
+				IL_006c: ldloc.0
+				IL_006d: stelem.ref
+				IL_006e: stloc.2
+				IL_006f: ldloc.2
+				IL_0070: ldc.i4.0
+				IL_0071: ldelem.ref
+				IL_0072: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+				IL_0077: ldloc.2
+				IL_0078: ldc.i4.2
+				IL_0079: ldelem.ref
+				IL_007a: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
+				IL_007f: ldloc.2
+				IL_0080: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
+				IL_0085: ldc.i4.1
+				IL_0086: conv.r8
+				IL_0087: ldstr ""
 				IL_008c: ldc.i4.0
-				IL_008d: ldelem.ref
-				IL_008e: stelem.ref
-				IL_008f: dup
-				IL_0090: ldc.i4.1
-				IL_0091: ldarg.0
-				IL_0092: ldc.i4.1
-				IL_0093: ldelem.ref
-				IL_0094: stelem.ref
-				IL_0095: dup
-				IL_0096: ldc.i4.2
-				IL_0097: ldloc.0
-				IL_0098: stelem.ref
-				IL_0099: stloc.2
-				IL_009a: ldloc.2
-				IL_009b: ldc.i4.0
-				IL_009c: ldelem.ref
-				IL_009d: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-				IL_00a2: ldloc.2
-				IL_00a3: ldc.i4.2
-				IL_00a4: ldelem.ref
-				IL_00a5: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
-				IL_00aa: ldloc.2
-				IL_00ab: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
-				IL_00b0: ldc.i4.0
-				IL_00b1: conv.r8
-				IL_00b2: ldstr ""
-				IL_00b7: ldc.i4.0
-				IL_00b8: ldc.i4.1
-				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_00be: stloc.s 4
-				IL_00c0: ldloc.1
-				IL_00c1: ldstr "on"
-				IL_00c6: ldstr "end"
-				IL_00cb: ldloc.s 4
-				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_00d2: pop
-				IL_00d3: ldnull
-				IL_00d4: ret
+				IL_008d: ldc.i4.1
+				IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0093: stloc.3
+				IL_0094: ldloc.1
+				IL_0095: ldstr "on"
+				IL_009a: ldstr "data"
+				IL_009f: ldloc.3
+				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_00a5: pop
+				IL_00a6: ldarg.2
+				IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ac: stloc.1
+				IL_00ad: ldc.i4.3
+				IL_00ae: newarr [System.Runtime]System.Object
+				IL_00b3: dup
+				IL_00b4: ldc.i4.0
+				IL_00b5: ldarg.0
+				IL_00b6: ldc.i4.0
+				IL_00b7: ldelem.ref
+				IL_00b8: stelem.ref
+				IL_00b9: dup
+				IL_00ba: ldc.i4.1
+				IL_00bb: ldarg.0
+				IL_00bc: ldc.i4.1
+				IL_00bd: ldelem.ref
+				IL_00be: stelem.ref
+				IL_00bf: dup
+				IL_00c0: ldc.i4.2
+				IL_00c1: ldloc.0
+				IL_00c2: stelem.ref
+				IL_00c3: stloc.2
+				IL_00c4: ldloc.2
+				IL_00c5: ldc.i4.0
+				IL_00c6: ldelem.ref
+				IL_00c7: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
+				IL_00cc: ldloc.2
+				IL_00cd: ldc.i4.2
+				IL_00ce: ldelem.ref
+				IL_00cf: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
+				IL_00d4: ldloc.2
+				IL_00d5: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
+				IL_00da: ldc.i4.0
+				IL_00db: conv.r8
+				IL_00dc: ldstr ""
+				IL_00e1: ldc.i4.0
+				IL_00e2: ldc.i4.1
+				IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_00e8: stloc.s 4
+				IL_00ea: ldloc.1
+				IL_00eb: ldstr "on"
+				IL_00f0: ldstr "end"
+				IL_00f5: ldloc.s 4
+				IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_00fc: pop
+				IL_00fd: ldnull
+				IL_00fe: ret
 			} // end of method FunctionExpression_req::__js_call__
 
 		} // end of class FunctionExpression_req
@@ -1756,7 +1805,7 @@
 				74 61 54 6f 6b 65 6e 0e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 381 (0x17d)
+			// Code size: 465 (0x1d1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/Scope,
@@ -1775,7 +1824,7 @@
 			IL_0007: ldfld object Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1784,14 +1833,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: ldarg.0
 			IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::http
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1802,12 +1851,12 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "address"
 			IL_0069: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M5>:__js_call__:9"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.3
 			IL_0079: volatile.
-			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0080: brfalse IL_0095
 
 			IL_0085: ldloc.1
@@ -1818,7 +1867,7 @@
 			IL_0095: ldloc.1
 			IL_0096: ldstr "port"
 			IL_009b: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M5>:__js_call__:11"
-			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00aa: stloc.s 4
@@ -1881,18 +1930,42 @@
 			IL_014e: stloc.2
 			IL_014f: ldloc.2
 			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0155: ldstr "write"
-			IL_015a: ldstr "alpha"
-			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0164: pop
-			IL_0165: ldloc.2
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016b: ldstr "end"
-			IL_0170: ldstr "beta"
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_017a: pop
-			IL_017b: ldnull
-			IL_017c: ret
+			IL_0155: volatile.
+			IL_0157: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_015c: brfalse IL_0175
+
+			IL_0161: ldstr "write"
+			IL_0166: ldstr "alpha"
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0170: br IL_018e
+
+			IL_0175: ldstr "write"
+			IL_017a: ldstr "alpha"
+			IL_017f: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M5>:__js_call__:24"
+			IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_018e: pop
+			IL_018f: ldloc.2
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0195: volatile.
+			IL_0197: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_019c: brfalse IL_01b5
+
+			IL_01a1: ldstr "end"
+			IL_01a6: ldstr "beta"
+			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01b0: br IL_01ce
+
+			IL_01b5: ldstr "end"
+			IL_01ba: ldstr "beta"
+			IL_01bf: ldstr "Http_Request_Streaming_Chunked_RequestBody:<TwoPhaseDummy_M5>:__js_call__:28"
+			IL_01c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_01ce: pop
+			IL_01cf: ldnull
+			IL_01d0: ret
 		} // end of method FunctionExpression_L26C30::__js_call__
 
 	} // end of class FunctionExpression_L26C30
@@ -2053,6 +2126,12 @@
 	.field assembly static int32 __jroc_dynamicLookup_25
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
@@ -209,7 +209,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 73 (0x49)
+			// Code size: 157 (0x9d)
 			.maxstack 8
 
 			IL_0000: ldarg.2
@@ -221,18 +221,42 @@
 			IL_001a: pop
 			IL_001b: ldarg.2
 			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0021: ldstr "write"
-			IL_0026: ldstr "alpha"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0030: pop
-			IL_0031: ldarg.2
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0037: ldstr "end"
-			IL_003c: ldstr "beta"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0046: pop
-			IL_0047: ldnull
-			IL_0048: ret
+			IL_0021: volatile.
+			IL_0023: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0028: brfalse IL_0041
+
+			IL_002d: ldstr "write"
+			IL_0032: ldstr "alpha"
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_003c: br IL_005a
+
+			IL_0041: ldstr "write"
+			IL_0046: ldstr "alpha"
+			IL_004b: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M4>:__js_call__:10"
+			IL_0050: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_005a: pop
+			IL_005b: ldarg.2
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0061: volatile.
+			IL_0063: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0068: brfalse IL_0081
+
+			IL_006d: ldstr "end"
+			IL_0072: ldstr "beta"
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_007c: br IL_009a
+
+			IL_0081: ldstr "end"
+			IL_0086: ldstr "beta"
+			IL_008b: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M4>:__js_call__:15"
+			IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_009a: pop
+			IL_009b: ldnull
+			IL_009c: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server
@@ -755,7 +779,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 156 (0x9c)
+					// Code size: 196 (0xc4)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/Scope,
@@ -824,13 +848,26 @@
 					IL_0084: ldc.i4.1
 					IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_008a: stloc.s 5
-					IL_008c: ldloc.2
-					IL_008d: ldstr "close"
-					IL_0092: ldloc.s 5
-					IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0099: pop
-					IL_009a: ldnull
-					IL_009b: ret
+					IL_008c: volatile.
+					IL_008e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+					IL_0093: brfalse IL_00aa
+
+					IL_0098: ldloc.2
+					IL_0099: ldstr "close"
+					IL_009e: ldloc.s 5
+					IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_00a5: br IL_00c1
+
+					IL_00aa: ldloc.2
+					IL_00ab: ldstr "close"
+					IL_00b0: ldloc.s 5
+					IL_00b2: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M8>:__js_call__:18"
+					IL_00b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+					IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_00c1: pop
+					IL_00c2: ldnull
+					IL_00c3: ret
 				} // end of method FunctionExpression_L32C20::__js_call__
 
 			} // end of class FunctionExpression_L32C20
@@ -988,7 +1025,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 369 (0x171)
+				// Code size: 411 (0x19b)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope,
@@ -1004,151 +1041,163 @@
 				IL_0005: stloc.0
 				IL_0006: ldarg.2
 				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000c: ldstr "setEncoding"
-				IL_0011: ldstr "utf8"
-				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001b: pop
-				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0021: stloc.1
-				IL_0022: volatile.
-				IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-				IL_0029: brfalse IL_003e
+				IL_000c: volatile.
+				IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0013: brfalse IL_002c
 
-				IL_002e: ldarg.2
-				IL_002f: ldstr "headers"
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0039: br IL_0053
+				IL_0018: ldstr "setEncoding"
+				IL_001d: ldstr "utf8"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0027: br IL_0045
 
-				IL_003e: ldarg.2
-				IL_003f: ldstr "headers"
-				IL_0044: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M6>:__js_call__:11"
-				IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_002c: ldstr "setEncoding"
+				IL_0031: ldstr "utf8"
+				IL_0036: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M6>:__js_call__:5"
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0053: stloc.2
-				IL_0054: volatile.
-				IL_0056: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_005b: brfalse IL_0070
+				IL_0045: pop
+				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_004b: stloc.1
+				IL_004c: volatile.
+				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_0053: brfalse IL_0068
 
-				IL_0060: ldloc.2
-				IL_0061: ldstr "transfer-encoding"
-				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_006b: br IL_0085
+				IL_0058: ldarg.2
+				IL_0059: ldstr "headers"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0063: br IL_007d
 
-				IL_0070: ldloc.2
-				IL_0071: ldstr "transfer-encoding"
-				IL_0076: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M6>:__js_call__:13"
-				IL_007b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0068: ldarg.2
+				IL_0069: ldstr "headers"
+				IL_006e: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M6>:__js_call__:11"
+				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0085: stloc.2
-				IL_0086: ldstr "transfer:"
-				IL_008b: ldloc.2
-				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0091: stloc.3
-				IL_0092: ldloc.1
-				IL_0093: ldloc.3
-				IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0099: pop
-				IL_009a: ldloc.0
-				IL_009b: ldc.r8 0.0
-				IL_00a4: box [System.Runtime]System.Double
-				IL_00a9: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::chunkCount
-				IL_00ae: ldloc.0
-				IL_00af: ldstr ""
-				IL_00b4: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::body
-				IL_00b9: ldarg.2
-				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00bf: stloc.2
-				IL_00c0: ldc.i4.3
-				IL_00c1: newarr [System.Runtime]System.Object
-				IL_00c6: dup
-				IL_00c7: ldc.i4.0
-				IL_00c8: ldarg.0
-				IL_00c9: ldc.i4.0
-				IL_00ca: ldelem.ref
-				IL_00cb: stelem.ref
-				IL_00cc: dup
-				IL_00cd: ldc.i4.1
-				IL_00ce: ldarg.0
-				IL_00cf: ldc.i4.1
-				IL_00d0: ldelem.ref
-				IL_00d1: stelem.ref
-				IL_00d2: dup
-				IL_00d3: ldc.i4.2
-				IL_00d4: ldloc.0
-				IL_00d5: stelem.ref
-				IL_00d6: stloc.s 4
-				IL_00d8: ldloc.s 4
-				IL_00da: ldc.i4.0
-				IL_00db: ldelem.ref
-				IL_00dc: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
-				IL_00e1: ldloc.s 4
-				IL_00e3: ldc.i4.2
-				IL_00e4: ldelem.ref
-				IL_00e5: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
-				IL_00ea: ldloc.s 4
-				IL_00ec: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
-				IL_00f1: ldc.i4.1
-				IL_00f2: conv.r8
-				IL_00f3: ldstr ""
-				IL_00f8: ldc.i4.0
+				IL_007d: stloc.2
+				IL_007e: volatile.
+				IL_0080: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_0085: brfalse IL_009a
+
+				IL_008a: ldloc.2
+				IL_008b: ldstr "transfer-encoding"
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0095: br IL_00af
+
+				IL_009a: ldloc.2
+				IL_009b: ldstr "transfer-encoding"
+				IL_00a0: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M6>:__js_call__:13"
+				IL_00a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_00af: stloc.2
+				IL_00b0: ldstr "transfer:"
+				IL_00b5: ldloc.2
+				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00bb: stloc.3
+				IL_00bc: ldloc.1
+				IL_00bd: ldloc.3
+				IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_00c3: pop
+				IL_00c4: ldloc.0
+				IL_00c5: ldc.r8 0.0
+				IL_00ce: box [System.Runtime]System.Double
+				IL_00d3: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::chunkCount
+				IL_00d8: ldloc.0
+				IL_00d9: ldstr ""
+				IL_00de: stfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::body
+				IL_00e3: ldarg.2
+				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00e9: stloc.2
+				IL_00ea: ldc.i4.3
+				IL_00eb: newarr [System.Runtime]System.Object
+				IL_00f0: dup
+				IL_00f1: ldc.i4.0
+				IL_00f2: ldarg.0
+				IL_00f3: ldc.i4.0
+				IL_00f4: ldelem.ref
+				IL_00f5: stelem.ref
+				IL_00f6: dup
+				IL_00f7: ldc.i4.1
+				IL_00f8: ldarg.0
 				IL_00f9: ldc.i4.1
-				IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_00ff: stloc.s 5
-				IL_0101: ldloc.2
-				IL_0102: ldstr "on"
-				IL_0107: ldstr "data"
-				IL_010c: ldloc.s 5
-				IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0113: pop
-				IL_0114: ldarg.2
-				IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_011a: stloc.2
-				IL_011b: ldc.i4.3
-				IL_011c: newarr [System.Runtime]System.Object
-				IL_0121: dup
+				IL_00fa: ldelem.ref
+				IL_00fb: stelem.ref
+				IL_00fc: dup
+				IL_00fd: ldc.i4.2
+				IL_00fe: ldloc.0
+				IL_00ff: stelem.ref
+				IL_0100: stloc.s 4
+				IL_0102: ldloc.s 4
+				IL_0104: ldc.i4.0
+				IL_0105: ldelem.ref
+				IL_0106: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
+				IL_010b: ldloc.s 4
+				IL_010d: ldc.i4.2
+				IL_010e: ldelem.ref
+				IL_010f: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
+				IL_0114: ldloc.s 4
+				IL_0116: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
+				IL_011b: ldc.i4.1
+				IL_011c: conv.r8
+				IL_011d: ldstr ""
 				IL_0122: ldc.i4.0
-				IL_0123: ldarg.0
-				IL_0124: ldc.i4.0
-				IL_0125: ldelem.ref
-				IL_0126: stelem.ref
-				IL_0127: dup
-				IL_0128: ldc.i4.1
-				IL_0129: ldarg.0
-				IL_012a: ldc.i4.1
-				IL_012b: ldelem.ref
-				IL_012c: stelem.ref
-				IL_012d: dup
-				IL_012e: ldc.i4.2
-				IL_012f: ldloc.0
-				IL_0130: stelem.ref
-				IL_0131: stloc.s 4
-				IL_0133: ldloc.s 4
-				IL_0135: ldc.i4.0
-				IL_0136: ldelem.ref
-				IL_0137: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
-				IL_013c: ldloc.s 4
-				IL_013e: ldc.i4.2
-				IL_013f: ldelem.ref
-				IL_0140: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
-				IL_0145: ldloc.s 4
-				IL_0147: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
+				IL_0123: ldc.i4.1
+				IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0129: stloc.s 5
+				IL_012b: ldloc.2
+				IL_012c: ldstr "on"
+				IL_0131: ldstr "data"
+				IL_0136: ldloc.s 5
+				IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_013d: pop
+				IL_013e: ldarg.2
+				IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0144: stloc.2
+				IL_0145: ldc.i4.3
+				IL_0146: newarr [System.Runtime]System.Object
+				IL_014b: dup
 				IL_014c: ldc.i4.0
-				IL_014d: conv.r8
-				IL_014e: ldstr ""
-				IL_0153: ldc.i4.0
+				IL_014d: ldarg.0
+				IL_014e: ldc.i4.0
+				IL_014f: ldelem.ref
+				IL_0150: stelem.ref
+				IL_0151: dup
+				IL_0152: ldc.i4.1
+				IL_0153: ldarg.0
 				IL_0154: ldc.i4.1
-				IL_0155: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_015a: stloc.s 6
-				IL_015c: ldloc.2
-				IL_015d: ldstr "on"
-				IL_0162: ldstr "end"
-				IL_0167: ldloc.s 6
-				IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_016e: pop
-				IL_016f: ldnull
-				IL_0170: ret
+				IL_0155: ldelem.ref
+				IL_0156: stelem.ref
+				IL_0157: dup
+				IL_0158: ldc.i4.2
+				IL_0159: ldloc.0
+				IL_015a: stelem.ref
+				IL_015b: stloc.s 4
+				IL_015d: ldloc.s 4
+				IL_015f: ldc.i4.0
+				IL_0160: ldelem.ref
+				IL_0161: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
+				IL_0166: ldloc.s 4
+				IL_0168: ldc.i4.2
+				IL_0169: ldelem.ref
+				IL_016a: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
+				IL_016f: ldloc.s 4
+				IL_0171: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
+				IL_0176: ldc.i4.0
+				IL_0177: conv.r8
+				IL_0178: ldstr ""
+				IL_017d: ldc.i4.0
+				IL_017e: ldc.i4.1
+				IL_017f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0184: stloc.s 6
+				IL_0186: ldloc.2
+				IL_0187: ldstr "on"
+				IL_018c: ldstr "end"
+				IL_0191: ldloc.s 6
+				IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0198: pop
+				IL_0199: ldnull
+				IL_019a: ret
 			} // end of method FunctionExpression_L20C4::__js_call__
 
 		} // end of class FunctionExpression_L20C4
@@ -1306,7 +1355,7 @@
 			IL_0007: ldfld object Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1315,7 +1364,7 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
@@ -1323,7 +1372,7 @@
 			IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::http
 			IL_0047: stloc.2
 			IL_0048: volatile.
-			IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_004f: brfalse IL_0064
 
 			IL_0054: ldloc.1
@@ -1334,12 +1383,12 @@
 			IL_0064: ldloc.1
 			IL_0065: ldstr "address"
 			IL_006a: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M5>:__js_call__:9"
-			IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0079: stloc.3
 			IL_007a: volatile.
-			IL_007c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_007c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_0081: brfalse IL_0096
 
 			IL_0086: ldloc.1
@@ -1350,7 +1399,7 @@
 			IL_0096: ldloc.1
 			IL_0097: ldstr "port"
 			IL_009c: ldstr "Http_Response_Streaming_Chunked_ResponseBody:<TwoPhaseDummy_M5>:__js_call__:11"
-			IL_00a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_00a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00ab: stloc.s 4
@@ -1556,6 +1605,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
@@ -205,7 +205,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 219 (0xdb)
+			// Code size: 261 (0x105)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -278,12 +278,24 @@
 			IL_00c2: pop
 			IL_00c3: ldarg.2
 			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c9: ldstr "end"
-			IL_00ce: ldstr "secure hello"
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d8: pop
-			IL_00d9: ldnull
-			IL_00da: ret
+			IL_00c9: volatile.
+			IL_00cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_00d0: brfalse IL_00e9
+
+			IL_00d5: ldstr "end"
+			IL_00da: ldstr "secure hello"
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e4: br IL_0102
+
+			IL_00e9: ldstr "end"
+			IL_00ee: ldstr "secure hello"
+			IL_00f3: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M6>:__js_call__:29"
+			IL_00f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0102: pop
+			IL_0103: ldnull
+			IL_0104: ret
 		} // end of method ArrowFunction_L6C67::__js_call__
 
 	} // end of class ArrowFunction_L6C67
@@ -663,7 +675,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 121 (0x79)
+					// Code size: 161 (0xa1)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/Scope,
@@ -717,13 +729,26 @@
 					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/ArrowFunction_L30C22/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/ArrowFunction_L30C22/FunctionObject>(!!0)
 					IL_0067: stloc.s 5
-					IL_0069: ldloc.2
-					IL_006a: ldstr "close"
-					IL_006f: ldloc.s 5
-					IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0076: pop
-					IL_0077: ldnull
-					IL_0078: ret
+					IL_0069: volatile.
+					IL_006b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+					IL_0070: brfalse IL_0087
+
+					IL_0075: ldloc.2
+					IL_0076: ldstr "close"
+					IL_007b: ldloc.s 5
+					IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0082: br IL_009e
+
+					IL_0087: ldloc.2
+					IL_0088: ldstr "close"
+					IL_008d: ldloc.s 5
+					IL_008f: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M10>:__js_call__:12"
+					IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+					IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_009e: pop
+					IL_009f: ldnull
+					IL_00a0: ret
 				} // end of method ArrowFunction_L28C21::__js_call__
 
 			} // end of class ArrowFunction_L28C21
@@ -841,7 +866,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 309 (0x135)
+				// Code size: 351 (0x15f)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope,
@@ -857,133 +882,145 @@
 				IL_0005: stloc.0
 				IL_0006: ldarg.2
 				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000c: ldstr "setEncoding"
-				IL_0011: ldstr "utf8"
-				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001b: pop
-				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0021: stloc.1
-				IL_0022: volatile.
-				IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-				IL_0029: brfalse IL_003e
+				IL_000c: volatile.
+				IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_0013: brfalse IL_002c
 
-				IL_002e: ldarg.2
-				IL_002f: ldstr "statusCode"
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0039: br IL_0053
+				IL_0018: ldstr "setEncoding"
+				IL_001d: ldstr "utf8"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0027: br IL_0045
 
-				IL_003e: ldarg.2
-				IL_003f: ldstr "statusCode"
-				IL_0044: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M8>:__js_call__:11"
-				IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_002c: ldstr "setEncoding"
+				IL_0031: ldstr "utf8"
+				IL_0036: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M8>:__js_call__:5"
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0053: stloc.2
-				IL_0054: ldstr "status:"
-				IL_0059: ldloc.2
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005f: stloc.3
-				IL_0060: ldloc.1
-				IL_0061: ldloc.3
-				IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0067: pop
-				IL_0068: ldloc.0
-				IL_0069: ldstr ""
-				IL_006e: stfld object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope::body
-				IL_0073: ldarg.2
-				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0079: stloc.2
-				IL_007a: ldc.i4.3
-				IL_007b: newarr [System.Runtime]System.Object
-				IL_0080: dup
-				IL_0081: ldc.i4.0
-				IL_0082: ldarg.0
-				IL_0083: ldc.i4.0
-				IL_0084: ldelem.ref
-				IL_0085: stelem.ref
-				IL_0086: dup
-				IL_0087: ldc.i4.1
-				IL_0088: ldarg.0
-				IL_0089: ldc.i4.1
-				IL_008a: ldelem.ref
-				IL_008b: stelem.ref
-				IL_008c: dup
-				IL_008d: ldc.i4.2
-				IL_008e: ldloc.0
-				IL_008f: stelem.ref
-				IL_0090: stloc.s 4
-				IL_0092: ldloc.s 4
-				IL_0094: ldc.i4.0
-				IL_0095: ldelem.ref
-				IL_0096: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
-				IL_009b: ldloc.s 4
-				IL_009d: ldc.i4.2
-				IL_009e: ldelem.ref
-				IL_009f: castclass Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope
-				IL_00a4: ldloc.s 4
-				IL_00a6: newobj instance void Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L25C22/FunctionObject::.ctor(class Modules.Https_Get_Loopback_SelfSigned/Scope, class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope, object[])
-				IL_00ab: ldc.i4.1
-				IL_00ac: conv.r8
-				IL_00ad: ldstr ""
-				IL_00b2: ldc.i4.0
-				IL_00b3: ldc.i4.0
-				IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L25C22/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L25C22/FunctionObject>(!!0)
-				IL_00be: stloc.s 5
-				IL_00c0: ldloc.2
-				IL_00c1: ldstr "on"
-				IL_00c6: ldstr "data"
-				IL_00cb: ldloc.s 5
-				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_00d2: pop
-				IL_00d3: ldarg.2
-				IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00d9: stloc.2
-				IL_00da: ldc.i4.3
-				IL_00db: newarr [System.Runtime]System.Object
-				IL_00e0: dup
-				IL_00e1: ldc.i4.0
-				IL_00e2: ldarg.0
-				IL_00e3: ldc.i4.0
-				IL_00e4: ldelem.ref
-				IL_00e5: stelem.ref
-				IL_00e6: dup
-				IL_00e7: ldc.i4.1
-				IL_00e8: ldarg.0
-				IL_00e9: ldc.i4.1
-				IL_00ea: ldelem.ref
-				IL_00eb: stelem.ref
-				IL_00ec: dup
-				IL_00ed: ldc.i4.2
-				IL_00ee: ldloc.0
-				IL_00ef: stelem.ref
-				IL_00f0: stloc.s 4
-				IL_00f2: ldloc.s 4
-				IL_00f4: ldc.i4.0
-				IL_00f5: ldelem.ref
-				IL_00f6: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
-				IL_00fb: ldloc.s 4
-				IL_00fd: ldc.i4.2
-				IL_00fe: ldelem.ref
-				IL_00ff: castclass Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope
-				IL_0104: ldloc.s 4
-				IL_0106: newobj instance void Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/FunctionObject::.ctor(class Modules.Https_Get_Loopback_SelfSigned/Scope, class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope, object[])
+				IL_0045: pop
+				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_004b: stloc.1
+				IL_004c: volatile.
+				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_0053: brfalse IL_0068
+
+				IL_0058: ldarg.2
+				IL_0059: ldstr "statusCode"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0063: br IL_007d
+
+				IL_0068: ldarg.2
+				IL_0069: ldstr "statusCode"
+				IL_006e: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M8>:__js_call__:11"
+				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_007d: stloc.2
+				IL_007e: ldstr "status:"
+				IL_0083: ldloc.2
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0089: stloc.3
+				IL_008a: ldloc.1
+				IL_008b: ldloc.3
+				IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0091: pop
+				IL_0092: ldloc.0
+				IL_0093: ldstr ""
+				IL_0098: stfld object Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope::body
+				IL_009d: ldarg.2
+				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00a3: stloc.2
+				IL_00a4: ldc.i4.3
+				IL_00a5: newarr [System.Runtime]System.Object
+				IL_00aa: dup
+				IL_00ab: ldc.i4.0
+				IL_00ac: ldarg.0
+				IL_00ad: ldc.i4.0
+				IL_00ae: ldelem.ref
+				IL_00af: stelem.ref
+				IL_00b0: dup
+				IL_00b1: ldc.i4.1
+				IL_00b2: ldarg.0
+				IL_00b3: ldc.i4.1
+				IL_00b4: ldelem.ref
+				IL_00b5: stelem.ref
+				IL_00b6: dup
+				IL_00b7: ldc.i4.2
+				IL_00b8: ldloc.0
+				IL_00b9: stelem.ref
+				IL_00ba: stloc.s 4
+				IL_00bc: ldloc.s 4
+				IL_00be: ldc.i4.0
+				IL_00bf: ldelem.ref
+				IL_00c0: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
+				IL_00c5: ldloc.s 4
+				IL_00c7: ldc.i4.2
+				IL_00c8: ldelem.ref
+				IL_00c9: castclass Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope
+				IL_00ce: ldloc.s 4
+				IL_00d0: newobj instance void Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L25C22/FunctionObject::.ctor(class Modules.Https_Get_Loopback_SelfSigned/Scope, class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope, object[])
+				IL_00d5: ldc.i4.1
+				IL_00d6: conv.r8
+				IL_00d7: ldstr ""
+				IL_00dc: ldc.i4.0
+				IL_00dd: ldc.i4.0
+				IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L25C22/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L25C22/FunctionObject>(!!0)
+				IL_00e8: stloc.s 5
+				IL_00ea: ldloc.2
+				IL_00eb: ldstr "on"
+				IL_00f0: ldstr "data"
+				IL_00f5: ldloc.s 5
+				IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_00fc: pop
+				IL_00fd: ldarg.2
+				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0103: stloc.2
+				IL_0104: ldc.i4.3
+				IL_0105: newarr [System.Runtime]System.Object
+				IL_010a: dup
 				IL_010b: ldc.i4.0
-				IL_010c: conv.r8
-				IL_010d: ldstr ""
-				IL_0112: ldc.i4.0
-				IL_0113: ldc.i4.0
-				IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/FunctionObject>(!!0)
-				IL_011e: stloc.s 6
-				IL_0120: ldloc.2
-				IL_0121: ldstr "on"
-				IL_0126: ldstr "end"
-				IL_012b: ldloc.s 6
-				IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0132: pop
-				IL_0133: ldnull
-				IL_0134: ret
+				IL_010c: ldarg.0
+				IL_010d: ldc.i4.0
+				IL_010e: ldelem.ref
+				IL_010f: stelem.ref
+				IL_0110: dup
+				IL_0111: ldc.i4.1
+				IL_0112: ldarg.0
+				IL_0113: ldc.i4.1
+				IL_0114: ldelem.ref
+				IL_0115: stelem.ref
+				IL_0116: dup
+				IL_0117: ldc.i4.2
+				IL_0118: ldloc.0
+				IL_0119: stelem.ref
+				IL_011a: stloc.s 4
+				IL_011c: ldloc.s 4
+				IL_011e: ldc.i4.0
+				IL_011f: ldelem.ref
+				IL_0120: castclass Modules.Https_Get_Loopback_SelfSigned/Scope
+				IL_0125: ldloc.s 4
+				IL_0127: ldc.i4.2
+				IL_0128: ldelem.ref
+				IL_0129: castclass Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope
+				IL_012e: ldloc.s 4
+				IL_0130: newobj instance void Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/FunctionObject::.ctor(class Modules.Https_Get_Loopback_SelfSigned/Scope, class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/Scope, object[])
+				IL_0135: ldc.i4.0
+				IL_0136: conv.r8
+				IL_0137: ldstr ""
+				IL_013c: ldc.i4.0
+				IL_013d: ldc.i4.0
+				IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Get_Loopback_SelfSigned/ArrowFunction_L13C31/ArrowFunction_L20C5/ArrowFunction_L28C21/FunctionObject>(!!0)
+				IL_0148: stloc.s 6
+				IL_014a: ldloc.2
+				IL_014b: ldstr "on"
+				IL_0150: ldstr "end"
+				IL_0155: ldloc.s 6
+				IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_015c: pop
+				IL_015d: ldnull
+				IL_015e: ret
 			} // end of method ArrowFunction_L20C5::__js_call__
 
 		} // end of class ArrowFunction_L20C5
@@ -1106,7 +1143,7 @@
 			IL_0007: ldfld object Modules.Https_Get_Loopback_SelfSigned/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1115,14 +1152,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M7>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0046: stloc.2
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1133,7 +1170,7 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "address"
 			IL_0069: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M7>:__js_call__:10"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.3
@@ -1153,7 +1190,7 @@
 			IL_009e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Get_Loopback_SelfSigned/Scope::https
 			IL_00a3: stloc.s 5
 			IL_00a5: volatile.
-			IL_00a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_00a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_00ac: brfalse IL_00c1
 
 			IL_00b1: ldloc.1
@@ -1164,7 +1201,7 @@
 			IL_00c1: ldloc.1
 			IL_00c2: ldstr "port"
 			IL_00c7: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M7>:__js_call__:19"
-			IL_00cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_00cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00d6: stloc.3
@@ -1505,6 +1542,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_22
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
@@ -364,7 +364,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 298 (0x12a)
+				// Code size: 337 (0x151)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -381,7 +381,7 @@
 				IL_0009: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
 				IL_000e: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
 				IL_0013: volatile.
-				IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+				IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 				IL_001a: brfalse IL_002e
 
 				IL_001f: ldstr "method"
@@ -390,7 +390,7 @@
 
 				IL_002e: ldstr "method"
 				IL_0033: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M9>:__js_call__:5"
-				IL_0038: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+				IL_0038: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0042: stloc.1
@@ -408,7 +408,7 @@
 				IL_005e: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
 				IL_0063: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
 				IL_0068: volatile.
-				IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+				IL_006a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 				IL_006f: brfalse IL_0083
 
 				IL_0074: ldstr "url"
@@ -417,7 +417,7 @@
 
 				IL_0083: ldstr "url"
 				IL_0088: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M9>:__js_call__:11"
-				IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+				IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0097: stloc.1
@@ -472,13 +472,26 @@
 				IL_0114: ldloc.3
 				IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 				IL_011a: stloc.2
-				IL_011b: ldloc.1
-				IL_011c: ldstr "end"
-				IL_0121: ldloc.2
-				IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0127: pop
-				IL_0128: ldnull
-				IL_0129: ret
+				IL_011b: volatile.
+				IL_011d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_0122: brfalse IL_0138
+
+				IL_0127: ldloc.1
+				IL_0128: ldstr "end"
+				IL_012d: ldloc.2
+				IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0133: br IL_014e
+
+				IL_0138: ldloc.1
+				IL_0139: ldstr "end"
+				IL_013e: ldloc.2
+				IL_013f: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M9>:__js_call__:29"
+				IL_0144: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_014e: pop
+				IL_014f: ldnull
+				IL_0150: ret
 			} // end of method ArrowFunction_L14C17::__js_call__
 
 		} // end of class ArrowFunction_L14C17
@@ -600,7 +613,7 @@
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
 			// Header size: 12
-			// Code size: 236 (0xec)
+			// Code size: 278 (0x116)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope,
@@ -621,93 +634,105 @@
 			IL_0014: ldloc.0
 			IL_0015: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
 			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: ldstr "setEncoding"
-			IL_0024: ldstr "utf8"
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_002e: pop
-			IL_002f: ldloc.0
-			IL_0030: ldstr ""
-			IL_0035: stfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::requestBody
-			IL_003a: ldloc.0
-			IL_003b: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0045: stloc.1
-			IL_0046: ldc.i4.2
-			IL_0047: newarr [System.Runtime]System.Object
-			IL_004c: dup
-			IL_004d: ldc.i4.0
-			IL_004e: ldarg.0
-			IL_004f: stelem.ref
-			IL_0050: dup
-			IL_0051: ldc.i4.1
-			IL_0052: ldloc.0
-			IL_0053: stelem.ref
-			IL_0054: stloc.2
-			IL_0055: ldloc.2
-			IL_0056: ldc.i4.0
-			IL_0057: ldelem.ref
-			IL_0058: castclass Modules.Https_Request_Post_Basic/Scope
-			IL_005d: ldloc.2
-			IL_005e: ldc.i4.1
-			IL_005f: ldelem.ref
-			IL_0060: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
-			IL_0065: ldloc.2
-			IL_0066: newobj instance void Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L10C18/FunctionObject::.ctor(class Modules.Https_Request_Post_Basic/Scope, class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope, object[])
-			IL_006b: ldc.i4.1
-			IL_006c: conv.r8
-			IL_006d: ldstr ""
-			IL_0072: ldc.i4.0
-			IL_0073: ldc.i4.0
-			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L10C18/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L10C18/FunctionObject>(!!0)
-			IL_007e: stloc.3
-			IL_007f: ldloc.1
-			IL_0080: ldstr "on"
-			IL_0085: ldstr "data"
-			IL_008a: ldloc.3
-			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0090: pop
-			IL_0091: ldloc.0
-			IL_0092: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009c: stloc.1
-			IL_009d: ldc.i4.2
-			IL_009e: newarr [System.Runtime]System.Object
-			IL_00a3: dup
-			IL_00a4: ldc.i4.0
-			IL_00a5: ldarg.0
-			IL_00a6: stelem.ref
-			IL_00a7: dup
-			IL_00a8: ldc.i4.1
-			IL_00a9: ldloc.0
-			IL_00aa: stelem.ref
-			IL_00ab: stloc.2
-			IL_00ac: ldloc.2
-			IL_00ad: ldc.i4.0
-			IL_00ae: ldelem.ref
-			IL_00af: castclass Modules.Https_Request_Post_Basic/Scope
-			IL_00b4: ldloc.2
-			IL_00b5: ldc.i4.1
-			IL_00b6: ldelem.ref
-			IL_00b7: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
-			IL_00bc: ldloc.2
-			IL_00bd: newobj instance void Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L14C17/FunctionObject::.ctor(class Modules.Https_Request_Post_Basic/Scope, class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope, object[])
-			IL_00c2: ldc.i4.0
-			IL_00c3: conv.r8
-			IL_00c4: ldstr ""
-			IL_00c9: ldc.i4.0
-			IL_00ca: ldc.i4.0
-			IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L14C17/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L14C17/FunctionObject>(!!0)
-			IL_00d5: stloc.s 4
-			IL_00d7: ldloc.1
-			IL_00d8: ldstr "on"
-			IL_00dd: ldstr "end"
-			IL_00e2: ldloc.s 4
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00e9: pop
-			IL_00ea: ldnull
-			IL_00eb: ret
+			IL_001f: volatile.
+			IL_0021: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0026: brfalse IL_003f
+
+			IL_002b: ldstr "setEncoding"
+			IL_0030: ldstr "utf8"
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_003a: br IL_0058
+
+			IL_003f: ldstr "setEncoding"
+			IL_0044: ldstr "utf8"
+			IL_0049: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M6>:__js_call__:9"
+			IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0058: pop
+			IL_0059: ldloc.0
+			IL_005a: ldstr ""
+			IL_005f: stfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::requestBody
+			IL_0064: ldloc.0
+			IL_0065: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006f: stloc.1
+			IL_0070: ldc.i4.2
+			IL_0071: newarr [System.Runtime]System.Object
+			IL_0076: dup
+			IL_0077: ldc.i4.0
+			IL_0078: ldarg.0
+			IL_0079: stelem.ref
+			IL_007a: dup
+			IL_007b: ldc.i4.1
+			IL_007c: ldloc.0
+			IL_007d: stelem.ref
+			IL_007e: stloc.2
+			IL_007f: ldloc.2
+			IL_0080: ldc.i4.0
+			IL_0081: ldelem.ref
+			IL_0082: castclass Modules.Https_Request_Post_Basic/Scope
+			IL_0087: ldloc.2
+			IL_0088: ldc.i4.1
+			IL_0089: ldelem.ref
+			IL_008a: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
+			IL_008f: ldloc.2
+			IL_0090: newobj instance void Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L10C18/FunctionObject::.ctor(class Modules.Https_Request_Post_Basic/Scope, class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope, object[])
+			IL_0095: ldc.i4.1
+			IL_0096: conv.r8
+			IL_0097: ldstr ""
+			IL_009c: ldc.i4.0
+			IL_009d: ldc.i4.0
+			IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L10C18/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L10C18/FunctionObject>(!!0)
+			IL_00a8: stloc.3
+			IL_00a9: ldloc.1
+			IL_00aa: ldstr "on"
+			IL_00af: ldstr "data"
+			IL_00b4: ldloc.3
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00ba: pop
+			IL_00bb: ldloc.0
+			IL_00bc: ldfld object Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope::req
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c6: stloc.1
+			IL_00c7: ldc.i4.2
+			IL_00c8: newarr [System.Runtime]System.Object
+			IL_00cd: dup
+			IL_00ce: ldc.i4.0
+			IL_00cf: ldarg.0
+			IL_00d0: stelem.ref
+			IL_00d1: dup
+			IL_00d2: ldc.i4.1
+			IL_00d3: ldloc.0
+			IL_00d4: stelem.ref
+			IL_00d5: stloc.2
+			IL_00d6: ldloc.2
+			IL_00d7: ldc.i4.0
+			IL_00d8: ldelem.ref
+			IL_00d9: castclass Modules.Https_Request_Post_Basic/Scope
+			IL_00de: ldloc.2
+			IL_00df: ldc.i4.1
+			IL_00e0: ldelem.ref
+			IL_00e1: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope
+			IL_00e6: ldloc.2
+			IL_00e7: newobj instance void Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L14C17/FunctionObject::.ctor(class Modules.Https_Request_Post_Basic/Scope, class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/Scope, object[])
+			IL_00ec: ldc.i4.0
+			IL_00ed: conv.r8
+			IL_00ee: ldstr ""
+			IL_00f3: ldc.i4.0
+			IL_00f4: ldc.i4.0
+			IL_00f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L14C17/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_Post_Basic/ArrowFunction_L6C67/ArrowFunction_L14C17/FunctionObject>(!!0)
+			IL_00ff: stloc.s 4
+			IL_0101: ldloc.1
+			IL_0102: ldstr "on"
+			IL_0107: ldstr "end"
+			IL_010c: ldloc.s 4
+			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0113: pop
+			IL_0114: ldnull
+			IL_0115: ret
 		} // end of method ArrowFunction_L6C67::__js_call__
 
 	} // end of class ArrowFunction_L6C67
@@ -1087,7 +1112,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 121 (0x79)
+					// Code size: 161 (0xa1)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/Scope,
@@ -1141,13 +1166,26 @@
 					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/ArrowFunction_L41C22/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/ArrowFunction_L41C22/FunctionObject>(!!0)
 					IL_0067: stloc.s 5
-					IL_0069: ldloc.2
-					IL_006a: ldstr "close"
-					IL_006f: ldloc.s 5
-					IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0076: pop
-					IL_0077: ldnull
-					IL_0078: ret
+					IL_0069: volatile.
+					IL_006b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+					IL_0070: brfalse IL_0087
+
+					IL_0075: ldloc.2
+					IL_0076: ldstr "close"
+					IL_007b: ldloc.s 5
+					IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0082: br IL_009e
+
+					IL_0087: ldloc.2
+					IL_0088: ldstr "close"
+					IL_008d: ldloc.s 5
+					IL_008f: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M12>:__js_call__:12"
+					IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+					IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_009e: pop
+					IL_009f: ldnull
+					IL_00a0: ret
 				} // end of method ArrowFunction_L39C21::__js_call__
 
 			} // end of class ArrowFunction_L39C21
@@ -1265,7 +1303,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 309 (0x135)
+				// Code size: 351 (0x15f)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope,
@@ -1281,133 +1319,145 @@
 				IL_0005: stloc.0
 				IL_0006: ldarg.2
 				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000c: ldstr "setEncoding"
-				IL_0011: ldstr "utf8"
-				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001b: pop
-				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0021: stloc.1
-				IL_0022: volatile.
-				IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-				IL_0029: brfalse IL_003e
+				IL_000c: volatile.
+				IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_0013: brfalse IL_002c
 
-				IL_002e: ldarg.2
-				IL_002f: ldstr "statusCode"
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0039: br IL_0053
+				IL_0018: ldstr "setEncoding"
+				IL_001d: ldstr "utf8"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0027: br IL_0045
 
-				IL_003e: ldarg.2
-				IL_003f: ldstr "statusCode"
-				IL_0044: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M10>:__js_call__:11"
-				IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_002c: ldstr "setEncoding"
+				IL_0031: ldstr "utf8"
+				IL_0036: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M10>:__js_call__:5"
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0053: stloc.2
-				IL_0054: ldstr "status:"
-				IL_0059: ldloc.2
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005f: stloc.3
-				IL_0060: ldloc.1
-				IL_0061: ldloc.3
-				IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0067: pop
-				IL_0068: ldloc.0
-				IL_0069: ldstr ""
-				IL_006e: stfld object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope::body
-				IL_0073: ldarg.2
-				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0079: stloc.2
-				IL_007a: ldc.i4.3
-				IL_007b: newarr [System.Runtime]System.Object
-				IL_0080: dup
-				IL_0081: ldc.i4.0
-				IL_0082: ldarg.0
-				IL_0083: ldc.i4.0
-				IL_0084: ldelem.ref
-				IL_0085: stelem.ref
-				IL_0086: dup
-				IL_0087: ldc.i4.1
-				IL_0088: ldarg.0
-				IL_0089: ldc.i4.1
-				IL_008a: ldelem.ref
-				IL_008b: stelem.ref
-				IL_008c: dup
-				IL_008d: ldc.i4.2
-				IL_008e: ldloc.0
-				IL_008f: stelem.ref
-				IL_0090: stloc.s 4
-				IL_0092: ldloc.s 4
-				IL_0094: ldc.i4.0
-				IL_0095: ldelem.ref
-				IL_0096: castclass Modules.Https_Request_Post_Basic/Scope
-				IL_009b: ldloc.s 4
-				IL_009d: ldc.i4.2
-				IL_009e: ldelem.ref
-				IL_009f: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope
-				IL_00a4: ldloc.s 4
-				IL_00a6: newobj instance void Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L36C22/FunctionObject::.ctor(class Modules.Https_Request_Post_Basic/Scope, class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope, object[])
-				IL_00ab: ldc.i4.1
-				IL_00ac: conv.r8
-				IL_00ad: ldstr ""
-				IL_00b2: ldc.i4.0
-				IL_00b3: ldc.i4.0
-				IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L36C22/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L36C22/FunctionObject>(!!0)
-				IL_00be: stloc.s 5
-				IL_00c0: ldloc.2
-				IL_00c1: ldstr "on"
-				IL_00c6: ldstr "data"
-				IL_00cb: ldloc.s 5
-				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_00d2: pop
-				IL_00d3: ldarg.2
-				IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00d9: stloc.2
-				IL_00da: ldc.i4.3
-				IL_00db: newarr [System.Runtime]System.Object
-				IL_00e0: dup
-				IL_00e1: ldc.i4.0
-				IL_00e2: ldarg.0
-				IL_00e3: ldc.i4.0
-				IL_00e4: ldelem.ref
-				IL_00e5: stelem.ref
-				IL_00e6: dup
-				IL_00e7: ldc.i4.1
-				IL_00e8: ldarg.0
-				IL_00e9: ldc.i4.1
-				IL_00ea: ldelem.ref
-				IL_00eb: stelem.ref
-				IL_00ec: dup
-				IL_00ed: ldc.i4.2
-				IL_00ee: ldloc.0
-				IL_00ef: stelem.ref
-				IL_00f0: stloc.s 4
-				IL_00f2: ldloc.s 4
-				IL_00f4: ldc.i4.0
-				IL_00f5: ldelem.ref
-				IL_00f6: castclass Modules.Https_Request_Post_Basic/Scope
-				IL_00fb: ldloc.s 4
-				IL_00fd: ldc.i4.2
-				IL_00fe: ldelem.ref
-				IL_00ff: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope
-				IL_0104: ldloc.s 4
-				IL_0106: newobj instance void Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/FunctionObject::.ctor(class Modules.Https_Request_Post_Basic/Scope, class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope, object[])
+				IL_0045: pop
+				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_004b: stloc.1
+				IL_004c: volatile.
+				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_0053: brfalse IL_0068
+
+				IL_0058: ldarg.2
+				IL_0059: ldstr "statusCode"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0063: br IL_007d
+
+				IL_0068: ldarg.2
+				IL_0069: ldstr "statusCode"
+				IL_006e: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M10>:__js_call__:11"
+				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_007d: stloc.2
+				IL_007e: ldstr "status:"
+				IL_0083: ldloc.2
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0089: stloc.3
+				IL_008a: ldloc.1
+				IL_008b: ldloc.3
+				IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0091: pop
+				IL_0092: ldloc.0
+				IL_0093: ldstr ""
+				IL_0098: stfld object Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope::body
+				IL_009d: ldarg.2
+				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00a3: stloc.2
+				IL_00a4: ldc.i4.3
+				IL_00a5: newarr [System.Runtime]System.Object
+				IL_00aa: dup
+				IL_00ab: ldc.i4.0
+				IL_00ac: ldarg.0
+				IL_00ad: ldc.i4.0
+				IL_00ae: ldelem.ref
+				IL_00af: stelem.ref
+				IL_00b0: dup
+				IL_00b1: ldc.i4.1
+				IL_00b2: ldarg.0
+				IL_00b3: ldc.i4.1
+				IL_00b4: ldelem.ref
+				IL_00b5: stelem.ref
+				IL_00b6: dup
+				IL_00b7: ldc.i4.2
+				IL_00b8: ldloc.0
+				IL_00b9: stelem.ref
+				IL_00ba: stloc.s 4
+				IL_00bc: ldloc.s 4
+				IL_00be: ldc.i4.0
+				IL_00bf: ldelem.ref
+				IL_00c0: castclass Modules.Https_Request_Post_Basic/Scope
+				IL_00c5: ldloc.s 4
+				IL_00c7: ldc.i4.2
+				IL_00c8: ldelem.ref
+				IL_00c9: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope
+				IL_00ce: ldloc.s 4
+				IL_00d0: newobj instance void Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L36C22/FunctionObject::.ctor(class Modules.Https_Request_Post_Basic/Scope, class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope, object[])
+				IL_00d5: ldc.i4.1
+				IL_00d6: conv.r8
+				IL_00d7: ldstr ""
+				IL_00dc: ldc.i4.0
+				IL_00dd: ldc.i4.0
+				IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L36C22/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L36C22/FunctionObject>(!!0)
+				IL_00e8: stloc.s 5
+				IL_00ea: ldloc.2
+				IL_00eb: ldstr "on"
+				IL_00f0: ldstr "data"
+				IL_00f5: ldloc.s 5
+				IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_00fc: pop
+				IL_00fd: ldarg.2
+				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0103: stloc.2
+				IL_0104: ldc.i4.3
+				IL_0105: newarr [System.Runtime]System.Object
+				IL_010a: dup
 				IL_010b: ldc.i4.0
-				IL_010c: conv.r8
-				IL_010d: ldstr ""
-				IL_0112: ldc.i4.0
-				IL_0113: ldc.i4.0
-				IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/FunctionObject>(!!0)
-				IL_011e: stloc.s 6
-				IL_0120: ldloc.2
-				IL_0121: ldstr "on"
-				IL_0126: ldstr "end"
-				IL_012b: ldloc.s 6
-				IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0132: pop
-				IL_0133: ldnull
-				IL_0134: ret
+				IL_010c: ldarg.0
+				IL_010d: ldc.i4.0
+				IL_010e: ldelem.ref
+				IL_010f: stelem.ref
+				IL_0110: dup
+				IL_0111: ldc.i4.1
+				IL_0112: ldarg.0
+				IL_0113: ldc.i4.1
+				IL_0114: ldelem.ref
+				IL_0115: stelem.ref
+				IL_0116: dup
+				IL_0117: ldc.i4.2
+				IL_0118: ldloc.0
+				IL_0119: stelem.ref
+				IL_011a: stloc.s 4
+				IL_011c: ldloc.s 4
+				IL_011e: ldc.i4.0
+				IL_011f: ldelem.ref
+				IL_0120: castclass Modules.Https_Request_Post_Basic/Scope
+				IL_0125: ldloc.s 4
+				IL_0127: ldc.i4.2
+				IL_0128: ldelem.ref
+				IL_0129: castclass Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope
+				IL_012e: ldloc.s 4
+				IL_0130: newobj instance void Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/FunctionObject::.ctor(class Modules.Https_Request_Post_Basic/Scope, class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/Scope, object[])
+				IL_0135: ldc.i4.0
+				IL_0136: conv.r8
+				IL_0137: ldstr ""
+				IL_013c: ldc.i4.0
+				IL_013d: ldc.i4.0
+				IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/ArrowFunction_L31C5/ArrowFunction_L39C21/FunctionObject>(!!0)
+				IL_0148: stloc.s 6
+				IL_014a: ldloc.2
+				IL_014b: ldstr "on"
+				IL_0150: ldstr "end"
+				IL_0155: ldloc.s 6
+				IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_015c: pop
+				IL_015d: ldnull
+				IL_015e: ret
 			} // end of method ArrowFunction_L31C5::__js_call__
 
 		} // end of class ArrowFunction_L31C5
@@ -1510,7 +1560,7 @@
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
 			// Header size: 12
-			// Code size: 292 (0x124)
+			// Code size: 334 (0x14e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Https_Request_Post_Basic/ArrowFunction_L21C31/Scope,
@@ -1528,7 +1578,7 @@
 			IL_0007: ldfld object Modules.Https_Request_Post_Basic/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1537,14 +1587,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: ldarg.0
 			IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule Modules.Https_Request_Post_Basic/Scope::https
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1555,7 +1605,7 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "port"
 			IL_0069: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:10"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.3
@@ -1613,12 +1663,24 @@
 			IL_010b: stloc.2
 			IL_010c: ldloc.2
 			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0112: ldstr "end"
-			IL_0117: ldstr "hello tls"
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0121: pop
-			IL_0122: ldnull
-			IL_0123: ret
+			IL_0112: volatile.
+			IL_0114: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0119: brfalse IL_0132
+
+			IL_011e: ldstr "end"
+			IL_0123: ldstr "hello tls"
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_012d: br IL_014b
+
+			IL_0132: ldstr "end"
+			IL_0137: ldstr "hello tls"
+			IL_013c: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M7>:__js_call__:22"
+			IL_0141: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_014b: pop
+			IL_014c: ldnull
+			IL_014d: ret
 		} // end of method ArrowFunction_L21C31::__js_call__
 
 	} // end of class ArrowFunction_L21C31
@@ -1911,6 +1973,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_30
 	.field assembly static int32 __jroc_dynamicLookup_31
 	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
+	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
+	.field assembly static int32 __jroc_dynamicLookup_37
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
@@ -205,7 +205,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 312 (0x138)
+			// Code size: 354 (0x162)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -311,12 +311,24 @@
 			IL_011f: pop
 			IL_0120: ldarg.2
 			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0126: ldstr "end"
-			IL_012b: ldstr "url-object-ok"
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0135: pop
-			IL_0136: ldnull
-			IL_0137: ret
+			IL_0126: volatile.
+			IL_0128: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_012d: brfalse IL_0146
+
+			IL_0132: ldstr "end"
+			IL_0137: ldstr "url-object-ok"
+			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0141: br IL_015f
+
+			IL_0146: ldstr "end"
+			IL_014b: ldstr "url-object-ok"
+			IL_0150: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M6>:__js_call__:31"
+			IL_0155: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_015f: pop
+			IL_0160: ldnull
+			IL_0161: ret
 		} // end of method ArrowFunction_L7C67::__js_call__
 
 	} // end of class ArrowFunction_L7C67
@@ -696,7 +708,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 121 (0x79)
+					// Code size: 161 (0xa1)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/Scope,
@@ -750,13 +762,26 @@
 					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/ArrowFunction_L35C22/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/ArrowFunction_L35C22/FunctionObject>(!!0)
 					IL_0067: stloc.s 5
-					IL_0069: ldloc.2
-					IL_006a: ldstr "close"
-					IL_006f: ldloc.s 5
-					IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0076: pop
-					IL_0077: ldnull
-					IL_0078: ret
+					IL_0069: volatile.
+					IL_006b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+					IL_0070: brfalse IL_0087
+
+					IL_0075: ldloc.2
+					IL_0076: ldstr "close"
+					IL_007b: ldloc.s 5
+					IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0082: br IL_009e
+
+					IL_0087: ldloc.2
+					IL_0088: ldstr "close"
+					IL_008d: ldloc.s 5
+					IL_008f: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M10>:__js_call__:12"
+					IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+					IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_009e: pop
+					IL_009f: ldnull
+					IL_00a0: ret
 				} // end of method ArrowFunction_L33C21::__js_call__
 
 			} // end of class ArrowFunction_L33C21
@@ -874,7 +899,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 309 (0x135)
+				// Code size: 351 (0x15f)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope,
@@ -890,133 +915,145 @@
 				IL_0005: stloc.0
 				IL_0006: ldarg.2
 				IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_000c: ldstr "setEncoding"
-				IL_0011: ldstr "utf8"
-				IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001b: pop
-				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0021: stloc.1
-				IL_0022: volatile.
-				IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-				IL_0029: brfalse IL_003e
+				IL_000c: volatile.
+				IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+				IL_0013: brfalse IL_002c
 
-				IL_002e: ldarg.2
-				IL_002f: ldstr "statusCode"
-				IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0039: br IL_0053
+				IL_0018: ldstr "setEncoding"
+				IL_001d: ldstr "utf8"
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0027: br IL_0045
 
-				IL_003e: ldarg.2
-				IL_003f: ldstr "statusCode"
-				IL_0044: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M8>:__js_call__:11"
-				IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_002c: ldstr "setEncoding"
+				IL_0031: ldstr "utf8"
+				IL_0036: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M8>:__js_call__:5"
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0053: stloc.2
-				IL_0054: ldstr "status:"
-				IL_0059: ldloc.2
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_005f: stloc.3
-				IL_0060: ldloc.1
-				IL_0061: ldloc.3
-				IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0067: pop
-				IL_0068: ldloc.0
-				IL_0069: ldstr ""
-				IL_006e: stfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
-				IL_0073: ldarg.2
-				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0079: stloc.2
-				IL_007a: ldc.i4.3
-				IL_007b: newarr [System.Runtime]System.Object
-				IL_0080: dup
-				IL_0081: ldc.i4.0
-				IL_0082: ldarg.0
-				IL_0083: ldc.i4.0
-				IL_0084: ldelem.ref
-				IL_0085: stelem.ref
-				IL_0086: dup
-				IL_0087: ldc.i4.1
-				IL_0088: ldarg.0
-				IL_0089: ldc.i4.1
-				IL_008a: ldelem.ref
-				IL_008b: stelem.ref
-				IL_008c: dup
-				IL_008d: ldc.i4.2
-				IL_008e: ldloc.0
-				IL_008f: stelem.ref
-				IL_0090: stloc.s 4
-				IL_0092: ldloc.s 4
-				IL_0094: ldc.i4.0
-				IL_0095: ldelem.ref
-				IL_0096: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
-				IL_009b: ldloc.s 4
-				IL_009d: ldc.i4.2
-				IL_009e: ldelem.ref
-				IL_009f: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
-				IL_00a4: ldloc.s 4
-				IL_00a6: newobj instance void Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L30C22/FunctionObject::.ctor(class Modules.Https_Request_UrlObject_WithOptions/Scope, class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope, object[])
-				IL_00ab: ldc.i4.1
-				IL_00ac: conv.r8
-				IL_00ad: ldstr ""
-				IL_00b2: ldc.i4.0
-				IL_00b3: ldc.i4.0
-				IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L30C22/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L30C22/FunctionObject>(!!0)
-				IL_00be: stloc.s 5
-				IL_00c0: ldloc.2
-				IL_00c1: ldstr "on"
-				IL_00c6: ldstr "data"
-				IL_00cb: ldloc.s 5
-				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_00d2: pop
-				IL_00d3: ldarg.2
-				IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00d9: stloc.2
-				IL_00da: ldc.i4.3
-				IL_00db: newarr [System.Runtime]System.Object
-				IL_00e0: dup
-				IL_00e1: ldc.i4.0
-				IL_00e2: ldarg.0
-				IL_00e3: ldc.i4.0
-				IL_00e4: ldelem.ref
-				IL_00e5: stelem.ref
-				IL_00e6: dup
-				IL_00e7: ldc.i4.1
-				IL_00e8: ldarg.0
-				IL_00e9: ldc.i4.1
-				IL_00ea: ldelem.ref
-				IL_00eb: stelem.ref
-				IL_00ec: dup
-				IL_00ed: ldc.i4.2
-				IL_00ee: ldloc.0
-				IL_00ef: stelem.ref
-				IL_00f0: stloc.s 4
-				IL_00f2: ldloc.s 4
-				IL_00f4: ldc.i4.0
-				IL_00f5: ldelem.ref
-				IL_00f6: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
-				IL_00fb: ldloc.s 4
-				IL_00fd: ldc.i4.2
-				IL_00fe: ldelem.ref
-				IL_00ff: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
-				IL_0104: ldloc.s 4
-				IL_0106: newobj instance void Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/FunctionObject::.ctor(class Modules.Https_Request_UrlObject_WithOptions/Scope, class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope, object[])
+				IL_0045: pop
+				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_004b: stloc.1
+				IL_004c: volatile.
+				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+				IL_0053: brfalse IL_0068
+
+				IL_0058: ldarg.2
+				IL_0059: ldstr "statusCode"
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0063: br IL_007d
+
+				IL_0068: ldarg.2
+				IL_0069: ldstr "statusCode"
+				IL_006e: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M8>:__js_call__:11"
+				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_007d: stloc.2
+				IL_007e: ldstr "status:"
+				IL_0083: ldloc.2
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0089: stloc.3
+				IL_008a: ldloc.1
+				IL_008b: ldloc.3
+				IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0091: pop
+				IL_0092: ldloc.0
+				IL_0093: ldstr ""
+				IL_0098: stfld object Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope::body
+				IL_009d: ldarg.2
+				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00a3: stloc.2
+				IL_00a4: ldc.i4.3
+				IL_00a5: newarr [System.Runtime]System.Object
+				IL_00aa: dup
+				IL_00ab: ldc.i4.0
+				IL_00ac: ldarg.0
+				IL_00ad: ldc.i4.0
+				IL_00ae: ldelem.ref
+				IL_00af: stelem.ref
+				IL_00b0: dup
+				IL_00b1: ldc.i4.1
+				IL_00b2: ldarg.0
+				IL_00b3: ldc.i4.1
+				IL_00b4: ldelem.ref
+				IL_00b5: stelem.ref
+				IL_00b6: dup
+				IL_00b7: ldc.i4.2
+				IL_00b8: ldloc.0
+				IL_00b9: stelem.ref
+				IL_00ba: stloc.s 4
+				IL_00bc: ldloc.s 4
+				IL_00be: ldc.i4.0
+				IL_00bf: ldelem.ref
+				IL_00c0: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
+				IL_00c5: ldloc.s 4
+				IL_00c7: ldc.i4.2
+				IL_00c8: ldelem.ref
+				IL_00c9: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
+				IL_00ce: ldloc.s 4
+				IL_00d0: newobj instance void Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L30C22/FunctionObject::.ctor(class Modules.Https_Request_UrlObject_WithOptions/Scope, class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope, object[])
+				IL_00d5: ldc.i4.1
+				IL_00d6: conv.r8
+				IL_00d7: ldstr ""
+				IL_00dc: ldc.i4.0
+				IL_00dd: ldc.i4.0
+				IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L30C22/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L30C22/FunctionObject>(!!0)
+				IL_00e8: stloc.s 5
+				IL_00ea: ldloc.2
+				IL_00eb: ldstr "on"
+				IL_00f0: ldstr "data"
+				IL_00f5: ldloc.s 5
+				IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_00fc: pop
+				IL_00fd: ldarg.2
+				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0103: stloc.2
+				IL_0104: ldc.i4.3
+				IL_0105: newarr [System.Runtime]System.Object
+				IL_010a: dup
 				IL_010b: ldc.i4.0
-				IL_010c: conv.r8
-				IL_010d: ldstr ""
-				IL_0112: ldc.i4.0
-				IL_0113: ldc.i4.0
-				IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/FunctionObject>(!!0)
-				IL_011e: stloc.s 6
-				IL_0120: ldloc.2
-				IL_0121: ldstr "on"
-				IL_0126: ldstr "end"
-				IL_012b: ldloc.s 6
-				IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0132: pop
-				IL_0133: ldnull
-				IL_0134: ret
+				IL_010c: ldarg.0
+				IL_010d: ldc.i4.0
+				IL_010e: ldelem.ref
+				IL_010f: stelem.ref
+				IL_0110: dup
+				IL_0111: ldc.i4.1
+				IL_0112: ldarg.0
+				IL_0113: ldc.i4.1
+				IL_0114: ldelem.ref
+				IL_0115: stelem.ref
+				IL_0116: dup
+				IL_0117: ldc.i4.2
+				IL_0118: ldloc.0
+				IL_0119: stelem.ref
+				IL_011a: stloc.s 4
+				IL_011c: ldloc.s 4
+				IL_011e: ldc.i4.0
+				IL_011f: ldelem.ref
+				IL_0120: castclass Modules.Https_Request_UrlObject_WithOptions/Scope
+				IL_0125: ldloc.s 4
+				IL_0127: ldc.i4.2
+				IL_0128: ldelem.ref
+				IL_0129: castclass Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope
+				IL_012e: ldloc.s 4
+				IL_0130: newobj instance void Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/FunctionObject::.ctor(class Modules.Https_Request_UrlObject_WithOptions/Scope, class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/Scope, object[])
+				IL_0135: ldc.i4.0
+				IL_0136: conv.r8
+				IL_0137: ldstr ""
+				IL_013c: ldc.i4.0
+				IL_013d: ldc.i4.0
+				IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Https_Request_UrlObject_WithOptions/ArrowFunction_L13C31/ArrowFunction_L25C5/ArrowFunction_L33C21/FunctionObject>(!!0)
+				IL_0148: stloc.s 6
+				IL_014a: ldloc.2
+				IL_014b: ldstr "on"
+				IL_0150: ldstr "end"
+				IL_0155: ldloc.s 6
+				IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_015c: pop
+				IL_015d: ldnull
+				IL_015e: ret
 			} // end of method ArrowFunction_L25C5::__js_call__
 
 		} // end of class ArrowFunction_L25C5
@@ -1140,7 +1177,7 @@
 			IL_0007: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1149,7 +1186,7 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M7>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
@@ -1157,7 +1194,7 @@
 			IL_0042: ldfld object Modules.Https_Request_UrlObject_WithOptions/Scope::NodeUrl
 			IL_0047: stloc.s 4
 			IL_0049: volatile.
-			IL_004b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_004b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0050: brfalse IL_0065
 
 			IL_0055: ldloc.1
@@ -1168,7 +1205,7 @@
 			IL_0065: ldloc.1
 			IL_0066: ldstr "port"
 			IL_006b: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M7>:__js_call__:10"
-			IL_0070: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0070: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_007a: stloc.s 5
@@ -1239,7 +1276,7 @@
 			IL_0131: ldloc.3
 			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0137: volatile.
-			IL_0139: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0139: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_013e: brfalse IL_0152
 
 			IL_0143: ldstr "end"
@@ -1248,7 +1285,7 @@
 
 			IL_0152: ldstr "end"
 			IL_0157: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M7>:__js_call__:29"
-			IL_015c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_015c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0166: pop
@@ -1584,6 +1621,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
 	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
@@ -199,18 +199,30 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 24 (0x18)
+			// Header size: 12
+			// Code size: 66 (0x42)
 			.maxstack 8
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "end"
-			IL_000b: ldstr "ctx-ok"
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0015: pop
-			IL_0016: ldnull
-			IL_0017: ret
+			IL_0006: volatile.
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_000d: brfalse IL_0026
+
+			IL_0012: ldstr "end"
+			IL_0017: ldstr "ctx-ok"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0021: br IL_003f
+
+			IL_0026: ldstr "end"
+			IL_002b: ldstr "ctx-ok"
+			IL_0030: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M6>:__js_call__:4"
+			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_003f: pop
+			IL_0040: ldnull
+			IL_0041: ret
 		} // end of method ArrowFunction_L9C52::__js_call__
 
 	} // end of class ArrowFunction_L9C52
@@ -328,8 +340,8 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Header size: 1
-				// Code size: 46 (0x2e)
+				// Header size: 12
+				// Code size: 88 (0x58)
 				.maxstack 8
 
 				IL_0000: ldarg.0
@@ -340,12 +352,24 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_001c: ldstr "setEncoding"
-				IL_0021: ldstr "utf8"
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_002b: pop
-				IL_002c: ldnull
-				IL_002d: ret
+				IL_001c: volatile.
+				IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_0023: brfalse IL_003c
+
+				IL_0028: ldstr "setEncoding"
+				IL_002d: ldstr "utf8"
+				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0037: br IL_0055
+
+				IL_003c: ldstr "setEncoding"
+				IL_0041: ldstr "utf8"
+				IL_0046: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M8>:__js_call__:4"
+				IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0055: pop
+				IL_0056: ldnull
+				IL_0057: ret
 			} // end of method ArrowFunction_L17C5::__js_call__
 
 		} // end of class ArrowFunction_L17C5
@@ -690,7 +714,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 78 (0x4e)
+				// Code size: 117 (0x75)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/Scope,
@@ -726,13 +750,26 @@
 				IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/ArrowFunction_L27C18/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Tls_CreateSecureContext_Server_Handshake/ArrowFunction_L13C31/ArrowFunction_L26C22/ArrowFunction_L27C18/FunctionObject>(!!0)
 				IL_003e: stloc.3
-				IL_003f: ldloc.1
-				IL_0040: ldstr "close"
-				IL_0045: ldloc.3
-				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004b: pop
-				IL_004c: ldnull
-				IL_004d: ret
+				IL_003f: volatile.
+				IL_0041: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0046: brfalse IL_005c
+
+				IL_004b: ldloc.1
+				IL_004c: ldstr "close"
+				IL_0051: ldloc.3
+				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0057: br IL_0072
+
+				IL_005c: ldloc.1
+				IL_005d: ldstr "close"
+				IL_0062: ldloc.3
+				IL_0063: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M10>:__js_call__:6"
+				IL_0068: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0072: pop
+				IL_0073: ldnull
+				IL_0074: ret
 			} // end of method ArrowFunction_L26C22::__js_call__
 
 		} // end of class ArrowFunction_L26C22
@@ -864,7 +901,7 @@
 			IL_0007: ldfld object Modules.Tls_CreateSecureContext_Server_Handshake/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -873,14 +910,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M7>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: ldarg.0
 			IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule Modules.Tls_CreateSecureContext_Server_Handshake/Scope::'tls'
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -891,7 +928,7 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "port"
 			IL_0069: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M7>:__js_call__:9"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.2
@@ -1341,6 +1378,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
@@ -199,24 +199,48 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 46 (0x2e)
+			// Header size: 12
+			// Code size: 130 (0x82)
 			.maxstack 8
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "setEncoding"
-			IL_000b: ldstr "utf8"
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0015: pop
-			IL_0016: ldarg.1
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001c: ldstr "end"
-			IL_0021: ldstr "pong"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_002b: pop
-			IL_002c: ldnull
-			IL_002d: ret
+			IL_0006: volatile.
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_000d: brfalse IL_0026
+
+			IL_0012: ldstr "setEncoding"
+			IL_0017: ldstr "utf8"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0021: br IL_003f
+
+			IL_0026: ldstr "setEncoding"
+			IL_002b: ldstr "utf8"
+			IL_0030: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M6>:__js_call__:4"
+			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_003f: pop
+			IL_0040: ldarg.1
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0046: volatile.
+			IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_004d: brfalse IL_0066
+
+			IL_0052: ldstr "end"
+			IL_0057: ldstr "pong"
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0061: br IL_007f
+
+			IL_0066: ldstr "end"
+			IL_006b: ldstr "pong"
+			IL_0070: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M6>:__js_call__:9"
+			IL_0075: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_007f: pop
+			IL_0080: ldnull
+			IL_0081: ret
 		} // end of method ArrowFunction_L6C65::__js_call__
 
 	} // end of class ArrowFunction_L6C65
@@ -335,7 +359,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 393 (0x189)
+				// Code size: 477 (0x1dd)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -353,125 +377,149 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_001c: ldstr "setEncoding"
-				IL_0021: ldstr "utf8"
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_002b: pop
-				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0031: stloc.0
-				IL_0032: ldarg.0
-				IL_0033: ldc.i4.1
-				IL_0034: ldelem.ref
-				IL_0035: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
-				IL_003a: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-				IL_003f: ldstr "Cannot access 'client' before initialization"
-				IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0049: volatile.
-				IL_004b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_0050: brfalse IL_0064
+				IL_001c: volatile.
+				IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_0023: brfalse IL_003c
 
-				IL_0055: ldstr "encrypted"
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_005f: br IL_0078
+				IL_0028: ldstr "setEncoding"
+				IL_002d: ldstr "utf8"
+				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0037: br IL_0055
 
-				IL_0064: ldstr "encrypted"
-				IL_0069: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M8>:__js_call__:10"
-				IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_003c: ldstr "setEncoding"
+				IL_0041: ldstr "utf8"
+				IL_0046: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M8>:__js_call__:4"
+				IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0078: stloc.1
-				IL_0079: ldstr "client secure:"
-				IL_007e: ldloc.1
-				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0084: stloc.2
-				IL_0085: ldloc.2
-				IL_0086: ldstr ":"
-				IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0090: stloc.2
-				IL_0091: ldarg.0
-				IL_0092: ldc.i4.1
-				IL_0093: ldelem.ref
-				IL_0094: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
-				IL_0099: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-				IL_009e: ldstr "Cannot access 'client' before initialization"
-				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00a8: volatile.
-				IL_00aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-				IL_00af: brfalse IL_00c3
+				IL_0055: pop
+				IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_005b: stloc.0
+				IL_005c: ldarg.0
+				IL_005d: ldc.i4.1
+				IL_005e: ldelem.ref
+				IL_005f: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
+				IL_0064: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+				IL_0069: ldstr "Cannot access 'client' before initialization"
+				IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0073: volatile.
+				IL_0075: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_007a: brfalse IL_008e
 
-				IL_00b4: ldstr "authorized"
-				IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00be: br IL_00d7
+				IL_007f: ldstr "encrypted"
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0089: br IL_00a2
 
-				IL_00c3: ldstr "authorized"
-				IL_00c8: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M8>:__js_call__:16"
-				IL_00cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_008e: ldstr "encrypted"
+				IL_0093: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M8>:__js_call__:10"
+				IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_00d7: stloc.1
-				IL_00d8: ldloc.2
-				IL_00d9: ldloc.1
-				IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00df: stloc.2
-				IL_00e0: ldloc.2
-				IL_00e1: ldstr ":"
-				IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00eb: stloc.2
-				IL_00ec: ldarg.0
-				IL_00ed: ldc.i4.1
-				IL_00ee: ldelem.ref
-				IL_00ef: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
-				IL_00f4: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-				IL_00f9: ldstr "Cannot access 'client' before initialization"
-				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0103: volatile.
-				IL_0105: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-				IL_010a: brfalse IL_011e
+				IL_00a2: stloc.1
+				IL_00a3: ldstr "client secure:"
+				IL_00a8: ldloc.1
+				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00ae: stloc.2
+				IL_00af: ldloc.2
+				IL_00b0: ldstr ":"
+				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00ba: stloc.2
+				IL_00bb: ldarg.0
+				IL_00bc: ldc.i4.1
+				IL_00bd: ldelem.ref
+				IL_00be: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
+				IL_00c3: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+				IL_00c8: ldstr "Cannot access 'client' before initialization"
+				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_00d2: volatile.
+				IL_00d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_00d9: brfalse IL_00ed
 
-				IL_010f: ldstr "authorizationError"
-				IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0119: br IL_0132
+				IL_00de: ldstr "authorized"
+				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00e8: br IL_0101
 
-				IL_011e: ldstr "authorizationError"
-				IL_0123: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M8>:__js_call__:22"
-				IL_0128: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-				IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_00ed: ldstr "authorized"
+				IL_00f2: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M8>:__js_call__:16"
+				IL_00f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0132: stloc.1
-				IL_0133: ldloc.1
-				IL_0134: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0139: ldc.i4.0
-				IL_013a: ceq
-				IL_013c: stloc.3
-				IL_013d: ldloc.3
-				IL_013e: ldc.i4.0
-				IL_013f: ceq
-				IL_0141: stloc.3
-				IL_0142: ldloc.3
-				IL_0143: box [System.Runtime]System.Boolean
-				IL_0148: stloc.s 4
-				IL_014a: ldloc.2
-				IL_014b: ldloc.s 4
-				IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0152: stloc.2
-				IL_0153: ldloc.0
-				IL_0154: ldloc.2
-				IL_0155: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_015a: pop
-				IL_015b: ldarg.0
-				IL_015c: ldc.i4.1
-				IL_015d: ldelem.ref
-				IL_015e: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
-				IL_0163: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
-				IL_0168: ldstr "Cannot access 'client' before initialization"
-				IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0177: ldstr "write"
-				IL_017c: ldstr "ping"
-				IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0186: pop
-				IL_0187: ldnull
-				IL_0188: ret
+				IL_0101: stloc.1
+				IL_0102: ldloc.2
+				IL_0103: ldloc.1
+				IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0109: stloc.2
+				IL_010a: ldloc.2
+				IL_010b: ldstr ":"
+				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0115: stloc.2
+				IL_0116: ldarg.0
+				IL_0117: ldc.i4.1
+				IL_0118: ldelem.ref
+				IL_0119: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
+				IL_011e: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+				IL_0123: ldstr "Cannot access 'client' before initialization"
+				IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_012d: volatile.
+				IL_012f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+				IL_0134: brfalse IL_0148
+
+				IL_0139: ldstr "authorizationError"
+				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0143: br IL_015c
+
+				IL_0148: ldstr "authorizationError"
+				IL_014d: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M8>:__js_call__:22"
+				IL_0152: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+				IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+				IL_015c: stloc.1
+				IL_015d: ldloc.1
+				IL_015e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0163: ldc.i4.0
+				IL_0164: ceq
+				IL_0166: stloc.3
+				IL_0167: ldloc.3
+				IL_0168: ldc.i4.0
+				IL_0169: ceq
+				IL_016b: stloc.3
+				IL_016c: ldloc.3
+				IL_016d: box [System.Runtime]System.Boolean
+				IL_0172: stloc.s 4
+				IL_0174: ldloc.2
+				IL_0175: ldloc.s 4
+				IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_017c: stloc.2
+				IL_017d: ldloc.0
+				IL_017e: ldloc.2
+				IL_017f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0184: pop
+				IL_0185: ldarg.0
+				IL_0186: ldc.i4.1
+				IL_0187: ldelem.ref
+				IL_0188: castclass Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope
+				IL_018d: ldfld object Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/Scope::client
+				IL_0192: ldstr "Cannot access 'client' before initialization"
+				IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01a1: volatile.
+				IL_01a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_01a8: brfalse IL_01c1
+
+				IL_01ad: ldstr "write"
+				IL_01b2: ldstr "ping"
+				IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01bc: br IL_01da
+
+				IL_01c1: ldstr "write"
+				IL_01c6: ldstr "ping"
+				IL_01cb: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M8>:__js_call__:32"
+				IL_01d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_01da: pop
+				IL_01db: ldnull
+				IL_01dc: ret
 			} // end of method ArrowFunction_L17C5::__js_call__
 
 		} // end of class ArrowFunction_L17C5
@@ -816,7 +864,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 78 (0x4e)
+				// Code size: 117 (0x75)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/Scope,
@@ -852,13 +900,26 @@
 				IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/ArrowFunction_L29C18/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Tls_CreateServer_Connect_Basic/ArrowFunction_L11C31/ArrowFunction_L28C22/ArrowFunction_L29C18/FunctionObject>(!!0)
 				IL_003e: stloc.3
-				IL_003f: ldloc.1
-				IL_0040: ldstr "close"
-				IL_0045: ldloc.3
-				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_004b: pop
-				IL_004c: ldnull
-				IL_004d: ret
+				IL_003f: volatile.
+				IL_0041: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_0046: brfalse IL_005c
+
+				IL_004b: ldloc.1
+				IL_004c: ldstr "close"
+				IL_0051: ldloc.3
+				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0057: br IL_0072
+
+				IL_005c: ldloc.1
+				IL_005d: ldstr "close"
+				IL_0062: ldloc.3
+				IL_0063: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M10>:__js_call__:6"
+				IL_0068: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0072: pop
+				IL_0073: ldnull
+				IL_0074: ret
 			} // end of method ArrowFunction_L28C22::__js_call__
 
 		} // end of class ArrowFunction_L28C22
@@ -992,7 +1053,7 @@
 			IL_0007: ldfld object Modules.Tls_CreateServer_Connect_Basic/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1001,14 +1062,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M7>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0046: stloc.2
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1019,7 +1080,7 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "address"
 			IL_0069: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M7>:__js_call__:10"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.3
@@ -1038,7 +1099,7 @@
 			IL_009d: ldarg.0
 			IL_009e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITlsModule Modules.Tls_CreateServer_Connect_Basic/Scope::'tls'
 			IL_00a3: volatile.
-			IL_00a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_00a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_00aa: brfalse IL_00bf
 
 			IL_00af: ldloc.1
@@ -1049,7 +1110,7 @@
 			IL_00bf: ldloc.1
 			IL_00c0: ldstr "port"
 			IL_00c5: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M7>:__js_call__:18"
-			IL_00ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_00ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00d4: stloc.3
@@ -1463,6 +1524,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_18
 	.field assembly static int32 __jroc_dynamicLookup_19
 	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly.verified.txt
@@ -171,7 +171,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 398 (0x18e)
+		// Code size: 438 (0x1b6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly/Scope,
@@ -260,76 +260,89 @@
 			IL_00d0: ldc.i4.1
 			IL_00d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_00d6: stloc.s 9
-			IL_00d8: ldloc.1
-			IL_00d9: ldstr "createServer"
-			IL_00de: ldloc.s 9
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00e5: pop
-			IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00eb: stloc.s 10
-			IL_00ed: ldloc.s 10
-			IL_00ef: ldstr "unexpected success"
-			IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00f9: pop
-			IL_00fa: leave IL_018a
+			IL_00d8: volatile.
+			IL_00da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_00df: brfalse IL_00f6
+
+			IL_00e4: ldloc.1
+			IL_00e5: ldstr "createServer"
+			IL_00ea: ldloc.s 9
+			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00f1: br IL_010d
+
+			IL_00f6: ldloc.1
+			IL_00f7: ldstr "createServer"
+			IL_00fc: ldloc.s 9
+			IL_00fe: ldstr "Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly:Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly:__js_module_init__:30"
+			IL_0103: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_010d: pop
+			IL_010e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0113: stloc.s 10
+			IL_0115: ldloc.s 10
+			IL_0117: ldstr "unexpected success"
+			IL_011c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0121: pop
+			IL_0122: leave IL_01b2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00ff: stloc.s 4
-			IL_0101: ldloc.s 4
-			IL_0103: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0108: dup
-			IL_0109: brtrue IL_011f
+			IL_0127: stloc.s 4
+			IL_0129: ldloc.s 4
+			IL_012b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0130: dup
+			IL_0131: brtrue IL_0147
 
-			IL_010e: pop
-			IL_010f: ldloc.s 4
-			IL_0111: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0116: dup
-			IL_0117: brtrue IL_012b
+			IL_0136: pop
+			IL_0137: ldloc.s 4
+			IL_0139: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_013e: dup
+			IL_013f: brtrue IL_0153
 
-			IL_011c: pop
-			IL_011d: rethrow
+			IL_0144: pop
+			IL_0145: rethrow
 
-			IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0124: stloc.s 5
-			IL_0126: br IL_012d
+			IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_014c: stloc.s 5
+			IL_014e: br IL_0155
 
-			IL_012b: stloc.s 5
+			IL_0153: stloc.s 5
 
-			IL_012d: ldloc.s 5
-			IL_012f: stloc.s 6
-			IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0136: stloc.s 10
-			IL_0138: volatile.
-			IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-			IL_013f: brfalse IL_0155
+			IL_0155: ldloc.s 5
+			IL_0157: stloc.s 6
+			IL_0159: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_015e: stloc.s 10
+			IL_0160: volatile.
+			IL_0162: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_0167: brfalse IL_017d
 
-			IL_0144: ldloc.s 6
-			IL_0146: ldstr "message"
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0150: br IL_016b
+			IL_016c: ldloc.s 6
+			IL_016e: ldstr "message"
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0178: br IL_0193
 
-			IL_0155: ldloc.s 6
-			IL_0157: ldstr "message"
-			IL_015c: ldstr "Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly:Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly:__js_module_init__:46"
-			IL_0161: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-			IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_017d: ldloc.s 6
+			IL_017f: ldstr "message"
+			IL_0184: ldstr "Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly:Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly:__js_module_init__:46"
+			IL_0189: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_016b: stloc.s 8
-			IL_016d: ldstr "message:"
-			IL_0172: ldloc.s 8
-			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0179: stloc.s 11
-			IL_017b: ldloc.s 10
-			IL_017d: ldloc.s 11
-			IL_017f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0184: pop
-			IL_0185: leave IL_018a
+			IL_0193: stloc.s 8
+			IL_0195: ldstr "message:"
+			IL_019a: ldloc.s 8
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01a1: stloc.s 11
+			IL_01a3: ldloc.s 10
+			IL_01a5: ldloc.s 11
+			IL_01a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01ac: pop
+			IL_01ad: leave IL_01b2
 		} // end handler
 
-		IL_018a: ldnull
-		IL_018b: stloc.s 7
-		IL_018d: ret
+		IL_01b2: ldnull
+		IL_01b3: stloc.s 7
+		IL_01b5: ret
 	} // end of method Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly::__js_module_init__
 
 } // end of class Modules.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly
@@ -428,6 +441,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
@@ -229,7 +229,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 60 (0x3c)
+				// Code size: 102 (0x66)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -245,22 +245,34 @@
 				IL_000d: stloc.0
 				IL_000e: ldarg.2
 				IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0014: ldstr "toString"
-				IL_0019: ldstr "utf8"
-				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0023: stloc.1
-				IL_0024: ldloc.0
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_002b: stloc.2
-				IL_002c: ldarg.0
-				IL_002d: ldc.i4.1
-				IL_002e: ldelem.ref
-				IL_002f: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
-				IL_0034: ldloc.2
-				IL_0035: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
-				IL_003a: ldnull
-				IL_003b: ret
+				IL_0014: volatile.
+				IL_0016: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+				IL_001b: brfalse IL_0034
+
+				IL_0020: ldstr "toString"
+				IL_0025: ldstr "utf8"
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_002f: br IL_004d
+
+				IL_0034: ldstr "toString"
+				IL_0039: ldstr "utf8"
+				IL_003e: ldstr "Net_CreateServer_AllowHalfOpen_Delayed_Response:<TwoPhaseDummy_M6>:__js_call__:5"
+				IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_004d: stloc.1
+				IL_004e: ldloc.0
+				IL_004f: ldloc.1
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0055: stloc.2
+				IL_0056: ldarg.0
+				IL_0057: ldc.i4.1
+				IL_0058: ldelem.ref
+				IL_0059: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
+				IL_005e: ldloc.2
+				IL_005f: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
+				IL_0064: ldnull
+				IL_0065: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -415,7 +427,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 217 (0xd9)
+					// Code size: 256 (0x100)
 					.maxstack 8
 					.locals init (
 						[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -432,7 +444,7 @@
 					IL_0009: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
 					IL_000e: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::socket
 					IL_0013: volatile.
-					IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+					IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 					IL_001a: brfalse IL_002e
 
 					IL_001f: ldstr "writable"
@@ -441,7 +453,7 @@
 
 					IL_002e: ldstr "writable"
 					IL_0033: ldstr "Net_CreateServer_AllowHalfOpen_Delayed_Response:<TwoPhaseDummy_M11>:__js_call__:5"
-					IL_0038: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+					IL_0038: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 					IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 					IL_0042: stloc.1
@@ -498,13 +510,26 @@
 					IL_00c3: ldloc.3
 					IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 					IL_00c9: stloc.2
-					IL_00ca: ldloc.1
-					IL_00cb: ldstr "end"
-					IL_00d0: ldloc.2
-					IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_00d6: pop
-					IL_00d7: ldnull
-					IL_00d8: ret
+					IL_00ca: volatile.
+					IL_00cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+					IL_00d1: brfalse IL_00e7
+
+					IL_00d6: ldloc.1
+					IL_00d7: ldstr "end"
+					IL_00dc: ldloc.2
+					IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_00e2: br IL_00fd
+
+					IL_00e7: ldloc.1
+					IL_00e8: ldstr "end"
+					IL_00ed: ldloc.2
+					IL_00ee: ldstr "Net_CreateServer_AllowHalfOpen_Delayed_Response:<TwoPhaseDummy_M11>:__js_call__:16"
+					IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+					IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_00fd: pop
+					IL_00fe: ldnull
+					IL_00ff: ret
 				} // end of method FunctionExpression_server::__js_call__
 
 			} // end of class FunctionExpression_server
@@ -1156,8 +1181,8 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Header size: 1
-				// Code size: 46 (0x2e)
+				// Header size: 12
+				// Code size: 88 (0x58)
 				.maxstack 8
 
 				IL_0000: ldarg.0
@@ -1168,12 +1193,24 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_001c: ldstr "end"
-				IL_0021: ldstr "ping"
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_002b: pop
-				IL_002c: ldnull
-				IL_002d: ret
+				IL_001c: volatile.
+				IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_0023: brfalse IL_003c
+
+				IL_0028: ldstr "end"
+				IL_002d: ldstr "ping"
+				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0037: br IL_0055
+
+				IL_003c: ldstr "end"
+				IL_0041: ldstr "ping"
+				IL_0046: ldstr "Net_CreateServer_AllowHalfOpen_Delayed_Response:<TwoPhaseDummy_M8>:__js_call__:4"
+				IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0055: pop
+				IL_0056: ldnull
+				IL_0057: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -1647,7 +1684,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 116 (0x74)
+				// Code size: 156 (0x9c)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/Scope,
@@ -1700,13 +1737,26 @@
 				IL_005c: ldc.i4.1
 				IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0062: stloc.s 5
-				IL_0064: ldloc.2
-				IL_0065: ldstr "close"
-				IL_006a: ldloc.s 5
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0071: pop
-				IL_0072: ldnull
-				IL_0073: ret
+				IL_0064: volatile.
+				IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_006b: brfalse IL_0082
+
+				IL_0070: ldloc.2
+				IL_0071: ldstr "close"
+				IL_0076: ldloc.s 5
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007d: br IL_0099
+
+				IL_0082: ldloc.2
+				IL_0083: ldstr "close"
+				IL_0088: ldloc.s 5
+				IL_008a: ldstr "Net_CreateServer_AllowHalfOpen_Delayed_Response:<TwoPhaseDummy_M10>:__js_call__:12"
+				IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0099: pop
+				IL_009a: ldnull
+				IL_009b: ret
 			} // end of method FunctionExpression_L34C19::__js_call__
 
 		} // end of class FunctionExpression_L34C19
@@ -1857,7 +1907,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 496 (0x1f0)
+			// Code size: 538 (0x21a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope,
@@ -1965,95 +2015,107 @@
 			IL_0100: ldstr "Cannot access 'client' before initialization"
 			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010f: ldstr "setEncoding"
-			IL_0114: ldstr "utf8"
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_011e: pop
-			IL_011f: ldloc.0
-			IL_0120: ldstr ""
-			IL_0125: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
-			IL_012a: ldloc.0
-			IL_012b: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_0130: ldstr "Cannot access 'client' before initialization"
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013f: stloc.3
-			IL_0140: ldc.i4.2
-			IL_0141: newarr [System.Runtime]System.Object
-			IL_0146: dup
-			IL_0147: ldc.i4.0
-			IL_0148: ldarg.0
-			IL_0149: stelem.ref
-			IL_014a: dup
-			IL_014b: ldc.i4.1
-			IL_014c: ldloc.0
-			IL_014d: stelem.ref
-			IL_014e: stloc.s 4
-			IL_0150: ldloc.s 4
-			IL_0152: ldc.i4.0
-			IL_0153: ldelem.ref
-			IL_0154: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-			IL_0159: ldloc.s 4
-			IL_015b: ldc.i4.1
-			IL_015c: ldelem.ref
-			IL_015d: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
-			IL_0162: ldloc.s 4
-			IL_0164: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
-			IL_0169: ldc.i4.1
-			IL_016a: conv.r8
-			IL_016b: ldstr ""
-			IL_0170: ldc.i4.0
-			IL_0171: ldc.i4.1
-			IL_0172: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0177: stloc.s 6
-			IL_0179: ldloc.3
-			IL_017a: ldstr "on"
-			IL_017f: ldstr "data"
-			IL_0184: ldloc.s 6
-			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_018b: pop
-			IL_018c: ldloc.0
-			IL_018d: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
-			IL_0192: ldstr "Cannot access 'client' before initialization"
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a1: stloc.3
-			IL_01a2: ldc.i4.2
-			IL_01a3: newarr [System.Runtime]System.Object
-			IL_01a8: dup
-			IL_01a9: ldc.i4.0
-			IL_01aa: ldarg.0
-			IL_01ab: stelem.ref
-			IL_01ac: dup
-			IL_01ad: ldc.i4.1
-			IL_01ae: ldloc.0
-			IL_01af: stelem.ref
-			IL_01b0: stloc.s 4
-			IL_01b2: ldloc.s 4
-			IL_01b4: ldc.i4.0
-			IL_01b5: ldelem.ref
-			IL_01b6: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-			IL_01bb: ldloc.s 4
-			IL_01bd: ldc.i4.1
-			IL_01be: ldelem.ref
-			IL_01bf: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
-			IL_01c4: ldloc.s 4
-			IL_01c6: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
-			IL_01cb: ldc.i4.0
-			IL_01cc: conv.r8
-			IL_01cd: ldstr ""
-			IL_01d2: ldc.i4.0
-			IL_01d3: ldc.i4.1
-			IL_01d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_01d9: stloc.s 7
-			IL_01db: ldloc.3
-			IL_01dc: ldstr "on"
-			IL_01e1: ldstr "end"
-			IL_01e6: ldloc.s 7
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01ed: pop
-			IL_01ee: ldnull
-			IL_01ef: ret
+			IL_010f: volatile.
+			IL_0111: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0116: brfalse IL_012f
+
+			IL_011b: ldstr "setEncoding"
+			IL_0120: ldstr "utf8"
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_012a: br IL_0148
+
+			IL_012f: ldstr "setEncoding"
+			IL_0134: ldstr "utf8"
+			IL_0139: ldstr "Net_CreateServer_AllowHalfOpen_Delayed_Response:<TwoPhaseDummy_M5>:__js_call__:20"
+			IL_013e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0148: pop
+			IL_0149: ldloc.0
+			IL_014a: ldstr ""
+			IL_014f: stfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::reply
+			IL_0154: ldloc.0
+			IL_0155: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_015a: ldstr "Cannot access 'client' before initialization"
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0169: stloc.3
+			IL_016a: ldc.i4.2
+			IL_016b: newarr [System.Runtime]System.Object
+			IL_0170: dup
+			IL_0171: ldc.i4.0
+			IL_0172: ldarg.0
+			IL_0173: stelem.ref
+			IL_0174: dup
+			IL_0175: ldc.i4.1
+			IL_0176: ldloc.0
+			IL_0177: stelem.ref
+			IL_0178: stloc.s 4
+			IL_017a: ldloc.s 4
+			IL_017c: ldc.i4.0
+			IL_017d: ldelem.ref
+			IL_017e: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
+			IL_0183: ldloc.s 4
+			IL_0185: ldc.i4.1
+			IL_0186: ldelem.ref
+			IL_0187: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
+			IL_018c: ldloc.s 4
+			IL_018e: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
+			IL_0193: ldc.i4.1
+			IL_0194: conv.r8
+			IL_0195: ldstr ""
+			IL_019a: ldc.i4.0
+			IL_019b: ldc.i4.1
+			IL_019c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01a1: stloc.s 6
+			IL_01a3: ldloc.3
+			IL_01a4: ldstr "on"
+			IL_01a9: ldstr "data"
+			IL_01ae: ldloc.s 6
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01b5: pop
+			IL_01b6: ldloc.0
+			IL_01b7: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::client
+			IL_01bc: ldstr "Cannot access 'client' before initialization"
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cb: stloc.3
+			IL_01cc: ldc.i4.2
+			IL_01cd: newarr [System.Runtime]System.Object
+			IL_01d2: dup
+			IL_01d3: ldc.i4.0
+			IL_01d4: ldarg.0
+			IL_01d5: stelem.ref
+			IL_01d6: dup
+			IL_01d7: ldc.i4.1
+			IL_01d8: ldloc.0
+			IL_01d9: stelem.ref
+			IL_01da: stloc.s 4
+			IL_01dc: ldloc.s 4
+			IL_01de: ldc.i4.0
+			IL_01df: ldelem.ref
+			IL_01e0: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
+			IL_01e5: ldloc.s 4
+			IL_01e7: ldc.i4.1
+			IL_01e8: ldelem.ref
+			IL_01e9: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
+			IL_01ee: ldloc.s 4
+			IL_01f0: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
+			IL_01f5: ldc.i4.0
+			IL_01f6: conv.r8
+			IL_01f7: ldstr ""
+			IL_01fc: ldc.i4.0
+			IL_01fd: ldc.i4.1
+			IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0203: stloc.s 7
+			IL_0205: ldloc.3
+			IL_0206: ldstr "on"
+			IL_020b: ldstr "end"
+			IL_0210: ldloc.s 7
+			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0217: pop
+			IL_0218: ldnull
+			IL_0219: ret
 		} // end of method FunctionExpression_L22C30::__js_call__
 
 	} // end of class FunctionExpression_L22C30
@@ -2221,6 +2283,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_29
 	.field assembly static int32 __jroc_dynamicLookup_30
 	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
+	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
@@ -229,7 +229,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 60 (0x3c)
+				// Code size: 102 (0x66)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -245,22 +245,34 @@
 				IL_000d: stloc.0
 				IL_000e: ldarg.2
 				IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0014: ldstr "toString"
-				IL_0019: ldstr "utf8"
-				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0023: stloc.1
-				IL_0024: ldloc.0
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_002b: stloc.2
-				IL_002c: ldarg.0
-				IL_002d: ldc.i4.1
-				IL_002e: ldelem.ref
-				IL_002f: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
-				IL_0034: ldloc.2
-				IL_0035: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
-				IL_003a: ldnull
-				IL_003b: ret
+				IL_0014: volatile.
+				IL_0016: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+				IL_001b: brfalse IL_0034
+
+				IL_0020: ldstr "toString"
+				IL_0025: ldstr "utf8"
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_002f: br IL_004d
+
+				IL_0034: ldstr "toString"
+				IL_0039: ldstr "utf8"
+				IL_003e: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M6>:__js_call__:5"
+				IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_004d: stloc.1
+				IL_004e: ldloc.0
+				IL_004f: ldloc.1
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0055: stloc.2
+				IL_0056: ldarg.0
+				IL_0057: ldc.i4.1
+				IL_0058: ldelem.ref
+				IL_0059: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
+				IL_005e: ldloc.2
+				IL_005f: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
+				IL_0064: ldnull
+				IL_0065: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -411,7 +423,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 236 (0xec)
+				// Code size: 275 (0x113)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -481,33 +493,46 @@
 				IL_0094: ldloc.3
 				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 				IL_009a: stloc.2
-				IL_009b: ldloc.1
-				IL_009c: ldstr "write"
-				IL_00a1: ldloc.2
-				IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00a7: pop
-				IL_00a8: ldarg.0
-				IL_00a9: ldc.i4.1
-				IL_00aa: ldelem.ref
-				IL_00ab: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
-				IL_00b0: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
-				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ba: volatile.
-				IL_00bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-				IL_00c1: brfalse IL_00d5
+				IL_009b: volatile.
+				IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+				IL_00a2: brfalse IL_00b8
 
-				IL_00c6: ldstr "end"
-				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_00d0: br IL_00e9
+				IL_00a7: ldloc.1
+				IL_00a8: ldstr "write"
+				IL_00ad: ldloc.2
+				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00b3: br IL_00ce
 
-				IL_00d5: ldstr "end"
-				IL_00da: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M7>:__js_call__:18"
-				IL_00df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+				IL_00b8: ldloc.1
+				IL_00b9: ldstr "write"
+				IL_00be: ldloc.2
+				IL_00bf: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M7>:__js_call__:14"
+				IL_00c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_00e9: pop
-				IL_00ea: ldnull
-				IL_00eb: ret
+				IL_00ce: pop
+				IL_00cf: ldarg.0
+				IL_00d0: ldc.i4.1
+				IL_00d1: ldelem.ref
+				IL_00d2: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
+				IL_00d7: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
+				IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00e1: volatile.
+				IL_00e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_00e8: brfalse IL_00fc
+
+				IL_00ed: ldstr "end"
+				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_00f7: br IL_0110
+
+				IL_00fc: ldstr "end"
+				IL_0101: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M7>:__js_call__:18"
+				IL_0106: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+				IL_0110: pop
+				IL_0111: ldnull
+				IL_0112: ret
 			} // end of method FunctionExpression_server_L12C19::__js_call__
 
 		} // end of class FunctionExpression_server_L12C19
@@ -911,8 +936,8 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Header size: 1
-				// Code size: 46 (0x2e)
+				// Header size: 12
+				// Code size: 88 (0x58)
 				.maxstack 8
 
 				IL_0000: ldarg.0
@@ -923,12 +948,24 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_001c: ldstr "end"
-				IL_0021: ldstr "ping"
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_002b: pop
-				IL_002c: ldnull
-				IL_002d: ret
+				IL_001c: volatile.
+				IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_0023: brfalse IL_003c
+
+				IL_0028: ldstr "end"
+				IL_002d: ldstr "ping"
+				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0037: br IL_0055
+
+				IL_003c: ldstr "end"
+				IL_0041: ldstr "ping"
+				IL_0046: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M8>:__js_call__:4"
+				IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0055: pop
+				IL_0056: ldnull
+				IL_0057: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -1086,7 +1123,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 60 (0x3c)
+				// Code size: 102 (0x66)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -1102,22 +1139,34 @@
 				IL_000d: stloc.0
 				IL_000e: ldarg.2
 				IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0014: ldstr "toString"
-				IL_0019: ldstr "utf8"
-				IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0023: stloc.1
-				IL_0024: ldloc.0
-				IL_0025: ldloc.1
-				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_002b: stloc.2
-				IL_002c: ldarg.0
-				IL_002d: ldc.i4.1
-				IL_002e: ldelem.ref
-				IL_002f: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
-				IL_0034: ldloc.2
-				IL_0035: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
-				IL_003a: ldnull
-				IL_003b: ret
+				IL_0014: volatile.
+				IL_0016: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_001b: brfalse IL_0034
+
+				IL_0020: ldstr "toString"
+				IL_0025: ldstr "utf8"
+				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_002f: br IL_004d
+
+				IL_0034: ldstr "toString"
+				IL_0039: ldstr "utf8"
+				IL_003e: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M9>:__js_call__:5"
+				IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_004d: stloc.1
+				IL_004e: ldloc.0
+				IL_004f: ldloc.1
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0055: stloc.2
+				IL_0056: ldarg.0
+				IL_0057: ldc.i4.1
+				IL_0058: ldelem.ref
+				IL_0059: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
+				IL_005e: ldloc.2
+				IL_005f: stfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::reply
+				IL_0064: ldnull
+				IL_0065: ret
 			} // end of method FunctionExpression_L28C20::__js_call__
 
 		} // end of class FunctionExpression_L28C20
@@ -1409,7 +1458,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 116 (0x74)
+				// Code size: 156 (0x9c)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/Scope,
@@ -1462,13 +1511,26 @@
 				IL_005c: ldc.i4.1
 				IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0062: stloc.s 5
-				IL_0064: ldloc.2
-				IL_0065: ldstr "close"
-				IL_006a: ldloc.s 5
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0071: pop
-				IL_0072: ldnull
-				IL_0073: ret
+				IL_0064: volatile.
+				IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_006b: brfalse IL_0082
+
+				IL_0070: ldloc.2
+				IL_0071: ldstr "close"
+				IL_0076: ldloc.s 5
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007d: br IL_0099
+
+				IL_0082: ldloc.2
+				IL_0083: ldstr "close"
+				IL_0088: ldloc.s 5
+				IL_008a: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M10>:__js_call__:12"
+				IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0099: pop
+				IL_009a: ldnull
+				IL_009b: ret
 			} // end of method FunctionExpression_L32C19::__js_call__
 
 		} // end of class FunctionExpression_L32C19
@@ -1642,7 +1704,7 @@
 			IL_0007: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1651,14 +1713,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0046: stloc.2
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1669,7 +1731,7 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "family"
 			IL_0069: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M5>:__js_call__:10"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.3
@@ -1682,7 +1744,7 @@
 			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0092: stloc.s 4
 			IL_0094: volatile.
-			IL_0096: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0096: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_009b: brfalse IL_00b0
 
 			IL_00a0: ldloc.1
@@ -1693,7 +1755,7 @@
 			IL_00b0: ldloc.1
 			IL_00b1: ldstr "address"
 			IL_00b6: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M5>:__js_call__:15"
-			IL_00bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_00bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00c5: stloc.3
@@ -1706,7 +1768,7 @@
 			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_00dc: stloc.s 4
 			IL_00de: volatile.
-			IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_00e5: brfalse IL_00fa
 
 			IL_00ea: ldloc.1
@@ -1717,7 +1779,7 @@
 			IL_00fa: ldloc.1
 			IL_00fb: ldstr "port"
 			IL_0100: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M5>:__js_call__:20"
-			IL_0105: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0105: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_010f: stloc.3
@@ -1740,7 +1802,7 @@
 			IL_0140: ldarg.0
 			IL_0141: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_CreateServer_Connect_Basic/Scope::net
 			IL_0146: volatile.
-			IL_0148: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0148: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_014d: brfalse IL_0162
 
 			IL_0152: ldloc.1
@@ -1751,12 +1813,12 @@
 			IL_0162: ldloc.1
 			IL_0163: ldstr "port"
 			IL_0168: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M5>:__js_call__:30"
-			IL_016d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_016d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0177: stloc.3
 			IL_0178: volatile.
-			IL_017a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_017a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_017f: brfalse IL_0194
 
 			IL_0184: ldloc.1
@@ -1767,7 +1829,7 @@
 			IL_0194: ldloc.1
 			IL_0195: ldstr "address"
 			IL_019a: ldstr "Net_CreateServer_Connect_Basic:<TwoPhaseDummy_M5>:__js_call__:32"
-			IL_019f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_019f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01a9: stloc.s 7
@@ -1937,7 +1999,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 180 (0xb4)
+		// Code size: 218 (0xda)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_CreateServer_Connect_Basic/Scope,
@@ -1979,45 +2041,57 @@
 		IL_0040: ldc.i4.1
 		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
-		IL_0047: ldstr "createServer"
-		IL_004c: ldloc.3
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0052: stloc.s 4
-		IL_0054: ldloc.0
-		IL_0055: ldloc.s 4
-		IL_0057: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-		IL_005c: ldloc.0
-		IL_005d: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0067: stloc.s 4
-		IL_0069: ldc.i4.1
-		IL_006a: newarr [System.Runtime]System.Object
-		IL_006f: dup
-		IL_0070: ldc.i4.0
-		IL_0071: ldloc.0
-		IL_0072: stelem.ref
-		IL_0073: stloc.2
-		IL_0074: ldloc.2
-		IL_0075: ldc.i4.0
-		IL_0076: ldelem.ref
-		IL_0077: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-		IL_007c: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
-		IL_0081: ldc.i4.0
-		IL_0082: conv.r8
-		IL_0083: ldstr ""
-		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.s 4
-		IL_0093: ldstr "listen"
-		IL_0098: ldc.r8 0.0
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: ldstr "127.0.0.1"
-		IL_00ab: ldloc.s 5
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b2: pop
-		IL_00b3: ret
+		IL_0047: volatile.
+		IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_004e: brfalse IL_0063
+
+		IL_0053: ldstr "createServer"
+		IL_0058: ldloc.3
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005e: br IL_0078
+
+		IL_0063: ldstr "createServer"
+		IL_0068: ldloc.3
+		IL_0069: ldstr "Net_CreateServer_Connect_Basic:Modules.Net_CreateServer_Connect_Basic:__js_module_init__:12"
+		IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0078: stloc.s 4
+		IL_007a: ldloc.0
+		IL_007b: ldloc.s 4
+		IL_007d: stfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
+		IL_0082: ldloc.0
+		IL_0083: ldfld object Modules.Net_CreateServer_Connect_Basic/Scope::server
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008d: stloc.s 4
+		IL_008f: ldc.i4.1
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldloc.0
+		IL_0098: stelem.ref
+		IL_0099: stloc.2
+		IL_009a: ldloc.2
+		IL_009b: ldc.i4.0
+		IL_009c: ldelem.ref
+		IL_009d: castclass Modules.Net_CreateServer_Connect_Basic/Scope
+		IL_00a2: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
+		IL_00a7: ldc.i4.0
+		IL_00a8: conv.r8
+		IL_00a9: ldstr ""
+		IL_00ae: ldc.i4.0
+		IL_00af: ldc.i4.1
+		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b5: stloc.s 5
+		IL_00b7: ldloc.s 4
+		IL_00b9: ldstr "listen"
+		IL_00be: ldc.r8 0.0
+		IL_00c7: box [System.Runtime]System.Double
+		IL_00cc: ldstr "127.0.0.1"
+		IL_00d1: ldloc.s 5
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00d8: pop
+		IL_00d9: ret
 	} // end of method Net_CreateServer_Connect_Basic::__js_module_init__
 
 } // end of class Modules.Net_CreateServer_Connect_Basic
@@ -2054,6 +2128,12 @@
 	.field assembly static int32 __jroc_dynamicLookup_28
 	.field assembly static int32 __jroc_dynamicLookup_29
 	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
+	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
@@ -250,7 +250,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 549 (0x225)
+				// Code size: 590 (0x24e)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
@@ -449,13 +449,26 @@
 				IL_020c: ldloc.1
 				IL_020d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 				IL_0212: stloc.s 13
-				IL_0214: ldloc.s 5
-				IL_0216: ldstr "end"
-				IL_021b: ldloc.s 13
-				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0222: pop
-				IL_0223: ldnull
-				IL_0224: ret
+				IL_0214: volatile.
+				IL_0216: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_021b: brfalse IL_0233
+
+				IL_0220: ldloc.s 5
+				IL_0222: ldstr "end"
+				IL_0227: ldloc.s 13
+				IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_022e: br IL_024b
+
+				IL_0233: ldloc.s 5
+				IL_0235: ldstr "end"
+				IL_023a: ldloc.s 13
+				IL_023c: ldstr "Net_Socket_Binary_Data_Defaults_To_Buffer:<TwoPhaseDummy_M6>:__js_call__:77"
+				IL_0241: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_024b: pop
+				IL_024c: ldnull
+				IL_024d: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -832,7 +845,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 114 (0x72)
+				// Code size: 152 (0x98)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
@@ -862,12 +875,24 @@
 				IL_0059: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 				IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 				IL_0063: stloc.0
-				IL_0064: ldstr "write"
-				IL_0069: ldloc.0
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_006f: pop
-				IL_0070: ldnull
-				IL_0071: ret
+				IL_0064: volatile.
+				IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_006b: brfalse IL_0080
+
+				IL_0070: ldstr "write"
+				IL_0075: ldloc.0
+				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007b: br IL_0095
+
+				IL_0080: ldstr "write"
+				IL_0085: ldloc.0
+				IL_0086: ldstr "Net_Socket_Binary_Data_Defaults_To_Buffer:<TwoPhaseDummy_M7>:__js_call__:9"
+				IL_008b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0095: pop
+				IL_0096: ldnull
+				IL_0097: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -1067,7 +1092,7 @@
 				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0058: volatile.
-				IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 				IL_005f: brfalse IL_0073
 
 				IL_0064: ldstr "end"
@@ -1076,7 +1101,7 @@
 
 				IL_0073: ldstr "end"
 				IL_0078: ldstr "Net_Socket_Binary_Data_Defaults_To_Buffer:<TwoPhaseDummy_M8>:__js_call__:15"
-				IL_007d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_007d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0087: pop
@@ -1373,7 +1398,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 304 (0x130)
+				// Code size: 345 (0x159)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/Scope,
@@ -1483,13 +1508,26 @@
 				IL_0117: ldc.i4.1
 				IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_011d: stloc.s 8
-				IL_011f: ldloc.s 6
-				IL_0121: ldstr "close"
-				IL_0126: ldloc.s 8
-				IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_012d: pop
-				IL_012e: ldnull
-				IL_012f: ret
+				IL_011f: volatile.
+				IL_0121: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+				IL_0126: brfalse IL_013e
+
+				IL_012b: ldloc.s 6
+				IL_012d: ldstr "close"
+				IL_0132: ldloc.s 8
+				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0139: br IL_0156
+
+				IL_013e: ldloc.s 6
+				IL_0140: ldstr "close"
+				IL_0145: ldloc.s 8
+				IL_0147: ldstr "Net_Socket_Binary_Data_Defaults_To_Buffer:<TwoPhaseDummy_M9>:__js_call__:36"
+				IL_014c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+				IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0156: pop
+				IL_0157: ldnull
+				IL_0158: ret
 			} // end of method FunctionExpression_L36C19::__js_call__
 
 		} // end of class FunctionExpression_L36C19
@@ -1660,7 +1698,7 @@
 			IL_0007: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1669,14 +1707,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Net_Socket_Binary_Data_Defaults_To_Buffer:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: ldarg.0
 			IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::net
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1687,12 +1725,12 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "port"
 			IL_0069: ldstr "Net_Socket_Binary_Data_Defaults_To_Buffer:<TwoPhaseDummy_M5>:__js_call__:9"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.2
 			IL_0079: volatile.
-			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_0080: brfalse IL_0095
 
 			IL_0085: ldloc.1
@@ -1703,7 +1741,7 @@
 			IL_0095: ldloc.1
 			IL_0096: ldstr "address"
 			IL_009b: ldstr "Net_Socket_Binary_Data_Defaults_To_Buffer:<TwoPhaseDummy_M5>:__js_call__:11"
-			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00aa: stloc.3
@@ -1876,7 +1914,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 180 (0xb4)
+		// Code size: 218 (0xda)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope,
@@ -1918,45 +1956,57 @@
 		IL_0040: ldc.i4.1
 		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
-		IL_0047: ldstr "createServer"
-		IL_004c: ldloc.3
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0052: stloc.s 4
-		IL_0054: ldloc.0
-		IL_0055: ldloc.s 4
-		IL_0057: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-		IL_005c: ldloc.0
-		IL_005d: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0067: stloc.s 4
-		IL_0069: ldc.i4.1
-		IL_006a: newarr [System.Runtime]System.Object
-		IL_006f: dup
-		IL_0070: ldc.i4.0
-		IL_0071: ldloc.0
-		IL_0072: stelem.ref
-		IL_0073: stloc.2
-		IL_0074: ldloc.2
-		IL_0075: ldc.i4.0
-		IL_0076: ldelem.ref
-		IL_0077: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-		IL_007c: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
-		IL_0081: ldc.i4.0
-		IL_0082: conv.r8
-		IL_0083: ldstr ""
-		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.s 4
-		IL_0093: ldstr "listen"
-		IL_0098: ldc.r8 0.0
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: ldstr "127.0.0.1"
-		IL_00ab: ldloc.s 5
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b2: pop
-		IL_00b3: ret
+		IL_0047: volatile.
+		IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_004e: brfalse IL_0063
+
+		IL_0053: ldstr "createServer"
+		IL_0058: ldloc.3
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005e: br IL_0078
+
+		IL_0063: ldstr "createServer"
+		IL_0068: ldloc.3
+		IL_0069: ldstr "Net_Socket_Binary_Data_Defaults_To_Buffer:Modules.Net_Socket_Binary_Data_Defaults_To_Buffer:__js_module_init__:12"
+		IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0078: stloc.s 4
+		IL_007a: ldloc.0
+		IL_007b: ldloc.s 4
+		IL_007d: stfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
+		IL_0082: ldloc.0
+		IL_0083: ldfld object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::server
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008d: stloc.s 4
+		IL_008f: ldc.i4.1
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldloc.0
+		IL_0098: stelem.ref
+		IL_0099: stloc.2
+		IL_009a: ldloc.2
+		IL_009b: ldc.i4.0
+		IL_009c: ldelem.ref
+		IL_009d: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
+		IL_00a2: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
+		IL_00a7: ldc.i4.0
+		IL_00a8: conv.r8
+		IL_00a9: ldstr ""
+		IL_00ae: ldc.i4.0
+		IL_00af: ldc.i4.1
+		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b5: stloc.s 5
+		IL_00b7: ldloc.s 4
+		IL_00b9: ldstr "listen"
+		IL_00be: ldc.r8 0.0
+		IL_00c7: box [System.Runtime]System.Double
+		IL_00cc: ldstr "127.0.0.1"
+		IL_00d1: ldloc.s 5
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00d8: pop
+		IL_00d9: ret
 	} // end of method Net_Socket_Binary_Data_Defaults_To_Buffer::__js_module_init__
 
 } // end of class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer
@@ -1990,6 +2040,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
 	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
@@ -217,7 +217,7 @@
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 81 (0x51)
+			// Code size: 166 (0xa6)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -228,33 +228,58 @@
 
 			IL_0000: ldarg.2
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "setKeepAlive"
-			IL_000b: ldc.i4.1
-			IL_000c: box [System.Runtime]System.Boolean
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0016: stloc.0
-			IL_0017: ldloc.0
-			IL_0018: ldarg.2
-			IL_0019: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_001e: stloc.1
-			IL_001f: ldloc.1
-			IL_0020: box [System.Runtime]System.Boolean
-			IL_0025: stloc.2
-			IL_0026: ldstr "server keepalive same:"
-			IL_002b: ldloc.2
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0031: stloc.3
-			IL_0032: ldarg.0
-			IL_0033: ldloc.3
-			IL_0034: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::serverKeepAliveLine
-			IL_0039: ldarg.2
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003f: ldstr "end"
-			IL_0044: ldstr "ok"
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_004e: pop
-			IL_004f: ldnull
-			IL_0050: ret
+			IL_0006: volatile.
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_000d: brfalse IL_0027
+
+			IL_0012: ldstr "setKeepAlive"
+			IL_0017: ldc.i4.1
+			IL_0018: box [System.Runtime]System.Boolean
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0022: br IL_0041
+
+			IL_0027: ldstr "setKeepAlive"
+			IL_002c: ldc.i4.1
+			IL_002d: box [System.Runtime]System.Boolean
+			IL_0032: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M4>:__js_call__:6"
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0041: stloc.0
+			IL_0042: ldloc.0
+			IL_0043: ldarg.2
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0049: stloc.1
+			IL_004a: ldloc.1
+			IL_004b: box [System.Runtime]System.Boolean
+			IL_0050: stloc.2
+			IL_0051: ldstr "server keepalive same:"
+			IL_0056: ldloc.2
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_005c: stloc.3
+			IL_005d: ldarg.0
+			IL_005e: ldloc.3
+			IL_005f: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::serverKeepAliveLine
+			IL_0064: ldarg.2
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006a: volatile.
+			IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0071: brfalse IL_008a
+
+			IL_0076: ldstr "end"
+			IL_007b: ldstr "ok"
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0085: br IL_00a3
+
+			IL_008a: ldstr "end"
+			IL_008f: ldstr "ok"
+			IL_0094: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M4>:__js_call__:16"
+			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00a3: pop
+			IL_00a4: ldnull
+			IL_00a5: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server
@@ -449,7 +474,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 468 (0x1d4)
+				// Code size: 511 (0x1ff)
 				.maxstack 8
 				.locals init (
 					[0] class [System.Runtime]System.Exception,
@@ -471,161 +496,174 @@
 				IL_000d: ldstr "Cannot access 'client' before initialization"
 				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_001c: ldstr "setKeepAlive"
-				IL_0021: ldc.i4.1
-				IL_0022: box [System.Runtime]System.Boolean
-				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_002c: stloc.s 4
-				IL_002e: ldarg.0
-				IL_002f: ldc.i4.1
-				IL_0030: ldelem.ref
-				IL_0031: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-				IL_0036: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-				IL_003b: ldstr "Cannot access 'client' before initialization"
-				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_0045: stloc.s 5
-				IL_0047: ldloc.s 4
-				IL_0049: ldloc.s 5
-				IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0050: stloc.s 6
-				IL_0052: ldloc.s 6
-				IL_0054: box [System.Runtime]System.Boolean
-				IL_0059: stloc.s 7
-				IL_005b: ldstr "client keepalive same:"
-				IL_0060: ldloc.s 7
-				IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0067: stloc.s 8
-				IL_0069: ldarg.0
-				IL_006a: ldc.i4.0
-				IL_006b: ldelem.ref
-				IL_006c: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_0071: ldloc.s 8
-				IL_0073: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveLine
-				IL_0078: ldarg.0
-				IL_0079: ldc.i4.1
-				IL_007a: ldelem.ref
-				IL_007b: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-				IL_0080: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-				IL_0085: ldstr "Cannot access 'client' before initialization"
-				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0094: volatile.
-				IL_0096: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-				IL_009b: brfalse IL_00af
+				IL_001c: volatile.
+				IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_0023: brfalse IL_003d
 
-				IL_00a0: ldstr "setNoDelay"
-				IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_00aa: br IL_00c3
+				IL_0028: ldstr "setKeepAlive"
+				IL_002d: ldc.i4.1
+				IL_002e: box [System.Runtime]System.Boolean
+				IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0038: br IL_0057
 
-				IL_00af: ldstr "setNoDelay"
-				IL_00b4: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M6>:__js_call__:16"
-				IL_00b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-				IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+				IL_003d: ldstr "setKeepAlive"
+				IL_0042: ldc.i4.1
+				IL_0043: box [System.Runtime]System.Boolean
+				IL_0048: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M6>:__js_call__:6"
+				IL_004d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_00c3: stloc.s 5
-				IL_00c5: ldarg.0
-				IL_00c6: ldc.i4.1
-				IL_00c7: ldelem.ref
-				IL_00c8: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-				IL_00cd: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-				IL_00d2: ldstr "Cannot access 'client' before initialization"
-				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-				IL_00dc: stloc.s 4
-				IL_00de: ldloc.s 5
-				IL_00e0: ldloc.s 4
-				IL_00e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00e7: stloc.s 6
-				IL_00e9: ldloc.s 6
-				IL_00eb: box [System.Runtime]System.Boolean
-				IL_00f0: stloc.s 7
-				IL_00f2: ldstr "client nodelay same:"
-				IL_00f7: ldloc.s 7
-				IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00fe: stloc.s 8
-				IL_0100: ldarg.0
-				IL_0101: ldc.i4.0
-				IL_0102: ldelem.ref
-				IL_0103: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-				IL_0108: ldloc.s 8
-				IL_010a: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientNoDelayLine
+				IL_0057: stloc.s 4
+				IL_0059: ldarg.0
+				IL_005a: ldc.i4.1
+				IL_005b: ldelem.ref
+				IL_005c: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+				IL_0061: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+				IL_0066: ldstr "Cannot access 'client' before initialization"
+				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0070: stloc.s 5
+				IL_0072: ldloc.s 4
+				IL_0074: ldloc.s 5
+				IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_007b: stloc.s 6
+				IL_007d: ldloc.s 6
+				IL_007f: box [System.Runtime]System.Boolean
+				IL_0084: stloc.s 7
+				IL_0086: ldstr "client keepalive same:"
+				IL_008b: ldloc.s 7
+				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0092: stloc.s 8
+				IL_0094: ldarg.0
+				IL_0095: ldc.i4.0
+				IL_0096: ldelem.ref
+				IL_0097: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_009c: ldloc.s 8
+				IL_009e: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveLine
+				IL_00a3: ldarg.0
+				IL_00a4: ldc.i4.1
+				IL_00a5: ldelem.ref
+				IL_00a6: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+				IL_00ab: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+				IL_00b0: ldstr "Cannot access 'client' before initialization"
+				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00bf: volatile.
+				IL_00c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+				IL_00c6: brfalse IL_00da
+
+				IL_00cb: ldstr "setNoDelay"
+				IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_00d5: br IL_00ee
+
+				IL_00da: ldstr "setNoDelay"
+				IL_00df: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M6>:__js_call__:16"
+				IL_00e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+				IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+				IL_00ee: stloc.s 5
+				IL_00f0: ldarg.0
+				IL_00f1: ldc.i4.1
+				IL_00f2: ldelem.ref
+				IL_00f3: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+				IL_00f8: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+				IL_00fd: ldstr "Cannot access 'client' before initialization"
+				IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+				IL_0107: stloc.s 4
+				IL_0109: ldloc.s 5
+				IL_010b: ldloc.s 4
+				IL_010d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0112: stloc.s 6
+				IL_0114: ldloc.s 6
+				IL_0116: box [System.Runtime]System.Boolean
+				IL_011b: stloc.s 7
+				IL_011d: ldstr "client nodelay same:"
+				IL_0122: ldloc.s 7
+				IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0129: stloc.s 8
+				IL_012b: ldarg.0
+				IL_012c: ldc.i4.0
+				IL_012d: ldelem.ref
+				IL_012e: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+				IL_0133: ldloc.s 8
+				IL_0135: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientNoDelayLine
 				.try
 				{
-					IL_010f: nop
-					IL_0110: ldarg.0
-					IL_0111: ldc.i4.1
-					IL_0112: ldelem.ref
-					IL_0113: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-					IL_0118: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-					IL_011d: ldstr "Cannot access 'client' before initialization"
-					IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-					IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_012c: ldstr "setKeepAlive"
-					IL_0131: ldc.i4.1
-					IL_0132: box [System.Runtime]System.Boolean
-					IL_0137: ldc.r8 25
-					IL_0140: box [System.Runtime]System.Double
-					IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_014a: pop
-					IL_014b: leave IL_01d0
+					IL_013a: nop
+					IL_013b: ldarg.0
+					IL_013c: ldc.i4.1
+					IL_013d: ldelem.ref
+					IL_013e: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+					IL_0143: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+					IL_0148: ldstr "Cannot access 'client' before initialization"
+					IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+					IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0157: ldstr "setKeepAlive"
+					IL_015c: ldc.i4.1
+					IL_015d: box [System.Runtime]System.Boolean
+					IL_0162: ldc.r8 25
+					IL_016b: box [System.Runtime]System.Double
+					IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0175: pop
+					IL_0176: leave IL_01fb
 				} // end .try
 				catch [System.Runtime]System.Exception
 				{
-					IL_0150: stloc.0
-					IL_0151: ldloc.0
-					IL_0152: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-					IL_0157: dup
-					IL_0158: brtrue IL_016d
+					IL_017b: stloc.0
+					IL_017c: ldloc.0
+					IL_017d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+					IL_0182: dup
+					IL_0183: brtrue IL_0198
 
-					IL_015d: pop
-					IL_015e: ldloc.0
-					IL_015f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-					IL_0164: dup
-					IL_0165: brtrue IL_0178
+					IL_0188: pop
+					IL_0189: ldloc.0
+					IL_018a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+					IL_018f: dup
+					IL_0190: brtrue IL_01a3
 
-					IL_016a: pop
-					IL_016b: rethrow
+					IL_0195: pop
+					IL_0196: rethrow
 
-					IL_016d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-					IL_0172: stloc.1
-					IL_0173: br IL_0179
+					IL_0198: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+					IL_019d: stloc.1
+					IL_019e: br IL_01a4
 
-					IL_0178: stloc.1
+					IL_01a3: stloc.1
 
-					IL_0179: ldloc.1
-					IL_017a: stloc.2
-					IL_017b: volatile.
-					IL_017d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-					IL_0182: brfalse IL_0197
+					IL_01a4: ldloc.1
+					IL_01a5: stloc.2
+					IL_01a6: volatile.
+					IL_01a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+					IL_01ad: brfalse IL_01c2
 
-					IL_0187: ldloc.2
-					IL_0188: ldstr "message"
-					IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0192: br IL_01ac
+					IL_01b2: ldloc.2
+					IL_01b3: ldstr "message"
+					IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01bd: br IL_01d7
 
-					IL_0197: ldloc.2
-					IL_0198: ldstr "message"
-					IL_019d: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M6>:__js_call__:43"
-					IL_01a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-					IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_01c2: ldloc.2
+					IL_01c3: ldstr "message"
+					IL_01c8: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M6>:__js_call__:43"
+					IL_01cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+					IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_01ac: stloc.s 4
-					IL_01ae: ldstr "client keepalive delay:"
-					IL_01b3: ldloc.s 4
-					IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_01ba: stloc.s 8
-					IL_01bc: ldarg.0
-					IL_01bd: ldc.i4.0
-					IL_01be: ldelem.ref
-					IL_01bf: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-					IL_01c4: ldloc.s 8
-					IL_01c6: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveDelayLine
-					IL_01cb: leave IL_01d0
+					IL_01d7: stloc.s 4
+					IL_01d9: ldstr "client keepalive delay:"
+					IL_01de: ldloc.s 4
+					IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_01e5: stloc.s 8
+					IL_01e7: ldarg.0
+					IL_01e8: ldc.i4.0
+					IL_01e9: ldelem.ref
+					IL_01ea: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+					IL_01ef: ldloc.s 8
+					IL_01f1: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::clientKeepAliveDelayLine
+					IL_01f6: leave IL_01fb
 				} // end handler
 
-				IL_01d0: ldnull
-				IL_01d1: stloc.3
-				IL_01d2: ldloc.3
-				IL_01d3: ret
+				IL_01fb: ldnull
+				IL_01fc: stloc.3
+				IL_01fd: ldloc.3
+				IL_01fe: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -1092,7 +1130,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 215 (0xd7)
+				// Code size: 255 (0xff)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/Scope,
@@ -1188,13 +1226,26 @@
 				IL_00bf: ldc.i4.1
 				IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_00c5: stloc.s 4
-				IL_00c7: ldloc.2
-				IL_00c8: ldstr "close"
-				IL_00cd: ldloc.s 4
-				IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00d4: pop
-				IL_00d5: ldnull
-				IL_00d6: ret
+				IL_00c7: volatile.
+				IL_00c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+				IL_00ce: brfalse IL_00e5
+
+				IL_00d3: ldloc.2
+				IL_00d4: ldstr "close"
+				IL_00d9: ldloc.s 4
+				IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00e0: br IL_00fc
+
+				IL_00e5: ldloc.2
+				IL_00e6: ldstr "close"
+				IL_00eb: ldloc.s 4
+				IL_00ed: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M8>:__js_call__:26"
+				IL_00f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+				IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_00fc: pop
+				IL_00fd: ldnull
+				IL_00fe: ret
 			} // end of method FunctionExpression_L34C19::__js_call__
 
 		} // end of class FunctionExpression_L34C19
@@ -1343,7 +1394,7 @@
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 485 (0x1e5)
+			// Code size: 527 (0x20f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope,
@@ -1362,7 +1413,7 @@
 			IL_0007: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1371,14 +1422,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: ldarg.0
 			IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::net
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1389,12 +1440,12 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "port"
 			IL_0069: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M5>:__js_call__:9"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.2
 			IL_0079: volatile.
-			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_0080: brfalse IL_0095
 
 			IL_0085: ldloc.1
@@ -1405,7 +1456,7 @@
 			IL_0095: ldloc.1
 			IL_0096: ldstr "address"
 			IL_009b: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M5>:__js_call__:11"
-			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00aa: stloc.3
@@ -1451,92 +1502,104 @@
 			IL_0100: ldstr "Cannot access 'client' before initialization"
 			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010f: ldstr "setEncoding"
-			IL_0114: ldstr "utf8"
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_011e: pop
-			IL_011f: ldloc.0
-			IL_0120: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_0125: ldstr "Cannot access 'client' before initialization"
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0134: stloc.3
-			IL_0135: ldc.i4.2
-			IL_0136: newarr [System.Runtime]System.Object
-			IL_013b: dup
-			IL_013c: ldc.i4.0
-			IL_013d: ldarg.0
-			IL_013e: stelem.ref
-			IL_013f: dup
-			IL_0140: ldc.i4.1
-			IL_0141: ldloc.0
-			IL_0142: stelem.ref
-			IL_0143: stloc.s 4
-			IL_0145: ldloc.s 4
-			IL_0147: ldc.i4.0
-			IL_0148: ldelem.ref
-			IL_0149: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-			IL_014e: ldloc.s 4
-			IL_0150: ldc.i4.1
-			IL_0151: ldelem.ref
-			IL_0152: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-			IL_0157: ldloc.s 4
-			IL_0159: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
-			IL_015e: ldc.i4.1
-			IL_015f: conv.r8
-			IL_0160: ldstr ""
-			IL_0165: ldc.i4.0
-			IL_0166: ldc.i4.1
-			IL_0167: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_016c: stloc.s 6
-			IL_016e: ldloc.3
-			IL_016f: ldstr "on"
-			IL_0174: ldstr "data"
-			IL_0179: ldloc.s 6
-			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0180: pop
-			IL_0181: ldloc.0
-			IL_0182: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
-			IL_0187: ldstr "Cannot access 'client' before initialization"
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0196: stloc.3
-			IL_0197: ldc.i4.2
-			IL_0198: newarr [System.Runtime]System.Object
-			IL_019d: dup
-			IL_019e: ldc.i4.0
-			IL_019f: ldarg.0
-			IL_01a0: stelem.ref
-			IL_01a1: dup
-			IL_01a2: ldc.i4.1
-			IL_01a3: ldloc.0
-			IL_01a4: stelem.ref
-			IL_01a5: stloc.s 4
-			IL_01a7: ldloc.s 4
-			IL_01a9: ldc.i4.0
-			IL_01aa: ldelem.ref
-			IL_01ab: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-			IL_01b0: ldloc.s 4
-			IL_01b2: ldc.i4.1
-			IL_01b3: ldelem.ref
-			IL_01b4: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
-			IL_01b9: ldloc.s 4
-			IL_01bb: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
-			IL_01c0: ldc.i4.0
-			IL_01c1: conv.r8
-			IL_01c2: ldstr ""
-			IL_01c7: ldc.i4.0
-			IL_01c8: ldc.i4.1
-			IL_01c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_01ce: stloc.s 7
-			IL_01d0: ldloc.3
-			IL_01d1: ldstr "on"
-			IL_01d6: ldstr "end"
-			IL_01db: ldloc.s 7
-			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01e2: pop
-			IL_01e3: ldnull
-			IL_01e4: ret
+			IL_010f: volatile.
+			IL_0111: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0116: brfalse IL_012f
+
+			IL_011b: ldstr "setEncoding"
+			IL_0120: ldstr "utf8"
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_012a: br IL_0148
+
+			IL_012f: ldstr "setEncoding"
+			IL_0134: ldstr "utf8"
+			IL_0139: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:<TwoPhaseDummy_M5>:__js_call__:20"
+			IL_013e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0148: pop
+			IL_0149: ldloc.0
+			IL_014a: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_014f: ldstr "Cannot access 'client' before initialization"
+			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015e: stloc.3
+			IL_015f: ldc.i4.2
+			IL_0160: newarr [System.Runtime]System.Object
+			IL_0165: dup
+			IL_0166: ldc.i4.0
+			IL_0167: ldarg.0
+			IL_0168: stelem.ref
+			IL_0169: dup
+			IL_016a: ldc.i4.1
+			IL_016b: ldloc.0
+			IL_016c: stelem.ref
+			IL_016d: stloc.s 4
+			IL_016f: ldloc.s 4
+			IL_0171: ldc.i4.0
+			IL_0172: ldelem.ref
+			IL_0173: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+			IL_0178: ldloc.s 4
+			IL_017a: ldc.i4.1
+			IL_017b: ldelem.ref
+			IL_017c: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+			IL_0181: ldloc.s 4
+			IL_0183: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
+			IL_0188: ldc.i4.1
+			IL_0189: conv.r8
+			IL_018a: ldstr ""
+			IL_018f: ldc.i4.0
+			IL_0190: ldc.i4.1
+			IL_0191: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0196: stloc.s 6
+			IL_0198: ldloc.3
+			IL_0199: ldstr "on"
+			IL_019e: ldstr "data"
+			IL_01a3: ldloc.s 6
+			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01aa: pop
+			IL_01ab: ldloc.0
+			IL_01ac: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::client
+			IL_01b1: ldstr "Cannot access 'client' before initialization"
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c0: stloc.3
+			IL_01c1: ldc.i4.2
+			IL_01c2: newarr [System.Runtime]System.Object
+			IL_01c7: dup
+			IL_01c8: ldc.i4.0
+			IL_01c9: ldarg.0
+			IL_01ca: stelem.ref
+			IL_01cb: dup
+			IL_01cc: ldc.i4.1
+			IL_01cd: ldloc.0
+			IL_01ce: stelem.ref
+			IL_01cf: stloc.s 4
+			IL_01d1: ldloc.s 4
+			IL_01d3: ldc.i4.0
+			IL_01d4: ldelem.ref
+			IL_01d5: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+			IL_01da: ldloc.s 4
+			IL_01dc: ldc.i4.1
+			IL_01dd: ldelem.ref
+			IL_01de: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
+			IL_01e3: ldloc.s 4
+			IL_01e5: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
+			IL_01ea: ldc.i4.0
+			IL_01eb: conv.r8
+			IL_01ec: ldstr ""
+			IL_01f1: ldc.i4.0
+			IL_01f2: ldc.i4.1
+			IL_01f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01f8: stloc.s 7
+			IL_01fa: ldloc.3
+			IL_01fb: ldstr "on"
+			IL_0200: ldstr "end"
+			IL_0205: ldloc.s 7
+			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_020c: pop
+			IL_020d: ldnull
+			IL_020e: ret
 		} // end of method FunctionExpression_L16C30::__js_call__
 
 	} // end of class FunctionExpression_L16C30
@@ -1599,7 +1662,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 240 (0xf0)
+		// Code size: 278 (0x116)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope,
@@ -1661,45 +1724,57 @@
 		IL_007c: ldc.i4.1
 		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.3
-		IL_0083: ldstr "createServer"
-		IL_0088: ldloc.3
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008e: stloc.s 4
-		IL_0090: ldloc.0
-		IL_0091: ldloc.s 4
-		IL_0093: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-		IL_0098: ldloc.0
-		IL_0099: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a3: stloc.s 4
-		IL_00a5: ldc.i4.1
-		IL_00a6: newarr [System.Runtime]System.Object
-		IL_00ab: dup
-		IL_00ac: ldc.i4.0
-		IL_00ad: ldloc.0
-		IL_00ae: stelem.ref
-		IL_00af: stloc.2
-		IL_00b0: ldloc.2
-		IL_00b1: ldc.i4.0
-		IL_00b2: ldelem.ref
-		IL_00b3: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-		IL_00b8: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
-		IL_00bd: ldc.i4.0
-		IL_00be: conv.r8
-		IL_00bf: ldstr ""
-		IL_00c4: ldc.i4.0
-		IL_00c5: ldc.i4.1
-		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00cb: stloc.s 5
-		IL_00cd: ldloc.s 4
-		IL_00cf: ldstr "listen"
-		IL_00d4: ldc.r8 0.0
-		IL_00dd: box [System.Runtime]System.Double
-		IL_00e2: ldstr "127.0.0.1"
-		IL_00e7: ldloc.s 5
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00ee: pop
-		IL_00ef: ret
+		IL_0083: volatile.
+		IL_0085: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_008a: brfalse IL_009f
+
+		IL_008f: ldstr "createServer"
+		IL_0094: ldloc.3
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009a: br IL_00b4
+
+		IL_009f: ldstr "createServer"
+		IL_00a4: ldloc.3
+		IL_00a5: ldstr "Net_Socket_KeepAlive_And_Unsupported_Options:Modules.Net_Socket_KeepAlive_And_Unsupported_Options:__js_module_init__:32"
+		IL_00aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00b4: stloc.s 4
+		IL_00b6: ldloc.0
+		IL_00b7: ldloc.s 4
+		IL_00b9: stfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
+		IL_00be: ldloc.0
+		IL_00bf: ldfld object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::server
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c9: stloc.s 4
+		IL_00cb: ldc.i4.1
+		IL_00cc: newarr [System.Runtime]System.Object
+		IL_00d1: dup
+		IL_00d2: ldc.i4.0
+		IL_00d3: ldloc.0
+		IL_00d4: stelem.ref
+		IL_00d5: stloc.2
+		IL_00d6: ldloc.2
+		IL_00d7: ldc.i4.0
+		IL_00d8: ldelem.ref
+		IL_00d9: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
+		IL_00de: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
+		IL_00e3: ldc.i4.0
+		IL_00e4: conv.r8
+		IL_00e5: ldstr ""
+		IL_00ea: ldc.i4.0
+		IL_00eb: ldc.i4.1
+		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f1: stloc.s 5
+		IL_00f3: ldloc.s 4
+		IL_00f5: ldstr "listen"
+		IL_00fa: ldc.r8 0.0
+		IL_0103: box [System.Runtime]System.Double
+		IL_0108: ldstr "127.0.0.1"
+		IL_010d: ldloc.s 5
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0114: pop
+		IL_0115: ret
 	} // end of method Net_Socket_KeepAlive_And_Unsupported_Options::__js_module_init__
 
 } // end of class Modules.Net_Socket_KeepAlive_And_Unsupported_Options
@@ -1734,6 +1809,12 @@
 	.field assembly static int32 __jroc_dynamicLookup_22
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
@@ -425,7 +425,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 100 (0x64)
+				// Code size: 139 (0x8b)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -467,13 +467,26 @@
 				IL_004e: ldloc.3
 				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 				IL_0054: stloc.2
-				IL_0055: ldloc.1
-				IL_0056: ldstr "end"
-				IL_005b: ldloc.2
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0061: pop
-				IL_0062: ldnull
-				IL_0063: ret
+				IL_0055: volatile.
+				IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_005c: brfalse IL_0072
+
+				IL_0061: ldloc.1
+				IL_0062: ldstr "end"
+				IL_0067: ldloc.2
+				IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_006d: br IL_0088
+
+				IL_0072: ldloc.1
+				IL_0073: ldstr "end"
+				IL_0078: ldloc.2
+				IL_0079: ldstr "Net_Socket_SetEncoding_Utf8:<TwoPhaseDummy_M7>:__js_call__:12"
+				IL_007e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0088: pop
+				IL_0089: ldnull
+				IL_008a: ret
 			} // end of method FunctionExpression_server_L14C19::__js_call__
 
 		} // end of class FunctionExpression_server_L14C19
@@ -628,7 +641,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 219 (0xdb)
+			// Code size: 261 (0x105)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope,
@@ -646,91 +659,103 @@
 			IL_000d: ldloc.0
 			IL_000e: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::socket
 			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0018: ldstr "setEncoding"
-			IL_001d: ldstr "utf8"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0027: pop
-			IL_0028: ldloc.0
-			IL_0029: ldstr ""
-			IL_002e: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::received
-			IL_0033: ldloc.0
-			IL_0034: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::socket
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003e: stloc.1
-			IL_003f: ldc.i4.2
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
-			IL_0046: ldc.i4.0
-			IL_0047: ldarg.0
-			IL_0048: stelem.ref
-			IL_0049: dup
-			IL_004a: ldc.i4.1
-			IL_004b: ldloc.0
-			IL_004c: stelem.ref
-			IL_004d: stloc.2
-			IL_004e: ldloc.2
-			IL_004f: ldc.i4.0
-			IL_0050: ldelem.ref
-			IL_0051: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-			IL_0056: ldloc.2
-			IL_0057: ldc.i4.1
-			IL_0058: ldelem.ref
-			IL_0059: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
-			IL_005e: ldloc.2
-			IL_005f: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
-			IL_0064: ldc.i4.1
-			IL_0065: conv.r8
-			IL_0066: ldstr ""
-			IL_006b: ldc.i4.0
-			IL_006c: ldc.i4.1
-			IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0072: stloc.3
-			IL_0073: ldloc.1
-			IL_0074: ldstr "on"
-			IL_0079: ldstr "data"
-			IL_007e: ldloc.3
-			IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0084: pop
-			IL_0085: ldloc.0
-			IL_0086: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::socket
-			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0090: stloc.1
-			IL_0091: ldc.i4.2
-			IL_0092: newarr [System.Runtime]System.Object
-			IL_0097: dup
-			IL_0098: ldc.i4.0
-			IL_0099: ldarg.0
-			IL_009a: stelem.ref
-			IL_009b: dup
-			IL_009c: ldc.i4.1
-			IL_009d: ldloc.0
-			IL_009e: stelem.ref
-			IL_009f: stloc.2
-			IL_00a0: ldloc.2
-			IL_00a1: ldc.i4.0
-			IL_00a2: ldelem.ref
-			IL_00a3: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-			IL_00a8: ldloc.2
-			IL_00a9: ldc.i4.1
-			IL_00aa: ldelem.ref
-			IL_00ab: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
-			IL_00b0: ldloc.2
-			IL_00b1: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
-			IL_00b6: ldc.i4.0
-			IL_00b7: conv.r8
-			IL_00b8: ldstr ""
-			IL_00bd: ldc.i4.0
-			IL_00be: ldc.i4.1
-			IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_00c4: stloc.s 4
-			IL_00c6: ldloc.1
-			IL_00c7: ldstr "on"
-			IL_00cc: ldstr "end"
-			IL_00d1: ldloc.s 4
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00d8: pop
-			IL_00d9: ldnull
-			IL_00da: ret
+			IL_0018: volatile.
+			IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_001f: brfalse IL_0038
+
+			IL_0024: ldstr "setEncoding"
+			IL_0029: ldstr "utf8"
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0033: br IL_0051
+
+			IL_0038: ldstr "setEncoding"
+			IL_003d: ldstr "utf8"
+			IL_0042: ldstr "Net_Socket_SetEncoding_Utf8:<TwoPhaseDummy_M4>:__js_call__:7"
+			IL_0047: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0051: pop
+			IL_0052: ldloc.0
+			IL_0053: ldstr ""
+			IL_0058: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::received
+			IL_005d: ldloc.0
+			IL_005e: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::socket
+			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0068: stloc.1
+			IL_0069: ldc.i4.2
+			IL_006a: newarr [System.Runtime]System.Object
+			IL_006f: dup
+			IL_0070: ldc.i4.0
+			IL_0071: ldarg.0
+			IL_0072: stelem.ref
+			IL_0073: dup
+			IL_0074: ldc.i4.1
+			IL_0075: ldloc.0
+			IL_0076: stelem.ref
+			IL_0077: stloc.2
+			IL_0078: ldloc.2
+			IL_0079: ldc.i4.0
+			IL_007a: ldelem.ref
+			IL_007b: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+			IL_0080: ldloc.2
+			IL_0081: ldc.i4.1
+			IL_0082: ldelem.ref
+			IL_0083: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
+			IL_0088: ldloc.2
+			IL_0089: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
+			IL_008e: ldc.i4.1
+			IL_008f: conv.r8
+			IL_0090: ldstr ""
+			IL_0095: ldc.i4.0
+			IL_0096: ldc.i4.1
+			IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_009c: stloc.3
+			IL_009d: ldloc.1
+			IL_009e: ldstr "on"
+			IL_00a3: ldstr "data"
+			IL_00a8: ldloc.3
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00ae: pop
+			IL_00af: ldloc.0
+			IL_00b0: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::socket
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ba: stloc.1
+			IL_00bb: ldc.i4.2
+			IL_00bc: newarr [System.Runtime]System.Object
+			IL_00c1: dup
+			IL_00c2: ldc.i4.0
+			IL_00c3: ldarg.0
+			IL_00c4: stelem.ref
+			IL_00c5: dup
+			IL_00c6: ldc.i4.1
+			IL_00c7: ldloc.0
+			IL_00c8: stelem.ref
+			IL_00c9: stloc.2
+			IL_00ca: ldloc.2
+			IL_00cb: ldc.i4.0
+			IL_00cc: ldelem.ref
+			IL_00cd: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+			IL_00d2: ldloc.2
+			IL_00d3: ldc.i4.1
+			IL_00d4: ldelem.ref
+			IL_00d5: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
+			IL_00da: ldloc.2
+			IL_00db: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
+			IL_00e0: ldc.i4.0
+			IL_00e1: conv.r8
+			IL_00e2: ldstr ""
+			IL_00e7: ldc.i4.0
+			IL_00e8: ldc.i4.1
+			IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00ee: stloc.s 4
+			IL_00f0: ldloc.1
+			IL_00f1: ldstr "on"
+			IL_00f6: ldstr "end"
+			IL_00fb: ldloc.s 4
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0102: pop
+			IL_0103: ldnull
+			IL_0104: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server
@@ -889,7 +914,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 84 (0x54)
+					// Code size: 122 (0x7a)
 					.maxstack 8
 					.locals init (
 						[0] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
@@ -913,12 +938,24 @@
 					IL_003b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 					IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 					IL_0045: stloc.0
-					IL_0046: ldstr "end"
-					IL_004b: ldloc.0
-					IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0051: pop
-					IL_0052: ldnull
-					IL_0053: ret
+					IL_0046: volatile.
+					IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+					IL_004d: brfalse IL_0062
+
+					IL_0052: ldstr "end"
+					IL_0057: ldloc.0
+					IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_005d: br IL_0077
+
+					IL_0062: ldstr "end"
+					IL_0067: ldloc.0
+					IL_0068: ldstr "Net_Socket_SetEncoding_Utf8:<TwoPhaseDummy_M11>:__js_call__:7"
+					IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+					IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+					IL_0077: pop
+					IL_0078: ldnull
+					IL_0079: ret
 				} // end of method FunctionExpression_client::__js_call__
 
 			} // end of class FunctionExpression_client
@@ -1065,7 +1102,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 177 (0xb1)
+				// Code size: 215 (0xd7)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/Scope,
@@ -1094,55 +1131,67 @@
 				IL_0041: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 				IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 				IL_004b: stloc.1
-				IL_004c: ldstr "write"
-				IL_0051: ldloc.1
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0057: pop
-				IL_0058: ldc.i4.3
-				IL_0059: newarr [System.Runtime]System.Object
-				IL_005e: dup
-				IL_005f: ldc.i4.0
-				IL_0060: ldarg.0
-				IL_0061: ldc.i4.0
-				IL_0062: ldelem.ref
-				IL_0063: stelem.ref
-				IL_0064: dup
-				IL_0065: ldc.i4.1
-				IL_0066: ldarg.0
-				IL_0067: ldc.i4.1
-				IL_0068: ldelem.ref
-				IL_0069: stelem.ref
-				IL_006a: dup
-				IL_006b: ldc.i4.2
-				IL_006c: ldloc.0
-				IL_006d: stelem.ref
-				IL_006e: stloc.2
-				IL_006f: ldloc.2
-				IL_0070: ldc.i4.0
-				IL_0071: ldelem.ref
-				IL_0072: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-				IL_0077: ldloc.2
-				IL_0078: ldc.i4.1
-				IL_0079: ldelem.ref
-				IL_007a: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
-				IL_007f: ldloc.2
-				IL_0080: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+				IL_004c: volatile.
+				IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_0053: brfalse IL_0068
+
+				IL_0058: ldstr "write"
+				IL_005d: ldloc.1
+				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0063: br IL_007d
+
+				IL_0068: ldstr "write"
+				IL_006d: ldloc.1
+				IL_006e: ldstr "Net_Socket_SetEncoding_Utf8:<TwoPhaseDummy_M8>:__js_call__:8"
+				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_007d: pop
+				IL_007e: ldc.i4.3
+				IL_007f: newarr [System.Runtime]System.Object
+				IL_0084: dup
 				IL_0085: ldc.i4.0
-				IL_0086: conv.r8
-				IL_0087: ldstr ""
-				IL_008c: ldc.i4.0
+				IL_0086: ldarg.0
+				IL_0087: ldc.i4.0
+				IL_0088: ldelem.ref
+				IL_0089: stelem.ref
+				IL_008a: dup
+				IL_008b: ldc.i4.1
+				IL_008c: ldarg.0
 				IL_008d: ldc.i4.1
-				IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0093: stloc.3
-				IL_0094: ldloc.3
-				IL_0095: ldc.r8 0.0
-				IL_009e: box [System.Runtime]System.Double
-				IL_00a3: ldc.i4.0
-				IL_00a4: newarr [System.Runtime]System.Object
-				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
-				IL_00ae: pop
-				IL_00af: ldnull
-				IL_00b0: ret
+				IL_008e: ldelem.ref
+				IL_008f: stelem.ref
+				IL_0090: dup
+				IL_0091: ldc.i4.2
+				IL_0092: ldloc.0
+				IL_0093: stelem.ref
+				IL_0094: stloc.2
+				IL_0095: ldloc.2
+				IL_0096: ldc.i4.0
+				IL_0097: ldelem.ref
+				IL_0098: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+				IL_009d: ldloc.2
+				IL_009e: ldc.i4.1
+				IL_009f: ldelem.ref
+				IL_00a0: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
+				IL_00a5: ldloc.2
+				IL_00a6: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+				IL_00ab: ldc.i4.0
+				IL_00ac: conv.r8
+				IL_00ad: ldstr ""
+				IL_00b2: ldc.i4.0
+				IL_00b3: ldc.i4.1
+				IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_00b9: stloc.3
+				IL_00ba: ldloc.3
+				IL_00bb: ldc.r8 0.0
+				IL_00c4: box [System.Runtime]System.Double
+				IL_00c9: ldc.i4.0
+				IL_00ca: newarr [System.Runtime]System.Object
+				IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
+				IL_00d4: pop
+				IL_00d5: ldnull
+				IL_00d6: ret
 			} // end of method FunctionExpression_client::__js_call__
 
 		} // end of class FunctionExpression_client
@@ -1637,7 +1686,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 116 (0x74)
+				// Code size: 156 (0x9c)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/Scope,
@@ -1690,13 +1739,26 @@
 				IL_005c: ldc.i4.1
 				IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0062: stloc.s 5
-				IL_0064: ldloc.2
-				IL_0065: ldstr "close"
-				IL_006a: ldloc.s 5
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0071: pop
-				IL_0072: ldnull
-				IL_0073: ret
+				IL_0064: volatile.
+				IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_006b: brfalse IL_0082
+
+				IL_0070: ldloc.2
+				IL_0071: ldstr "close"
+				IL_0076: ldloc.s 5
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007d: br IL_0099
+
+				IL_0082: ldloc.2
+				IL_0083: ldstr "close"
+				IL_0088: ldloc.s 5
+				IL_008a: ldstr "Net_Socket_SetEncoding_Utf8:<TwoPhaseDummy_M10>:__js_call__:12"
+				IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0099: pop
+				IL_009a: ldnull
+				IL_009b: ret
 			} // end of method FunctionExpression_L36C19::__js_call__
 
 		} // end of class FunctionExpression_L36C19
@@ -1847,7 +1909,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 496 (0x1f0)
+			// Code size: 538 (0x21a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope,
@@ -1866,7 +1928,7 @@
 			IL_0007: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1875,14 +1937,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Net_Socket_SetEncoding_Utf8:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: ldarg.0
 			IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_SetEncoding_Utf8/Scope::net
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1893,12 +1955,12 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "port"
 			IL_0069: ldstr "Net_Socket_SetEncoding_Utf8:<TwoPhaseDummy_M5>:__js_call__:9"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.2
 			IL_0079: volatile.
-			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_0080: brfalse IL_0095
 
 			IL_0085: ldloc.1
@@ -1909,7 +1971,7 @@
 			IL_0095: ldloc.1
 			IL_0096: ldstr "address"
 			IL_009b: ldstr "Net_Socket_SetEncoding_Utf8:<TwoPhaseDummy_M5>:__js_call__:11"
-			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00aa: stloc.3
@@ -1955,95 +2017,107 @@
 			IL_0100: ldstr "Cannot access 'client' before initialization"
 			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
 			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010f: ldstr "setEncoding"
-			IL_0114: ldstr "utf8"
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_011e: pop
-			IL_011f: ldloc.0
-			IL_0120: ldstr ""
-			IL_0125: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
-			IL_012a: ldloc.0
-			IL_012b: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_0130: ldstr "Cannot access 'client' before initialization"
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013f: stloc.3
-			IL_0140: ldc.i4.2
-			IL_0141: newarr [System.Runtime]System.Object
-			IL_0146: dup
-			IL_0147: ldc.i4.0
-			IL_0148: ldarg.0
-			IL_0149: stelem.ref
-			IL_014a: dup
-			IL_014b: ldc.i4.1
-			IL_014c: ldloc.0
-			IL_014d: stelem.ref
-			IL_014e: stloc.s 4
-			IL_0150: ldloc.s 4
-			IL_0152: ldc.i4.0
-			IL_0153: ldelem.ref
-			IL_0154: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-			IL_0159: ldloc.s 4
-			IL_015b: ldc.i4.1
-			IL_015c: ldelem.ref
-			IL_015d: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
-			IL_0162: ldloc.s 4
-			IL_0164: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
-			IL_0169: ldc.i4.1
-			IL_016a: conv.r8
-			IL_016b: ldstr ""
-			IL_0170: ldc.i4.0
-			IL_0171: ldc.i4.1
-			IL_0172: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0177: stloc.s 6
-			IL_0179: ldloc.3
-			IL_017a: ldstr "on"
-			IL_017f: ldstr "data"
-			IL_0184: ldloc.s 6
-			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_018b: pop
-			IL_018c: ldloc.0
-			IL_018d: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
-			IL_0192: ldstr "Cannot access 'client' before initialization"
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a1: stloc.3
-			IL_01a2: ldc.i4.2
-			IL_01a3: newarr [System.Runtime]System.Object
-			IL_01a8: dup
-			IL_01a9: ldc.i4.0
-			IL_01aa: ldarg.0
-			IL_01ab: stelem.ref
-			IL_01ac: dup
-			IL_01ad: ldc.i4.1
-			IL_01ae: ldloc.0
-			IL_01af: stelem.ref
-			IL_01b0: stloc.s 4
-			IL_01b2: ldloc.s 4
-			IL_01b4: ldc.i4.0
-			IL_01b5: ldelem.ref
-			IL_01b6: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-			IL_01bb: ldloc.s 4
-			IL_01bd: ldc.i4.1
-			IL_01be: ldelem.ref
-			IL_01bf: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
-			IL_01c4: ldloc.s 4
-			IL_01c6: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
-			IL_01cb: ldc.i4.0
-			IL_01cc: conv.r8
-			IL_01cd: ldstr ""
-			IL_01d2: ldc.i4.0
-			IL_01d3: ldc.i4.1
-			IL_01d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_01d9: stloc.s 7
-			IL_01db: ldloc.3
-			IL_01dc: ldstr "on"
-			IL_01e1: ldstr "end"
-			IL_01e6: ldloc.s 7
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01ed: pop
-			IL_01ee: ldnull
-			IL_01ef: ret
+			IL_010f: volatile.
+			IL_0111: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0116: brfalse IL_012f
+
+			IL_011b: ldstr "setEncoding"
+			IL_0120: ldstr "utf8"
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_012a: br IL_0148
+
+			IL_012f: ldstr "setEncoding"
+			IL_0134: ldstr "utf8"
+			IL_0139: ldstr "Net_Socket_SetEncoding_Utf8:<TwoPhaseDummy_M5>:__js_call__:20"
+			IL_013e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0148: pop
+			IL_0149: ldloc.0
+			IL_014a: ldstr ""
+			IL_014f: stfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::reply
+			IL_0154: ldloc.0
+			IL_0155: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_015a: ldstr "Cannot access 'client' before initialization"
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0169: stloc.3
+			IL_016a: ldc.i4.2
+			IL_016b: newarr [System.Runtime]System.Object
+			IL_0170: dup
+			IL_0171: ldc.i4.0
+			IL_0172: ldarg.0
+			IL_0173: stelem.ref
+			IL_0174: dup
+			IL_0175: ldc.i4.1
+			IL_0176: ldloc.0
+			IL_0177: stelem.ref
+			IL_0178: stloc.s 4
+			IL_017a: ldloc.s 4
+			IL_017c: ldc.i4.0
+			IL_017d: ldelem.ref
+			IL_017e: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+			IL_0183: ldloc.s 4
+			IL_0185: ldc.i4.1
+			IL_0186: ldelem.ref
+			IL_0187: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
+			IL_018c: ldloc.s 4
+			IL_018e: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+			IL_0193: ldc.i4.1
+			IL_0194: conv.r8
+			IL_0195: ldstr ""
+			IL_019a: ldc.i4.0
+			IL_019b: ldc.i4.1
+			IL_019c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01a1: stloc.s 6
+			IL_01a3: ldloc.3
+			IL_01a4: ldstr "on"
+			IL_01a9: ldstr "data"
+			IL_01ae: ldloc.s 6
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01b5: pop
+			IL_01b6: ldloc.0
+			IL_01b7: ldfld object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::client
+			IL_01bc: ldstr "Cannot access 'client' before initialization"
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cb: stloc.3
+			IL_01cc: ldc.i4.2
+			IL_01cd: newarr [System.Runtime]System.Object
+			IL_01d2: dup
+			IL_01d3: ldc.i4.0
+			IL_01d4: ldarg.0
+			IL_01d5: stelem.ref
+			IL_01d6: dup
+			IL_01d7: ldc.i4.1
+			IL_01d8: ldloc.0
+			IL_01d9: stelem.ref
+			IL_01da: stloc.s 4
+			IL_01dc: ldloc.s 4
+			IL_01de: ldc.i4.0
+			IL_01df: ldelem.ref
+			IL_01e0: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+			IL_01e5: ldloc.s 4
+			IL_01e7: ldc.i4.1
+			IL_01e8: ldelem.ref
+			IL_01e9: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
+			IL_01ee: ldloc.s 4
+			IL_01f0: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+			IL_01f5: ldc.i4.0
+			IL_01f6: conv.r8
+			IL_01f7: ldstr ""
+			IL_01fc: ldc.i4.0
+			IL_01fd: ldc.i4.1
+			IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0203: stloc.s 7
+			IL_0205: ldloc.3
+			IL_0206: ldstr "on"
+			IL_020b: ldstr "end"
+			IL_0210: ldloc.s 7
+			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0217: pop
+			IL_0218: ldnull
+			IL_0219: ret
 		} // end of method FunctionExpression_L20C30::__js_call__
 
 	} // end of class FunctionExpression_L20C30
@@ -2088,7 +2162,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 180 (0xb4)
+		// Code size: 218 (0xda)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_SetEncoding_Utf8/Scope,
@@ -2130,45 +2204,57 @@
 		IL_0040: ldc.i4.1
 		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
-		IL_0047: ldstr "createServer"
-		IL_004c: ldloc.3
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0052: stloc.s 4
-		IL_0054: ldloc.0
-		IL_0055: ldloc.s 4
-		IL_0057: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-		IL_005c: ldloc.0
-		IL_005d: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0067: stloc.s 4
-		IL_0069: ldc.i4.1
-		IL_006a: newarr [System.Runtime]System.Object
-		IL_006f: dup
-		IL_0070: ldc.i4.0
-		IL_0071: ldloc.0
-		IL_0072: stelem.ref
-		IL_0073: stloc.2
-		IL_0074: ldloc.2
-		IL_0075: ldc.i4.0
-		IL_0076: ldelem.ref
-		IL_0077: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-		IL_007c: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
-		IL_0081: ldc.i4.0
-		IL_0082: conv.r8
-		IL_0083: ldstr ""
-		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.s 4
-		IL_0093: ldstr "listen"
-		IL_0098: ldc.r8 0.0
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: ldstr "127.0.0.1"
-		IL_00ab: ldloc.s 5
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b2: pop
-		IL_00b3: ret
+		IL_0047: volatile.
+		IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_004e: brfalse IL_0063
+
+		IL_0053: ldstr "createServer"
+		IL_0058: ldloc.3
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005e: br IL_0078
+
+		IL_0063: ldstr "createServer"
+		IL_0068: ldloc.3
+		IL_0069: ldstr "Net_Socket_SetEncoding_Utf8:Modules.Net_Socket_SetEncoding_Utf8:__js_module_init__:12"
+		IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0078: stloc.s 4
+		IL_007a: ldloc.0
+		IL_007b: ldloc.s 4
+		IL_007d: stfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
+		IL_0082: ldloc.0
+		IL_0083: ldfld object Modules.Net_Socket_SetEncoding_Utf8/Scope::server
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008d: stloc.s 4
+		IL_008f: ldc.i4.1
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldloc.0
+		IL_0098: stelem.ref
+		IL_0099: stloc.2
+		IL_009a: ldloc.2
+		IL_009b: ldc.i4.0
+		IL_009c: ldelem.ref
+		IL_009d: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
+		IL_00a2: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
+		IL_00a7: ldc.i4.0
+		IL_00a8: conv.r8
+		IL_00a9: ldstr ""
+		IL_00ae: ldc.i4.0
+		IL_00af: ldc.i4.1
+		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b5: stloc.s 5
+		IL_00b7: ldloc.s 4
+		IL_00b9: ldstr "listen"
+		IL_00be: ldc.r8 0.0
+		IL_00c7: box [System.Runtime]System.Double
+		IL_00cc: ldstr "127.0.0.1"
+		IL_00d1: ldloc.s 5
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00d8: pop
+		IL_00d9: ret
 	} // end of method Net_Socket_SetEncoding_Utf8::__js_module_init__
 
 } // end of class Modules.Net_Socket_SetEncoding_Utf8
@@ -2201,6 +2287,13 @@
 	.field assembly static int32 __jroc_dynamicLookup_27
 	.field assembly static int32 __jroc_dynamicLookup_28
 	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
+	.field assembly static int32 __jroc_dynamicLookup_35
+	.field assembly static int32 __jroc_dynamicLookup_36
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
@@ -222,7 +222,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 141 (0x8d)
+				// Code size: 183 (0xb7)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -244,7 +244,7 @@
 				IL_001b: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope
 				IL_0020: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope::socket
 				IL_0025: volatile.
-				IL_0027: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+				IL_0027: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 				IL_002c: brfalse IL_0040
 
 				IL_0031: ldstr "writable"
@@ -253,7 +253,7 @@
 
 				IL_0040: ldstr "writable"
 				IL_0045: ldstr "Net_Socket_Timeout_Allows_Graceful_End:<TwoPhaseDummy_M6>:__js_call__:9"
-				IL_004a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+				IL_004a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 				IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0054: stloc.1
@@ -271,12 +271,24 @@
 				IL_006c: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope
 				IL_0071: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope::socket
 				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_007b: ldstr "end"
-				IL_0080: ldstr "timeout-response"
-				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_008a: pop
-				IL_008b: ldnull
-				IL_008c: ret
+				IL_007b: volatile.
+				IL_007d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+				IL_0082: brfalse IL_009b
+
+				IL_0087: ldstr "end"
+				IL_008c: ldstr "timeout-response"
+				IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0096: br IL_00b4
+
+				IL_009b: ldstr "end"
+				IL_00a0: ldstr "timeout-response"
+				IL_00a5: ldstr "Net_Socket_Timeout_Allows_Graceful_End:<TwoPhaseDummy_M6>:__js_call__:16"
+				IL_00aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+				IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_00b4: pop
+				IL_00b5: ldnull
+				IL_00b6: ret
 			} // end of method FunctionExpression_server::__js_call__
 
 		} // end of class FunctionExpression_server
@@ -1125,7 +1137,7 @@
 				IL_001a: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
 				IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0024: volatile.
-				IL_0026: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+				IL_0026: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 				IL_002b: brfalse IL_003f
 
 				IL_0030: ldstr "close"
@@ -1134,7 +1146,7 @@
 
 				IL_003f: ldstr "close"
 				IL_0044: ldstr "Net_Socket_Timeout_Allows_Graceful_End:<TwoPhaseDummy_M10>:__js_call__:7"
-				IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+				IL_0049: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_0053: pop
@@ -1278,7 +1290,7 @@
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
 			// Header size: 12
-			// Code size: 382 (0x17e)
+			// Code size: 424 (0x1a8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/Scope,
@@ -1298,7 +1310,7 @@
 			IL_0007: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0011: volatile.
-			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_0018: brfalse IL_002c
 
 			IL_001d: ldstr "address"
@@ -1307,14 +1319,14 @@
 
 			IL_002c: ldstr "address"
 			IL_0031: ldstr "Net_Socket_Timeout_Allows_Graceful_End:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0040: stloc.1
 			IL_0041: ldarg.0
 			IL_0042: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::net
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_004e: brfalse IL_0063
 
 			IL_0053: ldloc.1
@@ -1325,12 +1337,12 @@
 			IL_0063: ldloc.1
 			IL_0064: ldstr "port"
 			IL_0069: ldstr "Net_Socket_Timeout_Allows_Graceful_End:<TwoPhaseDummy_M5>:__js_call__:9"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0078: stloc.3
 			IL_0079: volatile.
-			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_0080: brfalse IL_0095
 
 			IL_0085: ldloc.1
@@ -1341,7 +1353,7 @@
 			IL_0095: ldloc.1
 			IL_0096: ldstr "address"
 			IL_009b: ldstr "Net_Socket_Timeout_Allows_Graceful_End:<TwoPhaseDummy_M5>:__js_call__:11"
-			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00aa: stloc.s 4
@@ -1368,69 +1380,81 @@
 			IL_00dc: stloc.2
 			IL_00dd: ldloc.2
 			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e3: ldstr "setEncoding"
-			IL_00e8: ldstr "utf8"
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f2: pop
-			IL_00f3: ldloc.2
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f9: stloc.s 4
-			IL_00fb: ldc.i4.1
-			IL_00fc: newarr [System.Runtime]System.Object
-			IL_0101: dup
-			IL_0102: ldc.i4.0
-			IL_0103: ldarg.0
-			IL_0104: stelem.ref
-			IL_0105: stloc.s 5
-			IL_0107: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject::.ctor()
-			IL_010c: ldc.i4.1
-			IL_010d: conv.r8
-			IL_010e: ldstr ""
-			IL_0113: ldc.i4.0
-			IL_0114: ldc.i4.1
-			IL_0115: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_011a: stloc.s 7
-			IL_011c: ldloc.s 4
-			IL_011e: ldstr "on"
-			IL_0123: ldstr "data"
-			IL_0128: ldloc.s 7
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_012f: pop
-			IL_0130: ldloc.2
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0136: stloc.s 4
-			IL_0138: ldc.i4.2
-			IL_0139: newarr [System.Runtime]System.Object
-			IL_013e: dup
-			IL_013f: ldc.i4.0
-			IL_0140: ldarg.0
-			IL_0141: stelem.ref
-			IL_0142: dup
-			IL_0143: ldc.i4.1
-			IL_0144: ldloc.0
-			IL_0145: stelem.ref
-			IL_0146: stloc.s 5
-			IL_0148: ldloc.s 5
-			IL_014a: ldc.i4.0
-			IL_014b: ldelem.ref
-			IL_014c: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-			IL_0151: ldloc.s 5
-			IL_0153: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object[])
-			IL_0158: ldc.i4.0
-			IL_0159: conv.r8
-			IL_015a: ldstr ""
-			IL_015f: ldc.i4.0
-			IL_0160: ldc.i4.1
-			IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0166: stloc.s 8
-			IL_0168: ldloc.s 4
-			IL_016a: ldstr "on"
-			IL_016f: ldstr "end"
-			IL_0174: ldloc.s 8
-			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_017b: pop
-			IL_017c: ldnull
-			IL_017d: ret
+			IL_00e3: volatile.
+			IL_00e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_00ea: brfalse IL_0103
+
+			IL_00ef: ldstr "setEncoding"
+			IL_00f4: ldstr "utf8"
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00fe: br IL_011c
+
+			IL_0103: ldstr "setEncoding"
+			IL_0108: ldstr "utf8"
+			IL_010d: ldstr "Net_Socket_Timeout_Allows_Graceful_End:<TwoPhaseDummy_M5>:__js_call__:19"
+			IL_0112: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_011c: pop
+			IL_011d: ldloc.2
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0123: stloc.s 4
+			IL_0125: ldc.i4.1
+			IL_0126: newarr [System.Runtime]System.Object
+			IL_012b: dup
+			IL_012c: ldc.i4.0
+			IL_012d: ldarg.0
+			IL_012e: stelem.ref
+			IL_012f: stloc.s 5
+			IL_0131: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject::.ctor()
+			IL_0136: ldc.i4.1
+			IL_0137: conv.r8
+			IL_0138: ldstr ""
+			IL_013d: ldc.i4.0
+			IL_013e: ldc.i4.1
+			IL_013f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0144: stloc.s 7
+			IL_0146: ldloc.s 4
+			IL_0148: ldstr "on"
+			IL_014d: ldstr "data"
+			IL_0152: ldloc.s 7
+			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0159: pop
+			IL_015a: ldloc.2
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0160: stloc.s 4
+			IL_0162: ldc.i4.2
+			IL_0163: newarr [System.Runtime]System.Object
+			IL_0168: dup
+			IL_0169: ldc.i4.0
+			IL_016a: ldarg.0
+			IL_016b: stelem.ref
+			IL_016c: dup
+			IL_016d: ldc.i4.1
+			IL_016e: ldloc.0
+			IL_016f: stelem.ref
+			IL_0170: stloc.s 5
+			IL_0172: ldloc.s 5
+			IL_0174: ldc.i4.0
+			IL_0175: ldelem.ref
+			IL_0176: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
+			IL_017b: ldloc.s 5
+			IL_017d: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object[])
+			IL_0182: ldc.i4.0
+			IL_0183: conv.r8
+			IL_0184: ldstr ""
+			IL_0189: ldc.i4.0
+			IL_018a: ldc.i4.1
+			IL_018b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0190: stloc.s 8
+			IL_0192: ldloc.s 4
+			IL_0194: ldstr "on"
+			IL_0199: ldstr "end"
+			IL_019e: ldloc.s 8
+			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01a5: pop
+			IL_01a6: ldnull
+			IL_01a7: ret
 		} // end of method FunctionExpression_L17C30::__js_call__
 
 	} // end of class FunctionExpression_L17C30
@@ -1475,7 +1499,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 180 (0xb4)
+		// Code size: 218 (0xda)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope,
@@ -1517,45 +1541,57 @@
 		IL_0040: ldc.i4.1
 		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
-		IL_0047: ldstr "createServer"
-		IL_004c: ldloc.3
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0052: stloc.s 4
-		IL_0054: ldloc.0
-		IL_0055: ldloc.s 4
-		IL_0057: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-		IL_005c: ldloc.0
-		IL_005d: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0067: stloc.s 4
-		IL_0069: ldc.i4.1
-		IL_006a: newarr [System.Runtime]System.Object
-		IL_006f: dup
-		IL_0070: ldc.i4.0
-		IL_0071: ldloc.0
-		IL_0072: stelem.ref
-		IL_0073: stloc.2
-		IL_0074: ldloc.2
-		IL_0075: ldc.i4.0
-		IL_0076: ldelem.ref
-		IL_0077: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-		IL_007c: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
-		IL_0081: ldc.i4.0
-		IL_0082: conv.r8
-		IL_0083: ldstr ""
-		IL_0088: ldc.i4.0
-		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.s 4
-		IL_0093: ldstr "listen"
-		IL_0098: ldc.r8 0.0
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: ldstr "127.0.0.1"
-		IL_00ab: ldloc.s 5
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b2: pop
-		IL_00b3: ret
+		IL_0047: volatile.
+		IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_004e: brfalse IL_0063
+
+		IL_0053: ldstr "createServer"
+		IL_0058: ldloc.3
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005e: br IL_0078
+
+		IL_0063: ldstr "createServer"
+		IL_0068: ldloc.3
+		IL_0069: ldstr "Net_Socket_Timeout_Allows_Graceful_End:Modules.Net_Socket_Timeout_Allows_Graceful_End:__js_module_init__:12"
+		IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0078: stloc.s 4
+		IL_007a: ldloc.0
+		IL_007b: ldloc.s 4
+		IL_007d: stfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
+		IL_0082: ldloc.0
+		IL_0083: ldfld object Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::server
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008d: stloc.s 4
+		IL_008f: ldc.i4.1
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldloc.0
+		IL_0098: stelem.ref
+		IL_0099: stloc.2
+		IL_009a: ldloc.2
+		IL_009b: ldc.i4.0
+		IL_009c: ldelem.ref
+		IL_009d: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
+		IL_00a2: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
+		IL_00a7: ldc.i4.0
+		IL_00a8: conv.r8
+		IL_00a9: ldstr ""
+		IL_00ae: ldc.i4.0
+		IL_00af: ldc.i4.1
+		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b5: stloc.s 5
+		IL_00b7: ldloc.s 4
+		IL_00b9: ldstr "listen"
+		IL_00be: ldc.r8 0.0
+		IL_00c7: box [System.Runtime]System.Double
+		IL_00cc: ldstr "127.0.0.1"
+		IL_00d1: ldloc.s 5
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00d8: pop
+		IL_00d9: ret
 	} // end of method Net_Socket_Timeout_Allows_Graceful_End::__js_module_init__
 
 } // end of class Modules.Net_Socket_Timeout_Allows_Graceful_End
@@ -1590,6 +1626,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
@@ -219,7 +219,7 @@
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
 			// Header size: 12
-			// Code size: 25 (0x19)
+			// Code size: 68 (0x44)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -227,13 +227,26 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-			IL_0006: ldstr "normalize"
-			IL_000b: ldarg.2
-			IL_000c: box [System.Runtime]System.Double
-			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0016: stloc.0
-			IL_0017: ldloc.0
-			IL_0018: ret
+			IL_0006: volatile.
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_000d: brfalse IL_0027
+
+			IL_0012: ldstr "normalize"
+			IL_0017: ldarg.2
+			IL_0018: box [System.Runtime]System.Double
+			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0022: br IL_0041
+
+			IL_0027: ldstr "normalize"
+			IL_002c: ldarg.2
+			IL_002d: box [System.Runtime]System.Double
+			IL_0032: ldstr "Require_Path_MemberOverrides:<TwoPhaseDummy_M4>:__js_call__:4"
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0041: stloc.0
+			IL_0042: ldloc.0
+			IL_0043: ret
 		} // end of method normalize::__js_call__
 
 	} // end of class normalize
@@ -993,6 +1006,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_ModuleRequireOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_ModuleRequireOverride.verified.txt
@@ -260,7 +260,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 236 (0xec)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_ModuleRequireOverride/Scope,
@@ -280,74 +280,86 @@
 		IL_0012: stloc.1
 		IL_0013: ldarg.2
 		IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0019: ldstr "Require"
-		IL_001e: ldstr "path"
-		IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0028: stloc.2
-		IL_0029: ldc.i4.1
-		IL_002a: newarr [System.Runtime]System.Object
-		IL_002f: dup
-		IL_0030: ldc.i4.0
-		IL_0031: ldloc.0
-		IL_0032: stelem.ref
-		IL_0033: stloc.3
-		IL_0034: newobj instance void Modules.Require_Path_ModuleRequireOverride/ArrowFunction_L5C31/FunctionObject::.ctor()
-		IL_0039: ldc.i4.0
-		IL_003a: conv.r8
-		IL_003b: ldstr ""
-		IL_0040: ldc.i4.0
-		IL_0041: ldc.i4.0
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_ModuleRequireOverride/ArrowFunction_L5C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Path_ModuleRequireOverride/ArrowFunction_L5C31/FunctionObject>(!!0)
-		IL_004c: stloc.s 4
-		IL_004e: ldloc.2
-		IL_004f: ldstr "join"
-		IL_0054: ldloc.s 4
-		IL_0056: ldc.i4.1
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_005c: pop
-		IL_005d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0062: stloc.s 5
-		IL_0064: ldloc.1
-		IL_0065: ldstr "join"
-		IL_006a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_006f: brtrue IL_0096
+		IL_0019: volatile.
+		IL_001b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0020: brfalse IL_0039
 
-		IL_0074: ldloc.1
-		IL_0075: ldc.i4.2
-		IL_0076: newarr [System.Runtime]System.Object
-		IL_007b: dup
-		IL_007c: ldc.i4.0
-		IL_007d: ldstr "a"
-		IL_0082: stelem.ref
-		IL_0083: dup
-		IL_0084: ldc.i4.1
-		IL_0085: ldstr "b"
-		IL_008a: stelem.ref
-		IL_008b: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_0090: stloc.2
-		IL_0091: br IL_00b8
+		IL_0025: ldstr "Require"
+		IL_002a: ldstr "path"
+		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0034: br IL_0052
 
-		IL_0096: ldloc.1
-		IL_0097: ldstr "join"
-		IL_009c: ldc.i4.2
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldstr "a"
-		IL_00a9: stelem.ref
-		IL_00aa: dup
-		IL_00ab: ldc.i4.1
-		IL_00ac: ldstr "b"
-		IL_00b1: stelem.ref
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-		IL_00b7: stloc.2
+		IL_0039: ldstr "Require"
+		IL_003e: ldstr "path"
+		IL_0043: ldstr "Require_Path_ModuleRequireOverride:Modules.Require_Path_ModuleRequireOverride:__js_module_init__:12"
+		IL_0048: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00b8: ldloc.s 5
-		IL_00ba: ldloc.2
-		IL_00bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_0052: stloc.2
+		IL_0053: ldc.i4.1
+		IL_0054: newarr [System.Runtime]System.Object
+		IL_0059: dup
+		IL_005a: ldc.i4.0
+		IL_005b: ldloc.0
+		IL_005c: stelem.ref
+		IL_005d: stloc.3
+		IL_005e: newobj instance void Modules.Require_Path_ModuleRequireOverride/ArrowFunction_L5C31/FunctionObject::.ctor()
+		IL_0063: ldc.i4.0
+		IL_0064: conv.r8
+		IL_0065: ldstr ""
+		IL_006a: ldc.i4.0
+		IL_006b: ldc.i4.0
+		IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_ModuleRequireOverride/ArrowFunction_L5C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Path_ModuleRequireOverride/ArrowFunction_L5C31/FunctionObject>(!!0)
+		IL_0076: stloc.s 4
+		IL_0078: ldloc.2
+		IL_0079: ldstr "join"
+		IL_007e: ldloc.s 4
+		IL_0080: ldc.i4.1
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0086: pop
+		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008c: stloc.s 5
+		IL_008e: ldloc.1
+		IL_008f: ldstr "join"
+		IL_0094: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_0099: brtrue IL_00c0
+
+		IL_009e: ldloc.1
+		IL_009f: ldc.i4.2
+		IL_00a0: newarr [System.Runtime]System.Object
+		IL_00a5: dup
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldstr "a"
+		IL_00ac: stelem.ref
+		IL_00ad: dup
+		IL_00ae: ldc.i4.1
+		IL_00af: ldstr "b"
+		IL_00b4: stelem.ref
+		IL_00b5: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_00ba: stloc.2
+		IL_00bb: br IL_00e2
+
+		IL_00c0: ldloc.1
+		IL_00c1: ldstr "join"
+		IL_00c6: ldc.i4.2
+		IL_00c7: newarr [System.Runtime]System.Object
+		IL_00cc: dup
+		IL_00cd: ldc.i4.0
+		IL_00ce: ldstr "a"
+		IL_00d3: stelem.ref
+		IL_00d4: dup
+		IL_00d5: ldc.i4.1
+		IL_00d6: ldstr "b"
+		IL_00db: stelem.ref
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_00e1: stloc.2
+
+		IL_00e2: ldloc.s 5
+		IL_00e4: ldloc.2
+		IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ea: pop
+		IL_00eb: ret
 	} // end of method Require_Path_ModuleRequireOverride::__js_module_init__
 
 } // end of class Modules.Require_Path_ModuleRequireOverride
@@ -372,4 +384,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Normalize_And_Sep.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Normalize_And_Sep.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 450 (0x1c2)
+		// Code size: 530 (0x212)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Normalize_And_Sep/Scope,
@@ -158,124 +158,150 @@
 		IL_0063: ldstr "c"
 		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 		IL_006d: stloc.s 5
-		IL_006f: ldloc.1
-		IL_0070: ldstr "normalize"
-		IL_0075: ldloc.s 5
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007c: stloc.3
-		IL_007d: ldloc.2
-		IL_007e: ldstr "tmp"
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0088: stloc.s 5
-		IL_008a: ldloc.s 5
-		IL_008c: ldloc.2
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0092: stloc.s 5
-		IL_0094: ldloc.s 5
-		IL_0096: ldloc.2
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_009c: stloc.s 5
-		IL_009e: ldloc.s 5
-		IL_00a0: ldstr "x"
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00aa: stloc.s 5
-		IL_00ac: ldloc.s 5
-		IL_00ae: ldloc.2
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00b4: stloc.s 5
-		IL_00b6: ldloc.s 5
-		IL_00b8: ldstr "."
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00c2: stloc.s 5
-		IL_00c4: ldloc.s 5
-		IL_00c6: ldloc.2
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00cc: stloc.s 5
-		IL_00ce: ldloc.s 5
-		IL_00d0: ldstr "y"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00da: stloc.s 5
-		IL_00dc: ldloc.1
-		IL_00dd: ldstr "normalize"
-		IL_00e2: ldloc.s 5
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e9: stloc.s 4
-		IL_00eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f0: stloc.s 6
-		IL_00f2: ldstr "a"
-		IL_00f7: ldloc.2
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00fd: stloc.s 5
-		IL_00ff: ldloc.s 5
-		IL_0101: ldstr "c"
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_010b: stloc.s 5
-		IL_010d: ldloc.3
-		IL_010e: ldloc.s 5
-		IL_0110: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0115: stloc.s 7
-		IL_0117: ldloc.s 7
-		IL_0119: box [System.Runtime]System.Boolean
-		IL_011e: stloc.s 8
-		IL_0120: ldloc.s 6
-		IL_0122: ldloc.s 8
-		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0129: pop
-		IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012f: stloc.s 6
-		IL_0131: ldc.i4.3
-		IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0137: dup
-		IL_0138: ldstr "tmp"
-		IL_013d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0142: dup
-		IL_0143: ldstr "x"
-		IL_0148: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_014d: dup
-		IL_014e: ldstr "y"
-		IL_0153: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0158: stloc.s 9
-		IL_015a: ldloc.s 9
-		IL_015c: ldc.i4.1
-		IL_015d: newarr [System.Runtime]System.Object
-		IL_0162: dup
-		IL_0163: ldc.i4.0
-		IL_0164: ldloc.2
-		IL_0165: stelem.ref
-		IL_0166: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_016b: stloc.s 10
-		IL_016d: ldloc.2
-		IL_016e: ldloc.s 10
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0175: stloc.s 5
-		IL_0177: ldloc.s 4
-		IL_0179: ldloc.s 5
-		IL_017b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0180: stloc.s 7
-		IL_0182: ldloc.s 7
-		IL_0184: box [System.Runtime]System.Boolean
-		IL_0189: stloc.s 8
-		IL_018b: ldloc.s 6
-		IL_018d: ldloc.s 8
-		IL_018f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0194: pop
-		IL_0195: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_019a: stloc.s 6
-		IL_019c: ldloc.1
-		IL_019d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
-		IL_01a2: stloc.s 11
-		IL_01a4: ldloc.s 11
-		IL_01a6: ldloc.2
-		IL_01a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01ac: stloc.s 7
-		IL_01ae: ldloc.s 7
-		IL_01b0: box [System.Runtime]System.Boolean
-		IL_01b5: stloc.s 8
-		IL_01b7: ldloc.s 6
-		IL_01b9: ldloc.s 8
-		IL_01bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01c0: pop
-		IL_01c1: ret
+		IL_006f: volatile.
+		IL_0071: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0076: brfalse IL_008d
+
+		IL_007b: ldloc.1
+		IL_007c: ldstr "normalize"
+		IL_0081: ldloc.s 5
+		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0088: br IL_00a4
+
+		IL_008d: ldloc.1
+		IL_008e: ldstr "normalize"
+		IL_0093: ldloc.s 5
+		IL_0095: ldstr "Require_Path_Normalize_And_Sep:Modules.Require_Path_Normalize_And_Sep:__js_module_init__:23"
+		IL_009a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a4: stloc.3
+		IL_00a5: ldloc.2
+		IL_00a6: ldstr "tmp"
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00b0: stloc.s 5
+		IL_00b2: ldloc.s 5
+		IL_00b4: ldloc.2
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00ba: stloc.s 5
+		IL_00bc: ldloc.s 5
+		IL_00be: ldloc.2
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00c4: stloc.s 5
+		IL_00c6: ldloc.s 5
+		IL_00c8: ldstr "x"
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00d2: stloc.s 5
+		IL_00d4: ldloc.s 5
+		IL_00d6: ldloc.2
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00dc: stloc.s 5
+		IL_00de: ldloc.s 5
+		IL_00e0: ldstr "."
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00ea: stloc.s 5
+		IL_00ec: ldloc.s 5
+		IL_00ee: ldloc.2
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00f4: stloc.s 5
+		IL_00f6: ldloc.s 5
+		IL_00f8: ldstr "y"
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0102: stloc.s 5
+		IL_0104: volatile.
+		IL_0106: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_010b: brfalse IL_0122
+
+		IL_0110: ldloc.1
+		IL_0111: ldstr "normalize"
+		IL_0116: ldloc.s 5
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011d: br IL_0139
+
+		IL_0122: ldloc.1
+		IL_0123: ldstr "normalize"
+		IL_0128: ldloc.s 5
+		IL_012a: ldstr "Require_Path_Normalize_And_Sep:Modules.Require_Path_Normalize_And_Sep:__js_module_init__:38"
+		IL_012f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0139: stloc.s 4
+		IL_013b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0140: stloc.s 6
+		IL_0142: ldstr "a"
+		IL_0147: ldloc.2
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_014d: stloc.s 5
+		IL_014f: ldloc.s 5
+		IL_0151: ldstr "c"
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_015b: stloc.s 5
+		IL_015d: ldloc.3
+		IL_015e: ldloc.s 5
+		IL_0160: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0165: stloc.s 7
+		IL_0167: ldloc.s 7
+		IL_0169: box [System.Runtime]System.Boolean
+		IL_016e: stloc.s 8
+		IL_0170: ldloc.s 6
+		IL_0172: ldloc.s 8
+		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0179: pop
+		IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017f: stloc.s 6
+		IL_0181: ldc.i4.3
+		IL_0182: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0187: dup
+		IL_0188: ldstr "tmp"
+		IL_018d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0192: dup
+		IL_0193: ldstr "x"
+		IL_0198: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_019d: dup
+		IL_019e: ldstr "y"
+		IL_01a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01a8: stloc.s 9
+		IL_01aa: ldloc.s 9
+		IL_01ac: ldc.i4.1
+		IL_01ad: newarr [System.Runtime]System.Object
+		IL_01b2: dup
+		IL_01b3: ldc.i4.0
+		IL_01b4: ldloc.2
+		IL_01b5: stelem.ref
+		IL_01b6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_01bb: stloc.s 10
+		IL_01bd: ldloc.2
+		IL_01be: ldloc.s 10
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01c5: stloc.s 5
+		IL_01c7: ldloc.s 4
+		IL_01c9: ldloc.s 5
+		IL_01cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01d0: stloc.s 7
+		IL_01d2: ldloc.s 7
+		IL_01d4: box [System.Runtime]System.Boolean
+		IL_01d9: stloc.s 8
+		IL_01db: ldloc.s 6
+		IL_01dd: ldloc.s 8
+		IL_01df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01e4: pop
+		IL_01e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ea: stloc.s 6
+		IL_01ec: ldloc.1
+		IL_01ed: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
+		IL_01f2: stloc.s 11
+		IL_01f4: ldloc.s 11
+		IL_01f6: ldloc.2
+		IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01fc: stloc.s 7
+		IL_01fe: ldloc.s 7
+		IL_0200: box [System.Runtime]System.Boolean
+		IL_0205: stloc.s 8
+		IL_0207: ldloc.s 6
+		IL_0209: ldloc.s 8
+		IL_020b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0210: pop
+		IL_0211: ret
 	} // end of method Require_Path_Normalize_And_Sep::__js_module_init__
 
 } // end of class Modules.Require_Path_Normalize_And_Sep
@@ -300,4 +326,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Parse_And_Format.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Parse_And_Format.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1266 (0x4f2)
+		// Code size: 1469 (0x5bd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Parse_And_Format/Scope,
@@ -167,392 +167,457 @@
 		IL_0062: ldloc.s 10
 		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 		IL_0069: stloc.3
-		IL_006a: ldloc.1
-		IL_006b: ldstr "parse"
-		IL_0070: ldloc.3
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0076: stloc.s 4
-		IL_0078: volatile.
-		IL_007a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_007f: brfalse IL_0095
+		IL_006a: volatile.
+		IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0071: brfalse IL_0087
 
-		IL_0084: ldloc.s 4
-		IL_0086: ldstr "dir"
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0090: br IL_00ab
+		IL_0076: ldloc.1
+		IL_0077: ldstr "parse"
+		IL_007c: ldloc.3
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0082: br IL_009d
 
-		IL_0095: ldloc.s 4
-		IL_0097: ldstr "dir"
-		IL_009c: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:25"
-		IL_00a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0087: ldloc.1
+		IL_0088: ldstr "parse"
+		IL_008d: ldloc.3
+		IL_008e: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:21"
+		IL_0093: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00ab: stloc.s 11
-		IL_00ad: ldloc.s 11
-		IL_00af: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_00b4: stloc.s 12
-		IL_00b6: ldloc.s 12
-		IL_00b8: brtrue IL_00c9
+		IL_009d: stloc.s 4
+		IL_009f: volatile.
+		IL_00a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a6: brfalse IL_00bc
 
-		IL_00bd: ldstr ""
-		IL_00c2: stloc.s 14
-		IL_00c4: br IL_00cd
+		IL_00ab: ldloc.s 4
+		IL_00ad: ldstr "dir"
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b7: br IL_00d2
 
-		IL_00c9: ldloc.s 11
-		IL_00cb: stloc.s 14
+		IL_00bc: ldloc.s 4
+		IL_00be: ldstr "dir"
+		IL_00c3: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:25"
+		IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00cd: ldloc.s 14
-		IL_00cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_00d4: stloc.s 5
-		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00db: stloc.s 15
-		IL_00dd: volatile.
-		IL_00df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00e4: brfalse IL_00fa
+		IL_00d2: stloc.s 11
+		IL_00d4: ldloc.s 11
+		IL_00d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_00db: stloc.s 12
+		IL_00dd: ldloc.s 12
+		IL_00df: brtrue IL_00f0
 
-		IL_00e9: ldloc.s 4
-		IL_00eb: ldstr "base"
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f5: br IL_0110
+		IL_00e4: ldstr ""
+		IL_00e9: stloc.s 14
+		IL_00eb: br IL_00f4
 
-		IL_00fa: ldloc.s 4
-		IL_00fc: ldstr "base"
-		IL_0101: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:39"
-		IL_0106: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00f0: ldloc.s 11
+		IL_00f2: stloc.s 14
 
-		IL_0110: stloc.s 11
-		IL_0112: ldloc.s 11
-		IL_0114: ldstr "file.txt"
-		IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_011e: stloc.s 12
-		IL_0120: ldloc.s 12
-		IL_0122: box [System.Runtime]System.Boolean
-		IL_0127: stloc.s 16
-		IL_0129: ldloc.s 15
-		IL_012b: ldloc.s 16
-		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0132: pop
-		IL_0133: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0138: stloc.s 15
-		IL_013a: volatile.
-		IL_013c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0141: brfalse IL_0157
+		IL_00f4: ldloc.s 14
+		IL_00f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_00fb: stloc.s 5
+		IL_00fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0102: stloc.s 15
+		IL_0104: volatile.
+		IL_0106: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_010b: brfalse IL_0121
 
-		IL_0146: ldloc.s 4
-		IL_0148: ldstr "ext"
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0152: br IL_016d
+		IL_0110: ldloc.s 4
+		IL_0112: ldstr "base"
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011c: br IL_0137
 
-		IL_0157: ldloc.s 4
-		IL_0159: ldstr "ext"
-		IL_015e: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:47"
-		IL_0163: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0121: ldloc.s 4
+		IL_0123: ldstr "base"
+		IL_0128: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:39"
+		IL_012d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_016d: stloc.s 11
-		IL_016f: ldloc.s 11
-		IL_0171: ldstr ".txt"
-		IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_017b: stloc.s 12
-		IL_017d: ldloc.s 12
-		IL_017f: box [System.Runtime]System.Boolean
-		IL_0184: stloc.s 16
-		IL_0186: ldloc.s 15
-		IL_0188: ldloc.s 16
-		IL_018a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018f: pop
-		IL_0190: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0195: stloc.s 15
-		IL_0197: volatile.
-		IL_0199: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_019e: brfalse IL_01b4
+		IL_0137: stloc.s 11
+		IL_0139: ldloc.s 11
+		IL_013b: ldstr "file.txt"
+		IL_0140: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0145: stloc.s 12
+		IL_0147: ldloc.s 12
+		IL_0149: box [System.Runtime]System.Boolean
+		IL_014e: stloc.s 16
+		IL_0150: ldloc.s 15
+		IL_0152: ldloc.s 16
+		IL_0154: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0159: pop
+		IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_015f: stloc.s 15
+		IL_0161: volatile.
+		IL_0163: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0168: brfalse IL_017e
 
-		IL_01a3: ldloc.s 4
-		IL_01a5: ldstr "name"
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01af: br IL_01ca
+		IL_016d: ldloc.s 4
+		IL_016f: ldstr "ext"
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0179: br IL_0194
 
-		IL_01b4: ldloc.s 4
-		IL_01b6: ldstr "name"
-		IL_01bb: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:55"
-		IL_01c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_017e: ldloc.s 4
+		IL_0180: ldstr "ext"
+		IL_0185: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:47"
+		IL_018a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01ca: stloc.s 11
-		IL_01cc: ldloc.s 11
-		IL_01ce: ldstr "file"
-		IL_01d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01d8: stloc.s 12
-		IL_01da: ldloc.s 12
-		IL_01dc: box [System.Runtime]System.Boolean
-		IL_01e1: stloc.s 16
-		IL_01e3: ldloc.s 15
-		IL_01e5: ldloc.s 16
-		IL_01e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ec: pop
-		IL_01ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f2: stloc.s 15
-		IL_01f4: volatile.
-		IL_01f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01fb: brfalse IL_0211
+		IL_0194: stloc.s 11
+		IL_0196: ldloc.s 11
+		IL_0198: ldstr ".txt"
+		IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01a2: stloc.s 12
+		IL_01a4: ldloc.s 12
+		IL_01a6: box [System.Runtime]System.Boolean
+		IL_01ab: stloc.s 16
+		IL_01ad: ldloc.s 15
+		IL_01af: ldloc.s 16
+		IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b6: pop
+		IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01bc: stloc.s 15
+		IL_01be: volatile.
+		IL_01c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01c5: brfalse IL_01db
 
-		IL_0200: ldloc.s 4
-		IL_0202: ldstr "root"
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020c: br IL_0227
+		IL_01ca: ldloc.s 4
+		IL_01cc: ldstr "name"
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d6: br IL_01f1
 
-		IL_0211: ldloc.s 4
-		IL_0213: ldstr "root"
-		IL_0218: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:63"
-		IL_021d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01db: ldloc.s 4
+		IL_01dd: ldstr "name"
+		IL_01e2: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:55"
+		IL_01e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0227: stloc.s 11
-		IL_0229: ldloc.s 11
-		IL_022b: ldloc.2
-		IL_022c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0231: stloc.s 12
-		IL_0233: ldloc.s 12
-		IL_0235: box [System.Runtime]System.Boolean
-		IL_023a: stloc.s 16
-		IL_023c: ldloc.s 16
-		IL_023e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_0243: stloc.s 12
-		IL_0245: ldloc.s 12
-		IL_0247: brtrue IL_02a1
+		IL_01f1: stloc.s 11
+		IL_01f3: ldloc.s 11
+		IL_01f5: ldstr "file"
+		IL_01fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01ff: stloc.s 12
+		IL_0201: ldloc.s 12
+		IL_0203: box [System.Runtime]System.Boolean
+		IL_0208: stloc.s 16
+		IL_020a: ldloc.s 15
+		IL_020c: ldloc.s 16
+		IL_020e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0213: pop
+		IL_0214: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0219: stloc.s 15
+		IL_021b: volatile.
+		IL_021d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0222: brfalse IL_0238
 
-		IL_024c: volatile.
-		IL_024e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0253: brfalse IL_0269
+		IL_0227: ldloc.s 4
+		IL_0229: ldstr "root"
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0233: br IL_024e
 
-		IL_0258: ldloc.s 4
-		IL_025a: ldstr "root"
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0264: br IL_027f
+		IL_0238: ldloc.s 4
+		IL_023a: ldstr "root"
+		IL_023f: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:63"
+		IL_0244: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0269: ldloc.s 4
-		IL_026b: ldstr "root"
-		IL_0270: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:69"
-		IL_0275: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_024e: stloc.s 11
+		IL_0250: ldloc.s 11
+		IL_0252: ldloc.2
+		IL_0253: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0258: stloc.s 12
+		IL_025a: ldloc.s 12
+		IL_025c: box [System.Runtime]System.Boolean
+		IL_0261: stloc.s 16
+		IL_0263: ldloc.s 16
+		IL_0265: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_026a: stloc.s 12
+		IL_026c: ldloc.s 12
+		IL_026e: brtrue IL_02c8
 
-		IL_027f: stloc.s 11
-		IL_0281: ldloc.s 11
-		IL_0283: ldstr ""
-		IL_0288: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_028d: stloc.s 12
-		IL_028f: ldloc.s 12
-		IL_0291: box [System.Runtime]System.Boolean
-		IL_0296: stloc.s 17
-		IL_0298: ldloc.s 17
-		IL_029a: stloc.s 18
-		IL_029c: br IL_02a5
+		IL_0273: volatile.
+		IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_027a: brfalse IL_0290
 
-		IL_02a1: ldloc.s 16
-		IL_02a3: stloc.s 18
+		IL_027f: ldloc.s 4
+		IL_0281: ldstr "root"
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028b: br IL_02a6
 
-		IL_02a5: ldloc.s 15
-		IL_02a7: ldloc.s 18
-		IL_02a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ae: pop
-		IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b4: stloc.s 15
-		IL_02b6: ldloc.s 5
-		IL_02b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_02bd: stloc.s 10
-		IL_02bf: ldc.i4.3
-		IL_02c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02c5: dup
-		IL_02c6: ldstr "home"
-		IL_02cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_02d0: dup
-		IL_02d1: ldstr "user"
-		IL_02d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_02db: dup
-		IL_02dc: ldstr "dir"
-		IL_02e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_02e6: stloc.s 9
-		IL_02e8: ldloc.s 9
-		IL_02ea: ldc.i4.1
-		IL_02eb: newarr [System.Runtime]System.Object
-		IL_02f0: dup
-		IL_02f1: ldc.i4.0
-		IL_02f2: ldloc.2
-		IL_02f3: stelem.ref
-		IL_02f4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_02f9: stloc.s 19
-		IL_02fb: ldloc.2
-		IL_02fc: ldloc.s 19
-		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0303: stloc.s 18
-		IL_0305: ldloc.s 10
-		IL_0307: ldstr "endsWith"
-		IL_030c: ldloc.s 18
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0313: stloc.s 11
-		IL_0315: ldloc.s 15
-		IL_0317: ldloc.s 11
-		IL_0319: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_031e: pop
-		IL_031f: ldloc.1
-		IL_0320: ldloc.s 4
-		IL_0322: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::format(object)
-		IL_0327: stloc.s 6
-		IL_0329: ldc.i4.2
-		IL_032a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_032f: dup
-		IL_0330: ldstr "tmp"
-		IL_0335: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_033a: dup
-		IL_033b: ldstr "demo"
-		IL_0340: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0345: stloc.s 9
-		IL_0347: ldloc.s 9
-		IL_0349: ldc.i4.1
-		IL_034a: newarr [System.Runtime]System.Object
-		IL_034f: dup
-		IL_0350: ldc.i4.0
-		IL_0351: ldloc.2
-		IL_0352: stelem.ref
-		IL_0353: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0358: stloc.s 10
-		IL_035a: ldloc.2
-		IL_035b: ldloc.s 10
-		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0362: stloc.s 18
-		IL_0364: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0369: dup
-		IL_036a: ldstr "dir"
-		IL_036f: ldloc.s 18
-		IL_0371: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0376: dup
-		IL_0377: ldstr "name"
-		IL_037c: ldstr "archive"
-		IL_0381: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0386: dup
-		IL_0387: ldstr "ext"
-		IL_038c: ldstr ".tar"
-		IL_0391: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0396: stloc.s 20
-		IL_0398: ldloc.1
-		IL_0399: ldloc.s 20
-		IL_039b: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::format(object)
-		IL_03a0: stloc.s 7
-		IL_03a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03a7: dup
-		IL_03a8: ldstr "root"
-		IL_03ad: ldloc.2
-		IL_03ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03b3: dup
-		IL_03b4: ldstr "base"
-		IL_03b9: ldstr "index.js"
-		IL_03be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03c3: stloc.s 20
-		IL_03c5: ldloc.1
-		IL_03c6: ldloc.s 20
-		IL_03c8: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::format(object)
-		IL_03cd: stloc.s 8
-		IL_03cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03d4: stloc.s 15
-		IL_03d6: ldloc.s 6
-		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03dd: stloc.s 11
-		IL_03df: ldc.i4.4
-		IL_03e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_03e5: dup
-		IL_03e6: ldstr "home"
-		IL_03eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_03f0: dup
-		IL_03f1: ldstr "user"
-		IL_03f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_03fb: dup
-		IL_03fc: ldstr "dir"
-		IL_0401: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0406: dup
-		IL_0407: ldstr "file.txt"
-		IL_040c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0411: stloc.s 9
-		IL_0413: ldloc.s 9
-		IL_0415: ldc.i4.1
-		IL_0416: newarr [System.Runtime]System.Object
-		IL_041b: dup
-		IL_041c: ldc.i4.0
-		IL_041d: ldloc.2
-		IL_041e: stelem.ref
-		IL_041f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0424: stloc.s 10
-		IL_0426: ldloc.2
-		IL_0427: ldloc.s 10
-		IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_042e: stloc.s 18
-		IL_0430: ldloc.s 11
-		IL_0432: ldstr "endsWith"
-		IL_0437: ldloc.s 18
-		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_043e: stloc.s 11
-		IL_0440: ldloc.s 15
-		IL_0442: ldloc.s 11
-		IL_0444: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0449: pop
-		IL_044a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_044f: stloc.s 15
-		IL_0451: ldloc.s 7
-		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0458: stloc.s 11
-		IL_045a: ldc.i4.3
-		IL_045b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0460: dup
-		IL_0461: ldstr "tmp"
-		IL_0466: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0290: ldloc.s 4
+		IL_0292: ldstr "root"
+		IL_0297: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:69"
+		IL_029c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02a6: stloc.s 11
+		IL_02a8: ldloc.s 11
+		IL_02aa: ldstr ""
+		IL_02af: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02b4: stloc.s 12
+		IL_02b6: ldloc.s 12
+		IL_02b8: box [System.Runtime]System.Boolean
+		IL_02bd: stloc.s 17
+		IL_02bf: ldloc.s 17
+		IL_02c1: stloc.s 18
+		IL_02c3: br IL_02cc
+
+		IL_02c8: ldloc.s 16
+		IL_02ca: stloc.s 18
+
+		IL_02cc: ldloc.s 15
+		IL_02ce: ldloc.s 18
+		IL_02d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d5: pop
+		IL_02d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02db: stloc.s 15
+		IL_02dd: ldloc.s 5
+		IL_02df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_02e4: stloc.s 10
+		IL_02e6: ldc.i4.3
+		IL_02e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02ec: dup
+		IL_02ed: ldstr "home"
+		IL_02f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_02f7: dup
+		IL_02f8: ldstr "user"
+		IL_02fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0302: dup
+		IL_0303: ldstr "dir"
+		IL_0308: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_030d: stloc.s 9
+		IL_030f: ldloc.s 9
+		IL_0311: ldc.i4.1
+		IL_0312: newarr [System.Runtime]System.Object
+		IL_0317: dup
+		IL_0318: ldc.i4.0
+		IL_0319: ldloc.2
+		IL_031a: stelem.ref
+		IL_031b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0320: stloc.s 19
+		IL_0322: ldloc.2
+		IL_0323: ldloc.s 19
+		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_032a: stloc.s 18
+		IL_032c: volatile.
+		IL_032e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0333: brfalse IL_034b
+
+		IL_0338: ldloc.s 10
+		IL_033a: ldstr "endsWith"
+		IL_033f: ldloc.s 18
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0346: br IL_0363
+
+		IL_034b: ldloc.s 10
+		IL_034d: ldstr "endsWith"
+		IL_0352: ldloc.s 18
+		IL_0354: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:88"
+		IL_0359: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0363: stloc.s 11
+		IL_0365: ldloc.s 15
+		IL_0367: ldloc.s 11
+		IL_0369: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_036e: pop
+		IL_036f: ldloc.1
+		IL_0370: ldloc.s 4
+		IL_0372: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::format(object)
+		IL_0377: stloc.s 6
+		IL_0379: ldc.i4.2
+		IL_037a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_037f: dup
+		IL_0380: ldstr "tmp"
+		IL_0385: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_038a: dup
+		IL_038b: ldstr "demo"
+		IL_0390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0395: stloc.s 9
+		IL_0397: ldloc.s 9
+		IL_0399: ldc.i4.1
+		IL_039a: newarr [System.Runtime]System.Object
+		IL_039f: dup
+		IL_03a0: ldc.i4.0
+		IL_03a1: ldloc.2
+		IL_03a2: stelem.ref
+		IL_03a3: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_03a8: stloc.s 10
+		IL_03aa: ldloc.2
+		IL_03ab: ldloc.s 10
+		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03b2: stloc.s 18
+		IL_03b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03b9: dup
+		IL_03ba: ldstr "dir"
+		IL_03bf: ldloc.s 18
+		IL_03c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03c6: dup
+		IL_03c7: ldstr "name"
+		IL_03cc: ldstr "archive"
+		IL_03d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03d6: dup
+		IL_03d7: ldstr "ext"
+		IL_03dc: ldstr ".tar"
+		IL_03e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03e6: stloc.s 20
+		IL_03e8: ldloc.1
+		IL_03e9: ldloc.s 20
+		IL_03eb: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::format(object)
+		IL_03f0: stloc.s 7
+		IL_03f2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03f7: dup
+		IL_03f8: ldstr "root"
+		IL_03fd: ldloc.2
+		IL_03fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0403: dup
+		IL_0404: ldstr "base"
+		IL_0409: ldstr "index.js"
+		IL_040e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0413: stloc.s 20
+		IL_0415: ldloc.1
+		IL_0416: ldloc.s 20
+		IL_0418: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::format(object)
+		IL_041d: stloc.s 8
+		IL_041f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0424: stloc.s 15
+		IL_0426: ldloc.s 6
+		IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_042d: stloc.s 11
+		IL_042f: ldc.i4.4
+		IL_0430: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0435: dup
+		IL_0436: ldstr "home"
+		IL_043b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0440: dup
+		IL_0441: ldstr "user"
+		IL_0446: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_044b: dup
+		IL_044c: ldstr "dir"
+		IL_0451: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0456: dup
+		IL_0457: ldstr "file.txt"
+		IL_045c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0461: stloc.s 9
+		IL_0463: ldloc.s 9
+		IL_0465: ldc.i4.1
+		IL_0466: newarr [System.Runtime]System.Object
 		IL_046b: dup
-		IL_046c: ldstr "demo"
-		IL_0471: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0476: dup
-		IL_0477: ldstr "archive.tar"
-		IL_047c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0481: stloc.s 9
-		IL_0483: ldloc.s 9
-		IL_0485: ldc.i4.1
-		IL_0486: newarr [System.Runtime]System.Object
-		IL_048b: dup
-		IL_048c: ldc.i4.0
-		IL_048d: ldloc.2
-		IL_048e: stelem.ref
-		IL_048f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0494: stloc.s 10
-		IL_0496: ldloc.2
-		IL_0497: ldloc.s 10
-		IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_049e: stloc.s 18
-		IL_04a0: ldloc.s 11
-		IL_04a2: ldstr "endsWith"
-		IL_04a7: ldloc.s 18
-		IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04ae: stloc.s 11
-		IL_04b0: ldloc.s 15
-		IL_04b2: ldloc.s 11
-		IL_04b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04b9: pop
-		IL_04ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04bf: stloc.s 15
-		IL_04c1: ldloc.s 8
-		IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c8: stloc.s 11
-		IL_04ca: ldloc.2
-		IL_04cb: ldstr "index.js"
-		IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_04d5: stloc.s 18
-		IL_04d7: ldloc.s 11
-		IL_04d9: ldstr "endsWith"
-		IL_04de: ldloc.s 18
-		IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04e5: stloc.s 11
-		IL_04e7: ldloc.s 15
-		IL_04e9: ldloc.s 11
-		IL_04eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04f0: pop
-		IL_04f1: ret
+		IL_046c: ldc.i4.0
+		IL_046d: ldloc.2
+		IL_046e: stelem.ref
+		IL_046f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0474: stloc.s 10
+		IL_0476: ldloc.2
+		IL_0477: ldloc.s 10
+		IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_047e: stloc.s 18
+		IL_0480: volatile.
+		IL_0482: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0487: brfalse IL_049f
+
+		IL_048c: ldloc.s 11
+		IL_048e: ldstr "endsWith"
+		IL_0493: ldloc.s 18
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_049a: br IL_04b7
+
+		IL_049f: ldloc.s 11
+		IL_04a1: ldstr "endsWith"
+		IL_04a6: ldloc.s 18
+		IL_04a8: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:119"
+		IL_04ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_04b7: stloc.s 11
+		IL_04b9: ldloc.s 15
+		IL_04bb: ldloc.s 11
+		IL_04bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04c2: pop
+		IL_04c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04c8: stloc.s 15
+		IL_04ca: ldloc.s 7
+		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d1: stloc.s 11
+		IL_04d3: ldc.i4.3
+		IL_04d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_04d9: dup
+		IL_04da: ldstr "tmp"
+		IL_04df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_04e4: dup
+		IL_04e5: ldstr "demo"
+		IL_04ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_04ef: dup
+		IL_04f0: ldstr "archive.tar"
+		IL_04f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_04fa: stloc.s 9
+		IL_04fc: ldloc.s 9
+		IL_04fe: ldc.i4.1
+		IL_04ff: newarr [System.Runtime]System.Object
+		IL_0504: dup
+		IL_0505: ldc.i4.0
+		IL_0506: ldloc.2
+		IL_0507: stelem.ref
+		IL_0508: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_050d: stloc.s 10
+		IL_050f: ldloc.2
+		IL_0510: ldloc.s 10
+		IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0517: stloc.s 18
+		IL_0519: volatile.
+		IL_051b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0520: brfalse IL_0538
+
+		IL_0525: ldloc.s 11
+		IL_0527: ldstr "endsWith"
+		IL_052c: ldloc.s 18
+		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0533: br IL_0550
+
+		IL_0538: ldloc.s 11
+		IL_053a: ldstr "endsWith"
+		IL_053f: ldloc.s 18
+		IL_0541: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:130"
+		IL_0546: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0550: stloc.s 11
+		IL_0552: ldloc.s 15
+		IL_0554: ldloc.s 11
+		IL_0556: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_055b: pop
+		IL_055c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0561: stloc.s 15
+		IL_0563: ldloc.s 8
+		IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_056a: stloc.s 11
+		IL_056c: ldloc.2
+		IL_056d: ldstr "index.js"
+		IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0577: stloc.s 18
+		IL_0579: volatile.
+		IL_057b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0580: brfalse IL_0598
+
+		IL_0585: ldloc.s 11
+		IL_0587: ldstr "endsWith"
+		IL_058c: ldloc.s 18
+		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0593: br IL_05b0
+
+		IL_0598: ldloc.s 11
+		IL_059a: ldstr "endsWith"
+		IL_059f: ldloc.s 18
+		IL_05a1: ldstr "Require_Path_Parse_And_Format:Modules.Require_Path_Parse_And_Format:__js_module_init__:137"
+		IL_05a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_05b0: stloc.s 11
+		IL_05b2: ldloc.s 15
+		IL_05b4: ldloc.s 11
+		IL_05b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05bb: pop
+		IL_05bc: ret
 	} // end of method Require_Path_Parse_And_Format::__js_module_init__
 
 } // end of class Modules.Require_Path_Parse_And_Format
@@ -588,6 +653,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_ToNamespacedPath.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_ToNamespacedPath.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 242 (0xf2)
+		// Code size: 281 (0x119)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_ToNamespacedPath/Scope,
@@ -174,40 +174,53 @@
 		IL_008e: stloc.s 4
 		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0095: stloc.s 7
-		IL_0097: ldloc.1
-		IL_0098: ldstr "toNamespacedPath"
-		IL_009d: ldloc.3
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a3: stloc.s 8
-		IL_00a5: ldloc.s 8
-		IL_00a7: ldloc.3
-		IL_00a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00ad: stloc.s 9
-		IL_00af: ldloc.s 9
-		IL_00b1: box [System.Runtime]System.Boolean
-		IL_00b6: stloc.s 10
-		IL_00b8: ldloc.s 7
-		IL_00ba: ldloc.s 10
-		IL_00bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c1: pop
-		IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c7: stloc.s 7
-		IL_00c9: ldloc.1
-		IL_00ca: ldloc.s 4
-		IL_00cc: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::toNamespacedPath(string)
-		IL_00d1: stloc.s 8
-		IL_00d3: ldloc.s 8
-		IL_00d5: ldloc.s 4
-		IL_00d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00dc: stloc.s 9
-		IL_00de: ldloc.s 9
-		IL_00e0: box [System.Runtime]System.Boolean
-		IL_00e5: stloc.s 10
-		IL_00e7: ldloc.s 7
-		IL_00e9: ldloc.s 10
-		IL_00eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f0: pop
-		IL_00f1: ret
+		IL_0097: volatile.
+		IL_0099: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_009e: brfalse IL_00b4
+
+		IL_00a3: ldloc.1
+		IL_00a4: ldstr "toNamespacedPath"
+		IL_00a9: ldloc.3
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00af: br IL_00ca
+
+		IL_00b4: ldloc.1
+		IL_00b5: ldstr "toNamespacedPath"
+		IL_00ba: ldloc.3
+		IL_00bb: ldstr "Require_Path_ToNamespacedPath:Modules.Require_Path_ToNamespacedPath:__js_module_init__:27"
+		IL_00c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ca: stloc.s 8
+		IL_00cc: ldloc.s 8
+		IL_00ce: ldloc.3
+		IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00d4: stloc.s 9
+		IL_00d6: ldloc.s 9
+		IL_00d8: box [System.Runtime]System.Boolean
+		IL_00dd: stloc.s 10
+		IL_00df: ldloc.s 7
+		IL_00e1: ldloc.s 10
+		IL_00e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e8: pop
+		IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ee: stloc.s 7
+		IL_00f0: ldloc.1
+		IL_00f1: ldloc.s 4
+		IL_00f3: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::toNamespacedPath(string)
+		IL_00f8: stloc.s 8
+		IL_00fa: ldloc.s 8
+		IL_00fc: ldloc.s 4
+		IL_00fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0103: stloc.s 9
+		IL_0105: ldloc.s 9
+		IL_0107: box [System.Runtime]System.Boolean
+		IL_010c: stloc.s 10
+		IL_010e: ldloc.s 7
+		IL_0110: ldloc.s 10
+		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0117: pop
+		IL_0118: ret
 	} // end of method Require_Path_ToNamespacedPath::__js_module_init__
 
 } // end of class Modules.Require_Path_ToNamespacedPath
@@ -232,4 +245,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Chdir_And_NextTick_Basics.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Chdir_And_NextTick_Basics.verified.txt
@@ -370,7 +370,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 504 (0x1f8)
+		// Code size: 621 (0x26d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_Chdir_And_NextTick_Basics/Scope,
@@ -408,147 +408,184 @@
 		IL_0046: ldstr "process"
 		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0055: ldstr "chdir"
-		IL_005a: ldarg.s __dirname
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0061: pop
-		IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0067: stloc.2
-		IL_0068: ldstr "process"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0077: volatile.
-		IL_0079: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_007e: brfalse IL_0092
+		IL_0055: volatile.
+		IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_005c: brfalse IL_0072
 
-		IL_0083: ldstr "cwd"
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_008d: br IL_00a6
+		IL_0061: ldstr "chdir"
+		IL_0066: ldarg.s __dirname
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006d: br IL_0088
 
-		IL_0092: ldstr "cwd"
-		IL_0097: ldstr "Process_Chdir_And_NextTick_Basics:Modules.Process_Chdir_And_NextTick_Basics:__js_module_init__:21"
-		IL_009c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0072: ldstr "chdir"
+		IL_0077: ldarg.s __dirname
+		IL_0079: ldstr "Process_Chdir_And_NextTick_Basics:Modules.Process_Chdir_And_NextTick_Basics:__js_module_init__:14"
+		IL_007e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00a6: stloc.3
-		IL_00a7: ldloc.3
-		IL_00a8: ldarg.s __dirname
-		IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00af: stloc.s 4
-		IL_00b1: ldloc.s 4
-		IL_00b3: box [System.Runtime]System.Boolean
-		IL_00b8: stloc.s 5
-		IL_00ba: ldloc.2
-		IL_00bb: ldstr "cwd changed"
-		IL_00c0: ldloc.s 5
-		IL_00c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00c7: pop
-		IL_00c8: ldstr "process"
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d7: ldstr "chdir"
-		IL_00dc: ldloc.1
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e2: pop
-		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e8: stloc.2
-		IL_00e9: ldstr "process"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f8: volatile.
-		IL_00fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_00ff: brfalse IL_0113
+		IL_0088: pop
+		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008e: stloc.2
+		IL_008f: ldstr "process"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009e: volatile.
+		IL_00a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00a5: brfalse IL_00b9
 
-		IL_0104: ldstr "cwd"
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_010e: br IL_0127
+		IL_00aa: ldstr "cwd"
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00b4: br IL_00cd
 
-		IL_0113: ldstr "cwd"
-		IL_0118: ldstr "Process_Chdir_And_NextTick_Basics:Modules.Process_Chdir_And_NextTick_Basics:__js_module_init__:37"
-		IL_011d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_00b9: ldstr "cwd"
+		IL_00be: ldstr "Process_Chdir_And_NextTick_Basics:Modules.Process_Chdir_And_NextTick_Basics:__js_module_init__:21"
+		IL_00c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0127: stloc.3
-		IL_0128: ldloc.3
-		IL_0129: ldloc.1
-		IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_012f: stloc.s 4
-		IL_0131: ldloc.s 4
-		IL_0133: box [System.Runtime]System.Boolean
-		IL_0138: stloc.s 5
-		IL_013a: ldloc.2
-		IL_013b: ldstr "cwd restored"
-		IL_0140: ldloc.s 5
-		IL_0142: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0147: pop
-		IL_0148: ldc.i4.0
-		IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_014e: stloc.s 6
-		IL_0150: ldloc.0
-		IL_0151: ldloc.s 6
-		IL_0153: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-		IL_0158: ldstr "process"
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0167: stloc.3
-		IL_0168: ldc.i4.1
-		IL_0169: newarr [System.Runtime]System.Object
-		IL_016e: dup
-		IL_016f: ldc.i4.0
-		IL_0170: ldloc.0
-		IL_0171: stelem.ref
-		IL_0172: stloc.s 7
-		IL_0174: ldloc.s 7
-		IL_0176: ldc.i4.0
-		IL_0177: ldelem.ref
-		IL_0178: castclass Modules.Process_Chdir_And_NextTick_Basics/Scope
-		IL_017d: newobj instance void Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L10C18/FunctionObject::.ctor(class Modules.Process_Chdir_And_NextTick_Basics/Scope)
-		IL_0182: ldc.i4.0
-		IL_0183: conv.r8
-		IL_0184: ldstr ""
-		IL_0189: ldc.i4.0
-		IL_018a: ldc.i4.0
-		IL_018b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L10C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0190: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L10C18/FunctionObject>(!!0)
-		IL_0195: stloc.s 8
-		IL_0197: ldloc.3
-		IL_0198: ldstr "nextTick"
-		IL_019d: ldloc.s 8
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a4: pop
-		IL_01a5: ldloc.0
-		IL_01a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
-		IL_01ab: stloc.s 6
-		IL_01ad: ldloc.s 6
-		IL_01af: ldstr "sync"
-		IL_01b4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_01b9: pop
-		IL_01ba: ldc.i4.1
-		IL_01bb: newarr [System.Runtime]System.Object
-		IL_01c0: dup
-		IL_01c1: ldc.i4.0
-		IL_01c2: ldloc.0
-		IL_01c3: stelem.ref
-		IL_01c4: stloc.s 7
-		IL_01c6: ldloc.s 7
-		IL_01c8: ldc.i4.0
-		IL_01c9: ldelem.ref
-		IL_01ca: castclass Modules.Process_Chdir_And_NextTick_Basics/Scope
-		IL_01cf: newobj instance void Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L12C14/FunctionObject::.ctor(class Modules.Process_Chdir_And_NextTick_Basics/Scope)
-		IL_01d4: ldc.i4.0
-		IL_01d5: conv.r8
-		IL_01d6: ldstr ""
-		IL_01db: ldc.i4.0
-		IL_01dc: ldc.i4.0
-		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L12C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L12C14/FunctionObject>(!!0)
-		IL_01e7: stloc.s 9
-		IL_01e9: ldloc.s 9
-		IL_01eb: ldc.i4.0
-		IL_01ec: newarr [System.Runtime]System.Object
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_01f6: pop
-		IL_01f7: ret
+		IL_00cd: stloc.3
+		IL_00ce: ldloc.3
+		IL_00cf: ldarg.s __dirname
+		IL_00d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00d6: stloc.s 4
+		IL_00d8: ldloc.s 4
+		IL_00da: box [System.Runtime]System.Boolean
+		IL_00df: stloc.s 5
+		IL_00e1: ldloc.2
+		IL_00e2: ldstr "cwd changed"
+		IL_00e7: ldloc.s 5
+		IL_00e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00ee: pop
+		IL_00ef: ldstr "process"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fe: volatile.
+		IL_0100: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0105: brfalse IL_011a
+
+		IL_010a: ldstr "chdir"
+		IL_010f: ldloc.1
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0115: br IL_012f
+
+		IL_011a: ldstr "chdir"
+		IL_011f: ldloc.1
+		IL_0120: ldstr "Process_Chdir_And_NextTick_Basics:Modules.Process_Chdir_And_NextTick_Basics:__js_module_init__:30"
+		IL_0125: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_012f: pop
+		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0135: stloc.2
+		IL_0136: ldstr "process"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0145: volatile.
+		IL_0147: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_014c: brfalse IL_0160
+
+		IL_0151: ldstr "cwd"
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_015b: br IL_0174
+
+		IL_0160: ldstr "cwd"
+		IL_0165: ldstr "Process_Chdir_And_NextTick_Basics:Modules.Process_Chdir_And_NextTick_Basics:__js_module_init__:37"
+		IL_016a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0174: stloc.3
+		IL_0175: ldloc.3
+		IL_0176: ldloc.1
+		IL_0177: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_017c: stloc.s 4
+		IL_017e: ldloc.s 4
+		IL_0180: box [System.Runtime]System.Boolean
+		IL_0185: stloc.s 5
+		IL_0187: ldloc.2
+		IL_0188: ldstr "cwd restored"
+		IL_018d: ldloc.s 5
+		IL_018f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0194: pop
+		IL_0195: ldc.i4.0
+		IL_0196: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_019b: stloc.s 6
+		IL_019d: ldloc.0
+		IL_019e: ldloc.s 6
+		IL_01a0: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
+		IL_01a5: ldstr "process"
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b4: stloc.3
+		IL_01b5: ldc.i4.1
+		IL_01b6: newarr [System.Runtime]System.Object
+		IL_01bb: dup
+		IL_01bc: ldc.i4.0
+		IL_01bd: ldloc.0
+		IL_01be: stelem.ref
+		IL_01bf: stloc.s 7
+		IL_01c1: ldloc.s 7
+		IL_01c3: ldc.i4.0
+		IL_01c4: ldelem.ref
+		IL_01c5: castclass Modules.Process_Chdir_And_NextTick_Basics/Scope
+		IL_01ca: newobj instance void Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L10C18/FunctionObject::.ctor(class Modules.Process_Chdir_And_NextTick_Basics/Scope)
+		IL_01cf: ldc.i4.0
+		IL_01d0: conv.r8
+		IL_01d1: ldstr ""
+		IL_01d6: ldc.i4.0
+		IL_01d7: ldc.i4.0
+		IL_01d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L10C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L10C18/FunctionObject>(!!0)
+		IL_01e2: stloc.s 8
+		IL_01e4: volatile.
+		IL_01e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01eb: brfalse IL_0202
+
+		IL_01f0: ldloc.3
+		IL_01f1: ldstr "nextTick"
+		IL_01f6: ldloc.s 8
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01fd: br IL_0219
+
+		IL_0202: ldloc.3
+		IL_0203: ldstr "nextTick"
+		IL_0208: ldloc.s 8
+		IL_020a: ldstr "Process_Chdir_And_NextTick_Basics:Modules.Process_Chdir_And_NextTick_Basics:__js_module_init__:50"
+		IL_020f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0219: pop
+		IL_021a: ldloc.0
+		IL_021b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_Chdir_And_NextTick_Basics/Scope::order
+		IL_0220: stloc.s 6
+		IL_0222: ldloc.s 6
+		IL_0224: ldstr "sync"
+		IL_0229: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_022e: pop
+		IL_022f: ldc.i4.1
+		IL_0230: newarr [System.Runtime]System.Object
+		IL_0235: dup
+		IL_0236: ldc.i4.0
+		IL_0237: ldloc.0
+		IL_0238: stelem.ref
+		IL_0239: stloc.s 7
+		IL_023b: ldloc.s 7
+		IL_023d: ldc.i4.0
+		IL_023e: ldelem.ref
+		IL_023f: castclass Modules.Process_Chdir_And_NextTick_Basics/Scope
+		IL_0244: newobj instance void Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L12C14/FunctionObject::.ctor(class Modules.Process_Chdir_And_NextTick_Basics/Scope)
+		IL_0249: ldc.i4.0
+		IL_024a: conv.r8
+		IL_024b: ldstr ""
+		IL_0250: ldc.i4.0
+		IL_0251: ldc.i4.0
+		IL_0252: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L12C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0257: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_Chdir_And_NextTick_Basics/ArrowFunction_L12C14/FunctionObject>(!!0)
+		IL_025c: stloc.s 9
+		IL_025e: ldloc.s 9
+		IL_0260: ldc.i4.0
+		IL_0261: newarr [System.Runtime]System.Object
+		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_026b: pop
+		IL_026c: ret
 	} // end of method Process_Chdir_And_NextTick_Basics::__js_module_init__
 
 } // end of class Modules.Process_Chdir_And_NextTick_Basics
@@ -581,6 +618,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Exit_WithCode_GeneratesCall.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Exit_WithCode_GeneratesCall.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 48 (0x30)
+		// Code size: 99 (0x63)
 		.maxstack 8
 		.locals (
 			[0] class Modules.Process_Exit_WithCode_GeneratesCall/Scope
@@ -115,12 +115,25 @@
 		IL_0007: ldstr "process"
 		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0016: ldstr "exit"
-		IL_001b: ldc.r8 3
-		IL_0024: box [System.Runtime]System.Double
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_002e: pop
-		IL_002f: ret
+		IL_0016: volatile.
+		IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_001d: brfalse IL_003f
+
+		IL_0022: ldstr "exit"
+		IL_0027: ldc.r8 3
+		IL_0030: box [System.Runtime]System.Double
+		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003a: br IL_0061
+
+		IL_003f: ldstr "exit"
+		IL_0044: ldc.r8 3
+		IL_004d: box [System.Runtime]System.Double
+		IL_0052: ldstr "Process_Exit_WithCode_GeneratesCall:Modules.Process_Exit_WithCode_GeneratesCall:__js_module_init__:9"
+		IL_0057: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0061: pop
+		IL_0062: ret
 	} // end of method Process_Exit_WithCode_GeneratesCall::__js_module_init__
 
 } // end of class Modules.Process_Exit_WithCode_GeneratesCall
@@ -145,4 +158,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_And_Promise_Ordering.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_And_Promise_Ordering.verified.txt
@@ -420,7 +420,7 @@
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 107 (0x6b)
+			// Code size: 147 (0x93)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/Scope,
@@ -468,13 +468,26 @@
 			IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/ArrowFunction_L11C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/ArrowFunction_L11C20/FunctionObject>(!!0)
 			IL_0059: stloc.s 4
-			IL_005b: ldloc.2
-			IL_005c: ldstr "nextTick"
-			IL_0061: ldloc.s 4
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0068: pop
-			IL_0069: ldnull
-			IL_006a: ret
+			IL_005b: volatile.
+			IL_005d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0062: brfalse IL_0079
+
+			IL_0067: ldloc.2
+			IL_0068: ldstr "nextTick"
+			IL_006d: ldloc.s 4
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0074: br IL_0090
+
+			IL_0079: ldloc.2
+			IL_007a: ldstr "nextTick"
+			IL_007f: ldloc.s 4
+			IL_0081: ldstr "Process_NextTick_And_Promise_Ordering:<TwoPhaseDummy_M5>:__js_call__:11"
+			IL_0086: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0090: pop
+			IL_0091: ldnull
+			IL_0092: ret
 		} // end of method ArrowFunction_L9C25::__js_call__
 
 	} // end of class ArrowFunction_L9C25
@@ -976,7 +989,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 343 (0x157)
+		// Code size: 463 (0x1cf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_NextTick_And_Promise_Ordering/Scope,
@@ -1029,97 +1042,136 @@
 		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L7C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L7C18/FunctionObject>(!!0)
 		IL_0063: stloc.s 4
-		IL_0065: ldloc.2
-		IL_0066: ldstr "nextTick"
-		IL_006b: ldloc.s 4
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0072: pop
-		IL_0073: ldc.r8 0.0
-		IL_007c: box [System.Runtime]System.Double
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008b: stloc.2
-		IL_008c: ldc.i4.1
-		IL_008d: newarr [System.Runtime]System.Object
-		IL_0092: dup
-		IL_0093: ldc.i4.0
-		IL_0094: ldloc.0
-		IL_0095: stelem.ref
-		IL_0096: stloc.3
-		IL_0097: ldloc.3
-		IL_0098: ldc.i4.0
-		IL_0099: ldelem.ref
-		IL_009a: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-		IL_009f: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/FunctionObject::.ctor(class Modules.Process_NextTick_And_Promise_Ordering/Scope)
-		IL_00a4: ldc.i4.0
-		IL_00a5: conv.r8
-		IL_00a6: ldstr ""
-		IL_00ab: ldc.i4.0
-		IL_00ac: ldc.i4.0
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/FunctionObject>(!!0)
-		IL_00b7: stloc.s 5
-		IL_00b9: ldloc.2
-		IL_00ba: ldstr "then"
-		IL_00bf: ldloc.s 5
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c6: pop
-		IL_00c7: ldc.r8 0.0
-		IL_00d0: box [System.Runtime]System.Double
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00df: stloc.2
-		IL_00e0: ldc.i4.1
-		IL_00e1: newarr [System.Runtime]System.Object
-		IL_00e6: dup
-		IL_00e7: ldc.i4.0
-		IL_00e8: ldloc.0
-		IL_00e9: stelem.ref
-		IL_00ea: stloc.3
-		IL_00eb: ldloc.3
-		IL_00ec: ldc.i4.0
-		IL_00ed: ldelem.ref
-		IL_00ee: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-		IL_00f3: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L14C25/FunctionObject::.ctor(class Modules.Process_NextTick_And_Promise_Ordering/Scope)
-		IL_00f8: ldc.i4.0
-		IL_00f9: conv.r8
-		IL_00fa: ldstr ""
-		IL_00ff: ldc.i4.0
-		IL_0100: ldc.i4.0
-		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L14C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L14C25/FunctionObject>(!!0)
-		IL_010b: stloc.s 6
-		IL_010d: ldloc.2
-		IL_010e: ldstr "then"
-		IL_0113: ldloc.s 6
-		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011a: pop
-		IL_011b: ldc.i4.1
-		IL_011c: newarr [System.Runtime]System.Object
-		IL_0121: dup
-		IL_0122: ldc.i4.0
-		IL_0123: ldloc.0
-		IL_0124: stelem.ref
-		IL_0125: stloc.3
-		IL_0126: ldloc.3
-		IL_0127: ldc.i4.0
-		IL_0128: ldelem.ref
-		IL_0129: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
-		IL_012e: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/FunctionObject::.ctor(class Modules.Process_NextTick_And_Promise_Ordering/Scope)
-		IL_0133: ldc.i4.0
-		IL_0134: conv.r8
-		IL_0135: ldstr ""
-		IL_013a: ldc.i4.0
-		IL_013b: ldc.i4.0
-		IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0141: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/FunctionObject>(!!0)
-		IL_0146: stloc.s 7
-		IL_0148: ldloc.s 7
-		IL_014a: ldc.i4.0
-		IL_014b: newarr [System.Runtime]System.Object
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0155: pop
-		IL_0156: ret
+		IL_0065: volatile.
+		IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_006c: brfalse IL_0083
+
+		IL_0071: ldloc.2
+		IL_0072: ldstr "nextTick"
+		IL_0077: ldloc.s 4
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007e: br IL_009a
+
+		IL_0083: ldloc.2
+		IL_0084: ldstr "nextTick"
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "Process_NextTick_And_Promise_Ordering:Modules.Process_NextTick_And_Promise_Ordering:__js_module_init__:16"
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009a: pop
+		IL_009b: ldc.r8 0.0
+		IL_00a4: box [System.Runtime]System.Double
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b3: stloc.2
+		IL_00b4: ldc.i4.1
+		IL_00b5: newarr [System.Runtime]System.Object
+		IL_00ba: dup
+		IL_00bb: ldc.i4.0
+		IL_00bc: ldloc.0
+		IL_00bd: stelem.ref
+		IL_00be: stloc.3
+		IL_00bf: ldloc.3
+		IL_00c0: ldc.i4.0
+		IL_00c1: ldelem.ref
+		IL_00c2: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+		IL_00c7: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/FunctionObject::.ctor(class Modules.Process_NextTick_And_Promise_Ordering/Scope)
+		IL_00cc: ldc.i4.0
+		IL_00cd: conv.r8
+		IL_00ce: ldstr ""
+		IL_00d3: ldc.i4.0
+		IL_00d4: ldc.i4.0
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L9C25/FunctionObject>(!!0)
+		IL_00df: stloc.s 5
+		IL_00e1: volatile.
+		IL_00e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_00e8: brfalse IL_00ff
+
+		IL_00ed: ldloc.2
+		IL_00ee: ldstr "then"
+		IL_00f3: ldloc.s 5
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fa: br IL_0116
+
+		IL_00ff: ldloc.2
+		IL_0100: ldstr "then"
+		IL_0105: ldloc.s 5
+		IL_0107: ldstr "Process_NextTick_And_Promise_Ordering:Modules.Process_NextTick_And_Promise_Ordering:__js_module_init__:24"
+		IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0116: pop
+		IL_0117: ldc.r8 0.0
+		IL_0120: box [System.Runtime]System.Double
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012f: stloc.2
+		IL_0130: ldc.i4.1
+		IL_0131: newarr [System.Runtime]System.Object
+		IL_0136: dup
+		IL_0137: ldc.i4.0
+		IL_0138: ldloc.0
+		IL_0139: stelem.ref
+		IL_013a: stloc.3
+		IL_013b: ldloc.3
+		IL_013c: ldc.i4.0
+		IL_013d: ldelem.ref
+		IL_013e: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+		IL_0143: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L14C25/FunctionObject::.ctor(class Modules.Process_NextTick_And_Promise_Ordering/Scope)
+		IL_0148: ldc.i4.0
+		IL_0149: conv.r8
+		IL_014a: ldstr ""
+		IL_014f: ldc.i4.0
+		IL_0150: ldc.i4.0
+		IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L14C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0156: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L14C25/FunctionObject>(!!0)
+		IL_015b: stloc.s 6
+		IL_015d: volatile.
+		IL_015f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0164: brfalse IL_017b
+
+		IL_0169: ldloc.2
+		IL_016a: ldstr "then"
+		IL_016f: ldloc.s 6
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0176: br IL_0192
+
+		IL_017b: ldloc.2
+		IL_017c: ldstr "then"
+		IL_0181: ldloc.s 6
+		IL_0183: ldstr "Process_NextTick_And_Promise_Ordering:Modules.Process_NextTick_And_Promise_Ordering:__js_module_init__:32"
+		IL_0188: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0192: pop
+		IL_0193: ldc.i4.1
+		IL_0194: newarr [System.Runtime]System.Object
+		IL_0199: dup
+		IL_019a: ldc.i4.0
+		IL_019b: ldloc.0
+		IL_019c: stelem.ref
+		IL_019d: stloc.3
+		IL_019e: ldloc.3
+		IL_019f: ldc.i4.0
+		IL_01a0: ldelem.ref
+		IL_01a1: castclass Modules.Process_NextTick_And_Promise_Ordering/Scope
+		IL_01a6: newobj instance void Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/FunctionObject::.ctor(class Modules.Process_NextTick_And_Promise_Ordering/Scope)
+		IL_01ab: ldc.i4.0
+		IL_01ac: conv.r8
+		IL_01ad: ldstr ""
+		IL_01b2: ldc.i4.0
+		IL_01b3: ldc.i4.0
+		IL_01b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_And_Promise_Ordering/ArrowFunction_L16C14/FunctionObject>(!!0)
+		IL_01be: stloc.s 7
+		IL_01c0: ldloc.s 7
+		IL_01c2: ldc.i4.0
+		IL_01c3: newarr [System.Runtime]System.Object
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_01cd: pop
+		IL_01ce: ret
 	} // end of method Process_NextTick_And_Promise_Ordering::__js_module_init__
 
 } // end of class Modules.Process_NextTick_And_Promise_Ordering
@@ -1144,4 +1196,15 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Precedes_SetImmediate_When_Queued_Later.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Precedes_SetImmediate_When_Queued_Later.verified.txt
@@ -512,7 +512,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 229 (0xe5)
+		// Code size: 270 (0x10e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope,
@@ -582,39 +582,52 @@
 		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/ArrowFunction_L6C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/ArrowFunction_L6C18/FunctionObject>(!!0)
 		IL_008a: stloc.s 5
-		IL_008c: ldloc.s 4
-		IL_008e: ldstr "nextTick"
-		IL_0093: ldloc.s 5
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009a: pop
-		IL_009b: ldc.i4.1
-		IL_009c: newarr [System.Runtime]System.Object
-		IL_00a1: dup
-		IL_00a2: ldc.i4.0
-		IL_00a3: ldloc.0
-		IL_00a4: stelem.ref
-		IL_00a5: stloc.2
-		IL_00a6: ldloc.2
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldelem.ref
-		IL_00a9: castclass Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope
-		IL_00ae: newobj instance void Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/ArrowFunction_L8C12/FunctionObject::.ctor(class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope)
-		IL_00b3: ldc.i4.0
-		IL_00b4: conv.r8
-		IL_00b5: ldstr ""
-		IL_00ba: ldc.i4.0
-		IL_00bb: ldc.i4.0
-		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/ArrowFunction_L8C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/ArrowFunction_L8C12/FunctionObject>(!!0)
-		IL_00c6: stloc.s 6
-		IL_00c8: ldloc.s 6
-		IL_00ca: ldc.r8 0.0
-		IL_00d3: box [System.Runtime]System.Double
-		IL_00d8: ldc.i4.0
-		IL_00d9: newarr [System.Runtime]System.Object
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
-		IL_00e3: pop
-		IL_00e4: ret
+		IL_008c: volatile.
+		IL_008e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0093: brfalse IL_00ab
+
+		IL_0098: ldloc.s 4
+		IL_009a: ldstr "nextTick"
+		IL_009f: ldloc.s 5
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a6: br IL_00c3
+
+		IL_00ab: ldloc.s 4
+		IL_00ad: ldstr "nextTick"
+		IL_00b2: ldloc.s 5
+		IL_00b4: ldstr "Process_NextTick_Precedes_SetImmediate_When_Queued_Later:Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later:__js_module_init__:16"
+		IL_00b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00c3: pop
+		IL_00c4: ldc.i4.1
+		IL_00c5: newarr [System.Runtime]System.Object
+		IL_00ca: dup
+		IL_00cb: ldc.i4.0
+		IL_00cc: ldloc.0
+		IL_00cd: stelem.ref
+		IL_00ce: stloc.2
+		IL_00cf: ldloc.2
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldelem.ref
+		IL_00d2: castclass Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope
+		IL_00d7: newobj instance void Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/ArrowFunction_L8C12/FunctionObject::.ctor(class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/Scope)
+		IL_00dc: ldc.i4.0
+		IL_00dd: conv.r8
+		IL_00de: ldstr ""
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldc.i4.0
+		IL_00e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/ArrowFunction_L8C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later/ArrowFunction_L8C12/FunctionObject>(!!0)
+		IL_00ef: stloc.s 6
+		IL_00f1: ldloc.s 6
+		IL_00f3: ldc.r8 0.0
+		IL_00fc: box [System.Runtime]System.Double
+		IL_0101: ldc.i4.0
+		IL_0102: newarr [System.Runtime]System.Object
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setTimeout(object, object, object[])
+		IL_010c: pop
+		IL_010d: ret
 	} // end of method Process_NextTick_Precedes_SetImmediate_When_Queued_Later::__js_module_init__
 
 } // end of class Modules.Process_NextTick_Precedes_SetImmediate_When_Queued_Later
@@ -639,4 +652,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Queue_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_NextTick_Queue_Semantics.verified.txt
@@ -639,7 +639,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 325 (0x145)
+		// Code size: 445 (0x1bd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_NextTick_Queue_Semantics/Scope,
@@ -685,102 +685,141 @@
 		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L6C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L6C18/FunctionObject>(!!0)
 		IL_0050: stloc.s 4
-		IL_0052: ldloc.2
-		IL_0053: ldstr "nextTick"
-		IL_0058: ldloc.s 4
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005f: pop
-		IL_0060: ldstr "process"
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006f: stloc.2
-		IL_0070: ldc.i4.1
-		IL_0071: newarr [System.Runtime]System.Object
-		IL_0076: dup
-		IL_0077: ldc.i4.0
-		IL_0078: ldloc.0
-		IL_0079: stelem.ref
-		IL_007a: stloc.3
-		IL_007b: ldloc.3
-		IL_007c: ldc.i4.0
-		IL_007d: ldelem.ref
-		IL_007e: castclass Modules.Process_NextTick_Queue_Semantics/Scope
-		IL_0083: newobj instance void Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L7C18/FunctionObject::.ctor(class Modules.Process_NextTick_Queue_Semantics/Scope)
-		IL_0088: ldc.i4.0
-		IL_0089: conv.r8
-		IL_008a: ldstr ""
-		IL_008f: ldc.i4.0
-		IL_0090: ldc.i4.0
-		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L7C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0096: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L7C18/FunctionObject>(!!0)
-		IL_009b: stloc.s 5
-		IL_009d: ldloc.2
-		IL_009e: ldstr "nextTick"
-		IL_00a3: ldloc.s 5
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00aa: pop
-		IL_00ab: ldloc.0
-		IL_00ac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
-		IL_00b1: stloc.1
-		IL_00b2: ldloc.1
-		IL_00b3: ldstr "sync"
-		IL_00b8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_00bd: pop
-		IL_00be: ldstr "process"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cd: stloc.2
-		IL_00ce: ldc.i4.1
-		IL_00cf: newarr [System.Runtime]System.Object
-		IL_00d4: dup
-		IL_00d5: ldc.i4.0
-		IL_00d6: ldloc.0
-		IL_00d7: stelem.ref
-		IL_00d8: stloc.3
-		IL_00d9: ldloc.3
-		IL_00da: ldc.i4.0
-		IL_00db: ldelem.ref
-		IL_00dc: castclass Modules.Process_NextTick_Queue_Semantics/Scope
-		IL_00e1: newobj instance void Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L11C18/FunctionObject::.ctor(class Modules.Process_NextTick_Queue_Semantics/Scope)
-		IL_00e6: ldc.i4.0
-		IL_00e7: conv.r8
-		IL_00e8: ldstr ""
-		IL_00ed: ldc.i4.0
-		IL_00ee: ldc.i4.0
-		IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L11C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L11C18/FunctionObject>(!!0)
-		IL_00f9: stloc.s 6
-		IL_00fb: ldloc.2
-		IL_00fc: ldstr "nextTick"
-		IL_0101: ldloc.s 6
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0108: pop
-		IL_0109: ldc.i4.1
-		IL_010a: newarr [System.Runtime]System.Object
-		IL_010f: dup
-		IL_0110: ldc.i4.0
-		IL_0111: ldloc.0
-		IL_0112: stelem.ref
-		IL_0113: stloc.3
-		IL_0114: ldloc.3
-		IL_0115: ldc.i4.0
-		IL_0116: ldelem.ref
-		IL_0117: castclass Modules.Process_NextTick_Queue_Semantics/Scope
-		IL_011c: newobj instance void Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L13C14/FunctionObject::.ctor(class Modules.Process_NextTick_Queue_Semantics/Scope)
-		IL_0121: ldc.i4.0
-		IL_0122: conv.r8
-		IL_0123: ldstr ""
-		IL_0128: ldc.i4.0
-		IL_0129: ldc.i4.0
-		IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L13C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L13C14/FunctionObject>(!!0)
-		IL_0134: stloc.s 7
-		IL_0136: ldloc.s 7
-		IL_0138: ldc.i4.0
-		IL_0139: newarr [System.Runtime]System.Object
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0143: pop
-		IL_0144: ret
+		IL_0052: volatile.
+		IL_0054: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0059: brfalse IL_0070
+
+		IL_005e: ldloc.2
+		IL_005f: ldstr "nextTick"
+		IL_0064: ldloc.s 4
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006b: br IL_0087
+
+		IL_0070: ldloc.2
+		IL_0071: ldstr "nextTick"
+		IL_0076: ldloc.s 4
+		IL_0078: ldstr "Process_NextTick_Queue_Semantics:Modules.Process_NextTick_Queue_Semantics:__js_module_init__:12"
+		IL_007d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0087: pop
+		IL_0088: ldstr "process"
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0097: stloc.2
+		IL_0098: ldc.i4.1
+		IL_0099: newarr [System.Runtime]System.Object
+		IL_009e: dup
+		IL_009f: ldc.i4.0
+		IL_00a0: ldloc.0
+		IL_00a1: stelem.ref
+		IL_00a2: stloc.3
+		IL_00a3: ldloc.3
+		IL_00a4: ldc.i4.0
+		IL_00a5: ldelem.ref
+		IL_00a6: castclass Modules.Process_NextTick_Queue_Semantics/Scope
+		IL_00ab: newobj instance void Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L7C18/FunctionObject::.ctor(class Modules.Process_NextTick_Queue_Semantics/Scope)
+		IL_00b0: ldc.i4.0
+		IL_00b1: conv.r8
+		IL_00b2: ldstr ""
+		IL_00b7: ldc.i4.0
+		IL_00b8: ldc.i4.0
+		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L7C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L7C18/FunctionObject>(!!0)
+		IL_00c3: stloc.s 5
+		IL_00c5: volatile.
+		IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00cc: brfalse IL_00e3
+
+		IL_00d1: ldloc.2
+		IL_00d2: ldstr "nextTick"
+		IL_00d7: ldloc.s 5
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00de: br IL_00fa
+
+		IL_00e3: ldloc.2
+		IL_00e4: ldstr "nextTick"
+		IL_00e9: ldloc.s 5
+		IL_00eb: ldstr "Process_NextTick_Queue_Semantics:Modules.Process_NextTick_Queue_Semantics:__js_module_init__:19"
+		IL_00f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00fa: pop
+		IL_00fb: ldloc.0
+		IL_00fc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Process_NextTick_Queue_Semantics/Scope::order
+		IL_0101: stloc.1
+		IL_0102: ldloc.1
+		IL_0103: ldstr "sync"
+		IL_0108: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_010d: pop
+		IL_010e: ldstr "process"
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011d: stloc.2
+		IL_011e: ldc.i4.1
+		IL_011f: newarr [System.Runtime]System.Object
+		IL_0124: dup
+		IL_0125: ldc.i4.0
+		IL_0126: ldloc.0
+		IL_0127: stelem.ref
+		IL_0128: stloc.3
+		IL_0129: ldloc.3
+		IL_012a: ldc.i4.0
+		IL_012b: ldelem.ref
+		IL_012c: castclass Modules.Process_NextTick_Queue_Semantics/Scope
+		IL_0131: newobj instance void Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L11C18/FunctionObject::.ctor(class Modules.Process_NextTick_Queue_Semantics/Scope)
+		IL_0136: ldc.i4.0
+		IL_0137: conv.r8
+		IL_0138: ldstr ""
+		IL_013d: ldc.i4.0
+		IL_013e: ldc.i4.0
+		IL_013f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L11C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0144: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L11C18/FunctionObject>(!!0)
+		IL_0149: stloc.s 6
+		IL_014b: volatile.
+		IL_014d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0152: brfalse IL_0169
+
+		IL_0157: ldloc.2
+		IL_0158: ldstr "nextTick"
+		IL_015d: ldloc.s 6
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0164: br IL_0180
+
+		IL_0169: ldloc.2
+		IL_016a: ldstr "nextTick"
+		IL_016f: ldloc.s 6
+		IL_0171: ldstr "Process_NextTick_Queue_Semantics:Modules.Process_NextTick_Queue_Semantics:__js_module_init__:30"
+		IL_0176: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0180: pop
+		IL_0181: ldc.i4.1
+		IL_0182: newarr [System.Runtime]System.Object
+		IL_0187: dup
+		IL_0188: ldc.i4.0
+		IL_0189: ldloc.0
+		IL_018a: stelem.ref
+		IL_018b: stloc.3
+		IL_018c: ldloc.3
+		IL_018d: ldc.i4.0
+		IL_018e: ldelem.ref
+		IL_018f: castclass Modules.Process_NextTick_Queue_Semantics/Scope
+		IL_0194: newobj instance void Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L13C14/FunctionObject::.ctor(class Modules.Process_NextTick_Queue_Semantics/Scope)
+		IL_0199: ldc.i4.0
+		IL_019a: conv.r8
+		IL_019b: ldstr ""
+		IL_01a0: ldc.i4.0
+		IL_01a1: ldc.i4.0
+		IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L13C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Process_NextTick_Queue_Semantics/ArrowFunction_L13C14/FunctionObject>(!!0)
+		IL_01ac: stloc.s 7
+		IL_01ae: ldloc.s 7
+		IL_01b0: ldc.i4.0
+		IL_01b1: newarr [System.Runtime]System.Object
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_01bb: pop
+		IL_01bc: ret
 	} // end of method Process_NextTick_Queue_Semantics::__js_module_init__
 
 } // end of class Modules.Process_NextTick_Queue_Semantics
@@ -805,4 +844,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Stdout_Stderr_Write.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Stdout_Stderr_Write.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 328 (0x148)
+		// Code size: 496 (0x1f0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Process_Stdout_Stderr_Write/Scope,
@@ -131,77 +131,125 @@
 		IL_0040: stloc.1
 		IL_0041: ldloc.1
 		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0047: ldstr "write"
-		IL_004c: ldstr "stdout"
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0056: pop
-		IL_0057: ldstr "process"
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0061: volatile.
-		IL_0063: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0068: brfalse IL_007c
+		IL_0047: volatile.
+		IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_004e: brfalse IL_0067
 
-		IL_006d: ldstr "stdout"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0077: br IL_0090
+		IL_0053: ldstr "write"
+		IL_0058: ldstr "stdout"
+		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0062: br IL_0080
 
-		IL_007c: ldstr "stdout"
-		IL_0081: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:15"
-		IL_0086: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0067: ldstr "write"
+		IL_006c: ldstr "stdout"
+		IL_0071: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:10"
+		IL_0076: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0090: stloc.1
-		IL_0091: ldloc.1
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0097: ldstr "write"
-		IL_009c: ldstr " ok\n"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a6: pop
-		IL_00a7: ldstr "process"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b1: volatile.
-		IL_00b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00b8: brfalse IL_00cc
+		IL_0080: pop
+		IL_0081: ldstr "process"
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_008b: volatile.
+		IL_008d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0092: brfalse IL_00a6
 
-		IL_00bd: ldstr "stderr"
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c7: br IL_00e0
+		IL_0097: ldstr "stdout"
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a1: br IL_00ba
 
-		IL_00cc: ldstr "stderr"
-		IL_00d1: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:23"
-		IL_00d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00a6: ldstr "stdout"
+		IL_00ab: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:15"
+		IL_00b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00e0: stloc.1
-		IL_00e1: ldloc.1
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e7: ldstr "write"
-		IL_00ec: ldstr "stderr"
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f6: pop
-		IL_00f7: ldstr "process"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0101: volatile.
-		IL_0103: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0108: brfalse IL_011c
+		IL_00ba: stloc.1
+		IL_00bb: ldloc.1
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c1: volatile.
+		IL_00c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00c8: brfalse IL_00e1
 
-		IL_010d: ldstr "stderr"
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0117: br IL_0130
+		IL_00cd: ldstr "write"
+		IL_00d2: ldstr " ok\n"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00dc: br IL_00fa
 
-		IL_011c: ldstr "stderr"
-		IL_0121: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:31"
-		IL_0126: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00e1: ldstr "write"
+		IL_00e6: ldstr " ok\n"
+		IL_00eb: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:18"
+		IL_00f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0130: stloc.1
-		IL_0131: ldloc.1
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0137: ldstr "write"
-		IL_013c: ldstr " ok\n"
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0146: pop
-		IL_0147: ret
+		IL_00fa: pop
+		IL_00fb: ldstr "process"
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0105: volatile.
+		IL_0107: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_010c: brfalse IL_0120
+
+		IL_0111: ldstr "stderr"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011b: br IL_0134
+
+		IL_0120: ldstr "stderr"
+		IL_0125: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:23"
+		IL_012a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0134: stloc.1
+		IL_0135: ldloc.1
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013b: volatile.
+		IL_013d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0142: brfalse IL_015b
+
+		IL_0147: ldstr "write"
+		IL_014c: ldstr "stderr"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0156: br IL_0174
+
+		IL_015b: ldstr "write"
+		IL_0160: ldstr "stderr"
+		IL_0165: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:26"
+		IL_016a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0174: pop
+		IL_0175: ldstr "process"
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_017f: volatile.
+		IL_0181: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0186: brfalse IL_019a
+
+		IL_018b: ldstr "stderr"
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0195: br IL_01ae
+
+		IL_019a: ldstr "stderr"
+		IL_019f: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:31"
+		IL_01a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_01ae: stloc.1
+		IL_01af: ldloc.1
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b5: volatile.
+		IL_01b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01bc: brfalse IL_01d5
+
+		IL_01c1: ldstr "write"
+		IL_01c6: ldstr " ok\n"
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d0: br IL_01ee
+
+		IL_01d5: ldstr "write"
+		IL_01da: ldstr " ok\n"
+		IL_01df: ldstr "Process_Stdout_Stderr_Write:Modules.Process_Stdout_Stderr_Write:__js_module_init__:34"
+		IL_01e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01ee: pop
+		IL_01ef: ret
 	} // end of method Process_Stdout_Stderr_Write::__js_module_init__
 
 } // end of class Modules.Process_Stdout_Stderr_Write
@@ -235,6 +283,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.Global___dirname_PrintsDirectory.verified.txt
+++ b/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.Global___dirname_PrintsDirectory.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 48 (0x30)
+		// Code size: 88 (0x58)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Global___dirname_PrintsDirectory/Scope,
@@ -121,16 +121,29 @@
 		IL_0012: stloc.1
 		IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0018: stloc.2
-		IL_0019: ldloc.1
-		IL_001a: ldstr "dirname"
-		IL_001f: ldarg.s __dirname
-		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0026: stloc.3
-		IL_0027: ldloc.2
-		IL_0028: ldloc.3
-		IL_0029: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_002e: pop
-		IL_002f: ret
+		IL_0019: volatile.
+		IL_001b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0020: brfalse IL_0037
+
+		IL_0025: ldloc.1
+		IL_0026: ldstr "dirname"
+		IL_002b: ldarg.s __dirname
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0032: br IL_004e
+
+		IL_0037: ldloc.1
+		IL_0038: ldstr "dirname"
+		IL_003d: ldarg.s __dirname
+		IL_003f: ldstr "Global___dirname_PrintsDirectory:Modules.Global___dirname_PrintsDirectory:__js_module_init__:11"
+		IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_004e: stloc.3
+		IL_004f: ldloc.2
+		IL_0050: ldloc.3
+		IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0056: pop
+		IL_0057: ret
 	} // end of method Global___dirname_PrintsDirectory::__js_module_init__
 
 } // end of class Modules.Global___dirname_PrintsDirectory
@@ -155,4 +168,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Callback_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Callback_Function_Objects.verified.txt
@@ -328,7 +328,7 @@
 			IL_000e: brfalse IL_004c
 
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldarg.2
@@ -339,7 +339,7 @@
 			IL_002f: ldarg.2
 			IL_0030: ldstr "message"
 			IL_0035: ldstr "Stream_Callback_Function_Objects:<TwoPhaseDummy_M5>:__js_call__:8"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0044: stloc.3
@@ -951,7 +951,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 356 (0x164)
+		// Code size: 440 (0x1b8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Callback_Function_Objects/Scope,
@@ -1027,89 +1027,113 @@
 		IL_008a: pop
 		IL_008b: ldloc.2
 		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0091: ldstr "end"
-		IL_0096: ldstr "async"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a0: pop
-		IL_00a1: ldloc.1
-		IL_00a2: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Writable()
-		IL_00a7: stloc.s 4
-		IL_00a9: ldloc.s 4
-		IL_00ab: dup
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_00b1: stloc.3
-		IL_00b2: ldc.i4.1
-		IL_00b3: newarr [System.Runtime]System.Object
-		IL_00b8: dup
-		IL_00b9: ldc.i4.0
-		IL_00ba: ldloc.0
-		IL_00bb: stelem.ref
-		IL_00bc: stloc.s 5
-		IL_00be: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject::.ctor()
-		IL_00c3: ldc.i4.0
-		IL_00c4: conv.r8
-		IL_00c5: ldstr ""
-		IL_00ca: ldc.i4.0
-		IL_00cb: ldc.i4.1
-		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00d1: stloc.s 8
-		IL_00d3: ldloc.3
-		IL_00d4: ldstr "_write"
-		IL_00d9: ldloc.s 8
-		IL_00db: ldc.i4.1
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00e1: pop
-		IL_00e2: ldc.i4.1
-		IL_00e3: newarr [System.Runtime]System.Object
-		IL_00e8: dup
-		IL_00e9: ldc.i4.0
-		IL_00ea: ldloc.0
-		IL_00eb: stelem.ref
-		IL_00ec: stloc.s 5
-		IL_00ee: ldloc.s 5
-		IL_00f0: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject::.ctor(object[])
+		IL_0091: volatile.
+		IL_0093: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0098: brfalse IL_00b1
+
+		IL_009d: ldstr "end"
+		IL_00a2: ldstr "async"
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ac: br IL_00ca
+
+		IL_00b1: ldstr "end"
+		IL_00b6: ldstr "async"
+		IL_00bb: ldstr "Stream_Callback_Function_Objects:Modules.Stream_Callback_Function_Objects:__js_module_init__:24"
+		IL_00c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ca: pop
+		IL_00cb: ldloc.1
+		IL_00cc: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::get_Writable()
+		IL_00d1: stloc.s 4
+		IL_00d3: ldloc.s 4
+		IL_00d5: dup
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_00db: stloc.3
+		IL_00dc: ldc.i4.1
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldloc.0
+		IL_00e5: stelem.ref
+		IL_00e6: stloc.s 5
+		IL_00e8: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject::.ctor()
+		IL_00ed: ldc.i4.0
+		IL_00ee: conv.r8
+		IL_00ef: ldstr ""
+		IL_00f4: ldc.i4.0
 		IL_00f5: ldc.i4.1
-		IL_00f6: conv.r8
-		IL_00f7: ldstr ""
-		IL_00fc: ldc.i4.1
-		IL_00fd: ldc.i4.1
-		IL_00fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0108: castclass Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject
-		IL_010d: stloc.s 9
-		IL_010f: ldloc.1
-		IL_0110: ldstr "finished"
-		IL_0115: ldloc.3
-		IL_0116: ldloc.s 9
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_011d: pop
-		IL_011e: ldloc.3
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0124: ldstr "end"
-		IL_0129: ldstr "generator"
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0133: pop
-		IL_0134: ldc.i4.1
-		IL_0135: newarr [System.Runtime]System.Object
-		IL_013a: dup
-		IL_013b: ldc.i4.0
-		IL_013c: ldloc.0
-		IL_013d: stelem.ref
-		IL_013e: stloc.s 5
-		IL_0140: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject::.ctor()
-		IL_0145: ldc.i4.0
-		IL_0146: conv.r8
-		IL_0147: ldstr ""
-		IL_014c: ldc.i4.0
-		IL_014d: ldc.i4.1
-		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0153: stloc.s 10
-		IL_0155: ldloc.s 10
-		IL_0157: ldc.i4.0
-		IL_0158: newarr [System.Runtime]System.Object
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0162: pop
-		IL_0163: ret
+		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00fb: stloc.s 8
+		IL_00fd: ldloc.3
+		IL_00fe: ldstr "_write"
+		IL_0103: ldloc.s 8
+		IL_0105: ldc.i4.1
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_010b: pop
+		IL_010c: ldc.i4.1
+		IL_010d: newarr [System.Runtime]System.Object
+		IL_0112: dup
+		IL_0113: ldc.i4.0
+		IL_0114: ldloc.0
+		IL_0115: stelem.ref
+		IL_0116: stloc.s 5
+		IL_0118: ldloc.s 5
+		IL_011a: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject::.ctor(object[])
+		IL_011f: ldc.i4.1
+		IL_0120: conv.r8
+		IL_0121: ldstr ""
+		IL_0126: ldc.i4.1
+		IL_0127: ldc.i4.1
+		IL_0128: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
+		IL_0132: castclass Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject
+		IL_0137: stloc.s 9
+		IL_0139: ldloc.1
+		IL_013a: ldstr "finished"
+		IL_013f: ldloc.3
+		IL_0140: ldloc.s 9
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0147: pop
+		IL_0148: ldloc.3
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014e: volatile.
+		IL_0150: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0155: brfalse IL_016e
+
+		IL_015a: ldstr "end"
+		IL_015f: ldstr "generator"
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0169: br IL_0187
+
+		IL_016e: ldstr "end"
+		IL_0173: ldstr "generator"
+		IL_0178: ldstr "Stream_Callback_Function_Objects:Modules.Stream_Callback_Function_Objects:__js_module_init__:41"
+		IL_017d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0187: pop
+		IL_0188: ldc.i4.1
+		IL_0189: newarr [System.Runtime]System.Object
+		IL_018e: dup
+		IL_018f: ldc.i4.0
+		IL_0190: ldloc.0
+		IL_0191: stelem.ref
+		IL_0192: stloc.s 5
+		IL_0194: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject::.ctor()
+		IL_0199: ldc.i4.0
+		IL_019a: conv.r8
+		IL_019b: ldstr ""
+		IL_01a0: ldc.i4.0
+		IL_01a1: ldc.i4.1
+		IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01a7: stloc.s 10
+		IL_01a9: ldloc.s 10
+		IL_01ab: ldc.i4.0
+		IL_01ac: newarr [System.Runtime]System.Object
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_01b6: pop
+		IL_01b7: ret
 	} // end of method Stream_Callback_Function_Objects::__js_module_init__
 
 } // end of class Modules.Stream_Callback_Function_Objects
@@ -1140,6 +1164,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
@@ -368,7 +368,7 @@
 			IL_000e: brfalse IL_004c
 
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldarg.2
@@ -379,7 +379,7 @@
 			IL_002f: ldarg.2
 			IL_0030: ldstr "message"
 			IL_0035: ldstr "Stream_Finished_Callback_Basic:<TwoPhaseDummy_M5>:__js_call__:8"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0044: stloc.3
@@ -403,7 +403,7 @@
 			IL_006e: ldarg.0
 			IL_006f: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
 			IL_0074: volatile.
-			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_007b: brfalse IL_008f
 
 			IL_0080: ldstr "destroyed"
@@ -412,7 +412,7 @@
 
 			IL_008f: ldstr "destroyed"
 			IL_0094: ldstr "Stream_Finished_Callback_Basic:<TwoPhaseDummy_M5>:__js_call__:22"
-			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00a3: stloc.3
@@ -468,7 +468,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 269 (0x10d)
+		// Code size: 311 (0x137)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Finished_Callback_Basic/Scope,
@@ -553,37 +553,49 @@
 		IL_009d: ldloc.0
 		IL_009e: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
 		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a8: ldstr "end"
-		IL_00ad: ldstr "done"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b7: pop
-		IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bd: stloc.s 6
-		IL_00bf: ldloc.0
-		IL_00c0: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
-		IL_00c5: volatile.
-		IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00cc: brfalse IL_00e0
+		IL_00a8: volatile.
+		IL_00aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00af: brfalse IL_00c8
 
-		IL_00d1: ldstr "writable"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00db: br IL_00f4
+		IL_00b4: ldstr "end"
+		IL_00b9: ldstr "done"
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c3: br IL_00e1
 
-		IL_00e0: ldstr "writable"
-		IL_00e5: ldstr "Stream_Finished_Callback_Basic:Modules.Stream_Finished_Callback_Basic:__js_module_init__:33"
-		IL_00ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00c8: ldstr "end"
+		IL_00cd: ldstr "done"
+		IL_00d2: ldstr "Stream_Finished_Callback_Basic:Modules.Stream_Finished_Callback_Basic:__js_module_init__:27"
+		IL_00d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00f4: stloc.2
-		IL_00f5: ldstr "after-end:"
-		IL_00fa: ldloc.2
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0100: stloc.s 7
-		IL_0102: ldloc.s 6
-		IL_0104: ldloc.s 7
-		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010b: pop
-		IL_010c: ret
+		IL_00e1: pop
+		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e7: stloc.s 6
+		IL_00e9: ldloc.0
+		IL_00ea: ldfld object Modules.Stream_Finished_Callback_Basic/Scope::writable
+		IL_00ef: volatile.
+		IL_00f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00f6: brfalse IL_010a
+
+		IL_00fb: ldstr "writable"
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0105: br IL_011e
+
+		IL_010a: ldstr "writable"
+		IL_010f: ldstr "Stream_Finished_Callback_Basic:Modules.Stream_Finished_Callback_Basic:__js_module_init__:33"
+		IL_0114: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_011e: stloc.2
+		IL_011f: ldstr "after-end:"
+		IL_0124: ldloc.2
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_012a: stloc.s 7
+		IL_012c: ldloc.s 6
+		IL_012e: ldloc.s 7
+		IL_0130: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0135: pop
+		IL_0136: ret
 	} // end of method Stream_Finished_Callback_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Finished_Callback_Basic
@@ -616,6 +628,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
@@ -236,7 +236,7 @@
 			IL_000e: brfalse IL_004c
 
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldarg.2
@@ -247,7 +247,7 @@
 			IL_002f: ldarg.2
 			IL_0030: ldstr "message"
 			IL_0035: ldstr "Stream_Finished_Callback_DestroyError:<TwoPhaseDummy_M4>:__js_call__:8"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0044: stloc.3
@@ -271,7 +271,7 @@
 			IL_006e: ldarg.0
 			IL_006f: ldfld object Modules.Stream_Finished_Callback_DestroyError/Scope::readable
 			IL_0074: volatile.
-			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_007b: brfalse IL_008f
 
 			IL_0080: ldstr "destroyed"
@@ -280,7 +280,7 @@
 
 			IL_008f: ldstr "destroyed"
 			IL_0094: ldstr "Stream_Finished_Callback_DestroyError:<TwoPhaseDummy_M4>:__js_call__:22"
-			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00a3: stloc.3
@@ -336,7 +336,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 142 (0x8e)
+		// Code size: 182 (0xb6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Finished_Callback_DestroyError/Scope,
@@ -399,12 +399,25 @@
 		IL_0073: ldstr "read boom"
 		IL_0078: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
 		IL_007d: stloc.s 5
-		IL_007f: ldloc.2
-		IL_0080: ldstr "destroy"
-		IL_0085: ldloc.s 5
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: pop
-		IL_008d: ret
+		IL_007f: volatile.
+		IL_0081: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0086: brfalse IL_009d
+
+		IL_008b: ldloc.2
+		IL_008c: ldstr "destroy"
+		IL_0091: ldloc.s 5
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0098: br IL_00b4
+
+		IL_009d: ldloc.2
+		IL_009e: ldstr "destroy"
+		IL_00a3: ldloc.s 5
+		IL_00a5: ldstr "Stream_Finished_Callback_DestroyError:Modules.Stream_Finished_Callback_DestroyError:__js_module_init__:22"
+		IL_00aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00b4: pop
+		IL_00b5: ret
 	} // end of method Stream_Finished_Callback_DestroyError::__js_module_init__
 
 } // end of class Modules.Stream_Finished_Callback_DestroyError
@@ -436,6 +449,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -1110,7 +1110,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 2484 (0x9b4)
+			// Code size: 2529 (0x9e1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope,
@@ -1280,7 +1280,7 @@
 
 			IL_011b: ldloc.0
 			IL_011c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0121: switch (IL_013a, IL_05fd, IL_05dd, IL_087c, IL_085c)
+			IL_0121: switch (IL_013a, IL_05fd, IL_05dd, IL_08a9, IL_0889)
 			.try
 			{
 				IL_013a: nop
@@ -1951,231 +1951,245 @@
 			IL_079e: ldloc.s 8
 			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_07a5: stloc.s 19
-			IL_07a7: ldloc.s 19
-			IL_07a9: ldstr "push"
-			IL_07ae: ldc.i4.0
-			IL_07af: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07b9: pop
-			IL_07ba: ldloc.0
-			IL_07bb: ldc.i4.4
-			IL_07bc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07c1: ldloc.0
-			IL_07c2: ldloc.s 9
-			IL_07c4: ldarg.0
-			IL_07c5: ldc.i4.2
-			IL_07c6: ldloc.0
-			IL_07c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07cc: ldc.i4.3
-			IL_07cd: ldstr "_pendingException"
-			IL_07d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
-			IL_07d7: ldloc.0
-			IL_07d8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_07dd: dup
-			IL_07de: ldc.i4.0
-			IL_07df: ldloc.1
-			IL_07e0: stelem.ref
-			IL_07e1: dup
-			IL_07e2: ldc.i4.1
-			IL_07e3: ldloc.2
-			IL_07e4: stelem.ref
-			IL_07e5: dup
-			IL_07e6: ldc.i4.2
-			IL_07e7: ldloc.3
-			IL_07e8: stelem.ref
-			IL_07e9: dup
-			IL_07ea: ldc.i4.3
-			IL_07eb: ldloc.s 4
-			IL_07ed: stelem.ref
-			IL_07ee: dup
-			IL_07ef: ldc.i4.4
-			IL_07f0: ldloc.s 5
-			IL_07f2: stelem.ref
-			IL_07f3: dup
-			IL_07f4: ldc.i4.5
-			IL_07f5: ldloc.s 6
-			IL_07f7: stelem.ref
-			IL_07f8: dup
-			IL_07f9: ldc.i4.6
-			IL_07fa: ldloc.s 7
-			IL_07fc: stelem.ref
-			IL_07fd: dup
-			IL_07fe: ldc.i4.7
-			IL_07ff: ldloc.s 8
-			IL_0801: stelem.ref
-			IL_0802: dup
-			IL_0803: ldc.i4.8
-			IL_0804: ldloc.s 9
-			IL_0806: stelem.ref
-			IL_0807: dup
-			IL_0808: ldc.i4.s 9
-			IL_080a: ldloc.s 10
-			IL_080c: stelem.ref
-			IL_080d: dup
-			IL_080e: ldc.i4.s 10
-			IL_0810: ldloc.s 11
-			IL_0812: stelem.ref
-			IL_0813: dup
-			IL_0814: ldc.i4.s 11
-			IL_0816: ldloc.s 12
-			IL_0818: stelem.ref
-			IL_0819: dup
-			IL_081a: ldc.i4.s 12
-			IL_081c: ldloc.s 13
-			IL_081e: stelem.ref
-			IL_081f: dup
-			IL_0820: ldc.i4.s 13
-			IL_0822: ldloc.s 14
+			IL_07a7: volatile.
+			IL_07a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_07ae: brfalse IL_07ca
+
+			IL_07b3: ldloc.s 19
+			IL_07b5: ldstr "push"
+			IL_07ba: ldc.i4.0
+			IL_07bb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_07c5: br IL_07e6
+
+			IL_07ca: ldloc.s 19
+			IL_07cc: ldstr "push"
+			IL_07d1: ldc.i4.0
+			IL_07d2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07d7: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:157"
+			IL_07dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_07e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_07e6: pop
+			IL_07e7: ldloc.0
+			IL_07e8: ldc.i4.4
+			IL_07e9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07ee: ldloc.0
+			IL_07ef: ldloc.s 9
+			IL_07f1: ldarg.0
+			IL_07f2: ldc.i4.2
+			IL_07f3: ldloc.0
+			IL_07f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07f9: ldc.i4.3
+			IL_07fa: ldstr "_pendingException"
+			IL_07ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
+			IL_0804: ldloc.0
+			IL_0805: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_080a: dup
+			IL_080b: ldc.i4.0
+			IL_080c: ldloc.1
+			IL_080d: stelem.ref
+			IL_080e: dup
+			IL_080f: ldc.i4.1
+			IL_0810: ldloc.2
+			IL_0811: stelem.ref
+			IL_0812: dup
+			IL_0813: ldc.i4.2
+			IL_0814: ldloc.3
+			IL_0815: stelem.ref
+			IL_0816: dup
+			IL_0817: ldc.i4.3
+			IL_0818: ldloc.s 4
+			IL_081a: stelem.ref
+			IL_081b: dup
+			IL_081c: ldc.i4.4
+			IL_081d: ldloc.s 5
+			IL_081f: stelem.ref
+			IL_0820: dup
+			IL_0821: ldc.i4.5
+			IL_0822: ldloc.s 6
 			IL_0824: stelem.ref
 			IL_0825: dup
-			IL_0826: ldc.i4.s 14
-			IL_0828: ldloc.s 15
-			IL_082a: stelem.ref
-			IL_082b: dup
-			IL_082c: ldc.i4.s 15
-			IL_082e: ldloc.s 16
-			IL_0830: stelem.ref
-			IL_0831: dup
-			IL_0832: ldc.i4.s 16
-			IL_0834: ldloc.s 17
-			IL_0836: stelem.ref
-			IL_0837: dup
-			IL_0838: ldc.i4.s 17
-			IL_083a: ldloc.s 18
-			IL_083c: stelem.ref
-			IL_083d: dup
-			IL_083e: ldc.i4.s 18
-			IL_0840: ldloc.s 19
-			IL_0842: stelem.ref
-			IL_0843: dup
-			IL_0844: ldc.i4.s 19
-			IL_0846: ldloc.s 20
-			IL_0848: stelem.ref
-			IL_0849: dup
-			IL_084a: ldc.i4.s 20
-			IL_084c: ldloc.s 21
-			IL_084e: stelem.ref
-			IL_084f: pop
-			IL_0850: ldloc.0
-			IL_0851: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0856: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_085b: ret
+			IL_0826: ldc.i4.6
+			IL_0827: ldloc.s 7
+			IL_0829: stelem.ref
+			IL_082a: dup
+			IL_082b: ldc.i4.7
+			IL_082c: ldloc.s 8
+			IL_082e: stelem.ref
+			IL_082f: dup
+			IL_0830: ldc.i4.8
+			IL_0831: ldloc.s 9
+			IL_0833: stelem.ref
+			IL_0834: dup
+			IL_0835: ldc.i4.s 9
+			IL_0837: ldloc.s 10
+			IL_0839: stelem.ref
+			IL_083a: dup
+			IL_083b: ldc.i4.s 10
+			IL_083d: ldloc.s 11
+			IL_083f: stelem.ref
+			IL_0840: dup
+			IL_0841: ldc.i4.s 11
+			IL_0843: ldloc.s 12
+			IL_0845: stelem.ref
+			IL_0846: dup
+			IL_0847: ldc.i4.s 12
+			IL_0849: ldloc.s 13
+			IL_084b: stelem.ref
+			IL_084c: dup
+			IL_084d: ldc.i4.s 13
+			IL_084f: ldloc.s 14
+			IL_0851: stelem.ref
+			IL_0852: dup
+			IL_0853: ldc.i4.s 14
+			IL_0855: ldloc.s 15
+			IL_0857: stelem.ref
+			IL_0858: dup
+			IL_0859: ldc.i4.s 15
+			IL_085b: ldloc.s 16
+			IL_085d: stelem.ref
+			IL_085e: dup
+			IL_085f: ldc.i4.s 16
+			IL_0861: ldloc.s 17
+			IL_0863: stelem.ref
+			IL_0864: dup
+			IL_0865: ldc.i4.s 17
+			IL_0867: ldloc.s 18
+			IL_0869: stelem.ref
+			IL_086a: dup
+			IL_086b: ldc.i4.s 18
+			IL_086d: ldloc.s 19
+			IL_086f: stelem.ref
+			IL_0870: dup
+			IL_0871: ldc.i4.s 19
+			IL_0873: ldloc.s 20
+			IL_0875: stelem.ref
+			IL_0876: dup
+			IL_0877: ldc.i4.s 20
+			IL_0879: ldloc.s 21
+			IL_087b: stelem.ref
+			IL_087c: pop
+			IL_087d: ldloc.0
+			IL_087e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0883: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0888: ret
 
-			IL_085c: ldloc.0
-			IL_085d: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
-			IL_0862: pop
-			IL_0863: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0868: stloc.s 17
-			IL_086a: ldloc.s 17
-			IL_086c: ldstr "promise-pipeline:ok"
-			IL_0871: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0876: pop
-			IL_0877: br IL_0981
+			IL_0889: ldloc.0
+			IL_088a: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
+			IL_088f: pop
+			IL_0890: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0895: stloc.s 17
+			IL_0897: ldloc.s 17
+			IL_0899: ldstr "promise-pipeline:ok"
+			IL_089e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_08a3: pop
+			IL_08a4: br IL_09ae
 
-			IL_087c: ldloc.0
-			IL_087d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0882: stloc.s 19
-			IL_0884: ldloc.0
-			IL_0885: ldc.i4.0
-			IL_0886: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_088b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0890: ldloc.s 19
-			IL_0892: stloc.s 10
-			IL_0894: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0899: stloc.s 17
-			IL_089b: volatile.
-			IL_089d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_08a2: brfalse IL_08b8
+			IL_08a9: ldloc.0
+			IL_08aa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_08af: stloc.s 19
+			IL_08b1: ldloc.0
+			IL_08b2: ldc.i4.0
+			IL_08b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_08b8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_08bd: ldloc.s 19
+			IL_08bf: stloc.s 10
+			IL_08c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08c6: stloc.s 17
+			IL_08c8: volatile.
+			IL_08ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_08cf: brfalse IL_08e5
 
-			IL_08a7: ldloc.s 10
-			IL_08a9: ldstr "name"
-			IL_08ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08b3: br IL_08ce
+			IL_08d4: ldloc.s 10
+			IL_08d6: ldstr "name"
+			IL_08db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08e0: br IL_08fb
 
-			IL_08b8: ldloc.s 10
-			IL_08ba: ldstr "name"
-			IL_08bf: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:175"
-			IL_08c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_08c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_08e5: ldloc.s 10
+			IL_08e7: ldstr "name"
+			IL_08ec: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:175"
+			IL_08f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08ce: stloc.s 19
-			IL_08d0: ldstr "promise-pipeline:"
-			IL_08d5: ldloc.s 19
-			IL_08d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_08dc: stloc.s 18
-			IL_08de: ldloc.s 18
-			IL_08e0: ldstr ":"
-			IL_08e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_08ea: stloc.s 18
-			IL_08ec: volatile.
-			IL_08ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_08f3: brfalse IL_0909
+			IL_08fb: stloc.s 19
+			IL_08fd: ldstr "promise-pipeline:"
+			IL_0902: ldloc.s 19
+			IL_0904: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0909: stloc.s 18
+			IL_090b: ldloc.s 18
+			IL_090d: ldstr ":"
+			IL_0912: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0917: stloc.s 18
+			IL_0919: volatile.
+			IL_091b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0920: brfalse IL_0936
 
-			IL_08f8: ldloc.s 10
-			IL_08fa: ldstr "code"
-			IL_08ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0904: br IL_091f
+			IL_0925: ldloc.s 10
+			IL_0927: ldstr "code"
+			IL_092c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0931: br IL_094c
 
-			IL_0909: ldloc.s 10
-			IL_090b: ldstr "code"
-			IL_0910: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:180"
-			IL_0915: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_091a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0936: ldloc.s 10
+			IL_0938: ldstr "code"
+			IL_093d: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:180"
+			IL_0942: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0947: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_091f: stloc.s 19
-			IL_0921: ldloc.s 18
-			IL_0923: ldloc.s 19
-			IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_092a: stloc.s 18
-			IL_092c: ldloc.s 17
-			IL_092e: ldloc.s 18
-			IL_0930: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0935: pop
-			IL_0936: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_093b: stloc.s 17
-			IL_093d: volatile.
-			IL_093f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_0944: brfalse IL_095a
+			IL_094c: stloc.s 19
+			IL_094e: ldloc.s 18
+			IL_0950: ldloc.s 19
+			IL_0952: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0957: stloc.s 18
+			IL_0959: ldloc.s 17
+			IL_095b: ldloc.s 18
+			IL_095d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0962: pop
+			IL_0963: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0968: stloc.s 17
+			IL_096a: volatile.
+			IL_096c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0971: brfalse IL_0987
 
-			IL_0949: ldloc.s 10
-			IL_094b: ldstr "message"
-			IL_0950: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0955: br IL_0970
+			IL_0976: ldloc.s 10
+			IL_0978: ldstr "message"
+			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0982: br IL_099d
 
-			IL_095a: ldloc.s 10
-			IL_095c: ldstr "message"
-			IL_0961: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:186"
-			IL_0966: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_096b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0987: ldloc.s 10
+			IL_0989: ldstr "message"
+			IL_098e: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:186"
+			IL_0993: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0970: stloc.s 19
-			IL_0972: ldloc.s 17
-			IL_0974: ldloc.s 19
-			IL_0976: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_097b: pop
-			IL_097c: br IL_0981
+			IL_099d: stloc.s 19
+			IL_099f: ldloc.s 17
+			IL_09a1: ldloc.s 19
+			IL_09a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_09a8: pop
+			IL_09a9: br IL_09ae
 
-			IL_0981: ldnull
-			IL_0982: stloc.s 11
-			IL_0984: ldloc.0
-			IL_0985: ldc.i4.m1
-			IL_0986: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_098b: ldloc.0
-			IL_098c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0991: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0996: ldarg.0
-			IL_0997: ldc.i4.1
-			IL_0998: newarr [System.Runtime]System.Object
-			IL_099d: dup
-			IL_099e: ldc.i4.0
-			IL_099f: ldloc.s 11
-			IL_09a1: stelem.ref
-			IL_09a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_09a7: pop
-			IL_09a8: ldloc.0
-			IL_09a9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09ae: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09b3: ret
+			IL_09ae: ldnull
+			IL_09af: stloc.s 11
+			IL_09b1: ldloc.0
+			IL_09b2: ldc.i4.m1
+			IL_09b3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_09b8: ldloc.0
+			IL_09b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_09c3: ldarg.0
+			IL_09c4: ldc.i4.1
+			IL_09c5: newarr [System.Runtime]System.Object
+			IL_09ca: dup
+			IL_09cb: ldc.i4.0
+			IL_09cc: ldloc.s 11
+			IL_09ce: stelem.ref
+			IL_09cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_09d4: pop
+			IL_09d5: ldloc.0
+			IL_09d6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09db: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09e0: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2372,6 +2386,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_21
 	.field assembly static int32 __jroc_dynamicLookup_22
 	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_PassThrough_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_PassThrough_Basic.verified.txt
@@ -465,7 +465,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 323 (0x143)
+		// Code size: 527 (0x20f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_PassThrough_Basic/Scope,
@@ -569,36 +569,97 @@
 		IL_00d7: pop
 		IL_00d8: ldloc.2
 		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00de: ldstr "pipe"
-		IL_00e3: ldloc.3
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e9: stloc.s 5
-		IL_00eb: ldloc.s 5
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f2: ldstr "pipe"
-		IL_00f7: ldloc.s 4
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fe: pop
-		IL_00ff: ldloc.2
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0105: ldstr "push"
-		IL_010a: ldstr "a"
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0114: pop
-		IL_0115: ldloc.2
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011b: ldstr "push"
-		IL_0120: ldstr "b"
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012a: pop
-		IL_012b: ldloc.2
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0131: ldstr "push"
-		IL_0136: ldc.i4.0
-		IL_0137: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0141: pop
-		IL_0142: ret
+		IL_00de: volatile.
+		IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00e5: brfalse IL_00fa
+
+		IL_00ea: ldstr "pipe"
+		IL_00ef: ldloc.3
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f5: br IL_010f
+
+		IL_00fa: ldstr "pipe"
+		IL_00ff: ldloc.3
+		IL_0100: ldstr "Stream_PassThrough_Basic:Modules.Stream_PassThrough_Basic:__js_module_init__:36"
+		IL_0105: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_010f: stloc.s 5
+		IL_0111: ldloc.s 5
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0118: volatile.
+		IL_011a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_011f: brfalse IL_0135
+
+		IL_0124: ldstr "pipe"
+		IL_0129: ldloc.s 4
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0130: br IL_014b
+
+		IL_0135: ldstr "pipe"
+		IL_013a: ldloc.s 4
+		IL_013c: ldstr "Stream_PassThrough_Basic:Modules.Stream_PassThrough_Basic:__js_module_init__:38"
+		IL_0141: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_014b: pop
+		IL_014c: ldloc.2
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0152: volatile.
+		IL_0154: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0159: brfalse IL_0172
+
+		IL_015e: ldstr "push"
+		IL_0163: ldstr "a"
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016d: br IL_018b
+
+		IL_0172: ldstr "push"
+		IL_0177: ldstr "a"
+		IL_017c: ldstr "Stream_PassThrough_Basic:Modules.Stream_PassThrough_Basic:__js_module_init__:42"
+		IL_0181: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_018b: pop
+		IL_018c: ldloc.2
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0192: volatile.
+		IL_0194: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0199: brfalse IL_01b2
+
+		IL_019e: ldstr "push"
+		IL_01a3: ldstr "b"
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ad: br IL_01cb
+
+		IL_01b2: ldstr "push"
+		IL_01b7: ldstr "b"
+		IL_01bc: ldstr "Stream_PassThrough_Basic:Modules.Stream_PassThrough_Basic:__js_module_init__:46"
+		IL_01c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01cb: pop
+		IL_01cc: ldloc.2
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d2: volatile.
+		IL_01d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01d9: brfalse IL_01f3
+
+		IL_01de: ldstr "push"
+		IL_01e3: ldc.i4.0
+		IL_01e4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ee: br IL_020d
+
+		IL_01f3: ldstr "push"
+		IL_01f8: ldc.i4.0
+		IL_01f9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_01fe: ldstr "Stream_PassThrough_Basic:Modules.Stream_PassThrough_Basic:__js_module_init__:51"
+		IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_020d: pop
+		IL_020e: ret
 	} // end of method Stream_PassThrough_Basic::__js_module_init__
 
 } // end of class Modules.Stream_PassThrough_Basic
@@ -623,4 +684,16 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
@@ -732,7 +732,7 @@
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 155 (0x9b)
+			// Code size: 238 (0xee)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -767,7 +767,7 @@
 			IL_003e: ldloc.3
 			IL_003f: ldloc.0
 			IL_0040: clt
-			IL_0042: brfalse IL_007d
+			IL_0042: brfalse IL_00a5
 
 			IL_0047: ldarg.0
 			IL_0048: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
@@ -781,24 +781,50 @@
 			IL_0061: ldloc.s 4
 			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
 			IL_0068: stloc.s 4
-			IL_006a: ldloc.2
-			IL_006b: ldstr "push"
-			IL_0070: ldloc.s 4
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0077: pop
-			IL_0078: br IL_0099
+			IL_006a: volatile.
+			IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0071: brfalse IL_0088
 
-			IL_007d: ldarg.0
-			IL_007e: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0088: ldstr "push"
-			IL_008d: ldc.i4.0
-			IL_008e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0098: pop
+			IL_0076: ldloc.2
+			IL_0077: ldstr "push"
+			IL_007c: ldloc.s 4
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0083: br IL_009f
 
-			IL_0099: ldnull
-			IL_009a: ret
+			IL_0088: ldloc.2
+			IL_0089: ldstr "push"
+			IL_008e: ldloc.s 4
+			IL_0090: ldstr "Stream_Pipe_Backpressure_Basic:<TwoPhaseDummy_M7>:__js_call__:20"
+			IL_0095: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_009f: pop
+			IL_00a0: br IL_00ec
+
+			IL_00a5: ldarg.0
+			IL_00a6: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b0: volatile.
+			IL_00b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_00b7: brfalse IL_00d1
+
+			IL_00bc: ldstr "push"
+			IL_00c1: ldc.i4.0
+			IL_00c2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00cc: br IL_00eb
+
+			IL_00d1: ldstr "push"
+			IL_00d6: ldc.i4.0
+			IL_00d7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00dc: ldstr "Stream_Pipe_Backpressure_Basic:<TwoPhaseDummy_M7>:__js_call__:28"
+			IL_00e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00eb: pop
+
+			IL_00ec: ldnull
+			IL_00ed: ret
 		} // end of method FunctionExpression_L27C21::__js_call__
 
 	} // end of class FunctionExpression_L27C21
@@ -847,7 +873,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 492 (0x1ec)
+		// Code size: 570 (0x23a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipe_Backpressure_Basic/Scope,
@@ -1026,26 +1052,51 @@
 		IL_019f: ldloc.0
 		IL_01a0: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
 		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01aa: ldstr "pipe"
-		IL_01af: ldloc.2
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b5: pop
-		IL_01b6: ldloc.0
-		IL_01b7: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c1: stloc.3
-		IL_01c2: ldloc.0
-		IL_01c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
-		IL_01c8: ldc.r8 0.0
-		IL_01d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01d6: castclass [System.Runtime]System.String
-		IL_01db: stloc.s 10
-		IL_01dd: ldloc.3
-		IL_01de: ldstr "push"
-		IL_01e3: ldloc.s 10
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ea: pop
-		IL_01eb: ret
+		IL_01aa: volatile.
+		IL_01ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01b1: brfalse IL_01c6
+
+		IL_01b6: ldstr "pipe"
+		IL_01bb: ldloc.2
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c1: br IL_01db
+
+		IL_01c6: ldstr "pipe"
+		IL_01cb: ldloc.2
+		IL_01cc: ldstr "Stream_Pipe_Backpressure_Basic:Modules.Stream_Pipe_Backpressure_Basic:__js_module_init__:59"
+		IL_01d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01db: pop
+		IL_01dc: ldloc.0
+		IL_01dd: ldfld object Modules.Stream_Pipe_Backpressure_Basic/Scope::readable
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e7: stloc.3
+		IL_01e8: ldloc.0
+		IL_01e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Backpressure_Basic/Scope::chunks
+		IL_01ee: ldc.r8 0.0
+		IL_01f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01fc: castclass [System.Runtime]System.String
+		IL_0201: stloc.s 10
+		IL_0203: volatile.
+		IL_0205: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_020a: brfalse IL_0221
+
+		IL_020f: ldloc.3
+		IL_0210: ldstr "push"
+		IL_0215: ldloc.s 10
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021c: br IL_0238
+
+		IL_0221: ldloc.3
+		IL_0222: ldstr "push"
+		IL_0227: ldloc.s 10
+		IL_0229: ldstr "Stream_Pipe_Backpressure_Basic:Modules.Stream_Pipe_Backpressure_Basic:__js_module_init__:66"
+		IL_022e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0238: pop
+		IL_0239: ret
 	} // end of method Stream_Pipe_Backpressure_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipe_Backpressure_Basic
@@ -1070,4 +1121,15 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
@@ -315,7 +315,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 399 (0x18f)
+		// Code size: 607 (0x25f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipe_Basic/Scope,
@@ -390,89 +390,150 @@
 		IL_007c: pop
 		IL_007d: ldloc.s 4
 		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0084: ldstr "pipe"
-		IL_0089: ldloc.s 5
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ldloc.s 4
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0098: ldstr "push"
-		IL_009d: ldstr "data1"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a7: pop
-		IL_00a8: ldloc.s 4
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00af: ldstr "push"
-		IL_00b4: ldstr "data2"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00be: pop
-		IL_00bf: ldloc.s 4
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c6: ldstr "push"
-		IL_00cb: ldstr "data3"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d5: pop
-		IL_00d6: ldloc.s 4
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00dd: ldstr "push"
-		IL_00e2: ldc.i4.0
-		IL_00e3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ed: pop
-		IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f3: stloc.s 10
-		IL_00f5: ldloc.0
-		IL_00f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
-		IL_00fb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0100: box [System.Runtime]System.Double
-		IL_0105: stloc.s 11
-		IL_0107: ldloc.s 10
-		IL_0109: ldstr "Written data count:"
-		IL_010e: ldloc.s 11
-		IL_0110: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0115: pop
-		IL_0116: ldc.r8 0.0
-		IL_011f: stloc.s 6
-		// loop start (head: IL_0121)
-			IL_0121: ldloc.s 6
-			IL_0123: stloc.s 12
-			IL_0125: ldloc.0
-			IL_0126: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
-			IL_012b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0130: stloc.s 13
-			IL_0132: ldloc.s 12
-			IL_0134: ldloc.s 13
-			IL_0136: clt
-			IL_0138: brfalse IL_018e
+		IL_0084: volatile.
+		IL_0086: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_008b: brfalse IL_00a1
 
-			IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0142: stloc.s 10
-			IL_0144: ldstr "Chunk "
-			IL_0149: ldloc.s 6
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0150: stloc.s 14
-			IL_0152: ldloc.s 14
-			IL_0154: ldstr ":"
-			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_015e: stloc.s 14
-			IL_0160: ldloc.0
-			IL_0161: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
-			IL_0166: ldloc.s 6
-			IL_0168: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_016d: stloc.s 15
-			IL_016f: ldloc.s 10
-			IL_0171: ldloc.s 14
-			IL_0173: ldloc.s 15
-			IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_017a: pop
-			IL_017b: ldloc.s 6
-			IL_017d: ldc.r8 1
-			IL_0186: add
-			IL_0187: stloc.s 6
-			IL_0189: br IL_0121
+		IL_0090: ldstr "pipe"
+		IL_0095: ldloc.s 5
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009c: br IL_00b7
+
+		IL_00a1: ldstr "pipe"
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldstr "Stream_Pipe_Basic:Modules.Stream_Pipe_Basic:__js_module_init__:30"
+		IL_00ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00b7: pop
+		IL_00b8: ldloc.s 4
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00bf: volatile.
+		IL_00c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00c6: brfalse IL_00df
+
+		IL_00cb: ldstr "push"
+		IL_00d0: ldstr "data1"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00da: br IL_00f8
+
+		IL_00df: ldstr "push"
+		IL_00e4: ldstr "data1"
+		IL_00e9: ldstr "Stream_Pipe_Basic:Modules.Stream_Pipe_Basic:__js_module_init__:34"
+		IL_00ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f8: pop
+		IL_00f9: ldloc.s 4
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0100: volatile.
+		IL_0102: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0107: brfalse IL_0120
+
+		IL_010c: ldstr "push"
+		IL_0111: ldstr "data2"
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011b: br IL_0139
+
+		IL_0120: ldstr "push"
+		IL_0125: ldstr "data2"
+		IL_012a: ldstr "Stream_Pipe_Basic:Modules.Stream_Pipe_Basic:__js_module_init__:38"
+		IL_012f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0139: pop
+		IL_013a: ldloc.s 4
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0141: volatile.
+		IL_0143: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0148: brfalse IL_0161
+
+		IL_014d: ldstr "push"
+		IL_0152: ldstr "data3"
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015c: br IL_017a
+
+		IL_0161: ldstr "push"
+		IL_0166: ldstr "data3"
+		IL_016b: ldstr "Stream_Pipe_Basic:Modules.Stream_Pipe_Basic:__js_module_init__:42"
+		IL_0170: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_017a: pop
+		IL_017b: ldloc.s 4
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0182: volatile.
+		IL_0184: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0189: brfalse IL_01a3
+
+		IL_018e: ldstr "push"
+		IL_0193: ldc.i4.0
+		IL_0194: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019e: br IL_01bd
+
+		IL_01a3: ldstr "push"
+		IL_01a8: ldc.i4.0
+		IL_01a9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_01ae: ldstr "Stream_Pipe_Basic:Modules.Stream_Pipe_Basic:__js_module_init__:47"
+		IL_01b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01bd: pop
+		IL_01be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c3: stloc.s 10
+		IL_01c5: ldloc.0
+		IL_01c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
+		IL_01cb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_01d0: box [System.Runtime]System.Double
+		IL_01d5: stloc.s 11
+		IL_01d7: ldloc.s 10
+		IL_01d9: ldstr "Written data count:"
+		IL_01de: ldloc.s 11
+		IL_01e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01e5: pop
+		IL_01e6: ldc.r8 0.0
+		IL_01ef: stloc.s 6
+		// loop start (head: IL_01f1)
+			IL_01f1: ldloc.s 6
+			IL_01f3: stloc.s 12
+			IL_01f5: ldloc.0
+			IL_01f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
+			IL_01fb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0200: stloc.s 13
+			IL_0202: ldloc.s 12
+			IL_0204: ldloc.s 13
+			IL_0206: clt
+			IL_0208: brfalse IL_025e
+
+			IL_020d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0212: stloc.s 10
+			IL_0214: ldstr "Chunk "
+			IL_0219: ldloc.s 6
+			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0220: stloc.s 14
+			IL_0222: ldloc.s 14
+			IL_0224: ldstr ":"
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_022e: stloc.s 14
+			IL_0230: ldloc.0
+			IL_0231: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Pipe_Basic/Scope::writtenData
+			IL_0236: ldloc.s 6
+			IL_0238: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_023d: stloc.s 15
+			IL_023f: ldloc.s 10
+			IL_0241: ldloc.s 14
+			IL_0243: ldloc.s 15
+			IL_0245: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_024a: pop
+			IL_024b: ldloc.s 6
+			IL_024d: ldc.r8 1
+			IL_0256: add
+			IL_0257: stloc.s 6
+			IL_0259: br IL_01f1
 		// end loop
 
-		IL_018e: ret
+		IL_025e: ret
 	} // end of method Stream_Pipe_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipe_Basic
@@ -497,4 +558,16 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
@@ -401,7 +401,7 @@
 			IL_000e: brfalse IL_004c
 
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldarg.2
@@ -412,7 +412,7 @@
 			IL_002f: ldarg.2
 			IL_0030: ldstr "message"
 			IL_0035: ldstr "Stream_Pipeline_Basic:<TwoPhaseDummy_M5>:__js_call__:8"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0044: stloc.3
@@ -456,7 +456,7 @@
 			IL_00a6: ldarg.0
 			IL_00a7: ldfld object Modules.Stream_Pipeline_Basic/Scope::pass
 			IL_00ac: volatile.
-			IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_00b3: brfalse IL_00c7
 
 			IL_00b8: ldstr "destroyed"
@@ -465,7 +465,7 @@
 
 			IL_00c7: ldstr "destroyed"
 			IL_00cc: ldstr "Stream_Pipeline_Basic:<TwoPhaseDummy_M5>:__js_call__:30"
-			IL_00d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_00d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00db: stloc.3
@@ -523,7 +523,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 301 (0x12d)
+		// Code size: 428 (0x1ac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipeline_Basic/Scope,
@@ -644,24 +644,61 @@
 		IL_00e8: pop
 		IL_00e9: ldloc.2
 		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ef: ldstr "push"
-		IL_00f4: ldstr "a"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fe: pop
-		IL_00ff: ldloc.2
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0105: ldstr "push"
-		IL_010a: ldstr "b"
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0114: pop
-		IL_0115: ldloc.2
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011b: ldstr "push"
-		IL_0120: ldc.i4.0
-		IL_0121: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012b: pop
-		IL_012c: ret
+		IL_00ef: volatile.
+		IL_00f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00f6: brfalse IL_010f
+
+		IL_00fb: ldstr "push"
+		IL_0100: ldstr "a"
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010a: br IL_0128
+
+		IL_010f: ldstr "push"
+		IL_0114: ldstr "a"
+		IL_0119: ldstr "Stream_Pipeline_Basic:Modules.Stream_Pipeline_Basic:__js_module_init__:36"
+		IL_011e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0128: pop
+		IL_0129: ldloc.2
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012f: volatile.
+		IL_0131: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0136: brfalse IL_014f
+
+		IL_013b: ldstr "push"
+		IL_0140: ldstr "b"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014a: br IL_0168
+
+		IL_014f: ldstr "push"
+		IL_0154: ldstr "b"
+		IL_0159: ldstr "Stream_Pipeline_Basic:Modules.Stream_Pipeline_Basic:__js_module_init__:40"
+		IL_015e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0168: pop
+		IL_0169: ldloc.2
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016f: volatile.
+		IL_0171: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0176: brfalse IL_0190
+
+		IL_017b: ldstr "push"
+		IL_0180: ldc.i4.0
+		IL_0181: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018b: br IL_01aa
+
+		IL_0190: ldstr "push"
+		IL_0195: ldc.i4.0
+		IL_0196: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_019b: ldstr "Stream_Pipeline_Basic:Modules.Stream_Pipeline_Basic:__js_module_init__:45"
+		IL_01a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01aa: pop
+		IL_01ab: ret
 	} // end of method Stream_Pipeline_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipeline_Basic
@@ -693,6 +730,9 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
@@ -518,7 +518,7 @@
 			IL_000e: brfalse IL_004c
 
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldarg.2
@@ -529,7 +529,7 @@
 			IL_002f: ldarg.2
 			IL_0030: ldstr "message"
 			IL_0035: ldstr "Stream_Pipeline_Error:<TwoPhaseDummy_M6>:__js_call__:8"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0044: stloc.3
@@ -553,7 +553,7 @@
 			IL_006e: ldarg.0
 			IL_006f: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
 			IL_0074: volatile.
-			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_007b: brfalse IL_008f
 
 			IL_0080: ldstr "destroyed"
@@ -562,7 +562,7 @@
 
 			IL_008f: ldstr "destroyed"
 			IL_0094: ldstr "Stream_Pipeline_Error:<TwoPhaseDummy_M6>:__js_call__:22"
-			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00a3: stloc.3
@@ -579,7 +579,7 @@
 			IL_00c0: ldarg.0
 			IL_00c1: ldfld object Modules.Stream_Pipeline_Error/Scope::transform
 			IL_00c6: volatile.
-			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_00cd: brfalse IL_00e1
 
 			IL_00d2: ldstr "destroyed"
@@ -588,7 +588,7 @@
 
 			IL_00e1: ldstr "destroyed"
 			IL_00e6: ldstr "Stream_Pipeline_Error:<TwoPhaseDummy_M6>:__js_call__:30"
-			IL_00eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_00eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00f5: stloc.3
@@ -605,7 +605,7 @@
 			IL_0112: ldarg.0
 			IL_0113: ldfld object Modules.Stream_Pipeline_Error/Scope::writable
 			IL_0118: volatile.
-			IL_011a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_011a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_011f: brfalse IL_0133
 
 			IL_0124: ldstr "destroyed"
@@ -614,7 +614,7 @@
 
 			IL_0133: ldstr "destroyed"
 			IL_0138: ldstr "Stream_Pipeline_Error:<TwoPhaseDummy_M6>:__js_call__:38"
-			IL_013d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_013d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0147: stloc.3
@@ -675,7 +675,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 316 (0x13c)
+		// Code size: 358 (0x166)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipeline_Error/Scope,
@@ -826,11 +826,23 @@
 		IL_0120: ldloc.0
 		IL_0121: ldfld object Modules.Stream_Pipeline_Error/Scope::readable
 		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012b: ldstr "push"
-		IL_0130: ldstr "a"
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013a: pop
-		IL_013b: ret
+		IL_012b: volatile.
+		IL_012d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0132: brfalse IL_014b
+
+		IL_0137: ldstr "push"
+		IL_013c: ldstr "a"
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0146: br IL_0164
+
+		IL_014b: ldstr "push"
+		IL_0150: ldstr "a"
+		IL_0155: ldstr "Stream_Pipeline_Error:Modules.Stream_Pipeline_Error:__js_module_init__:43"
+		IL_015a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0164: pop
+		IL_0165: ret
 	} // end of method Stream_Pipeline_Error::__js_module_init__
 
 } // end of class Modules.Stream_Pipeline_Error
@@ -864,6 +876,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
@@ -363,7 +363,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -374,7 +374,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "message"
 			IL_0028: ldstr "Stream_Pipeline_Error_PropagatesToPeers:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -533,7 +533,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -544,7 +544,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "message"
 			IL_0028: ldstr "Stream_Pipeline_Error_PropagatesToPeers:<TwoPhaseDummy_M6>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -703,7 +703,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -714,7 +714,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "message"
 			IL_0028: ldstr "Stream_Pipeline_Error_PropagatesToPeers:<TwoPhaseDummy_M7>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -896,7 +896,7 @@
 			IL_000e: brfalse IL_004c
 
 			IL_0013: volatile.
-			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_001a: brfalse IL_002f
 
 			IL_001f: ldarg.2
@@ -907,7 +907,7 @@
 			IL_002f: ldarg.2
 			IL_0030: ldstr "message"
 			IL_0035: ldstr "Stream_Pipeline_Error_PropagatesToPeers:<TwoPhaseDummy_M8>:__js_call__:8"
-			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_003a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0044: stloc.3
@@ -931,7 +931,7 @@
 			IL_006e: ldarg.0
 			IL_006f: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
 			IL_0074: volatile.
-			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0076: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 			IL_007b: brfalse IL_008f
 
 			IL_0080: ldstr "destroyed"
@@ -940,7 +940,7 @@
 
 			IL_008f: ldstr "destroyed"
 			IL_0094: ldstr "Stream_Pipeline_Error_PropagatesToPeers:<TwoPhaseDummy_M8>:__js_call__:22"
-			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00a3: stloc.3
@@ -957,7 +957,7 @@
 			IL_00c0: ldarg.0
 			IL_00c1: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::pass
 			IL_00c6: volatile.
-			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_00cd: brfalse IL_00e1
 
 			IL_00d2: ldstr "destroyed"
@@ -966,7 +966,7 @@
 
 			IL_00e1: ldstr "destroyed"
 			IL_00e6: ldstr "Stream_Pipeline_Error_PropagatesToPeers:<TwoPhaseDummy_M8>:__js_call__:30"
-			IL_00eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_00eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00f5: stloc.3
@@ -983,7 +983,7 @@
 			IL_0112: ldarg.0
 			IL_0113: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::writable
 			IL_0118: volatile.
-			IL_011a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_011a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_011f: brfalse IL_0133
 
 			IL_0124: ldstr "destroyed"
@@ -992,7 +992,7 @@
 
 			IL_0133: ldstr "destroyed"
 			IL_0138: ldstr "Stream_Pipeline_Error_PropagatesToPeers:<TwoPhaseDummy_M8>:__js_call__:38"
-			IL_013d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_013d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0147: stloc.3
@@ -1052,7 +1052,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 451 (0x1c3)
+		// Code size: 493 (0x1ed)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope,
@@ -1256,11 +1256,23 @@
 		IL_01a7: ldloc.0
 		IL_01a8: ldfld object Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::readable
 		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b2: ldstr "push"
-		IL_01b7: ldstr "a"
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c1: pop
-		IL_01c2: ret
+		IL_01b2: volatile.
+		IL_01b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01b9: brfalse IL_01d2
+
+		IL_01be: ldstr "push"
+		IL_01c3: ldstr "a"
+		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01cd: br IL_01eb
+
+		IL_01d2: ldstr "push"
+		IL_01d7: ldstr "a"
+		IL_01dc: ldstr "Stream_Pipeline_Error_PropagatesToPeers:Modules.Stream_Pipeline_Error_PropagatesToPeers:__js_module_init__:58"
+		IL_01e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01eb: pop
+		IL_01ec: ret
 	} // end of method Stream_Pipeline_Error_PropagatesToPeers::__js_module_init__
 
 } // end of class Modules.Stream_Pipeline_Error_PropagatesToPeers
@@ -1297,6 +1309,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
@@ -317,7 +317,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 638 (0x27e)
+			// Code size: 682 (0x2aa)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Promises_Finished_Basic/main/Scope,
@@ -423,7 +423,7 @@
 
 			IL_00bf: ldloc.0
 			IL_00c0: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00c5: switch (IL_00d2, IL_01a8)
+			IL_00c5: switch (IL_00d2, IL_01d4)
 
 			IL_00d2: ldarg.0
 			IL_00d3: ldc.i4.1
@@ -474,135 +474,148 @@
 			IL_013b: ldloc.1
 			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0141: stloc.s 4
-			IL_0143: ldloc.s 4
-			IL_0145: ldstr "end"
-			IL_014a: ldstr "done"
-			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0154: pop
-			IL_0155: ldloc.0
-			IL_0156: ldc.i4.1
-			IL_0157: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_015c: ldloc.0
-			IL_015d: ldloc.2
-			IL_015e: ldarg.0
-			IL_015f: ldc.i4.1
-			IL_0160: ldloc.0
-			IL_0161: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0166: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_016b: ldloc.0
-			IL_016c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0171: dup
-			IL_0172: ldc.i4.0
-			IL_0173: ldloc.1
-			IL_0174: stelem.ref
-			IL_0175: dup
-			IL_0176: ldc.i4.1
-			IL_0177: ldloc.2
-			IL_0178: stelem.ref
-			IL_0179: dup
-			IL_017a: ldc.i4.2
-			IL_017b: ldloc.3
-			IL_017c: stelem.ref
-			IL_017d: dup
-			IL_017e: ldc.i4.3
-			IL_017f: ldloc.s 4
-			IL_0181: stelem.ref
-			IL_0182: dup
-			IL_0183: ldc.i4.4
-			IL_0184: ldloc.s 5
-			IL_0186: stelem.ref
-			IL_0187: dup
-			IL_0188: ldc.i4.5
-			IL_0189: ldloc.s 6
-			IL_018b: stelem.ref
-			IL_018c: dup
-			IL_018d: ldc.i4.6
-			IL_018e: ldloc.s 7
-			IL_0190: stelem.ref
-			IL_0191: dup
-			IL_0192: ldc.i4.7
-			IL_0193: ldloc.s 8
-			IL_0195: stelem.ref
-			IL_0196: dup
-			IL_0197: ldc.i4.8
-			IL_0198: ldloc.s 9
-			IL_019a: stelem.ref
-			IL_019b: pop
-			IL_019c: ldloc.0
-			IL_019d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01a2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01a7: ret
+			IL_0143: volatile.
+			IL_0145: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_014a: brfalse IL_0165
 
-			IL_01a8: ldloc.0
-			IL_01a9: ldfld object Modules.Stream_Promises_Finished_Basic/main/Scope::_awaited1
-			IL_01ae: pop
-			IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01b4: stloc.s 8
-			IL_01b6: volatile.
-			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-			IL_01bd: brfalse IL_01d2
+			IL_014f: ldloc.s 4
+			IL_0151: ldstr "end"
+			IL_0156: ldstr "done"
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0160: br IL_0180
 
-			IL_01c2: ldloc.1
-			IL_01c3: ldstr "destroyed"
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01cd: br IL_01e7
+			IL_0165: ldloc.s 4
+			IL_0167: ldstr "end"
+			IL_016c: ldstr "done"
+			IL_0171: ldstr "Stream_Promises_Finished_Basic:<TwoPhaseDummy_M4>:__js_call__:18"
+			IL_0176: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_01d2: ldloc.1
-			IL_01d3: ldstr "destroyed"
-			IL_01d8: ldstr "Stream_Promises_Finished_Basic:<TwoPhaseDummy_M4>:__js_call__:25"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0180: pop
+			IL_0181: ldloc.0
+			IL_0182: ldc.i4.1
+			IL_0183: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0188: ldloc.0
+			IL_0189: ldloc.2
+			IL_018a: ldarg.0
+			IL_018b: ldc.i4.1
+			IL_018c: ldloc.0
+			IL_018d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0192: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0197: ldloc.0
+			IL_0198: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_019d: dup
+			IL_019e: ldc.i4.0
+			IL_019f: ldloc.1
+			IL_01a0: stelem.ref
+			IL_01a1: dup
+			IL_01a2: ldc.i4.1
+			IL_01a3: ldloc.2
+			IL_01a4: stelem.ref
+			IL_01a5: dup
+			IL_01a6: ldc.i4.2
+			IL_01a7: ldloc.3
+			IL_01a8: stelem.ref
+			IL_01a9: dup
+			IL_01aa: ldc.i4.3
+			IL_01ab: ldloc.s 4
+			IL_01ad: stelem.ref
+			IL_01ae: dup
+			IL_01af: ldc.i4.4
+			IL_01b0: ldloc.s 5
+			IL_01b2: stelem.ref
+			IL_01b3: dup
+			IL_01b4: ldc.i4.5
+			IL_01b5: ldloc.s 6
+			IL_01b7: stelem.ref
+			IL_01b8: dup
+			IL_01b9: ldc.i4.6
+			IL_01ba: ldloc.s 7
+			IL_01bc: stelem.ref
+			IL_01bd: dup
+			IL_01be: ldc.i4.7
+			IL_01bf: ldloc.s 8
+			IL_01c1: stelem.ref
+			IL_01c2: dup
+			IL_01c3: ldc.i4.8
+			IL_01c4: ldloc.s 9
+			IL_01c6: stelem.ref
+			IL_01c7: pop
+			IL_01c8: ldloc.0
+			IL_01c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01ce: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01d3: ret
 
-			IL_01e7: stloc.s 4
-			IL_01e9: ldstr "destroyed:"
-			IL_01ee: ldloc.s 4
-			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01f5: stloc.s 9
-			IL_01f7: ldloc.s 8
-			IL_01f9: ldloc.s 9
-			IL_01fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0200: pop
-			IL_0201: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0206: stloc.s 8
-			IL_0208: volatile.
-			IL_020a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_020f: brfalse IL_0224
+			IL_01d4: ldloc.0
+			IL_01d5: ldfld object Modules.Stream_Promises_Finished_Basic/main/Scope::_awaited1
+			IL_01da: pop
+			IL_01db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01e0: stloc.s 8
+			IL_01e2: volatile.
+			IL_01e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_01e9: brfalse IL_01fe
 
-			IL_0214: ldloc.1
-			IL_0215: ldstr "writable"
-			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_021f: br IL_0239
+			IL_01ee: ldloc.1
+			IL_01ef: ldstr "destroyed"
+			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f9: br IL_0213
 
-			IL_0224: ldloc.1
-			IL_0225: ldstr "writable"
-			IL_022a: ldstr "Stream_Promises_Finished_Basic:<TwoPhaseDummy_M4>:__js_call__:32"
-			IL_022f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01fe: ldloc.1
+			IL_01ff: ldstr "destroyed"
+			IL_0204: ldstr "Stream_Promises_Finished_Basic:<TwoPhaseDummy_M4>:__js_call__:25"
+			IL_0209: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0239: stloc.s 4
-			IL_023b: ldstr "writable:"
-			IL_0240: ldloc.s 4
-			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0247: stloc.s 9
-			IL_0249: ldloc.s 8
-			IL_024b: ldloc.s 9
-			IL_024d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0252: pop
-			IL_0253: ldloc.0
-			IL_0254: ldc.i4.m1
-			IL_0255: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_025a: ldloc.0
-			IL_025b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0260: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0265: ldarg.0
-			IL_0266: ldc.i4.1
-			IL_0267: newarr [System.Runtime]System.Object
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0271: pop
-			IL_0272: ldloc.0
-			IL_0273: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0278: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_027d: ret
+			IL_0213: stloc.s 4
+			IL_0215: ldstr "destroyed:"
+			IL_021a: ldloc.s 4
+			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0221: stloc.s 9
+			IL_0223: ldloc.s 8
+			IL_0225: ldloc.s 9
+			IL_0227: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_022c: pop
+			IL_022d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0232: stloc.s 8
+			IL_0234: volatile.
+			IL_0236: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_023b: brfalse IL_0250
+
+			IL_0240: ldloc.1
+			IL_0241: ldstr "writable"
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_024b: br IL_0265
+
+			IL_0250: ldloc.1
+			IL_0251: ldstr "writable"
+			IL_0256: ldstr "Stream_Promises_Finished_Basic:<TwoPhaseDummy_M4>:__js_call__:32"
+			IL_025b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0265: stloc.s 4
+			IL_0267: ldstr "writable:"
+			IL_026c: ldloc.s 4
+			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0273: stloc.s 9
+			IL_0275: ldloc.s 8
+			IL_0277: ldloc.s 9
+			IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_027e: pop
+			IL_027f: ldloc.0
+			IL_0280: ldc.i4.m1
+			IL_0281: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0286: ldloc.0
+			IL_0287: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_028c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0291: ldarg.0
+			IL_0292: ldc.i4.1
+			IL_0293: newarr [System.Runtime]System.Object
+			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_029d: pop
+			IL_029e: ldloc.0
+			IL_029f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02a4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02a9: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -735,6 +748,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
@@ -228,7 +228,7 @@
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_AbortSignal/Scope::written
 			IL_0006: stloc.0
 			IL_0007: volatile.
-			IL_0009: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0009: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_000e: brfalse IL_0023
 
 			IL_0013: ldarg.2
@@ -239,7 +239,7 @@
 			IL_0023: ldarg.2
 			IL_0024: ldstr "value"
 			IL_0029: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M4>:__js_call__:4"
-			IL_002e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_002e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0038: stloc.1
@@ -390,19 +390,31 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Header size: 1
-			// Code size: 33 (0x21)
+			// Header size: 12
+			// Code size: 75 (0x4b)
 			.maxstack 8
 
 			IL_0000: ldstr "console"
 			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000f: ldstr "log"
-			IL_0014: ldstr "no-abort"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_001e: pop
-			IL_001f: ldnull
-			IL_0020: ret
+			IL_000f: volatile.
+			IL_0011: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0016: brfalse IL_002f
+
+			IL_001b: ldstr "log"
+			IL_0020: ldstr "no-abort"
+			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002a: br IL_0048
+
+			IL_002f: ldstr "log"
+			IL_0034: ldstr "no-abort"
+			IL_0039: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M5>:__js_call__:5"
+			IL_003e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0048: pop
+			IL_0049: ldnull
+			IL_004a: ret
 		} // end of method FunctionExpression_L22C8::__js_call__
 
 	} // end of class FunctionExpression_L22C8
@@ -552,7 +564,7 @@
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 239 (0xef)
+			// Code size: 356 (0x164)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -564,7 +576,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.2
@@ -575,67 +587,106 @@
 			IL_002c: ldarg.2
 			IL_002d: ldstr "name"
 			IL_0032: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:6"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
-			IL_0042: ldloc.0
-			IL_0043: ldstr "log"
-			IL_0048: ldloc.1
-			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_004e: pop
-			IL_004f: ldstr "console"
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005e: stloc.1
-			IL_005f: volatile.
-			IL_0061: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0066: brfalse IL_007b
+			IL_0042: volatile.
+			IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0049: brfalse IL_005f
 
-			IL_006b: ldarg.2
-			IL_006c: ldstr "code"
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0076: br IL_0090
+			IL_004e: ldloc.0
+			IL_004f: ldstr "log"
+			IL_0054: ldloc.1
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_005a: br IL_0075
 
-			IL_007b: ldarg.2
-			IL_007c: ldstr "code"
-			IL_0081: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:14"
-			IL_0086: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_005f: ldloc.0
+			IL_0060: ldstr "log"
+			IL_0065: ldloc.1
+			IL_0066: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:7"
+			IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0090: stloc.0
-			IL_0091: ldloc.1
-			IL_0092: ldstr "log"
-			IL_0097: ldloc.0
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_009d: pop
-			IL_009e: ldstr "console"
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ad: stloc.0
-			IL_00ae: volatile.
-			IL_00b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_00b5: brfalse IL_00ca
+			IL_0075: pop
+			IL_0076: ldstr "console"
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0085: stloc.1
+			IL_0086: volatile.
+			IL_0088: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_008d: brfalse IL_00a2
 
-			IL_00ba: ldarg.2
-			IL_00bb: ldstr "message"
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c5: br IL_00df
+			IL_0092: ldarg.2
+			IL_0093: ldstr "code"
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009d: br IL_00b7
 
-			IL_00ca: ldarg.2
-			IL_00cb: ldstr "message"
-			IL_00d0: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:22"
-			IL_00d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00a2: ldarg.2
+			IL_00a3: ldstr "code"
+			IL_00a8: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:14"
+			IL_00ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00df: stloc.1
-			IL_00e0: ldloc.0
-			IL_00e1: ldstr "log"
-			IL_00e6: ldloc.1
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ec: pop
-			IL_00ed: ldnull
-			IL_00ee: ret
+			IL_00b7: stloc.0
+			IL_00b8: volatile.
+			IL_00ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_00bf: brfalse IL_00d5
+
+			IL_00c4: ldloc.1
+			IL_00c5: ldstr "log"
+			IL_00ca: ldloc.0
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d0: br IL_00eb
+
+			IL_00d5: ldloc.1
+			IL_00d6: ldstr "log"
+			IL_00db: ldloc.0
+			IL_00dc: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:15"
+			IL_00e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00eb: pop
+			IL_00ec: ldstr "console"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fb: stloc.0
+			IL_00fc: volatile.
+			IL_00fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0103: brfalse IL_0118
+
+			IL_0108: ldarg.2
+			IL_0109: ldstr "message"
+			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0113: br IL_012d
+
+			IL_0118: ldarg.2
+			IL_0119: ldstr "message"
+			IL_011e: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:22"
+			IL_0123: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_012d: stloc.1
+			IL_012e: volatile.
+			IL_0130: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0135: brfalse IL_014b
+
+			IL_013a: ldloc.0
+			IL_013b: ldstr "log"
+			IL_0140: ldloc.1
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0146: br IL_0161
+
+			IL_014b: ldloc.0
+			IL_014c: ldstr "log"
+			IL_0151: ldloc.1
+			IL_0152: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:23"
+			IL_0157: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0161: pop
+			IL_0162: ldnull
+			IL_0163: ret
 		} // end of method FunctionExpression_L25C9::__js_call__
 
 	} // end of class FunctionExpression_L25C9
@@ -778,7 +829,7 @@
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 354 (0x162)
+			// Code size: 510 (0x1fe)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -805,100 +856,152 @@
 			IL_002f: ldloc.1
 			IL_0030: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0035: stloc.1
-			IL_0036: ldloc.0
-			IL_0037: ldstr "log"
-			IL_003c: ldloc.1
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0042: pop
-			IL_0043: ldstr "console"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0052: stloc.0
-			IL_0053: ldarg.0
-			IL_0054: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
-			IL_0059: volatile.
-			IL_005b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0060: brfalse IL_0074
+			IL_0036: volatile.
+			IL_0038: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_003d: brfalse IL_0053
 
-			IL_0065: ldstr "destroyed"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006f: br IL_0088
+			IL_0042: ldloc.0
+			IL_0043: ldstr "log"
+			IL_0048: ldloc.1
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_004e: br IL_0069
 
-			IL_0074: ldstr "destroyed"
-			IL_0079: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:17"
-			IL_007e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0053: ldloc.0
+			IL_0054: ldstr "log"
+			IL_0059: ldloc.1
+			IL_005a: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:9"
+			IL_005f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0088: stloc.2
-			IL_0089: ldstr "readable-destroyed:"
-			IL_008e: ldloc.2
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0094: stloc.3
-			IL_0095: ldloc.0
-			IL_0096: ldstr "log"
-			IL_009b: ldloc.3
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00a1: pop
-			IL_00a2: ldstr "console"
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b1: stloc.0
-			IL_00b2: ldarg.0
-			IL_00b3: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::pass
-			IL_00b8: volatile.
-			IL_00ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_00bf: brfalse IL_00d3
+			IL_0069: pop
+			IL_006a: ldstr "console"
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0079: stloc.0
+			IL_007a: ldarg.0
+			IL_007b: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::readable
+			IL_0080: volatile.
+			IL_0082: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0087: brfalse IL_009b
 
-			IL_00c4: ldstr "destroyed"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ce: br IL_00e7
+			IL_008c: ldstr "destroyed"
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0096: br IL_00af
 
-			IL_00d3: ldstr "destroyed"
-			IL_00d8: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:27"
-			IL_00dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_009b: ldstr "destroyed"
+			IL_00a0: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:17"
+			IL_00a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00e7: stloc.2
-			IL_00e8: ldstr "pass-destroyed:"
-			IL_00ed: ldloc.2
-			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00f3: stloc.3
-			IL_00f4: ldloc.0
-			IL_00f5: ldstr "log"
-			IL_00fa: ldloc.3
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0100: pop
-			IL_0101: ldstr "console"
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0110: stloc.0
-			IL_0111: ldarg.0
-			IL_0112: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
-			IL_0117: volatile.
-			IL_0119: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_011e: brfalse IL_0132
+			IL_00af: stloc.2
+			IL_00b0: ldstr "readable-destroyed:"
+			IL_00b5: ldloc.2
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00bb: stloc.3
+			IL_00bc: volatile.
+			IL_00be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_00c3: brfalse IL_00d9
 
-			IL_0123: ldstr "destroyed"
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_012d: br IL_0146
+			IL_00c8: ldloc.0
+			IL_00c9: ldstr "log"
+			IL_00ce: ldloc.3
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d4: br IL_00ef
 
-			IL_0132: ldstr "destroyed"
-			IL_0137: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:37"
-			IL_013c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00d9: ldloc.0
+			IL_00da: ldstr "log"
+			IL_00df: ldloc.3
+			IL_00e0: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:19"
+			IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0146: stloc.2
-			IL_0147: ldstr "writable-destroyed:"
-			IL_014c: ldloc.2
-			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0152: stloc.3
-			IL_0153: ldloc.0
-			IL_0154: ldstr "log"
-			IL_0159: ldloc.3
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_015f: pop
-			IL_0160: ldnull
-			IL_0161: ret
+			IL_00ef: pop
+			IL_00f0: ldstr "console"
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ff: stloc.0
+			IL_0100: ldarg.0
+			IL_0101: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::pass
+			IL_0106: volatile.
+			IL_0108: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_010d: brfalse IL_0121
+
+			IL_0112: ldstr "destroyed"
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_011c: br IL_0135
+
+			IL_0121: ldstr "destroyed"
+			IL_0126: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:27"
+			IL_012b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0135: stloc.2
+			IL_0136: ldstr "pass-destroyed:"
+			IL_013b: ldloc.2
+			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0141: stloc.3
+			IL_0142: volatile.
+			IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0149: brfalse IL_015f
+
+			IL_014e: ldloc.0
+			IL_014f: ldstr "log"
+			IL_0154: ldloc.3
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_015a: br IL_0175
+
+			IL_015f: ldloc.0
+			IL_0160: ldstr "log"
+			IL_0165: ldloc.3
+			IL_0166: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:29"
+			IL_016b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0175: pop
+			IL_0176: ldstr "console"
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0185: stloc.0
+			IL_0186: ldarg.0
+			IL_0187: ldfld object Modules.Stream_Promises_Pipeline_AbortSignal/Scope::writable
+			IL_018c: volatile.
+			IL_018e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0193: brfalse IL_01a7
+
+			IL_0198: ldstr "destroyed"
+			IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01a2: br IL_01bb
+
+			IL_01a7: ldstr "destroyed"
+			IL_01ac: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:37"
+			IL_01b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_01bb: stloc.2
+			IL_01bc: ldstr "writable-destroyed:"
+			IL_01c1: ldloc.2
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01c7: stloc.3
+			IL_01c8: volatile.
+			IL_01ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_01cf: brfalse IL_01e5
+
+			IL_01d4: ldloc.0
+			IL_01d5: ldstr "log"
+			IL_01da: ldloc.3
+			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01e0: br IL_01fb
+
+			IL_01e5: ldloc.0
+			IL_01e6: ldstr "log"
+			IL_01eb: ldloc.3
+			IL_01ec: ldstr "Stream_Promises_Pipeline_AbortSignal:<TwoPhaseDummy_M7>:__js_call__:39"
+			IL_01f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_01fb: pop
+			IL_01fc: ldnull
+			IL_01fd: ret
 		} // end of method FunctionExpression_L30C8::__js_call__
 
 	} // end of class FunctionExpression_L30C8
@@ -950,7 +1053,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 755 (0x2f3)
+		// Code size: 959 (0x3bf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Promises_Pipeline_AbortSignal/Scope,
@@ -1154,98 +1257,161 @@
 		IL_01f7: ldc.r8 1
 		IL_0200: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_0205: stloc.s 6
-		IL_0207: ldstr "push"
-		IL_020c: ldloc.s 6
-		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0213: pop
-		IL_0214: ldloc.3
-		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021a: ldstr "abort"
-		IL_021f: ldstr "stop"
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0229: pop
-		IL_022a: ldloc.s 4
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0231: stloc.s 11
-		IL_0233: ldc.i4.1
-		IL_0234: newarr [System.Runtime]System.Object
-		IL_0239: dup
-		IL_023a: ldc.i4.0
-		IL_023b: ldloc.0
-		IL_023c: stelem.ref
-		IL_023d: stloc.s 8
-		IL_023f: ldloc.s 8
-		IL_0241: ldc.i4.0
-		IL_0242: ldelem.ref
-		IL_0243: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_0248: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
-		IL_024d: ldc.i4.0
-		IL_024e: conv.r8
-		IL_024f: ldstr ""
-		IL_0254: ldc.i4.0
-		IL_0255: ldc.i4.1
-		IL_0256: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_025b: stloc.s 13
-		IL_025d: ldloc.s 11
-		IL_025f: ldstr "then"
-		IL_0264: ldloc.s 13
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026b: stloc.s 11
-		IL_026d: ldloc.s 11
-		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0274: stloc.s 11
-		IL_0276: ldc.i4.1
-		IL_0277: newarr [System.Runtime]System.Object
-		IL_027c: dup
-		IL_027d: ldc.i4.0
-		IL_027e: ldloc.0
-		IL_027f: stelem.ref
-		IL_0280: stloc.s 8
-		IL_0282: ldloc.s 8
-		IL_0284: ldc.i4.0
-		IL_0285: ldelem.ref
-		IL_0286: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_028b: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
-		IL_0290: ldc.i4.1
-		IL_0291: conv.r8
-		IL_0292: ldstr ""
-		IL_0297: ldc.i4.0
-		IL_0298: ldc.i4.1
-		IL_0299: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_029e: stloc.s 14
-		IL_02a0: ldloc.s 11
-		IL_02a2: ldstr "catch"
-		IL_02a7: ldloc.s 14
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ae: stloc.s 11
-		IL_02b0: ldloc.s 11
-		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b7: stloc.s 11
-		IL_02b9: ldc.i4.1
-		IL_02ba: newarr [System.Runtime]System.Object
-		IL_02bf: dup
-		IL_02c0: ldc.i4.0
-		IL_02c1: ldloc.0
-		IL_02c2: stelem.ref
-		IL_02c3: stloc.s 8
-		IL_02c5: ldloc.s 8
-		IL_02c7: ldc.i4.0
-		IL_02c8: ldelem.ref
-		IL_02c9: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_02ce: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
-		IL_02d3: ldc.i4.0
-		IL_02d4: conv.r8
-		IL_02d5: ldstr ""
-		IL_02da: ldc.i4.0
-		IL_02db: ldc.i4.1
-		IL_02dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02e1: stloc.s 15
-		IL_02e3: ldloc.s 11
-		IL_02e5: ldstr "then"
-		IL_02ea: ldloc.s 15
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f1: pop
-		IL_02f2: ret
+		IL_0207: volatile.
+		IL_0209: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_020e: brfalse IL_0224
+
+		IL_0213: ldstr "push"
+		IL_0218: ldloc.s 6
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021f: br IL_023a
+
+		IL_0224: ldstr "push"
+		IL_0229: ldloc.s 6
+		IL_022b: ldstr "Stream_Promises_Pipeline_AbortSignal:Modules.Stream_Promises_Pipeline_AbortSignal:__js_module_init__:67"
+		IL_0230: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_023a: pop
+		IL_023b: ldloc.3
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0241: volatile.
+		IL_0243: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0248: brfalse IL_0261
+
+		IL_024d: ldstr "abort"
+		IL_0252: ldstr "stop"
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025c: br IL_027a
+
+		IL_0261: ldstr "abort"
+		IL_0266: ldstr "stop"
+		IL_026b: ldstr "Stream_Promises_Pipeline_AbortSignal:Modules.Stream_Promises_Pipeline_AbortSignal:__js_module_init__:71"
+		IL_0270: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_027a: pop
+		IL_027b: ldloc.s 4
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0282: stloc.s 11
+		IL_0284: ldc.i4.1
+		IL_0285: newarr [System.Runtime]System.Object
+		IL_028a: dup
+		IL_028b: ldc.i4.0
+		IL_028c: ldloc.0
+		IL_028d: stelem.ref
+		IL_028e: stloc.s 8
+		IL_0290: ldloc.s 8
+		IL_0292: ldc.i4.0
+		IL_0293: ldelem.ref
+		IL_0294: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
+		IL_0299: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
+		IL_029e: ldc.i4.0
+		IL_029f: conv.r8
+		IL_02a0: ldstr ""
+		IL_02a5: ldc.i4.0
+		IL_02a6: ldc.i4.1
+		IL_02a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02ac: stloc.s 13
+		IL_02ae: volatile.
+		IL_02b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_02b5: brfalse IL_02cd
+
+		IL_02ba: ldloc.s 11
+		IL_02bc: ldstr "then"
+		IL_02c1: ldloc.s 13
+		IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c8: br IL_02e5
+
+		IL_02cd: ldloc.s 11
+		IL_02cf: ldstr "then"
+		IL_02d4: ldloc.s 13
+		IL_02d6: ldstr "Stream_Promises_Pipeline_AbortSignal:Modules.Stream_Promises_Pipeline_AbortSignal:__js_module_init__:76"
+		IL_02db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02e5: stloc.s 11
+		IL_02e7: ldloc.s 11
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ee: stloc.s 11
+		IL_02f0: ldc.i4.1
+		IL_02f1: newarr [System.Runtime]System.Object
+		IL_02f6: dup
+		IL_02f7: ldc.i4.0
+		IL_02f8: ldloc.0
+		IL_02f9: stelem.ref
+		IL_02fa: stloc.s 8
+		IL_02fc: ldloc.s 8
+		IL_02fe: ldc.i4.0
+		IL_02ff: ldelem.ref
+		IL_0300: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
+		IL_0305: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
+		IL_030a: ldc.i4.1
+		IL_030b: conv.r8
+		IL_030c: ldstr ""
+		IL_0311: ldc.i4.0
+		IL_0312: ldc.i4.1
+		IL_0313: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0318: stloc.s 14
+		IL_031a: volatile.
+		IL_031c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0321: brfalse IL_0339
+
+		IL_0326: ldloc.s 11
+		IL_0328: ldstr "catch"
+		IL_032d: ldloc.s 14
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0334: br IL_0351
+
+		IL_0339: ldloc.s 11
+		IL_033b: ldstr "catch"
+		IL_0340: ldloc.s 14
+		IL_0342: ldstr "Stream_Promises_Pipeline_AbortSignal:Modules.Stream_Promises_Pipeline_AbortSignal:__js_module_init__:80"
+		IL_0347: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0351: stloc.s 11
+		IL_0353: ldloc.s 11
+		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_035a: stloc.s 11
+		IL_035c: ldc.i4.1
+		IL_035d: newarr [System.Runtime]System.Object
+		IL_0362: dup
+		IL_0363: ldc.i4.0
+		IL_0364: ldloc.0
+		IL_0365: stelem.ref
+		IL_0366: stloc.s 8
+		IL_0368: ldloc.s 8
+		IL_036a: ldc.i4.0
+		IL_036b: ldelem.ref
+		IL_036c: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
+		IL_0371: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
+		IL_0376: ldc.i4.0
+		IL_0377: conv.r8
+		IL_0378: ldstr ""
+		IL_037d: ldc.i4.0
+		IL_037e: ldc.i4.1
+		IL_037f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0384: stloc.s 15
+		IL_0386: volatile.
+		IL_0388: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_038d: brfalse IL_03a5
+
+		IL_0392: ldloc.s 11
+		IL_0394: ldstr "then"
+		IL_0399: ldloc.s 15
+		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a0: br IL_03bd
+
+		IL_03a5: ldloc.s 11
+		IL_03a7: ldstr "then"
+		IL_03ac: ldloc.s 15
+		IL_03ae: ldstr "Stream_Promises_Pipeline_AbortSignal:Modules.Stream_Promises_Pipeline_AbortSignal:__js_module_init__:84"
+		IL_03b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03bd: pop
+		IL_03be: ret
 	} // end of method Stream_Promises_Pipeline_AbortSignal::__js_module_init__
 
 } // end of class Modules.Stream_Promises_Pipeline_AbortSignal
@@ -1284,6 +1450,19 @@
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
@@ -248,7 +248,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 116 (0x74)
+				// Code size: 155 (0x9b)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -263,7 +263,7 @@
 				IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0010: stloc.0
 				IL_0011: volatile.
-				IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 				IL_0018: brfalse IL_002d
 
 				IL_001d: ldarg.3
@@ -274,7 +274,7 @@
 				IL_002d: ldarg.3
 				IL_002e: ldstr "value"
 				IL_0033: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M5>:__js_call__:5"
-				IL_0038: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+				IL_0038: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0042: stloc.1
@@ -288,13 +288,26 @@
 				IL_005e: ldloc.2
 				IL_005f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 				IL_0064: stloc.3
-				IL_0065: ldloc.0
-				IL_0066: ldstr "push"
-				IL_006b: ldloc.3
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0071: pop
-				IL_0072: ldnull
-				IL_0073: ret
+				IL_0065: volatile.
+				IL_0067: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_006c: brfalse IL_0082
+
+				IL_0071: ldloc.0
+				IL_0072: ldstr "push"
+				IL_0077: ldloc.3
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007d: br IL_0098
+
+				IL_0082: ldloc.0
+				IL_0083: ldstr "push"
+				IL_0088: ldloc.3
+				IL_0089: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M5>:__js_call__:9"
+				IL_008e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_0098: pop
+				IL_0099: ldnull
+				IL_009a: ret
 			} // end of method FunctionExpression_L12C25::__js_call__
 
 		} // end of class FunctionExpression_L12C25
@@ -466,7 +479,7 @@
 				IL_0008: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
 				IL_000d: stloc.0
 				IL_000e: volatile.
-				IL_0010: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0010: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 				IL_0015: brfalse IL_002a
 
 				IL_001a: ldarg.2
@@ -477,7 +490,7 @@
 				IL_002a: ldarg.2
 				IL_002b: ldstr "value"
 				IL_0030: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M6>:__js_call__:4"
-				IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 				IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_003f: stloc.1
@@ -601,7 +614,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 1317 (0x525)
+			// Code size: 1444 (0x5a4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope,
@@ -741,7 +754,7 @@
 
 			IL_00f7: ldloc.0
 			IL_00f8: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00fd: switch (IL_010a, IL_0371)
+			IL_00fd: switch (IL_010a, IL_03f0)
 
 			IL_010a: ldarg.0
 			IL_010b: ldc.i4.1
@@ -913,254 +926,294 @@
 			IL_028d: ldc.r8 1
 			IL_0296: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 			IL_029b: stloc.s 7
-			IL_029d: ldloc.s 6
-			IL_029f: ldstr "push"
-			IL_02a4: ldloc.s 7
-			IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02ab: pop
-			IL_02ac: ldloc.1
-			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b2: stloc.s 6
-			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02b9: dup
-			IL_02ba: ldstr "value"
-			IL_02bf: ldc.r8 2
-			IL_02c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_02cd: stloc.s 7
-			IL_02cf: ldloc.s 6
-			IL_02d1: ldstr "push"
-			IL_02d6: ldloc.s 7
-			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02dd: pop
-			IL_02de: ldloc.1
-			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02e4: stloc.s 6
-			IL_02e6: ldloc.s 6
-			IL_02e8: ldstr "push"
-			IL_02ed: ldc.i4.0
-			IL_02ee: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02f8: pop
-			IL_02f9: ldloc.0
-			IL_02fa: ldc.i4.1
-			IL_02fb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0300: ldloc.0
-			IL_0301: ldloc.s 4
-			IL_0303: ldarg.0
-			IL_0304: ldc.i4.1
-			IL_0305: ldloc.0
-			IL_0306: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_030b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0310: ldloc.0
-			IL_0311: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0316: dup
-			IL_0317: ldc.i4.0
-			IL_0318: ldloc.1
-			IL_0319: stelem.ref
-			IL_031a: dup
-			IL_031b: ldc.i4.1
-			IL_031c: ldloc.2
-			IL_031d: stelem.ref
-			IL_031e: dup
-			IL_031f: ldc.i4.2
-			IL_0320: ldloc.3
-			IL_0321: stelem.ref
-			IL_0322: dup
-			IL_0323: ldc.i4.3
-			IL_0324: ldloc.s 4
-			IL_0326: stelem.ref
-			IL_0327: dup
-			IL_0328: ldc.i4.4
-			IL_0329: ldloc.s 5
-			IL_032b: stelem.ref
-			IL_032c: dup
-			IL_032d: ldc.i4.5
-			IL_032e: ldloc.s 6
-			IL_0330: stelem.ref
-			IL_0331: dup
-			IL_0332: ldc.i4.6
-			IL_0333: ldloc.s 7
-			IL_0335: stelem.ref
-			IL_0336: dup
-			IL_0337: ldc.i4.7
-			IL_0338: ldloc.s 8
-			IL_033a: stelem.ref
-			IL_033b: dup
-			IL_033c: ldc.i4.8
-			IL_033d: ldloc.s 9
-			IL_033f: stelem.ref
-			IL_0340: dup
-			IL_0341: ldc.i4.s 9
-			IL_0343: ldloc.s 10
-			IL_0345: stelem.ref
-			IL_0346: dup
-			IL_0347: ldc.i4.s 10
-			IL_0349: ldloc.s 11
-			IL_034b: stelem.ref
-			IL_034c: dup
-			IL_034d: ldc.i4.s 11
-			IL_034f: ldloc.s 12
-			IL_0351: stelem.ref
-			IL_0352: dup
-			IL_0353: ldc.i4.s 12
-			IL_0355: ldloc.s 13
-			IL_0357: stelem.ref
-			IL_0358: dup
-			IL_0359: ldc.i4.s 13
-			IL_035b: ldloc.s 14
-			IL_035d: stelem.ref
-			IL_035e: dup
-			IL_035f: ldc.i4.s 14
-			IL_0361: ldloc.s 15
-			IL_0363: stelem.ref
-			IL_0364: pop
-			IL_0365: ldloc.0
-			IL_0366: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0370: ret
+			IL_029d: volatile.
+			IL_029f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_02a4: brfalse IL_02bc
 
-			IL_0371: ldloc.0
-			IL_0372: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::_awaited1
+			IL_02a9: ldloc.s 6
+			IL_02ab: ldstr "push"
+			IL_02b0: ldloc.s 7
+			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02b7: br IL_02d4
+
+			IL_02bc: ldloc.s 6
+			IL_02be: ldstr "push"
+			IL_02c3: ldloc.s 7
+			IL_02c5: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:43"
+			IL_02ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_02d4: pop
+			IL_02d5: ldloc.1
+			IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02db: stloc.s 6
+			IL_02dd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02e2: dup
+			IL_02e3: ldstr "value"
+			IL_02e8: ldc.r8 2
+			IL_02f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_02f6: stloc.s 7
+			IL_02f8: volatile.
+			IL_02fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_02ff: brfalse IL_0317
+
+			IL_0304: ldloc.s 6
+			IL_0306: ldstr "push"
+			IL_030b: ldloc.s 7
+			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0312: br IL_032f
+
+			IL_0317: ldloc.s 6
+			IL_0319: ldstr "push"
+			IL_031e: ldloc.s 7
+			IL_0320: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:48"
+			IL_0325: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_032f: pop
+			IL_0330: ldloc.1
+			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0336: stloc.s 6
+			IL_0338: volatile.
+			IL_033a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_033f: brfalse IL_035b
+
+			IL_0344: ldloc.s 6
+			IL_0346: ldstr "push"
+			IL_034b: ldc.i4.0
+			IL_034c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0356: br IL_0377
+
+			IL_035b: ldloc.s 6
+			IL_035d: ldstr "push"
+			IL_0362: ldc.i4.0
+			IL_0363: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0368: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:53"
+			IL_036d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
 			IL_0377: pop
-			IL_0378: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_037d: stloc.s 13
-			IL_037f: volatile.
-			IL_0381: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0386: brfalse IL_039b
+			IL_0378: ldloc.0
+			IL_0379: ldc.i4.1
+			IL_037a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_037f: ldloc.0
+			IL_0380: ldloc.s 4
+			IL_0382: ldarg.0
+			IL_0383: ldc.i4.1
+			IL_0384: ldloc.0
+			IL_0385: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_038a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_038f: ldloc.0
+			IL_0390: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0395: dup
+			IL_0396: ldc.i4.0
+			IL_0397: ldloc.1
+			IL_0398: stelem.ref
+			IL_0399: dup
+			IL_039a: ldc.i4.1
+			IL_039b: ldloc.2
+			IL_039c: stelem.ref
+			IL_039d: dup
+			IL_039e: ldc.i4.2
+			IL_039f: ldloc.3
+			IL_03a0: stelem.ref
+			IL_03a1: dup
+			IL_03a2: ldc.i4.3
+			IL_03a3: ldloc.s 4
+			IL_03a5: stelem.ref
+			IL_03a6: dup
+			IL_03a7: ldc.i4.4
+			IL_03a8: ldloc.s 5
+			IL_03aa: stelem.ref
+			IL_03ab: dup
+			IL_03ac: ldc.i4.5
+			IL_03ad: ldloc.s 6
+			IL_03af: stelem.ref
+			IL_03b0: dup
+			IL_03b1: ldc.i4.6
+			IL_03b2: ldloc.s 7
+			IL_03b4: stelem.ref
+			IL_03b5: dup
+			IL_03b6: ldc.i4.7
+			IL_03b7: ldloc.s 8
+			IL_03b9: stelem.ref
+			IL_03ba: dup
+			IL_03bb: ldc.i4.8
+			IL_03bc: ldloc.s 9
+			IL_03be: stelem.ref
+			IL_03bf: dup
+			IL_03c0: ldc.i4.s 9
+			IL_03c2: ldloc.s 10
+			IL_03c4: stelem.ref
+			IL_03c5: dup
+			IL_03c6: ldc.i4.s 10
+			IL_03c8: ldloc.s 11
+			IL_03ca: stelem.ref
+			IL_03cb: dup
+			IL_03cc: ldc.i4.s 11
+			IL_03ce: ldloc.s 12
+			IL_03d0: stelem.ref
+			IL_03d1: dup
+			IL_03d2: ldc.i4.s 12
+			IL_03d4: ldloc.s 13
+			IL_03d6: stelem.ref
+			IL_03d7: dup
+			IL_03d8: ldc.i4.s 13
+			IL_03da: ldloc.s 14
+			IL_03dc: stelem.ref
+			IL_03dd: dup
+			IL_03de: ldc.i4.s 14
+			IL_03e0: ldloc.s 15
+			IL_03e2: stelem.ref
+			IL_03e3: pop
+			IL_03e4: ldloc.0
+			IL_03e5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03ea: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03ef: ret
 
-			IL_038b: ldloc.1
-			IL_038c: ldstr "readableObjectMode"
-			IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0396: br IL_03b0
+			IL_03f0: ldloc.0
+			IL_03f1: ldfld object Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::_awaited1
+			IL_03f6: pop
+			IL_03f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03fc: stloc.s 13
+			IL_03fe: volatile.
+			IL_0400: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0405: brfalse IL_041a
 
-			IL_039b: ldloc.1
-			IL_039c: ldstr "readableObjectMode"
-			IL_03a1: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:60"
-			IL_03a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_040a: ldloc.1
+			IL_040b: ldstr "readableObjectMode"
+			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0415: br IL_042f
 
-			IL_03b0: stloc.s 6
-			IL_03b2: ldstr "readableObjectMode:"
-			IL_03b7: ldloc.s 6
-			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03be: stloc.s 14
-			IL_03c0: ldloc.s 13
-			IL_03c2: ldloc.s 14
-			IL_03c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03c9: pop
-			IL_03ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03cf: stloc.s 13
-			IL_03d1: volatile.
-			IL_03d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_03d8: brfalse IL_03ed
+			IL_041a: ldloc.1
+			IL_041b: ldstr "readableObjectMode"
+			IL_0420: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:60"
+			IL_0425: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03dd: ldloc.2
-			IL_03de: ldstr "readableObjectMode"
-			IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e8: br IL_0402
+			IL_042f: stloc.s 6
+			IL_0431: ldstr "readableObjectMode:"
+			IL_0436: ldloc.s 6
+			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_043d: stloc.s 14
+			IL_043f: ldloc.s 13
+			IL_0441: ldloc.s 14
+			IL_0443: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0448: pop
+			IL_0449: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_044e: stloc.s 13
+			IL_0450: volatile.
+			IL_0452: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0457: brfalse IL_046c
 
-			IL_03ed: ldloc.2
-			IL_03ee: ldstr "readableObjectMode"
-			IL_03f3: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:67"
-			IL_03f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_045c: ldloc.2
+			IL_045d: ldstr "readableObjectMode"
+			IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0467: br IL_0481
 
-			IL_0402: stloc.s 6
-			IL_0404: ldstr "transformReadableObjectMode:"
-			IL_0409: ldloc.s 6
-			IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0410: stloc.s 14
-			IL_0412: ldloc.s 13
-			IL_0414: ldloc.s 14
-			IL_0416: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_041b: pop
-			IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0421: stloc.s 13
-			IL_0423: volatile.
-			IL_0425: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_042a: brfalse IL_043f
+			IL_046c: ldloc.2
+			IL_046d: ldstr "readableObjectMode"
+			IL_0472: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:67"
+			IL_0477: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_042f: ldloc.2
-			IL_0430: ldstr "writableObjectMode"
-			IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_043a: br IL_0454
+			IL_0481: stloc.s 6
+			IL_0483: ldstr "transformReadableObjectMode:"
+			IL_0488: ldloc.s 6
+			IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_048f: stloc.s 14
+			IL_0491: ldloc.s 13
+			IL_0493: ldloc.s 14
+			IL_0495: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_049a: pop
+			IL_049b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04a0: stloc.s 13
+			IL_04a2: volatile.
+			IL_04a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_04a9: brfalse IL_04be
 
-			IL_043f: ldloc.2
-			IL_0440: ldstr "writableObjectMode"
-			IL_0445: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:74"
-			IL_044a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04ae: ldloc.2
+			IL_04af: ldstr "writableObjectMode"
+			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04b9: br IL_04d3
 
-			IL_0454: stloc.s 6
-			IL_0456: ldstr "transformWritableObjectMode:"
-			IL_045b: ldloc.s 6
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0462: stloc.s 14
-			IL_0464: ldloc.s 13
-			IL_0466: ldloc.s 14
-			IL_0468: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_046d: pop
-			IL_046e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0473: stloc.s 13
-			IL_0475: volatile.
-			IL_0477: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_047c: brfalse IL_0491
+			IL_04be: ldloc.2
+			IL_04bf: ldstr "writableObjectMode"
+			IL_04c4: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:74"
+			IL_04c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0481: ldloc.3
-			IL_0482: ldstr "writableObjectMode"
-			IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_048c: br IL_04a6
+			IL_04d3: stloc.s 6
+			IL_04d5: ldstr "transformWritableObjectMode:"
+			IL_04da: ldloc.s 6
+			IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04e1: stloc.s 14
+			IL_04e3: ldloc.s 13
+			IL_04e5: ldloc.s 14
+			IL_04e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04ec: pop
+			IL_04ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04f2: stloc.s 13
+			IL_04f4: volatile.
+			IL_04f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_04fb: brfalse IL_0510
 
-			IL_0491: ldloc.3
-			IL_0492: ldstr "writableObjectMode"
-			IL_0497: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:81"
-			IL_049c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0500: ldloc.3
+			IL_0501: ldstr "writableObjectMode"
+			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_050b: br IL_0525
 
-			IL_04a6: stloc.s 6
-			IL_04a8: ldstr "writableObjectMode:"
-			IL_04ad: ldloc.s 6
-			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04b4: stloc.s 14
-			IL_04b6: ldloc.s 13
-			IL_04b8: ldloc.s 14
-			IL_04ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04bf: pop
-			IL_04c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04c5: stloc.s 13
-			IL_04c7: ldloc.0
-			IL_04c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
-			IL_04cd: ldc.i4.1
-			IL_04ce: newarr [System.Runtime]System.Object
-			IL_04d3: dup
-			IL_04d4: ldc.i4.0
-			IL_04d5: ldstr ","
-			IL_04da: stelem.ref
-			IL_04db: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_04e0: stloc.s 15
-			IL_04e2: ldstr "written:"
-			IL_04e7: ldloc.s 15
-			IL_04e9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04ee: stloc.s 15
-			IL_04f0: ldloc.s 13
-			IL_04f2: ldloc.s 15
-			IL_04f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04f9: pop
-			IL_04fa: ldloc.0
-			IL_04fb: ldc.i4.m1
-			IL_04fc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0501: ldloc.0
-			IL_0502: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0507: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_050c: ldarg.0
-			IL_050d: ldc.i4.1
-			IL_050e: newarr [System.Runtime]System.Object
-			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0518: pop
-			IL_0519: ldloc.0
-			IL_051a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_051f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0524: ret
+			IL_0510: ldloc.3
+			IL_0511: ldstr "writableObjectMode"
+			IL_0516: ldstr "Stream_Promises_Pipeline_ObjectMode:<TwoPhaseDummy_M4>:__js_call__:81"
+			IL_051b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0525: stloc.s 6
+			IL_0527: ldstr "writableObjectMode:"
+			IL_052c: ldloc.s 6
+			IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0533: stloc.s 14
+			IL_0535: ldloc.s 13
+			IL_0537: ldloc.s 14
+			IL_0539: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_053e: pop
+			IL_053f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0544: stloc.s 13
+			IL_0546: ldloc.0
+			IL_0547: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope::written
+			IL_054c: ldc.i4.1
+			IL_054d: newarr [System.Runtime]System.Object
+			IL_0552: dup
+			IL_0553: ldc.i4.0
+			IL_0554: ldstr ","
+			IL_0559: stelem.ref
+			IL_055a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_055f: stloc.s 15
+			IL_0561: ldstr "written:"
+			IL_0566: ldloc.s 15
+			IL_0568: call string [System.Runtime]System.String::Concat(string, string)
+			IL_056d: stloc.s 15
+			IL_056f: ldloc.s 13
+			IL_0571: ldloc.s 15
+			IL_0573: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0578: pop
+			IL_0579: ldloc.0
+			IL_057a: ldc.i4.m1
+			IL_057b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0580: ldloc.0
+			IL_0581: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0586: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_058b: ldarg.0
+			IL_058c: ldc.i4.1
+			IL_058d: newarr [System.Runtime]System.Object
+			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0597: pop
+			IL_0598: ldloc.0
+			IL_0599: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_059e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05a3: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1297,6 +1350,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
 	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
@@ -430,7 +430,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 424 (0x1a8)
+		// Code size: 551 (0x227)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Readable_Basic/Scope,
@@ -538,57 +538,94 @@
 		IL_00fc: pop
 		IL_00fd: ldloc.3
 		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0103: ldstr "push"
-		IL_0108: ldstr "chunk1"
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0112: pop
-		IL_0113: ldloc.3
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0119: ldstr "push"
-		IL_011e: ldstr "chunk2"
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0128: pop
-		IL_0129: ldloc.3
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012f: ldstr "push"
-		IL_0134: ldc.i4.0
-		IL_0135: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013f: pop
-		IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0145: stloc.s 4
-		IL_0147: ldloc.0
-		IL_0148: ldfld object Modules.Stream_Readable_Basic/Scope::dataReceived
-		IL_014d: stloc.s 5
-		IL_014f: ldloc.s 4
-		IL_0151: ldstr "Data events:"
-		IL_0156: ldloc.s 5
-		IL_0158: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_015d: pop
-		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0163: stloc.s 4
-		IL_0165: volatile.
-		IL_0167: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_016c: brfalse IL_0181
+		IL_0103: volatile.
+		IL_0105: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_010a: brfalse IL_0123
 
-		IL_0171: ldloc.3
-		IL_0172: ldstr "readable"
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017c: br IL_0196
+		IL_010f: ldstr "push"
+		IL_0114: ldstr "chunk1"
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011e: br IL_013c
 
-		IL_0181: ldloc.3
-		IL_0182: ldstr "readable"
-		IL_0187: ldstr "Stream_Readable_Basic:Modules.Stream_Readable_Basic:__js_module_init__:57"
-		IL_018c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0123: ldstr "push"
+		IL_0128: ldstr "chunk1"
+		IL_012d: ldstr "Stream_Readable_Basic:Modules.Stream_Readable_Basic:__js_module_init__:38"
+		IL_0132: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0196: stloc.s 5
-		IL_0198: ldloc.s 4
-		IL_019a: ldstr "Readable after end:"
-		IL_019f: ldloc.s 5
-		IL_01a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01a6: pop
-		IL_01a7: ret
+		IL_013c: pop
+		IL_013d: ldloc.3
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0143: volatile.
+		IL_0145: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_014a: brfalse IL_0163
+
+		IL_014f: ldstr "push"
+		IL_0154: ldstr "chunk2"
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015e: br IL_017c
+
+		IL_0163: ldstr "push"
+		IL_0168: ldstr "chunk2"
+		IL_016d: ldstr "Stream_Readable_Basic:Modules.Stream_Readable_Basic:__js_module_init__:42"
+		IL_0172: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_017c: pop
+		IL_017d: ldloc.3
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0183: volatile.
+		IL_0185: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_018a: brfalse IL_01a4
+
+		IL_018f: ldstr "push"
+		IL_0194: ldc.i4.0
+		IL_0195: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019f: br IL_01be
+
+		IL_01a4: ldstr "push"
+		IL_01a9: ldc.i4.0
+		IL_01aa: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_01af: ldstr "Stream_Readable_Basic:Modules.Stream_Readable_Basic:__js_module_init__:47"
+		IL_01b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01be: pop
+		IL_01bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c4: stloc.s 4
+		IL_01c6: ldloc.0
+		IL_01c7: ldfld object Modules.Stream_Readable_Basic/Scope::dataReceived
+		IL_01cc: stloc.s 5
+		IL_01ce: ldloc.s 4
+		IL_01d0: ldstr "Data events:"
+		IL_01d5: ldloc.s 5
+		IL_01d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01dc: pop
+		IL_01dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e2: stloc.s 4
+		IL_01e4: volatile.
+		IL_01e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01eb: brfalse IL_0200
+
+		IL_01f0: ldloc.3
+		IL_01f1: ldstr "readable"
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01fb: br IL_0215
+
+		IL_0200: ldloc.3
+		IL_0201: ldstr "readable"
+		IL_0206: ldstr "Stream_Readable_Basic:Modules.Stream_Readable_Basic:__js_module_init__:57"
+		IL_020b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0215: stloc.s 5
+		IL_0217: ldloc.s 4
+		IL_0219: ldstr "Readable after end:"
+		IL_021e: ldloc.s 5
+		IL_0220: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0225: pop
+		IL_0226: ret
 	} // end of method Stream_Readable_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Readable_Basic
@@ -620,6 +657,9 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
@@ -754,7 +754,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 531 (0x213)
+		// Code size: 700 (0x2bc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Readable_Pause_Resume/Scope,
@@ -916,52 +916,101 @@
 		IL_016e: pop
 		IL_016f: ldloc.2
 		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0175: ldstr "push"
-		IL_017a: ldstr "a"
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0184: pop
-		IL_0185: ldloc.2
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018b: ldstr "push"
-		IL_0190: ldstr "b"
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019a: pop
-		IL_019b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a0: stloc.s 10
-		IL_01a2: ldloc.s 10
-		IL_01a4: ldstr "paused"
-		IL_01a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0175: volatile.
+		IL_0177: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_017c: brfalse IL_0195
+
+		IL_0181: ldstr "push"
+		IL_0186: ldstr "a"
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0190: br IL_01ae
+
+		IL_0195: ldstr "push"
+		IL_019a: ldstr "a"
+		IL_019f: ldstr "Stream_Readable_Pause_Resume:Modules.Stream_Readable_Pause_Resume:__js_module_init__:45"
+		IL_01a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
 		IL_01ae: pop
 		IL_01af: ldloc.2
 		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_01b5: volatile.
-		IL_01b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01bc: brfalse IL_01d0
+		IL_01b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01bc: brfalse IL_01d5
 
-		IL_01c1: ldstr "resume"
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01cb: br IL_01e4
+		IL_01c1: ldstr "push"
+		IL_01c6: ldstr "b"
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d0: br IL_01ee
 
-		IL_01d0: ldstr "resume"
-		IL_01d5: ldstr "Stream_Readable_Pause_Resume:Modules.Stream_Readable_Pause_Resume:__js_module_init__:56"
-		IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01d5: ldstr "push"
+		IL_01da: ldstr "b"
+		IL_01df: ldstr "Stream_Readable_Pause_Resume:Modules.Stream_Readable_Pause_Resume:__js_module_init__:49"
+		IL_01e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01e4: pop
-		IL_01e5: ldloc.2
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01eb: ldstr "push"
-		IL_01f0: ldstr "c"
-		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fa: pop
-		IL_01fb: ldloc.2
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0201: ldstr "push"
-		IL_0206: ldc.i4.0
-		IL_0207: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0211: pop
-		IL_0212: ret
+		IL_01ee: pop
+		IL_01ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f4: stloc.s 10
+		IL_01f6: ldloc.s 10
+		IL_01f8: ldstr "paused"
+		IL_01fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0202: pop
+		IL_0203: ldloc.2
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0209: volatile.
+		IL_020b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0210: brfalse IL_0224
+
+		IL_0215: ldstr "resume"
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_021f: br IL_0238
+
+		IL_0224: ldstr "resume"
+		IL_0229: ldstr "Stream_Readable_Pause_Resume:Modules.Stream_Readable_Pause_Resume:__js_module_init__:56"
+		IL_022e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0238: pop
+		IL_0239: ldloc.2
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023f: volatile.
+		IL_0241: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0246: brfalse IL_025f
+
+		IL_024b: ldstr "push"
+		IL_0250: ldstr "c"
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025a: br IL_0278
+
+		IL_025f: ldstr "push"
+		IL_0264: ldstr "c"
+		IL_0269: ldstr "Stream_Readable_Pause_Resume:Modules.Stream_Readable_Pause_Resume:__js_module_init__:60"
+		IL_026e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0278: pop
+		IL_0279: ldloc.2
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027f: volatile.
+		IL_0281: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0286: brfalse IL_02a0
+
+		IL_028b: ldstr "push"
+		IL_0290: ldc.i4.0
+		IL_0291: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029b: br IL_02ba
+
+		IL_02a0: ldstr "push"
+		IL_02a5: ldc.i4.0
+		IL_02a6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_02ab: ldstr "Stream_Readable_Pause_Resume:Modules.Stream_Readable_Pause_Resume:__js_module_init__:65"
+		IL_02b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02ba: pop
+		IL_02bb: ret
 	} // end of method Stream_Readable_Pause_Resume::__js_module_init__
 
 } // end of class Modules.Stream_Readable_Pause_Resume
@@ -993,6 +1042,10 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
@@ -388,7 +388,7 @@
 			IL_0006: ldarg.0
 			IL_0007: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
 			IL_000c: volatile.
-			IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_000e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0013: brfalse IL_0027
 
 			IL_0018: ldstr "readableEncoding"
@@ -397,7 +397,7 @@
 
 			IL_0027: ldstr "readableEncoding"
 			IL_002c: ldstr "Stream_Readable_SetEncoding_Utf8:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_0031: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_0031: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_003b: stloc.1
@@ -453,7 +453,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 517 (0x205)
+		// Code size: 719 (0x2cf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Readable_SetEncoding_Utf8/Scope,
@@ -499,144 +499,205 @@
 		IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 		IL_005d: stloc.s 4
-		IL_005f: ldstr "push"
-		IL_0064: ldloc.s 4
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006b: pop
-		IL_006c: ldloc.0
-		IL_006d: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0077: ldc.i4.1
-		IL_0078: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_007d: dup
-		IL_007e: ldc.r8 172
-		IL_0087: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0091: stloc.s 4
-		IL_0093: ldstr "push"
-		IL_0098: ldloc.s 4
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009f: pop
-		IL_00a0: ldloc.0
-		IL_00a1: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ab: ldstr "setEncoding"
-		IL_00b0: ldstr "utf8"
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ba: pop
-		IL_00bb: ldloc.0
-		IL_00bc: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c6: volatile.
-		IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00cd: brfalse IL_00e1
+		IL_005f: volatile.
+		IL_0061: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0066: brfalse IL_007c
 
-		IL_00d2: ldstr "read"
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00dc: br IL_00f5
+		IL_006b: ldstr "push"
+		IL_0070: ldloc.s 4
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0077: br IL_0092
 
-		IL_00e1: ldstr "read"
-		IL_00e6: ldstr "Stream_Readable_SetEncoding_Utf8:Modules.Stream_Readable_SetEncoding_Utf8:__js_module_init__:35"
-		IL_00eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_007c: ldstr "push"
+		IL_0081: ldloc.s 4
+		IL_0083: ldstr "Stream_Readable_SetEncoding_Utf8:Modules.Stream_Readable_SetEncoding_Utf8:__js_module_init__:19"
+		IL_0088: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00f5: stloc.2
-		IL_00f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fb: stloc.s 5
-		IL_00fd: ldstr "buffered:"
-		IL_0102: ldloc.2
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0108: stloc.s 6
-		IL_010a: ldloc.s 5
-		IL_010c: ldloc.s 6
-		IL_010e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0113: pop
-		IL_0114: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0119: stloc.s 5
-		IL_011b: ldloc.2
-		IL_011c: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0121: stloc.s 7
-		IL_0123: ldstr "buffered-type:"
-		IL_0128: ldloc.s 7
-		IL_012a: call string [System.Runtime]System.String::Concat(string, string)
-		IL_012f: stloc.s 7
-		IL_0131: ldloc.s 5
-		IL_0133: ldloc.s 7
-		IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013a: pop
-		IL_013b: ldloc.0
-		IL_013c: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0146: stloc.3
-		IL_0147: ldc.i4.1
-		IL_0148: newarr [System.Runtime]System.Object
-		IL_014d: dup
-		IL_014e: ldc.i4.0
-		IL_014f: ldloc.0
-		IL_0150: stelem.ref
-		IL_0151: stloc.s 8
-		IL_0153: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject::.ctor()
-		IL_0158: ldc.i4.1
-		IL_0159: conv.r8
-		IL_015a: ldstr ""
-		IL_015f: ldc.i4.0
-		IL_0160: ldc.i4.1
-		IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0166: stloc.s 9
-		IL_0168: ldloc.3
-		IL_0169: ldstr "on"
-		IL_016e: ldstr "data"
-		IL_0173: ldloc.s 9
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_017a: pop
-		IL_017b: ldloc.0
-		IL_017c: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0186: stloc.3
-		IL_0187: ldc.i4.1
-		IL_0188: newarr [System.Runtime]System.Object
-		IL_018d: dup
-		IL_018e: ldc.i4.0
-		IL_018f: ldloc.0
-		IL_0190: stelem.ref
-		IL_0191: stloc.s 8
-		IL_0193: ldloc.s 8
-		IL_0195: ldc.i4.0
-		IL_0196: ldelem.ref
-		IL_0197: castclass Modules.Stream_Readable_SetEncoding_Utf8/Scope
-		IL_019c: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject::.ctor(class Modules.Stream_Readable_SetEncoding_Utf8/Scope)
-		IL_01a1: ldc.i4.0
-		IL_01a2: conv.r8
-		IL_01a3: ldstr ""
-		IL_01a8: ldc.i4.0
-		IL_01a9: ldc.i4.1
-		IL_01aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01af: stloc.s 10
-		IL_01b1: ldloc.3
-		IL_01b2: ldstr "on"
-		IL_01b7: ldstr "end"
-		IL_01bc: ldloc.s 10
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01c3: pop
-		IL_01c4: ldloc.0
-		IL_01c5: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cf: ldstr " ok"
-		IL_01d4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_01d9: stloc.s 4
-		IL_01db: ldstr "push"
-		IL_01e0: ldloc.s 4
-		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e7: pop
-		IL_01e8: ldloc.0
-		IL_01e9: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f3: ldstr "push"
-		IL_01f8: ldc.i4.0
-		IL_01f9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0203: pop
-		IL_0204: ret
+		IL_0092: pop
+		IL_0093: ldloc.0
+		IL_0094: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009e: ldc.i4.1
+		IL_009f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00a4: dup
+		IL_00a5: ldc.r8 172
+		IL_00ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_00b8: stloc.s 4
+		IL_00ba: volatile.
+		IL_00bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00c1: brfalse IL_00d7
+
+		IL_00c6: ldstr "push"
+		IL_00cb: ldloc.s 4
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d2: br IL_00ed
+
+		IL_00d7: ldstr "push"
+		IL_00dc: ldloc.s 4
+		IL_00de: ldstr "Stream_Readable_SetEncoding_Utf8:Modules.Stream_Readable_SetEncoding_Utf8:__js_module_init__:26"
+		IL_00e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ed: pop
+		IL_00ee: ldloc.0
+		IL_00ef: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f9: volatile.
+		IL_00fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0100: brfalse IL_0119
+
+		IL_0105: ldstr "setEncoding"
+		IL_010a: ldstr "utf8"
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0114: br IL_0132
+
+		IL_0119: ldstr "setEncoding"
+		IL_011e: ldstr "utf8"
+		IL_0123: ldstr "Stream_Readable_SetEncoding_Utf8:Modules.Stream_Readable_SetEncoding_Utf8:__js_module_init__:31"
+		IL_0128: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0132: pop
+		IL_0133: ldloc.0
+		IL_0134: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013e: volatile.
+		IL_0140: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0145: brfalse IL_0159
+
+		IL_014a: ldstr "read"
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0154: br IL_016d
+
+		IL_0159: ldstr "read"
+		IL_015e: ldstr "Stream_Readable_SetEncoding_Utf8:Modules.Stream_Readable_SetEncoding_Utf8:__js_module_init__:35"
+		IL_0163: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_016d: stloc.2
+		IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0173: stloc.s 5
+		IL_0175: ldstr "buffered:"
+		IL_017a: ldloc.2
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0180: stloc.s 6
+		IL_0182: ldloc.s 5
+		IL_0184: ldloc.s 6
+		IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_018b: pop
+		IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0191: stloc.s 5
+		IL_0193: ldloc.2
+		IL_0194: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0199: stloc.s 7
+		IL_019b: ldstr "buffered-type:"
+		IL_01a0: ldloc.s 7
+		IL_01a2: call string [System.Runtime]System.String::Concat(string, string)
+		IL_01a7: stloc.s 7
+		IL_01a9: ldloc.s 5
+		IL_01ab: ldloc.s 7
+		IL_01ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b2: pop
+		IL_01b3: ldloc.0
+		IL_01b4: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01be: stloc.3
+		IL_01bf: ldc.i4.1
+		IL_01c0: newarr [System.Runtime]System.Object
+		IL_01c5: dup
+		IL_01c6: ldc.i4.0
+		IL_01c7: ldloc.0
+		IL_01c8: stelem.ref
+		IL_01c9: stloc.s 8
+		IL_01cb: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject::.ctor()
+		IL_01d0: ldc.i4.1
+		IL_01d1: conv.r8
+		IL_01d2: ldstr ""
+		IL_01d7: ldc.i4.0
+		IL_01d8: ldc.i4.1
+		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01de: stloc.s 9
+		IL_01e0: ldloc.3
+		IL_01e1: ldstr "on"
+		IL_01e6: ldstr "data"
+		IL_01eb: ldloc.s 9
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01f2: pop
+		IL_01f3: ldloc.0
+		IL_01f4: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01fe: stloc.3
+		IL_01ff: ldc.i4.1
+		IL_0200: newarr [System.Runtime]System.Object
+		IL_0205: dup
+		IL_0206: ldc.i4.0
+		IL_0207: ldloc.0
+		IL_0208: stelem.ref
+		IL_0209: stloc.s 8
+		IL_020b: ldloc.s 8
+		IL_020d: ldc.i4.0
+		IL_020e: ldelem.ref
+		IL_020f: castclass Modules.Stream_Readable_SetEncoding_Utf8/Scope
+		IL_0214: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject::.ctor(class Modules.Stream_Readable_SetEncoding_Utf8/Scope)
+		IL_0219: ldc.i4.0
+		IL_021a: conv.r8
+		IL_021b: ldstr ""
+		IL_0220: ldc.i4.0
+		IL_0221: ldc.i4.1
+		IL_0222: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0227: stloc.s 10
+		IL_0229: ldloc.3
+		IL_022a: ldstr "on"
+		IL_022f: ldstr "end"
+		IL_0234: ldloc.s 10
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_023b: pop
+		IL_023c: ldloc.0
+		IL_023d: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0247: ldstr " ok"
+		IL_024c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0251: stloc.s 4
+		IL_0253: volatile.
+		IL_0255: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_025a: brfalse IL_0270
+
+		IL_025f: ldstr "push"
+		IL_0264: ldloc.s 4
+		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026b: br IL_0286
+
+		IL_0270: ldstr "push"
+		IL_0275: ldloc.s 4
+		IL_0277: ldstr "Stream_Readable_SetEncoding_Utf8:Modules.Stream_Readable_SetEncoding_Utf8:__js_module_init__:67"
+		IL_027c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0286: pop
+		IL_0287: ldloc.0
+		IL_0288: ldfld object Modules.Stream_Readable_SetEncoding_Utf8/Scope::readable
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0292: volatile.
+		IL_0294: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0299: brfalse IL_02b3
+
+		IL_029e: ldstr "push"
+		IL_02a3: ldc.i4.0
+		IL_02a4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ae: br IL_02cd
+
+		IL_02b3: ldstr "push"
+		IL_02b8: ldc.i4.0
+		IL_02b9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_02be: ldstr "Stream_Readable_SetEncoding_Utf8:Modules.Stream_Readable_SetEncoding_Utf8:__js_module_init__:73"
+		IL_02c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02cd: pop
+		IL_02ce: ret
 	} // end of method Stream_Readable_SetEncoding_Utf8::__js_module_init__
 
 } // end of class Modules.Stream_Readable_SetEncoding_Utf8
@@ -668,6 +729,11 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
@@ -221,7 +221,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 143 (0x8f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -263,13 +263,26 @@
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 			IL_0058: stloc.1
 
-			IL_0059: ldloc.0
-			IL_005a: ldstr "push"
-			IL_005f: ldloc.1
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0065: pop
-			IL_0066: ldnull
-			IL_0067: ret
+			IL_0059: volatile.
+			IL_005b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0060: brfalse IL_0076
+
+			IL_0065: ldloc.0
+			IL_0066: ldstr "push"
+			IL_006b: ldloc.1
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0071: br IL_008c
+
+			IL_0076: ldloc.0
+			IL_0077: ldstr "push"
+			IL_007c: ldloc.1
+			IL_007d: ldstr "Stream_Transform_Basic:<TwoPhaseDummy_M4>:__js_call__:6"
+			IL_0082: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_008c: pop
+			IL_008d: ldnull
+			IL_008e: ret
 		} // end of method FunctionExpression_L9C23::__js_call__
 
 	} // end of class FunctionExpression_L9C23
@@ -653,7 +666,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 371 (0x173)
+		// Code size: 575 (0x23f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Transform_Basic/Scope,
@@ -779,36 +792,97 @@
 		IL_0107: pop
 		IL_0108: ldloc.2
 		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010e: ldstr "pipe"
-		IL_0113: ldloc.3
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0119: stloc.s 5
-		IL_011b: ldloc.s 5
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0122: ldstr "pipe"
-		IL_0127: ldloc.s 4
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_012e: pop
-		IL_012f: ldloc.2
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0135: ldstr "push"
-		IL_013a: ldstr "a"
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0144: pop
-		IL_0145: ldloc.2
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014b: ldstr "push"
-		IL_0150: ldstr "b"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015a: pop
-		IL_015b: ldloc.2
-		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0161: ldstr "push"
-		IL_0166: ldc.i4.0
-		IL_0167: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0171: pop
-		IL_0172: ret
+		IL_010e: volatile.
+		IL_0110: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0115: brfalse IL_012a
+
+		IL_011a: ldstr "pipe"
+		IL_011f: ldloc.3
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0125: br IL_013f
+
+		IL_012a: ldstr "pipe"
+		IL_012f: ldloc.3
+		IL_0130: ldstr "Stream_Transform_Basic:Modules.Stream_Transform_Basic:__js_module_init__:41"
+		IL_0135: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_013f: stloc.s 5
+		IL_0141: ldloc.s 5
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0148: volatile.
+		IL_014a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_014f: brfalse IL_0165
+
+		IL_0154: ldstr "pipe"
+		IL_0159: ldloc.s 4
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0160: br IL_017b
+
+		IL_0165: ldstr "pipe"
+		IL_016a: ldloc.s 4
+		IL_016c: ldstr "Stream_Transform_Basic:Modules.Stream_Transform_Basic:__js_module_init__:43"
+		IL_0171: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_017b: pop
+		IL_017c: ldloc.2
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0182: volatile.
+		IL_0184: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0189: brfalse IL_01a2
+
+		IL_018e: ldstr "push"
+		IL_0193: ldstr "a"
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019d: br IL_01bb
+
+		IL_01a2: ldstr "push"
+		IL_01a7: ldstr "a"
+		IL_01ac: ldstr "Stream_Transform_Basic:Modules.Stream_Transform_Basic:__js_module_init__:47"
+		IL_01b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01bb: pop
+		IL_01bc: ldloc.2
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c2: volatile.
+		IL_01c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01c9: brfalse IL_01e2
+
+		IL_01ce: ldstr "push"
+		IL_01d3: ldstr "b"
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01dd: br IL_01fb
+
+		IL_01e2: ldstr "push"
+		IL_01e7: ldstr "b"
+		IL_01ec: ldstr "Stream_Transform_Basic:Modules.Stream_Transform_Basic:__js_module_init__:51"
+		IL_01f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01fb: pop
+		IL_01fc: ldloc.2
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0202: volatile.
+		IL_0204: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0209: brfalse IL_0223
+
+		IL_020e: ldstr "push"
+		IL_0213: ldc.i4.0
+		IL_0214: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021e: br IL_023d
+
+		IL_0223: ldstr "push"
+		IL_0228: ldc.i4.0
+		IL_0229: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_022e: ldstr "Stream_Transform_Basic:Modules.Stream_Transform_Basic:__js_module_init__:56"
+		IL_0233: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_023d: pop
+		IL_023e: ret
 	} // end of method Stream_Transform_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Transform_Basic
@@ -833,4 +907,17 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Basic.verified.txt
@@ -385,7 +385,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 400 (0x190)
+		// Code size: 526 (0x20e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Writable_Basic/Scope,
@@ -487,56 +487,92 @@
 		IL_00e5: stloc.s 4
 		IL_00e7: ldloc.3
 		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ed: ldstr "write"
-		IL_00f2: ldstr "chunk1"
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fc: stloc.s 5
-		IL_00fe: ldloc.s 4
-		IL_0100: ldloc.s 5
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0107: pop
-		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010d: stloc.s 4
-		IL_010f: ldloc.3
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0115: ldstr "write"
-		IL_011a: ldstr "chunk2"
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0124: stloc.s 5
-		IL_0126: ldloc.s 4
-		IL_0128: ldloc.s 5
-		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012f: pop
-		IL_0130: ldloc.3
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0136: ldstr "end"
-		IL_013b: ldstr "final chunk"
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0145: pop
-		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014b: stloc.s 4
-		IL_014d: volatile.
-		IL_014f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0154: brfalse IL_0169
+		IL_00ed: volatile.
+		IL_00ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00f4: brfalse IL_010d
 
-		IL_0159: ldloc.3
-		IL_015a: ldstr "writable"
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0164: br IL_017e
+		IL_00f9: ldstr "write"
+		IL_00fe: ldstr "chunk1"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0108: br IL_0126
 
-		IL_0169: ldloc.3
-		IL_016a: ldstr "writable"
-		IL_016f: ldstr "Stream_Writable_Basic:Modules.Stream_Writable_Basic:__js_module_init__:51"
-		IL_0174: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_010d: ldstr "write"
+		IL_0112: ldstr "chunk1"
+		IL_0117: ldstr "Stream_Writable_Basic:Modules.Stream_Writable_Basic:__js_module_init__:35"
+		IL_011c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_017e: stloc.s 5
-		IL_0180: ldloc.s 4
-		IL_0182: ldstr "Writable after end:"
-		IL_0187: ldloc.s 5
-		IL_0189: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_018e: pop
-		IL_018f: ret
+		IL_0126: stloc.s 5
+		IL_0128: ldloc.s 4
+		IL_012a: ldloc.s 5
+		IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0131: pop
+		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0137: stloc.s 4
+		IL_0139: ldloc.3
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013f: volatile.
+		IL_0141: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0146: brfalse IL_015f
+
+		IL_014b: ldstr "write"
+		IL_0150: ldstr "chunk2"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015a: br IL_0178
+
+		IL_015f: ldstr "write"
+		IL_0164: ldstr "chunk2"
+		IL_0169: ldstr "Stream_Writable_Basic:Modules.Stream_Writable_Basic:__js_module_init__:41"
+		IL_016e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0178: stloc.s 5
+		IL_017a: ldloc.s 4
+		IL_017c: ldloc.s 5
+		IL_017e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0183: pop
+		IL_0184: ldloc.3
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018a: volatile.
+		IL_018c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0191: brfalse IL_01aa
+
+		IL_0196: ldstr "end"
+		IL_019b: ldstr "final chunk"
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a5: br IL_01c3
+
+		IL_01aa: ldstr "end"
+		IL_01af: ldstr "final chunk"
+		IL_01b4: ldstr "Stream_Writable_Basic:Modules.Stream_Writable_Basic:__js_module_init__:46"
+		IL_01b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01c3: pop
+		IL_01c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c9: stloc.s 4
+		IL_01cb: volatile.
+		IL_01cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01d2: brfalse IL_01e7
+
+		IL_01d7: ldloc.3
+		IL_01d8: ldstr "writable"
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e2: br IL_01fc
+
+		IL_01e7: ldloc.3
+		IL_01e8: ldstr "writable"
+		IL_01ed: ldstr "Stream_Writable_Basic:Modules.Stream_Writable_Basic:__js_module_init__:51"
+		IL_01f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_01fc: stloc.s 5
+		IL_01fe: ldloc.s 4
+		IL_0200: ldstr "Writable after end:"
+		IL_0205: ldloc.s 5
+		IL_0207: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_020c: pop
+		IL_020d: ret
 	} // end of method Stream_Writable_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Writable_Basic
@@ -568,6 +604,9 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
@@ -323,7 +323,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 366 (0x16e)
+		// Code size: 450 (0x1c2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Writable_CustomWrite/Scope,
@@ -389,86 +389,110 @@
 		IL_006a: pop
 		IL_006b: ldloc.3
 		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0071: ldstr "write"
-		IL_0076: ldstr "test1"
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0080: pop
-		IL_0081: ldloc.3
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0087: ldstr "write"
-		IL_008c: ldstr "test2"
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0096: pop
-		IL_0097: ldloc.3
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009d: volatile.
-		IL_009f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00a4: brfalse IL_00b8
+		IL_0071: volatile.
+		IL_0073: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0078: brfalse IL_0091
 
-		IL_00a9: ldstr "end"
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00b3: br IL_00cc
+		IL_007d: ldstr "write"
+		IL_0082: ldstr "test1"
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008c: br IL_00aa
 
-		IL_00b8: ldstr "end"
-		IL_00bd: ldstr "Stream_Writable_CustomWrite:Modules.Stream_Writable_CustomWrite:__js_module_init__:32"
-		IL_00c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0091: ldstr "write"
+		IL_0096: ldstr "test1"
+		IL_009b: ldstr "Stream_Writable_CustomWrite:Modules.Stream_Writable_CustomWrite:__js_module_init__:25"
+		IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00cc: pop
-		IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d2: stloc.s 8
-		IL_00d4: ldloc.0
-		IL_00d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
-		IL_00da: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_00df: box [System.Runtime]System.Double
-		IL_00e4: stloc.s 9
-		IL_00e6: ldloc.s 8
-		IL_00e8: ldstr "Written data count:"
-		IL_00ed: ldloc.s 9
-		IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00f4: pop
-		IL_00f5: ldc.r8 0.0
-		IL_00fe: stloc.s 4
-		// loop start (head: IL_0100)
-			IL_0100: ldloc.s 4
-			IL_0102: stloc.s 10
-			IL_0104: ldloc.0
-			IL_0105: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
-			IL_010a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_010f: stloc.s 11
-			IL_0111: ldloc.s 10
-			IL_0113: ldloc.s 11
-			IL_0115: clt
-			IL_0117: brfalse IL_016d
+		IL_00aa: pop
+		IL_00ab: ldloc.3
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b1: volatile.
+		IL_00b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00b8: brfalse IL_00d1
 
-			IL_011c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0121: stloc.s 8
-			IL_0123: ldstr "Chunk "
-			IL_0128: ldloc.s 4
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_012f: stloc.s 12
-			IL_0131: ldloc.s 12
-			IL_0133: ldstr ":"
-			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_013d: stloc.s 12
-			IL_013f: ldloc.0
-			IL_0140: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
-			IL_0145: ldloc.s 4
-			IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_014c: stloc.s 13
-			IL_014e: ldloc.s 8
-			IL_0150: ldloc.s 12
-			IL_0152: ldloc.s 13
-			IL_0154: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0159: pop
-			IL_015a: ldloc.s 4
-			IL_015c: ldc.r8 1
-			IL_0165: add
-			IL_0166: stloc.s 4
-			IL_0168: br IL_0100
+		IL_00bd: ldstr "write"
+		IL_00c2: ldstr "test2"
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cc: br IL_00ea
+
+		IL_00d1: ldstr "write"
+		IL_00d6: ldstr "test2"
+		IL_00db: ldstr "Stream_Writable_CustomWrite:Modules.Stream_Writable_CustomWrite:__js_module_init__:29"
+		IL_00e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ea: pop
+		IL_00eb: ldloc.3
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f1: volatile.
+		IL_00f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00f8: brfalse IL_010c
+
+		IL_00fd: ldstr "end"
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0107: br IL_0120
+
+		IL_010c: ldstr "end"
+		IL_0111: ldstr "Stream_Writable_CustomWrite:Modules.Stream_Writable_CustomWrite:__js_module_init__:32"
+		IL_0116: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0120: pop
+		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0126: stloc.s 8
+		IL_0128: ldloc.0
+		IL_0129: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
+		IL_012e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0133: box [System.Runtime]System.Double
+		IL_0138: stloc.s 9
+		IL_013a: ldloc.s 8
+		IL_013c: ldstr "Written data count:"
+		IL_0141: ldloc.s 9
+		IL_0143: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0148: pop
+		IL_0149: ldc.r8 0.0
+		IL_0152: stloc.s 4
+		// loop start (head: IL_0154)
+			IL_0154: ldloc.s 4
+			IL_0156: stloc.s 10
+			IL_0158: ldloc.0
+			IL_0159: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
+			IL_015e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0163: stloc.s 11
+			IL_0165: ldloc.s 10
+			IL_0167: ldloc.s 11
+			IL_0169: clt
+			IL_016b: brfalse IL_01c1
+
+			IL_0170: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0175: stloc.s 8
+			IL_0177: ldstr "Chunk "
+			IL_017c: ldloc.s 4
+			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0183: stloc.s 12
+			IL_0185: ldloc.s 12
+			IL_0187: ldstr ":"
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0191: stloc.s 12
+			IL_0193: ldloc.0
+			IL_0194: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_CustomWrite/Scope::writtenData
+			IL_0199: ldloc.s 4
+			IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01a0: stloc.s 13
+			IL_01a2: ldloc.s 8
+			IL_01a4: ldloc.s 12
+			IL_01a6: ldloc.s 13
+			IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01ad: pop
+			IL_01ae: ldloc.s 4
+			IL_01b0: ldc.r8 1
+			IL_01b9: add
+			IL_01ba: stloc.s 4
+			IL_01bc: br IL_0154
 		// end loop
 
-		IL_016d: ret
+		IL_01c1: ret
 	} // end of method Stream_Writable_CustomWrite::__js_module_init__
 
 } // end of class Modules.Stream_Writable_CustomWrite
@@ -499,6 +523,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
@@ -391,7 +391,7 @@
 			IL_0001: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Stream_Writable_Destroy_Error/Scope::sequence
 			IL_0006: stloc.0
 			IL_0007: volatile.
-			IL_0009: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0009: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_000e: brfalse IL_0023
 
 			IL_0013: ldarg.2
@@ -402,7 +402,7 @@
 			IL_0023: ldarg.2
 			IL_0024: ldstr "message"
 			IL_0029: ldstr "Stream_Writable_Destroy_Error:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_002e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0038: stloc.1
@@ -753,7 +753,7 @@
 			IL_0041: ldarg.0
 			IL_0042: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
 			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_004e: brfalse IL_0062
 
 			IL_0053: ldstr "destroyed"
@@ -762,7 +762,7 @@
 
 			IL_0062: ldstr "destroyed"
 			IL_0067: ldstr "Stream_Writable_Destroy_Error:<TwoPhaseDummy_M7>:__js_call__:15"
-			IL_006c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_006c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0076: stloc.3
@@ -821,7 +821,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 387 (0x183)
+		// Code size: 429 (0x1ad)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Writable_Destroy_Error/Scope,
@@ -976,19 +976,31 @@
 		IL_0150: ldloc.0
 		IL_0151: ldfld object Modules.Stream_Writable_Destroy_Error/Scope::writable
 		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015b: ldstr "write"
-		IL_0160: ldstr "x"
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016a: stloc.2
-		IL_016b: ldstr "write-return:"
-		IL_0170: ldloc.2
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0176: stloc.s 10
-		IL_0178: ldloc.s 9
-		IL_017a: ldloc.s 10
-		IL_017c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0181: pop
-		IL_0182: ret
+		IL_015b: volatile.
+		IL_015d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0162: brfalse IL_017b
+
+		IL_0167: ldstr "write"
+		IL_016c: ldstr "x"
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0176: br IL_0194
+
+		IL_017b: ldstr "write"
+		IL_0180: ldstr "x"
+		IL_0185: ldstr "Stream_Writable_Destroy_Error:Modules.Stream_Writable_Destroy_Error:__js_module_init__:48"
+		IL_018a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0194: stloc.2
+		IL_0195: ldstr "write-return:"
+		IL_019a: ldloc.2
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01a0: stloc.s 10
+		IL_01a2: ldloc.s 9
+		IL_01a4: ldloc.s 10
+		IL_01a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ab: pop
+		IL_01ac: ret
 	} // end of method Stream_Writable_Destroy_Error::__js_module_init__
 
 } // end of class Modules.Stream_Writable_Destroy_Error
@@ -1020,6 +1032,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
@@ -632,7 +632,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 436 (0x1b4)
+		// Code size: 520 (0x208)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Writable_Drain_Finish_Order/Scope,
@@ -765,51 +765,75 @@
 		IL_011e: stloc.s 9
 		IL_0120: ldloc.2
 		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0126: ldstr "write"
-		IL_012b: ldstr "a"
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0135: stloc.3
-		IL_0136: ldstr "write:"
-		IL_013b: ldloc.3
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0141: stloc.s 10
-		IL_0143: ldloc.s 9
-		IL_0145: ldloc.s 10
-		IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_014c: pop
-		IL_014d: ldloc.2
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0153: ldstr "end"
-		IL_0158: ldstr "b"
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0162: pop
-		IL_0163: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0168: stloc.s 9
-		IL_016a: volatile.
-		IL_016c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0171: brfalse IL_0186
+		IL_0126: volatile.
+		IL_0128: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_012d: brfalse IL_0146
 
-		IL_0176: ldloc.2
-		IL_0177: ldstr "writable"
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0181: br IL_019b
+		IL_0132: ldstr "write"
+		IL_0137: ldstr "a"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0141: br IL_015f
 
-		IL_0186: ldloc.2
-		IL_0187: ldstr "writable"
-		IL_018c: ldstr "Stream_Writable_Drain_Finish_Order:Modules.Stream_Writable_Drain_Finish_Order:__js_module_init__:55"
-		IL_0191: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0146: ldstr "write"
+		IL_014b: ldstr "a"
+		IL_0150: ldstr "Stream_Writable_Drain_Finish_Order:Modules.Stream_Writable_Drain_Finish_Order:__js_module_init__:44"
+		IL_0155: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_019b: stloc.3
-		IL_019c: ldstr "after-end:"
-		IL_01a1: ldloc.3
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01a7: stloc.s 10
-		IL_01a9: ldloc.s 9
-		IL_01ab: ldloc.s 10
-		IL_01ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b2: pop
-		IL_01b3: ret
+		IL_015f: stloc.3
+		IL_0160: ldstr "write:"
+		IL_0165: ldloc.3
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_016b: stloc.s 10
+		IL_016d: ldloc.s 9
+		IL_016f: ldloc.s 10
+		IL_0171: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0176: pop
+		IL_0177: ldloc.2
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017d: volatile.
+		IL_017f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0184: brfalse IL_019d
+
+		IL_0189: ldstr "end"
+		IL_018e: ldstr "b"
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0198: br IL_01b6
+
+		IL_019d: ldstr "end"
+		IL_01a2: ldstr "b"
+		IL_01a7: ldstr "Stream_Writable_Drain_Finish_Order:Modules.Stream_Writable_Drain_Finish_Order:__js_module_init__:50"
+		IL_01ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01b6: pop
+		IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01bc: stloc.s 9
+		IL_01be: volatile.
+		IL_01c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01c5: brfalse IL_01da
+
+		IL_01ca: ldloc.2
+		IL_01cb: ldstr "writable"
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d5: br IL_01ef
+
+		IL_01da: ldloc.2
+		IL_01db: ldstr "writable"
+		IL_01e0: ldstr "Stream_Writable_Drain_Finish_Order:Modules.Stream_Writable_Drain_Finish_Order:__js_module_init__:55"
+		IL_01e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_01ef: stloc.3
+		IL_01f0: ldstr "after-end:"
+		IL_01f5: ldloc.3
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01fb: stloc.s 10
+		IL_01fd: ldloc.s 9
+		IL_01ff: ldloc.s 10
+		IL_0201: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0206: pop
+		IL_0207: ret
 	} // end of method Stream_Writable_Drain_Finish_Order::__js_module_init__
 
 } // end of class Modules.Stream_Writable_Drain_Finish_Order
@@ -840,6 +864,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
+++ b/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
@@ -403,7 +403,7 @@
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
 			// Header size: 12
-			// Code size: 243 (0xf3)
+			// Code size: 281 (0x119)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -476,39 +476,51 @@
 			IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0094: stloc.3
 			IL_0095: ldloc.3
-			IL_0096: brfalse IL_00f1
+			IL_0096: brfalse IL_0117
 
 			IL_009b: ldloc.1
 			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a1: ldstr "write"
-			IL_00a6: ldarg.3
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ac: stloc.2
-			IL_00ad: ldloc.1
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b3: volatile.
-			IL_00b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-			IL_00ba: brfalse IL_00ce
+			IL_00a1: volatile.
+			IL_00a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_00a8: brfalse IL_00bd
 
-			IL_00bf: ldstr "end"
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00c9: br IL_00e2
+			IL_00ad: ldstr "write"
+			IL_00b2: ldarg.3
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b8: br IL_00d2
 
-			IL_00ce: ldstr "end"
-			IL_00d3: ldstr "Require_StringDecoder_MemoryStreamStyle:<TwoPhaseDummy_M5>:__js_call__:32"
-			IL_00d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_00bd: ldstr "write"
+			IL_00c2: ldarg.3
+			IL_00c3: ldstr "Require_StringDecoder_MemoryStreamStyle:<TwoPhaseDummy_M5>:__js_call__:30"
+			IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_00e2: stloc.s 6
-			IL_00e4: ldloc.2
-			IL_00e5: ldloc.s 6
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00ec: stloc.s 5
-			IL_00ee: ldloc.s 5
-			IL_00f0: ret
+			IL_00d2: stloc.2
+			IL_00d3: ldloc.1
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d9: volatile.
+			IL_00db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_00e0: brfalse IL_00f4
 
-			IL_00f1: ldarg.3
-			IL_00f2: ret
+			IL_00e5: ldstr "end"
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00ef: br IL_0108
+
+			IL_00f4: ldstr "end"
+			IL_00f9: ldstr "Require_StringDecoder_MemoryStreamStyle:<TwoPhaseDummy_M5>:__js_call__:32"
+			IL_00fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+			IL_0108: stloc.s 6
+			IL_010a: ldloc.2
+			IL_010b: ldloc.s 6
+			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0112: stloc.s 5
+			IL_0114: ldloc.s 5
+			IL_0116: ret
+
+			IL_0117: ldarg.3
+			IL_0118: ret
 		} // end of method FunctionExpression_L9C40::__js_call__
 
 	} // end of class FunctionExpression_L9C40
@@ -730,6 +742,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_NodePrefix.verified.txt
+++ b/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_NodePrefix.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 212 (0xd4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_StringDecoder_NodePrefix/Scope,
@@ -136,30 +136,54 @@
 		IL_0034: ldstr "ok"
 		IL_0039: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 		IL_003e: stloc.s 5
-		IL_0040: ldstr "write"
-		IL_0045: ldloc.s 5
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004c: stloc.3
-		IL_004d: ldloc.s 4
-		IL_004f: ldloc.3
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0055: pop
-		IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005b: stloc.s 4
-		IL_005d: ldloc.2
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0063: ldstr "!"
-		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_006d: stloc.s 5
-		IL_006f: ldstr "end"
-		IL_0074: ldloc.s 5
-		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007b: stloc.3
-		IL_007c: ldloc.s 4
-		IL_007e: ldloc.3
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_0040: volatile.
+		IL_0042: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0047: brfalse IL_005d
+
+		IL_004c: ldstr "write"
+		IL_0051: ldloc.s 5
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0058: br IL_0073
+
+		IL_005d: ldstr "write"
+		IL_0062: ldloc.s 5
+		IL_0064: ldstr "Require_StringDecoder_NodePrefix:Modules.Require_StringDecoder_NodePrefix:__js_module_init__:18"
+		IL_0069: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0073: stloc.3
+		IL_0074: ldloc.s 4
+		IL_0076: ldloc.3
+		IL_0077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007c: pop
+		IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0082: stloc.s 4
+		IL_0084: ldloc.2
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008a: ldstr "!"
+		IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0094: stloc.s 5
+		IL_0096: volatile.
+		IL_0098: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_009d: brfalse IL_00b3
+
+		IL_00a2: ldstr "end"
+		IL_00a7: ldloc.s 5
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ae: br IL_00c9
+
+		IL_00b3: ldstr "end"
+		IL_00b8: ldloc.s 5
+		IL_00ba: ldstr "Require_StringDecoder_NodePrefix:Modules.Require_StringDecoder_NodePrefix:__js_module_init__:25"
+		IL_00bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00c9: stloc.3
+		IL_00ca: ldloc.s 4
+		IL_00cc: ldloc.3
+		IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d2: pop
+		IL_00d3: ret
 	} // end of method Require_StringDecoder_NodePrefix::__js_module_init__
 
 } // end of class Modules.Require_StringDecoder_NodePrefix
@@ -184,4 +208,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_Utf8_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_Utf8_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 621 (0x26d)
+		// Code size: 738 (0x2e2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_StringDecoder_Utf8_Basic/Scope,
@@ -184,127 +184,163 @@
 		IL_00ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_00cf: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
 		IL_00d4: stloc.s 8
-		IL_00d6: ldstr "write"
-		IL_00db: ldloc.s 8
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e2: stloc.s 6
-		IL_00e4: ldstr "first:"
-		IL_00e9: ldloc.s 6
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00f0: stloc.s 7
-		IL_00f2: ldloc.s 5
-		IL_00f4: ldloc.s 7
-		IL_00f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fb: pop
-		IL_00fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0101: stloc.s 5
-		IL_0103: ldloc.2
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0109: ldc.i4.3
-		IL_010a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_010f: dup
-		IL_0110: ldc.r8 172
-		IL_0119: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_011e: dup
-		IL_011f: ldc.r8 32
-		IL_0128: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_012d: dup
-		IL_012e: ldc.r8 65
-		IL_0137: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_013c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0141: stloc.s 8
-		IL_0143: ldstr "write"
-		IL_0148: ldloc.s 8
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014f: stloc.s 6
-		IL_0151: ldstr "second:"
-		IL_0156: ldloc.s 6
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_015d: stloc.s 7
-		IL_015f: ldloc.s 5
-		IL_0161: ldloc.s 7
-		IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0168: pop
-		IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016e: stloc.s 5
-		IL_0170: ldloc.2
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0176: volatile.
-		IL_0178: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_017d: brfalse IL_0191
+		IL_00d6: volatile.
+		IL_00d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00dd: brfalse IL_00f3
 
-		IL_0182: ldstr "end"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_018c: br IL_01a5
+		IL_00e2: ldstr "write"
+		IL_00e7: ldloc.s 8
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ee: br IL_0109
 
-		IL_0191: ldstr "end"
-		IL_0196: ldstr "Require_StringDecoder_Utf8_Basic:Modules.Require_StringDecoder_Utf8_Basic:__js_module_init__:47"
-		IL_019b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_00f3: ldstr "write"
+		IL_00f8: ldloc.s 8
+		IL_00fa: ldstr "Require_StringDecoder_Utf8_Basic:Modules.Require_StringDecoder_Utf8_Basic:__js_module_init__:28"
+		IL_00ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01a5: stloc.s 6
-		IL_01a7: ldstr "end:"
-		IL_01ac: ldloc.s 6
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01b3: stloc.s 7
-		IL_01b5: ldloc.s 5
-		IL_01b7: ldloc.s 7
-		IL_01b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01be: pop
-		IL_01bf: ldloc.1
-		IL_01c0: dup
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_01c6: stloc.3
-		IL_01c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01cc: stloc.s 5
-		IL_01ce: ldloc.3
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d4: ldc.i4.1
-		IL_01d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01da: dup
-		IL_01db: ldc.r8 226
-		IL_01e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01e9: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_01ee: stloc.s 8
-		IL_01f0: ldstr "write"
-		IL_01f5: ldloc.s 8
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fc: stloc.s 6
-		IL_01fe: ldstr "dangling-write:"
-		IL_0203: ldloc.s 6
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_020a: stloc.s 7
-		IL_020c: ldloc.s 5
-		IL_020e: ldloc.s 7
-		IL_0210: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0215: pop
-		IL_0216: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021b: stloc.s 5
-		IL_021d: ldloc.3
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0223: volatile.
-		IL_0225: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_022a: brfalse IL_023e
+		IL_0109: stloc.s 6
+		IL_010b: ldstr "first:"
+		IL_0110: ldloc.s 6
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0117: stloc.s 7
+		IL_0119: ldloc.s 5
+		IL_011b: ldloc.s 7
+		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0122: pop
+		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0128: stloc.s 5
+		IL_012a: ldloc.2
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0130: ldc.i4.3
+		IL_0131: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0136: dup
+		IL_0137: ldc.r8 172
+		IL_0140: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0145: dup
+		IL_0146: ldc.r8 32
+		IL_014f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0154: dup
+		IL_0155: ldc.r8 65
+		IL_015e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0163: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0168: stloc.s 8
+		IL_016a: volatile.
+		IL_016c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0171: brfalse IL_0187
 
-		IL_022f: ldstr "end"
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0239: br IL_0252
+		IL_0176: ldstr "write"
+		IL_017b: ldloc.s 8
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0182: br IL_019d
 
-		IL_023e: ldstr "end"
-		IL_0243: ldstr "Require_StringDecoder_Utf8_Basic:Modules.Require_StringDecoder_Utf8_Basic:__js_module_init__:67"
-		IL_0248: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0187: ldstr "write"
+		IL_018c: ldloc.s 8
+		IL_018e: ldstr "Require_StringDecoder_Utf8_Basic:Modules.Require_StringDecoder_Utf8_Basic:__js_module_init__:40"
+		IL_0193: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0252: stloc.s 6
-		IL_0254: ldstr "dangling-end:"
-		IL_0259: ldloc.s 6
-		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0260: stloc.s 7
-		IL_0262: ldloc.s 5
-		IL_0264: ldloc.s 7
-		IL_0266: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026b: pop
-		IL_026c: ret
+		IL_019d: stloc.s 6
+		IL_019f: ldstr "second:"
+		IL_01a4: ldloc.s 6
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01ab: stloc.s 7
+		IL_01ad: ldloc.s 5
+		IL_01af: ldloc.s 7
+		IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b6: pop
+		IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01bc: stloc.s 5
+		IL_01be: ldloc.2
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c4: volatile.
+		IL_01c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01cb: brfalse IL_01df
+
+		IL_01d0: ldstr "end"
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01da: br IL_01f3
+
+		IL_01df: ldstr "end"
+		IL_01e4: ldstr "Require_StringDecoder_Utf8_Basic:Modules.Require_StringDecoder_Utf8_Basic:__js_module_init__:47"
+		IL_01e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_01f3: stloc.s 6
+		IL_01f5: ldstr "end:"
+		IL_01fa: ldloc.s 6
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0201: stloc.s 7
+		IL_0203: ldloc.s 5
+		IL_0205: ldloc.s 7
+		IL_0207: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_020c: pop
+		IL_020d: ldloc.1
+		IL_020e: dup
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0214: stloc.3
+		IL_0215: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_021a: stloc.s 5
+		IL_021c: ldloc.3
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0222: ldc.i4.1
+		IL_0223: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0228: dup
+		IL_0229: ldc.r8 226
+		IL_0232: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0237: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_023c: stloc.s 8
+		IL_023e: volatile.
+		IL_0240: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0245: brfalse IL_025b
+
+		IL_024a: ldstr "write"
+		IL_024f: ldloc.s 8
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0256: br IL_0271
+
+		IL_025b: ldstr "write"
+		IL_0260: ldloc.s 8
+		IL_0262: ldstr "Require_StringDecoder_Utf8_Basic:Modules.Require_StringDecoder_Utf8_Basic:__js_module_init__:60"
+		IL_0267: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0271: stloc.s 6
+		IL_0273: ldstr "dangling-write:"
+		IL_0278: ldloc.s 6
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_027f: stloc.s 7
+		IL_0281: ldloc.s 5
+		IL_0283: ldloc.s 7
+		IL_0285: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_028a: pop
+		IL_028b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0290: stloc.s 5
+		IL_0292: ldloc.3
+		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0298: volatile.
+		IL_029a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_029f: brfalse IL_02b3
+
+		IL_02a4: ldstr "end"
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02ae: br IL_02c7
+
+		IL_02b3: ldstr "end"
+		IL_02b8: ldstr "Require_StringDecoder_Utf8_Basic:Modules.Require_StringDecoder_Utf8_Basic:__js_module_init__:67"
+		IL_02bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_02c7: stloc.s 6
+		IL_02c9: ldstr "dangling-end:"
+		IL_02ce: ldloc.s 6
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02d5: stloc.s 7
+		IL_02d7: ldloc.s 5
+		IL_02d9: ldloc.s 7
+		IL_02db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e0: pop
+		IL_02e1: ret
 	} // end of method Require_StringDecoder_Utf8_Basic::__js_module_init__
 
 } // end of class Modules.Require_StringDecoder_Utf8_Basic
@@ -337,6 +373,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
+++ b/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
@@ -235,7 +235,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 508 (0x1fc)
+		// Code size: 547 (0x223)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.GlobalTimers_AsValues_WindowLikeAssignment/Scope,
@@ -411,18 +411,31 @@
 		IL_01cf: box [System.Runtime]System.Double
 		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 		IL_01d9: stloc.2
-		IL_01da: ldloc.1
-		IL_01db: ldstr "clearTimeout"
-		IL_01e0: ldloc.2
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e6: pop
-		IL_01e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ec: stloc.s 4
-		IL_01ee: ldloc.s 4
-		IL_01f0: ldstr "ok"
-		IL_01f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01fa: pop
-		IL_01fb: ret
+		IL_01da: volatile.
+		IL_01dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01e1: brfalse IL_01f7
+
+		IL_01e6: ldloc.1
+		IL_01e7: ldstr "clearTimeout"
+		IL_01ec: ldloc.2
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01f2: br IL_020d
+
+		IL_01f7: ldloc.1
+		IL_01f8: ldstr "clearTimeout"
+		IL_01fd: ldloc.2
+		IL_01fe: ldstr "GlobalTimers_AsValues_WindowLikeAssignment:Modules.GlobalTimers_AsValues_WindowLikeAssignment:__js_module_init__:58"
+		IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_020d: pop
+		IL_020e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0213: stloc.s 4
+		IL_0215: ldloc.s 4
+		IL_0217: ldstr "ok"
+		IL_021c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0221: pop
+		IL_0222: ret
 	} // end of method GlobalTimers_AsValues_WindowLikeAssignment::__js_module_init__
 
 } // end of class Modules.GlobalTimers_AsValues_WindowLikeAssignment
@@ -456,6 +469,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_AbortListener_StableFunctionIdentity.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_AbortListener_StableFunctionIdentity.verified.txt
@@ -294,7 +294,7 @@
 			IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_005c: stloc.1
 			IL_005d: volatile.
-			IL_005f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_005f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_0064: brfalse IL_0083
 
 			IL_0069: ldarg.1
@@ -309,7 +309,7 @@
 			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_008e: ldstr "listener"
 			IL_0093: ldstr "TimersPromises_AbortListener_StableFunctionIdentity:<TwoPhaseDummy_M4>:__js_call__:24"
-			IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00a2: stloc.3
@@ -548,7 +548,7 @@
 			IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0017: stloc.1
 			IL_0018: volatile.
-			IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_001f: brfalse IL_003e
 
 			IL_0024: ldarg.1
@@ -563,7 +563,7 @@
 			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0049: ldstr "addedListener"
 			IL_004e: ldstr "TimersPromises_AbortListener_StableFunctionIdentity:<TwoPhaseDummy_M5>:__js_call__:9"
-			IL_0053: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0053: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_005d: stloc.2
@@ -579,7 +579,7 @@
 			IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_0074: pop
 			IL_0075: volatile.
-			IL_0077: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0077: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_007c: brfalse IL_009b
 
 			IL_0081: ldarg.1
@@ -594,7 +594,7 @@
 			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_00a6: ldstr "listener"
 			IL_00ab: ldstr "TimersPromises_AbortListener_StableFunctionIdentity:<TwoPhaseDummy_M5>:__js_call__:17"
-			IL_00b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_00b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00ba: stloc.2
@@ -778,7 +778,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.2
@@ -789,7 +789,7 @@
 			IL_0022: ldarg.2
 			IL_0023: ldstr "name"
 			IL_0028: ldstr "TimersPromises_AbortListener_StableFunctionIdentity:<TwoPhaseDummy_M6>:__js_call__:4"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -802,7 +802,7 @@
 			IL_0046: ldarg.0
 			IL_0047: ldfld object Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope::signal
 			IL_004c: volatile.
-			IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_004e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0053: brfalse IL_0067
 
 			IL_0058: ldstr "listener"
@@ -811,7 +811,7 @@
 
 			IL_0067: ldstr "listener"
 			IL_006c: ldstr "TimersPromises_AbortListener_StableFunctionIdentity:<TwoPhaseDummy_M6>:__js_call__:10"
-			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_007b: stloc.1
@@ -871,7 +871,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 457 (0x1c9)
+		// Code size: 498 (0x1f2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope,
@@ -1043,12 +1043,25 @@
 		IL_01b1: ldc.i4.1
 		IL_01b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01b7: stloc.s 11
-		IL_01b9: ldloc.s 8
-		IL_01bb: ldstr "catch"
-		IL_01c0: ldloc.s 11
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c7: pop
-		IL_01c8: ret
+		IL_01b9: volatile.
+		IL_01bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01c0: brfalse IL_01d8
+
+		IL_01c5: ldloc.s 8
+		IL_01c7: ldstr "catch"
+		IL_01cc: ldloc.s 11
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d3: br IL_01f0
+
+		IL_01d8: ldloc.s 8
+		IL_01da: ldstr "catch"
+		IL_01df: ldloc.s 11
+		IL_01e1: ldstr "TimersPromises_AbortListener_StableFunctionIdentity:Modules.TimersPromises_AbortListener_StableFunctionIdentity:__js_module_init__:54"
+		IL_01e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01f0: pop
+		IL_01f1: ret
 	} // end of method TimersPromises_AbortListener_StableFunctionIdentity::__js_module_init__
 
 } // end of class Modules.TimersPromises_AbortListener_StableFunctionIdentity
@@ -1084,6 +1097,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
@@ -503,7 +503,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -514,7 +514,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "name"
 			IL_0028: ldstr "TimersPromises_Abort_GetterErrors_SurfaceCorrectly:<TwoPhaseDummy_M6>:__js_call__:4"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -525,7 +525,7 @@
 			IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0045: stloc.0
 			IL_0046: volatile.
-			IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_004d: brfalse IL_0062
 
 			IL_0052: ldarg.1
@@ -536,7 +536,7 @@
 			IL_0062: ldarg.1
 			IL_0063: ldstr "message"
 			IL_0068: ldstr "TimersPromises_Abort_GetterErrors_SurfaceCorrectly:<TwoPhaseDummy_M6>:__js_call__:10"
-			IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0077: stloc.1
@@ -1132,7 +1132,7 @@
 				IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_0100: stloc.s 11
 				IL_0102: volatile.
-				IL_0104: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+				IL_0104: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 				IL_0109: brfalse IL_011f
 
 				IL_010e: ldloc.s 4
@@ -1143,7 +1143,7 @@
 				IL_011f: ldloc.s 4
 				IL_0121: ldstr "name"
 				IL_0126: ldstr "TimersPromises_Abort_GetterErrors_SurfaceCorrectly:<TwoPhaseDummy_M7>:__js_call__:36"
-				IL_012b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+				IL_012b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 				IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0135: stloc.s 12
@@ -1154,7 +1154,7 @@
 				IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_0146: stloc.s 11
 				IL_0148: volatile.
-				IL_014a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+				IL_014a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 				IL_014f: brfalse IL_0165
 
 				IL_0154: ldloc.s 4
@@ -1165,7 +1165,7 @@
 				IL_0165: ldloc.s 4
 				IL_0167: ldstr "message"
 				IL_016c: ldstr "TimersPromises_Abort_GetterErrors_SurfaceCorrectly:<TwoPhaseDummy_M7>:__js_call__:41"
-				IL_0171: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+				IL_0171: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 				IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_017b: stloc.s 12
@@ -1223,7 +1223,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 392 (0x188)
+		// Code size: 515 (0x203)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope,
@@ -1332,62 +1332,101 @@
 		IL_00f3: ldc.i4.1
 		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00f9: stloc.s 10
-		IL_00fb: ldloc.s 8
-		IL_00fd: ldstr "then"
-		IL_0102: ldloc.s 10
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0109: stloc.s 8
-		IL_010b: ldloc.s 8
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0112: stloc.s 8
-		IL_0114: ldc.i4.1
-		IL_0115: newarr [System.Runtime]System.Object
-		IL_011a: dup
-		IL_011b: ldc.i4.0
-		IL_011c: ldloc.0
-		IL_011d: stelem.ref
-		IL_011e: stloc.s 4
-		IL_0120: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject::.ctor()
-		IL_0125: ldc.i4.1
-		IL_0126: conv.r8
-		IL_0127: ldstr ""
-		IL_012c: ldc.i4.0
-		IL_012d: ldc.i4.1
-		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0133: stloc.s 11
-		IL_0135: ldloc.s 8
-		IL_0137: ldstr "catch"
-		IL_013c: ldloc.s 11
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0143: stloc.s 8
-		IL_0145: ldloc.s 8
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: stloc.s 8
+		IL_00fb: volatile.
+		IL_00fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0102: brfalse IL_011a
+
+		IL_0107: ldloc.s 8
+		IL_0109: ldstr "then"
+		IL_010e: ldloc.s 10
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0115: br IL_0132
+
+		IL_011a: ldloc.s 8
+		IL_011c: ldstr "then"
+		IL_0121: ldloc.s 10
+		IL_0123: ldstr "TimersPromises_Abort_GetterErrors_SurfaceCorrectly:Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly:__js_module_init__:34"
+		IL_0128: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0132: stloc.s 8
+		IL_0134: ldloc.s 8
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013b: stloc.s 8
+		IL_013d: ldc.i4.1
+		IL_013e: newarr [System.Runtime]System.Object
+		IL_0143: dup
+		IL_0144: ldc.i4.0
+		IL_0145: ldloc.0
+		IL_0146: stelem.ref
+		IL_0147: stloc.s 4
+		IL_0149: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject::.ctor()
 		IL_014e: ldc.i4.1
-		IL_014f: newarr [System.Runtime]System.Object
-		IL_0154: dup
+		IL_014f: conv.r8
+		IL_0150: ldstr ""
 		IL_0155: ldc.i4.0
-		IL_0156: ldloc.0
-		IL_0157: stelem.ref
-		IL_0158: stloc.s 4
-		IL_015a: ldloc.s 4
-		IL_015c: ldc.i4.0
-		IL_015d: ldelem.ref
-		IL_015e: castclass Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope
-		IL_0163: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject::.ctor(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope)
-		IL_0168: ldc.i4.0
-		IL_0169: conv.r8
-		IL_016a: ldstr ""
-		IL_016f: ldc.i4.0
-		IL_0170: ldc.i4.1
-		IL_0171: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0176: stloc.s 12
-		IL_0178: ldloc.s 8
-		IL_017a: ldstr "then"
-		IL_017f: ldloc.s 12
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0186: pop
-		IL_0187: ret
+		IL_0156: ldc.i4.1
+		IL_0157: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_015c: stloc.s 11
+		IL_015e: volatile.
+		IL_0160: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0165: brfalse IL_017d
+
+		IL_016a: ldloc.s 8
+		IL_016c: ldstr "catch"
+		IL_0171: ldloc.s 11
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0178: br IL_0195
+
+		IL_017d: ldloc.s 8
+		IL_017f: ldstr "catch"
+		IL_0184: ldloc.s 11
+		IL_0186: ldstr "TimersPromises_Abort_GetterErrors_SurfaceCorrectly:Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly:__js_module_init__:38"
+		IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0195: stloc.s 8
+		IL_0197: ldloc.s 8
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019e: stloc.s 8
+		IL_01a0: ldc.i4.1
+		IL_01a1: newarr [System.Runtime]System.Object
+		IL_01a6: dup
+		IL_01a7: ldc.i4.0
+		IL_01a8: ldloc.0
+		IL_01a9: stelem.ref
+		IL_01aa: stloc.s 4
+		IL_01ac: ldloc.s 4
+		IL_01ae: ldc.i4.0
+		IL_01af: ldelem.ref
+		IL_01b0: castclass Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope
+		IL_01b5: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject::.ctor(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope)
+		IL_01ba: ldc.i4.0
+		IL_01bb: conv.r8
+		IL_01bc: ldstr ""
+		IL_01c1: ldc.i4.0
+		IL_01c2: ldc.i4.1
+		IL_01c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01c8: stloc.s 12
+		IL_01ca: volatile.
+		IL_01cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01d1: brfalse IL_01e9
+
+		IL_01d6: ldloc.s 8
+		IL_01d8: ldstr "then"
+		IL_01dd: ldloc.s 12
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e4: br IL_0201
+
+		IL_01e9: ldloc.s 8
+		IL_01eb: ldstr "then"
+		IL_01f0: ldloc.s 12
+		IL_01f2: ldstr "TimersPromises_Abort_GetterErrors_SurfaceCorrectly:Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly:__js_module_init__:42"
+		IL_01f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0201: pop
+		IL_0202: ret
 	} // end of method TimersPromises_Abort_GetterErrors_SurfaceCorrectly::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly
@@ -1422,6 +1461,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
@@ -483,7 +483,7 @@
 				IL_001b: brfalse IL_007d
 
 				IL_0020: volatile.
-				IL_0022: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_0022: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_0027: brfalse IL_0046
 
 				IL_002c: ldarg.1
@@ -498,7 +498,7 @@
 				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0051: ldstr "listener"
 				IL_0056: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M10>:__js_call__:9"
-				IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0065: stloc.2
@@ -731,7 +731,7 @@
 				IL_0024: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
 				IL_0029: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
 				IL_002e: volatile.
-				IL_0030: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_0030: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 				IL_0035: brfalse IL_0049
 
 				IL_003a: ldstr "listener"
@@ -740,7 +740,7 @@
 
 				IL_0049: ldstr "listener"
 				IL_004e: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M11>:__js_call__:9"
-				IL_0053: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_0053: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 				IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_005d: stloc.0
@@ -757,7 +757,7 @@
 				IL_0073: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::signal
 				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_007d: volatile.
-				IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 				IL_0084: brfalse IL_0098
 
 				IL_0089: ldstr "listener"
@@ -766,7 +766,7 @@
 
 				IL_0098: ldstr "listener"
 				IL_009d: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M11>:__js_call__:15"
-				IL_00a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_00a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 				IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_00ac: pop
@@ -1166,7 +1166,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -1177,7 +1177,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "name"
 			IL_0028: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M5>:__js_call__:4"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -1188,7 +1188,7 @@
 			IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0045: stloc.0
 			IL_0046: volatile.
-			IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_004d: brfalse IL_0062
 
 			IL_0052: ldarg.1
@@ -1199,7 +1199,7 @@
 			IL_0062: ldarg.1
 			IL_0063: ldstr "code"
 			IL_0068: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M5>:__js_call__:10"
-			IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0077: stloc.1
@@ -1210,7 +1210,7 @@
 			IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0085: stloc.0
 			IL_0086: volatile.
-			IL_0088: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0088: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_008d: brfalse IL_00a2
 
 			IL_0092: ldarg.1
@@ -1221,7 +1221,7 @@
 			IL_00a2: ldarg.1
 			IL_00a3: ldstr "message"
 			IL_00a8: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M5>:__js_call__:16"
-			IL_00ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_00ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00b7: stloc.1
@@ -2015,7 +2015,7 @@
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
 			// Header size: 12
-			// Code size: 297 (0x129)
+			// Code size: 377 (0x179)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope,
@@ -2043,7 +2043,7 @@
 			IL_001c: ldloc.1
 			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0022: volatile.
-			IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_0029: brfalse IL_003d
 
 			IL_002e: ldstr "abort"
@@ -2052,7 +2052,7 @@
 
 			IL_003d: ldstr "abort"
 			IL_0042: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:8"
-			IL_0047: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0047: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0051: pop
@@ -2060,7 +2060,7 @@
 			IL_0053: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
 			IL_0058: stloc.2
 			IL_0059: volatile.
-			IL_005b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_005b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_0060: brfalse IL_0075
 
 			IL_0065: ldloc.1
@@ -2071,7 +2071,7 @@
 			IL_0075: ldloc.1
 			IL_0076: ldstr "signal"
 			IL_007b: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:13"
-			IL_0080: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0080: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_008a: stloc.3
@@ -2104,45 +2104,71 @@
 			IL_00cc: ldc.i4.1
 			IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00d2: stloc.s 6
-			IL_00d4: ldloc.3
-			IL_00d5: ldstr "then"
-			IL_00da: ldloc.s 6
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00e1: stloc.3
-			IL_00e2: ldloc.3
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e8: stloc.3
-			IL_00e9: ldc.i4.2
-			IL_00ea: newarr [System.Runtime]System.Object
-			IL_00ef: dup
-			IL_00f0: ldc.i4.0
-			IL_00f1: ldarg.0
-			IL_00f2: stelem.ref
-			IL_00f3: dup
-			IL_00f4: ldc.i4.1
-			IL_00f5: ldloc.0
-			IL_00f6: stelem.ref
-			IL_00f7: stloc.s 5
-			IL_00f9: ldloc.s 5
-			IL_00fb: ldc.i4.0
-			IL_00fc: ldelem.ref
-			IL_00fd: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-			IL_0102: ldloc.s 5
-			IL_0104: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object[])
-			IL_0109: ldc.i4.1
-			IL_010a: conv.r8
-			IL_010b: ldstr ""
-			IL_0110: ldc.i4.0
-			IL_0111: ldc.i4.1
-			IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0117: stloc.s 7
-			IL_0119: ldloc.3
-			IL_011a: ldstr "catch"
-			IL_011f: ldloc.s 7
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0126: stloc.3
-			IL_0127: ldloc.3
-			IL_0128: ret
+			IL_00d4: volatile.
+			IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_00db: brfalse IL_00f2
+
+			IL_00e0: ldloc.3
+			IL_00e1: ldstr "then"
+			IL_00e6: ldloc.s 6
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ed: br IL_0109
+
+			IL_00f2: ldloc.3
+			IL_00f3: ldstr "then"
+			IL_00f8: ldloc.s 6
+			IL_00fa: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:19"
+			IL_00ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0109: stloc.3
+			IL_010a: ldloc.3
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0110: stloc.3
+			IL_0111: ldc.i4.2
+			IL_0112: newarr [System.Runtime]System.Object
+			IL_0117: dup
+			IL_0118: ldc.i4.0
+			IL_0119: ldarg.0
+			IL_011a: stelem.ref
+			IL_011b: dup
+			IL_011c: ldc.i4.1
+			IL_011d: ldloc.0
+			IL_011e: stelem.ref
+			IL_011f: stloc.s 5
+			IL_0121: ldloc.s 5
+			IL_0123: ldc.i4.0
+			IL_0124: ldelem.ref
+			IL_0125: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+			IL_012a: ldloc.s 5
+			IL_012c: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object[])
+			IL_0131: ldc.i4.1
+			IL_0132: conv.r8
+			IL_0133: ldstr ""
+			IL_0138: ldc.i4.0
+			IL_0139: ldc.i4.1
+			IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_013f: stloc.s 7
+			IL_0141: volatile.
+			IL_0143: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0148: brfalse IL_015f
+
+			IL_014d: ldloc.3
+			IL_014e: ldstr "catch"
+			IL_0153: ldloc.s 7
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_015a: br IL_0176
+
+			IL_015f: ldloc.3
+			IL_0160: ldstr "catch"
+			IL_0165: ldloc.s 7
+			IL_0167: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:23"
+			IL_016c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0176: stloc.3
+			IL_0177: ldloc.3
+			IL_0178: ret
 		} // end of method FunctionExpression_L48C8::__js_call__
 
 	} // end of class FunctionExpression_L48C8
@@ -2192,7 +2218,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 483 (0x1e3)
+		// Code size: 606 (0x25e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope,
@@ -2332,66 +2358,105 @@
 		IL_0149: ldc.i4.1
 		IL_014a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_014f: stloc.s 9
-		IL_0151: ldloc.s 7
-		IL_0153: ldstr "then"
-		IL_0158: ldloc.s 9
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015f: stloc.s 7
-		IL_0161: ldloc.s 7
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0168: stloc.s 7
-		IL_016a: ldc.i4.1
-		IL_016b: newarr [System.Runtime]System.Object
-		IL_0170: dup
-		IL_0171: ldc.i4.0
-		IL_0172: ldloc.0
-		IL_0173: stelem.ref
-		IL_0174: stloc.3
-		IL_0175: ldloc.3
-		IL_0176: ldc.i4.0
-		IL_0177: ldelem.ref
-		IL_0178: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_017d: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
-		IL_0182: ldc.i4.1
-		IL_0183: conv.r8
-		IL_0184: ldstr ""
-		IL_0189: ldc.i4.0
-		IL_018a: ldc.i4.1
-		IL_018b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0190: stloc.s 10
-		IL_0192: ldloc.s 7
-		IL_0194: ldstr "catch"
-		IL_0199: ldloc.s 10
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a0: stloc.s 7
-		IL_01a2: ldloc.s 7
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a9: stloc.s 7
+		IL_0151: volatile.
+		IL_0153: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0158: brfalse IL_0170
+
+		IL_015d: ldloc.s 7
+		IL_015f: ldstr "then"
+		IL_0164: ldloc.s 9
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016b: br IL_0188
+
+		IL_0170: ldloc.s 7
+		IL_0172: ldstr "then"
+		IL_0177: ldloc.s 9
+		IL_0179: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:38"
+		IL_017e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0188: stloc.s 7
+		IL_018a: ldloc.s 7
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0191: stloc.s 7
+		IL_0193: ldc.i4.1
+		IL_0194: newarr [System.Runtime]System.Object
+		IL_0199: dup
+		IL_019a: ldc.i4.0
+		IL_019b: ldloc.0
+		IL_019c: stelem.ref
+		IL_019d: stloc.3
+		IL_019e: ldloc.3
+		IL_019f: ldc.i4.0
+		IL_01a0: ldelem.ref
+		IL_01a1: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_01a6: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
 		IL_01ab: ldc.i4.1
-		IL_01ac: newarr [System.Runtime]System.Object
-		IL_01b1: dup
+		IL_01ac: conv.r8
+		IL_01ad: ldstr ""
 		IL_01b2: ldc.i4.0
-		IL_01b3: ldloc.0
-		IL_01b4: stelem.ref
-		IL_01b5: stloc.3
-		IL_01b6: ldloc.3
-		IL_01b7: ldc.i4.0
-		IL_01b8: ldelem.ref
-		IL_01b9: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_01be: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
-		IL_01c3: ldc.i4.0
-		IL_01c4: conv.r8
-		IL_01c5: ldstr ""
-		IL_01ca: ldc.i4.0
-		IL_01cb: ldc.i4.1
-		IL_01cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01d1: stloc.s 11
-		IL_01d3: ldloc.s 7
-		IL_01d5: ldstr "then"
-		IL_01da: ldloc.s 11
-		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e1: pop
-		IL_01e2: ret
+		IL_01b3: ldc.i4.1
+		IL_01b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01b9: stloc.s 10
+		IL_01bb: volatile.
+		IL_01bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01c2: brfalse IL_01da
+
+		IL_01c7: ldloc.s 7
+		IL_01c9: ldstr "catch"
+		IL_01ce: ldloc.s 10
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d5: br IL_01f2
+
+		IL_01da: ldloc.s 7
+		IL_01dc: ldstr "catch"
+		IL_01e1: ldloc.s 10
+		IL_01e3: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:42"
+		IL_01e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01f2: stloc.s 7
+		IL_01f4: ldloc.s 7
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01fb: stloc.s 7
+		IL_01fd: ldc.i4.1
+		IL_01fe: newarr [System.Runtime]System.Object
+		IL_0203: dup
+		IL_0204: ldc.i4.0
+		IL_0205: ldloc.0
+		IL_0206: stelem.ref
+		IL_0207: stloc.3
+		IL_0208: ldloc.3
+		IL_0209: ldc.i4.0
+		IL_020a: ldelem.ref
+		IL_020b: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_0210: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
+		IL_0215: ldc.i4.0
+		IL_0216: conv.r8
+		IL_0217: ldstr ""
+		IL_021c: ldc.i4.0
+		IL_021d: ldc.i4.1
+		IL_021e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0223: stloc.s 11
+		IL_0225: volatile.
+		IL_0227: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_022c: brfalse IL_0244
+
+		IL_0231: ldloc.s 7
+		IL_0233: ldstr "then"
+		IL_0238: ldloc.s 11
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023f: br IL_025c
+
+		IL_0244: ldloc.s 7
+		IL_0246: ldstr "then"
+		IL_024b: ldloc.s 11
+		IL_024d: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:46"
+		IL_0252: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_025c: pop
+		IL_025d: ret
 	} // end of method TimersPromises_Abort_RejectsSupportedOneShotApis::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis
@@ -2431,6 +2496,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_20
 	.field assembly static int32 __jroc_dynamicLookup_21
 	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
@@ -752,7 +752,7 @@
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 125 (0x7d)
+			// Code size: 165 (0xa5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/Scope,
@@ -808,13 +808,26 @@
 			IL_0065: ldc.i4.1
 			IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_006b: stloc.s 5
-			IL_006d: ldloc.3
-			IL_006e: ldstr "then"
-			IL_0073: ldloc.s 5
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007a: stloc.3
-			IL_007b: ldloc.3
-			IL_007c: ret
+			IL_006d: volatile.
+			IL_006f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0074: brfalse IL_008b
+
+			IL_0079: ldloc.3
+			IL_007a: ldstr "then"
+			IL_007f: ldloc.s 5
+			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0086: br IL_00a2
+
+			IL_008b: ldloc.3
+			IL_008c: ldstr "then"
+			IL_0091: ldloc.s 5
+			IL_0093: ldstr "TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks:<TwoPhaseDummy_M6>:__js_call__:14"
+			IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00a2: stloc.3
+			IL_00a3: ldloc.3
+			IL_00a4: ret
 		} // end of method FunctionExpression_L16C46::__js_call__
 
 	} // end of class FunctionExpression_L16C46
@@ -860,7 +873,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 295 (0x127)
+		// Code size: 415 (0x19f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope,
@@ -919,75 +932,114 @@
 		IL_006d: ldc.i4.1
 		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0073: stloc.s 5
-		IL_0075: ldloc.3
-		IL_0076: ldstr "nextTick"
-		IL_007b: ldloc.s 5
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ldc.r8 0.0
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009b: stloc.3
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: stloc.s 4
-		IL_00a8: ldloc.s 4
-		IL_00aa: ldc.i4.0
-		IL_00ab: ldelem.ref
-		IL_00ac: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_00b1: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
-		IL_00b6: ldc.i4.0
-		IL_00b7: conv.r8
-		IL_00b8: ldstr ""
-		IL_00bd: ldc.i4.0
-		IL_00be: ldc.i4.1
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00c4: stloc.s 6
-		IL_00c6: ldloc.3
-		IL_00c7: ldstr "then"
-		IL_00cc: ldloc.s 6
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ldloc.0
-		IL_00d5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
-		IL_00da: stloc.1
-		IL_00db: ldloc.1
-		IL_00dc: ldstr "immediate"
-		IL_00e1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setImmediate(object)
-		IL_00e6: stloc.3
-		IL_00e7: ldloc.3
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ed: stloc.3
-		IL_00ee: ldc.i4.1
-		IL_00ef: newarr [System.Runtime]System.Object
-		IL_00f4: dup
-		IL_00f5: ldc.i4.0
-		IL_00f6: ldloc.0
-		IL_00f7: stelem.ref
-		IL_00f8: stloc.s 4
-		IL_00fa: ldloc.s 4
-		IL_00fc: ldc.i4.0
-		IL_00fd: ldelem.ref
-		IL_00fe: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_0103: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
-		IL_0108: ldc.i4.1
-		IL_0109: conv.r8
-		IL_010a: ldstr ""
-		IL_010f: ldc.i4.0
-		IL_0110: ldc.i4.1
-		IL_0111: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0116: stloc.s 7
-		IL_0118: ldloc.3
-		IL_0119: ldstr "then"
-		IL_011e: ldloc.s 7
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0125: pop
-		IL_0126: ret
+		IL_0075: volatile.
+		IL_0077: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_007c: brfalse IL_0093
+
+		IL_0081: ldloc.3
+		IL_0082: ldstr "nextTick"
+		IL_0087: ldloc.s 5
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008e: br IL_00aa
+
+		IL_0093: ldloc.3
+		IL_0094: ldstr "nextTick"
+		IL_0099: ldloc.s 5
+		IL_009b: ldstr "TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks:Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks:__js_module_init__:21"
+		IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00aa: pop
+		IL_00ab: ldc.r8 0.0
+		IL_00b4: box [System.Runtime]System.Double
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c3: stloc.3
+		IL_00c4: ldc.i4.1
+		IL_00c5: newarr [System.Runtime]System.Object
+		IL_00ca: dup
+		IL_00cb: ldc.i4.0
+		IL_00cc: ldloc.0
+		IL_00cd: stelem.ref
+		IL_00ce: stloc.s 4
+		IL_00d0: ldloc.s 4
+		IL_00d2: ldc.i4.0
+		IL_00d3: ldelem.ref
+		IL_00d4: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+		IL_00d9: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
+		IL_00de: ldc.i4.0
+		IL_00df: conv.r8
+		IL_00e0: ldstr ""
+		IL_00e5: ldc.i4.0
+		IL_00e6: ldc.i4.1
+		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ec: stloc.s 6
+		IL_00ee: volatile.
+		IL_00f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_00f5: brfalse IL_010c
+
+		IL_00fa: ldloc.3
+		IL_00fb: ldstr "then"
+		IL_0100: ldloc.s 6
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0107: br IL_0123
+
+		IL_010c: ldloc.3
+		IL_010d: ldstr "then"
+		IL_0112: ldloc.s 6
+		IL_0114: ldstr "TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks:Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks:__js_module_init__:29"
+		IL_0119: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0123: pop
+		IL_0124: ldloc.0
+		IL_0125: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::timersPromises
+		IL_012a: stloc.1
+		IL_012b: ldloc.1
+		IL_012c: ldstr "immediate"
+		IL_0131: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setImmediate(object)
+		IL_0136: stloc.3
+		IL_0137: ldloc.3
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013d: stloc.3
+		IL_013e: ldc.i4.1
+		IL_013f: newarr [System.Runtime]System.Object
+		IL_0144: dup
+		IL_0145: ldc.i4.0
+		IL_0146: ldloc.0
+		IL_0147: stelem.ref
+		IL_0148: stloc.s 4
+		IL_014a: ldloc.s 4
+		IL_014c: ldc.i4.0
+		IL_014d: ldelem.ref
+		IL_014e: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
+		IL_0153: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
+		IL_0158: ldc.i4.1
+		IL_0159: conv.r8
+		IL_015a: ldstr ""
+		IL_015f: ldc.i4.0
+		IL_0160: ldc.i4.1
+		IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0166: stloc.s 7
+		IL_0168: volatile.
+		IL_016a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_016f: brfalse IL_0186
+
+		IL_0174: ldloc.3
+		IL_0175: ldstr "then"
+		IL_017a: ldloc.s 7
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0181: br IL_019d
+
+		IL_0186: ldloc.3
+		IL_0187: ldstr "then"
+		IL_018c: ldloc.s 7
+		IL_018e: ldstr "TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks:Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks:__js_module_init__:37"
+		IL_0193: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_019d: pop
+		IL_019e: ret
 	} // end of method TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks::__js_module_init__
 
 } // end of class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
@@ -1012,4 +1064,15 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetImmediate_AwaitsValue.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetImmediate_AwaitsValue.verified.txt
@@ -184,7 +184,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 304 (0x130)
+			// Code size: 347 (0x15b)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetImmediate_AwaitsValue/main/Scope,
@@ -260,70 +260,83 @@
 
 			IL_0090: ldloc.0
 			IL_0091: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0096: switch (IL_00a3, IL_00f0)
+			IL_0096: switch (IL_00a3, IL_011b)
 
 			IL_00a3: ldarg.2
 			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00a9: stloc.2
-			IL_00aa: ldloc.2
-			IL_00ab: ldstr "setImmediate"
-			IL_00b0: ldstr "immediate-value"
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ba: stloc.2
-			IL_00bb: ldloc.0
-			IL_00bc: ldc.i4.1
-			IL_00bd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00c2: ldloc.0
-			IL_00c3: ldloc.2
-			IL_00c4: ldarg.0
-			IL_00c5: ldc.i4.1
-			IL_00c6: ldloc.0
-			IL_00c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_00d1: ldloc.0
-			IL_00d2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00d7: dup
-			IL_00d8: ldc.i4.0
-			IL_00d9: ldloc.1
-			IL_00da: stelem.ref
-			IL_00db: dup
-			IL_00dc: ldc.i4.1
-			IL_00dd: ldloc.2
-			IL_00de: stelem.ref
-			IL_00df: dup
-			IL_00e0: ldc.i4.2
-			IL_00e1: ldloc.3
-			IL_00e2: stelem.ref
-			IL_00e3: pop
-			IL_00e4: ldloc.0
-			IL_00e5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_00ea: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_00ef: ret
+			IL_00aa: volatile.
+			IL_00ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00b1: brfalse IL_00cb
 
-			IL_00f0: ldloc.0
-			IL_00f1: ldfld object Modules.TimersPromises_SetImmediate_AwaitsValue/main/Scope::_awaited1
-			IL_00f6: stloc.1
-			IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00fc: stloc.3
-			IL_00fd: ldloc.3
-			IL_00fe: ldloc.1
-			IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0104: pop
-			IL_0105: ldloc.0
-			IL_0106: ldc.i4.m1
-			IL_0107: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_010c: ldloc.0
-			IL_010d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0117: ldarg.0
-			IL_0118: ldc.i4.1
-			IL_0119: newarr [System.Runtime]System.Object
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0123: pop
-			IL_0124: ldloc.0
-			IL_0125: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_012a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_012f: ret
+			IL_00b6: ldloc.2
+			IL_00b7: ldstr "setImmediate"
+			IL_00bc: ldstr "immediate-value"
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c6: br IL_00e5
+
+			IL_00cb: ldloc.2
+			IL_00cc: ldstr "setImmediate"
+			IL_00d1: ldstr "immediate-value"
+			IL_00d6: ldstr "TimersPromises_SetImmediate_AwaitsValue:<TwoPhaseDummy_M4>:__js_call__:5"
+			IL_00db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00e5: stloc.2
+			IL_00e6: ldloc.0
+			IL_00e7: ldc.i4.1
+			IL_00e8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00ed: ldloc.0
+			IL_00ee: ldloc.2
+			IL_00ef: ldarg.0
+			IL_00f0: ldc.i4.1
+			IL_00f1: ldloc.0
+			IL_00f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_00fc: ldloc.0
+			IL_00fd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0102: dup
+			IL_0103: ldc.i4.0
+			IL_0104: ldloc.1
+			IL_0105: stelem.ref
+			IL_0106: dup
+			IL_0107: ldc.i4.1
+			IL_0108: ldloc.2
+			IL_0109: stelem.ref
+			IL_010a: dup
+			IL_010b: ldc.i4.2
+			IL_010c: ldloc.3
+			IL_010d: stelem.ref
+			IL_010e: pop
+			IL_010f: ldloc.0
+			IL_0110: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0115: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_011a: ret
+
+			IL_011b: ldloc.0
+			IL_011c: ldfld object Modules.TimersPromises_SetImmediate_AwaitsValue/main/Scope::_awaited1
+			IL_0121: stloc.1
+			IL_0122: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0127: stloc.3
+			IL_0128: ldloc.3
+			IL_0129: ldloc.1
+			IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_012f: pop
+			IL_0130: ldloc.0
+			IL_0131: ldc.i4.m1
+			IL_0132: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0137: ldloc.0
+			IL_0138: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0142: ldarg.0
+			IL_0143: ldc.i4.1
+			IL_0144: newarr [System.Runtime]System.Object
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_014e: pop
+			IL_014f: ldloc.0
+			IL_0150: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0155: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_015a: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -432,4 +445,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -483,7 +483,7 @@
 				IL_001b: brfalse IL_007d
 
 				IL_0020: volatile.
-				IL_0022: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0022: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 				IL_0027: brfalse IL_0046
 
 				IL_002c: ldarg.1
@@ -498,7 +498,7 @@
 				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0051: ldstr "listener"
 				IL_0056: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M7>:__js_call__:9"
-				IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0065: stloc.2
@@ -750,7 +750,7 @@
 				IL_0040: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
 				IL_0045: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
 				IL_004a: volatile.
-				IL_004c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_004c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 				IL_0051: brfalse IL_0065
 
 				IL_0056: ldstr "listener"
@@ -759,7 +759,7 @@
 
 				IL_0065: ldstr "listener"
 				IL_006a: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M8>:__js_call__:14"
-				IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+				IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0079: stloc.0
@@ -776,7 +776,7 @@
 				IL_008f: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::signal
 				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0099: volatile.
-				IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 				IL_00a0: brfalse IL_00b4
 
 				IL_00a5: ldstr "listener"
@@ -785,7 +785,7 @@
 
 				IL_00b4: ldstr "listener"
 				IL_00b9: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M8>:__js_call__:20"
-				IL_00be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+				IL_00be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 				IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 				IL_00c8: pop
@@ -1335,7 +1335,7 @@
 				IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_0005: stloc.0
 				IL_0006: volatile.
-				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_000d: brfalse IL_0022
 
 				IL_0012: ldarg.1
@@ -1346,7 +1346,7 @@
 				IL_0022: ldarg.1
 				IL_0023: ldstr "name"
 				IL_0028: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M10>:__js_call__:4"
-				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0037: stloc.1
@@ -1357,7 +1357,7 @@
 				IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_0045: stloc.0
 				IL_0046: volatile.
-				IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+				IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 				IL_004d: brfalse IL_0062
 
 				IL_0052: ldarg.1
@@ -1368,7 +1368,7 @@
 				IL_0062: ldarg.1
 				IL_0063: ldstr "code"
 				IL_0068: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M10>:__js_call__:10"
-				IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+				IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0077: stloc.1
@@ -1379,7 +1379,7 @@
 				IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_0085: stloc.0
 				IL_0086: volatile.
-				IL_0088: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_0088: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 				IL_008d: brfalse IL_00a2
 
 				IL_0092: ldarg.1
@@ -1390,7 +1390,7 @@
 				IL_00a2: ldarg.1
 				IL_00a3: ldstr "message"
 				IL_00a8: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M10>:__js_call__:16"
-				IL_00ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+				IL_00ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 				IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00b7: stloc.1
@@ -1401,7 +1401,7 @@
 				IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_00c5: stloc.0
 				IL_00c6: volatile.
-				IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 				IL_00cd: brfalse IL_00e2
 
 				IL_00d2: ldarg.1
@@ -1412,12 +1412,12 @@
 				IL_00e2: ldarg.1
 				IL_00e3: ldstr "cause"
 				IL_00e8: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M10>:__js_call__:22"
-				IL_00ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+				IL_00ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00f7: stloc.1
 				IL_00f8: volatile.
-				IL_00fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_00fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 				IL_00ff: brfalse IL_0114
 
 				IL_0104: ldloc.1
@@ -1428,7 +1428,7 @@
 				IL_0114: ldloc.1
 				IL_0115: ldstr "name"
 				IL_011a: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M10>:__js_call__:24"
-				IL_011f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+				IL_011f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 				IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0129: stloc.1
@@ -1439,7 +1439,7 @@
 				IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 				IL_0137: stloc.0
 				IL_0138: volatile.
-				IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 				IL_013f: brfalse IL_0154
 
 				IL_0144: ldarg.1
@@ -1450,12 +1450,12 @@
 				IL_0154: ldarg.1
 				IL_0155: ldstr "cause"
 				IL_015a: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M10>:__js_call__:30"
-				IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+				IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 				IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0169: stloc.1
 				IL_016a: volatile.
-				IL_016c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+				IL_016c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 				IL_0171: brfalse IL_0186
 
 				IL_0176: ldloc.1
@@ -1466,7 +1466,7 @@
 				IL_0186: ldloc.1
 				IL_0187: ldstr "message"
 				IL_018c: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M10>:__js_call__:32"
-				IL_0191: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+				IL_0191: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 				IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_019b: stloc.1
@@ -1592,7 +1592,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 1135 (0x46f)
+			// Code size: 1258 (0x4ea)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope,
@@ -1995,99 +1995,138 @@
 			IL_036f: ldstr "boom-reason"
 			IL_0374: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
 			IL_0379: stloc.s 10
-			IL_037b: ldloc.s 7
-			IL_037d: ldstr "abort"
-			IL_0382: ldloc.s 10
-			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0389: pop
-			IL_038a: ldloc.2
-			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0390: stloc.s 7
-			IL_0392: volatile.
-			IL_0394: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0399: brfalse IL_03af
+			IL_037b: volatile.
+			IL_037d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0382: brfalse IL_039a
 
-			IL_039e: ldloc.s 7
-			IL_03a0: ldstr "next"
-			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_03aa: br IL_03c5
+			IL_0387: ldloc.s 7
+			IL_0389: ldstr "abort"
+			IL_038e: ldloc.s 10
+			IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0395: br IL_03b2
 
-			IL_03af: ldloc.s 7
-			IL_03b1: ldstr "next"
-			IL_03b6: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:43"
-			IL_03bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_039a: ldloc.s 7
+			IL_039c: ldstr "abort"
+			IL_03a1: ldloc.s 10
+			IL_03a3: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:40"
+			IL_03a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_03c5: stloc.s 7
+			IL_03b2: pop
+			IL_03b3: ldloc.2
+			IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b9: stloc.s 7
+			IL_03bb: volatile.
+			IL_03bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_03c2: brfalse IL_03d8
+
 			IL_03c7: ldloc.s 7
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ce: stloc.s 7
-			IL_03d0: ldc.i4.1
-			IL_03d1: newarr [System.Runtime]System.Object
-			IL_03d6: dup
-			IL_03d7: ldc.i4.0
-			IL_03d8: ldarg.0
-			IL_03d9: ldc.i4.1
-			IL_03da: ldelem.ref
-			IL_03db: stelem.ref
-			IL_03dc: stloc.s 5
-			IL_03de: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject::.ctor()
-			IL_03e3: ldc.i4.0
-			IL_03e4: conv.r8
-			IL_03e5: ldstr ""
-			IL_03ea: ldc.i4.0
-			IL_03eb: ldc.i4.1
-			IL_03ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_03f1: stloc.s 11
-			IL_03f3: ldloc.s 7
-			IL_03f5: ldstr "then"
-			IL_03fa: ldloc.s 11
-			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0401: stloc.s 7
-			IL_0403: ldloc.s 7
-			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_040a: stloc.s 7
-			IL_040c: ldc.i4.1
-			IL_040d: newarr [System.Runtime]System.Object
-			IL_0412: dup
+			IL_03c9: ldstr "next"
+			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_03d3: br IL_03ee
+
+			IL_03d8: ldloc.s 7
+			IL_03da: ldstr "next"
+			IL_03df: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:43"
+			IL_03e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+			IL_03ee: stloc.s 7
+			IL_03f0: ldloc.s 7
+			IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03f7: stloc.s 7
+			IL_03f9: ldc.i4.1
+			IL_03fa: newarr [System.Runtime]System.Object
+			IL_03ff: dup
+			IL_0400: ldc.i4.0
+			IL_0401: ldarg.0
+			IL_0402: ldc.i4.1
+			IL_0403: ldelem.ref
+			IL_0404: stelem.ref
+			IL_0405: stloc.s 5
+			IL_0407: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject::.ctor()
+			IL_040c: ldc.i4.0
+			IL_040d: conv.r8
+			IL_040e: ldstr ""
 			IL_0413: ldc.i4.0
-			IL_0414: ldarg.0
-			IL_0415: ldc.i4.1
-			IL_0416: ldelem.ref
-			IL_0417: stelem.ref
-			IL_0418: stloc.s 5
-			IL_041a: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject::.ctor()
-			IL_041f: ldc.i4.1
-			IL_0420: conv.r8
-			IL_0421: ldstr ""
-			IL_0426: ldc.i4.0
-			IL_0427: ldc.i4.1
-			IL_0428: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_042d: stloc.s 12
-			IL_042f: ldloc.s 7
-			IL_0431: ldstr "catch"
-			IL_0436: ldloc.s 12
-			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_043d: stloc.s 7
-			IL_043f: ldloc.0
-			IL_0440: ldc.i4.m1
-			IL_0441: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0446: ldloc.0
-			IL_0447: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_044c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0451: ldarg.0
-			IL_0452: ldc.i4.1
-			IL_0453: newarr [System.Runtime]System.Object
-			IL_0458: dup
-			IL_0459: ldc.i4.0
-			IL_045a: ldloc.s 7
-			IL_045c: stelem.ref
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0462: pop
-			IL_0463: ldloc.0
-			IL_0464: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0469: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_046e: ret
+			IL_0414: ldc.i4.1
+			IL_0415: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_041a: stloc.s 11
+			IL_041c: volatile.
+			IL_041e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0423: brfalse IL_043b
+
+			IL_0428: ldloc.s 7
+			IL_042a: ldstr "then"
+			IL_042f: ldloc.s 11
+			IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0436: br IL_0453
+
+			IL_043b: ldloc.s 7
+			IL_043d: ldstr "then"
+			IL_0442: ldloc.s 11
+			IL_0444: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:47"
+			IL_0449: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0453: stloc.s 7
+			IL_0455: ldloc.s 7
+			IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_045c: stloc.s 7
+			IL_045e: ldc.i4.1
+			IL_045f: newarr [System.Runtime]System.Object
+			IL_0464: dup
+			IL_0465: ldc.i4.0
+			IL_0466: ldarg.0
+			IL_0467: ldc.i4.1
+			IL_0468: ldelem.ref
+			IL_0469: stelem.ref
+			IL_046a: stloc.s 5
+			IL_046c: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject::.ctor()
+			IL_0471: ldc.i4.1
+			IL_0472: conv.r8
+			IL_0473: ldstr ""
+			IL_0478: ldc.i4.0
+			IL_0479: ldc.i4.1
+			IL_047a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_047f: stloc.s 12
+			IL_0481: volatile.
+			IL_0483: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0488: brfalse IL_04a0
+
+			IL_048d: ldloc.s 7
+			IL_048f: ldstr "catch"
+			IL_0494: ldloc.s 12
+			IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_049b: br IL_04b8
+
+			IL_04a0: ldloc.s 7
+			IL_04a2: ldstr "catch"
+			IL_04a7: ldloc.s 12
+			IL_04a9: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:51"
+			IL_04ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_04b8: stloc.s 7
+			IL_04ba: ldloc.0
+			IL_04bb: ldc.i4.m1
+			IL_04bc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04c1: ldloc.0
+			IL_04c2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04cc: ldarg.0
+			IL_04cd: ldc.i4.1
+			IL_04ce: newarr [System.Runtime]System.Object
+			IL_04d3: dup
+			IL_04d4: ldc.i4.0
+			IL_04d5: ldloc.s 7
+			IL_04d7: stelem.ref
+			IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04dd: pop
+			IL_04de: ldloc.0
+			IL_04df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04e4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04e9: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2251,6 +2290,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
 	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Global_Url_And_SearchParams.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Global_Url_And_SearchParams.verified.txt
@@ -181,7 +181,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3764 (0xeb4)
+		// Code size: 3974 (0xf86)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Global_Url_And_SearchParams/Scope,
@@ -335,991 +335,1051 @@
 		IL_01be: stloc.s 16
 		IL_01c0: ldloc.s 16
 		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c7: ldstr "get"
-		IL_01cc: ldstr "q"
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d6: stloc.s 16
-		IL_01d8: ldloc.s 17
-		IL_01da: ldstr "log"
-		IL_01df: ldstr "search q:"
-		IL_01e4: ldloc.s 16
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01eb: pop
-		IL_01ec: ldstr "URL"
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f6: stloc.s 16
-		IL_01f8: ldloc.s 16
-		IL_01fa: dup
-		IL_01fb: ldstr "../guide"
-		IL_0200: ldstr "https://example.com/docs/start/"
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_020a: stloc.2
-		IL_020b: ldstr "console"
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_021a: stloc.s 16
-		IL_021c: volatile.
-		IL_021e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0223: brfalse IL_0238
+		IL_01c7: volatile.
+		IL_01c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01ce: brfalse IL_01e7
 
-		IL_0228: ldloc.2
-		IL_0229: ldstr "href"
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0233: br IL_024d
+		IL_01d3: ldstr "get"
+		IL_01d8: ldstr "q"
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e2: br IL_0200
 
-		IL_0238: ldloc.2
-		IL_0239: ldstr "href"
-		IL_023e: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:71"
-		IL_0243: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01e7: ldstr "get"
+		IL_01ec: ldstr "q"
+		IL_01f1: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:56"
+		IL_01f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_024d: stloc.s 17
-		IL_024f: ldloc.s 16
-		IL_0251: ldstr "log"
-		IL_0256: ldstr "based href:"
-		IL_025b: ldloc.s 17
-		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0262: pop
-		IL_0263: ldstr "URLSearchParams"
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_026d: stloc.s 17
-		IL_026f: ldloc.s 17
-		IL_0271: dup
-		IL_0272: ldstr "a=1&a=2"
-		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_027c: stloc.3
-		IL_027d: ldstr "console"
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028c: stloc.s 17
-		IL_028e: ldloc.3
-		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0294: ldstr "getAll"
-		IL_0299: ldstr "a"
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a3: stloc.s 16
-		IL_02a5: ldloc.s 16
-		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ac: ldstr "join"
-		IL_02b1: ldstr "|"
-		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02bb: stloc.s 16
-		IL_02bd: ldloc.s 17
-		IL_02bf: ldstr "log"
-		IL_02c4: ldstr "params a:"
-		IL_02c9: ldloc.s 16
-		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02d0: pop
-		IL_02d1: ldstr "console"
-		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e0: stloc.s 16
-		IL_02e2: ldloc.3
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e8: volatile.
-		IL_02ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02ef: brfalse IL_0303
+		IL_0200: stloc.s 16
+		IL_0202: ldloc.s 17
+		IL_0204: ldstr "log"
+		IL_0209: ldstr "search q:"
+		IL_020e: ldloc.s 16
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0215: pop
+		IL_0216: ldstr "URL"
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0220: stloc.s 16
+		IL_0222: ldloc.s 16
+		IL_0224: dup
+		IL_0225: ldstr "../guide"
+		IL_022a: ldstr "https://example.com/docs/start/"
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+		IL_0234: stloc.2
+		IL_0235: ldstr "console"
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0244: stloc.s 16
+		IL_0246: volatile.
+		IL_0248: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_024d: brfalse IL_0262
 
-		IL_02f4: ldstr "toString"
-		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_02fe: br IL_0317
+		IL_0252: ldloc.2
+		IL_0253: ldstr "href"
+		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_025d: br IL_0277
 
-		IL_0303: ldstr "toString"
-		IL_0308: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:97"
-		IL_030d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0262: ldloc.2
+		IL_0263: ldstr "href"
+		IL_0268: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:71"
+		IL_026d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0317: stloc.s 17
-		IL_0319: ldloc.s 16
-		IL_031b: ldstr "log"
-		IL_0320: ldstr "params string:"
-		IL_0325: ldloc.s 17
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_032c: pop
-		IL_032d: ldarg.1
-		IL_032e: ldstr "url"
-		IL_0333: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule>(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object)
-		IL_0338: stloc.s 4
-		IL_033a: ldstr "console"
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0349: stloc.s 17
-		IL_034b: ldstr "globalThis"
-		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0355: volatile.
-		IL_0357: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_035c: brfalse IL_0370
+		IL_0277: stloc.s 17
+		IL_0279: ldloc.s 16
+		IL_027b: ldstr "log"
+		IL_0280: ldstr "based href:"
+		IL_0285: ldloc.s 17
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_028c: pop
+		IL_028d: ldstr "URLSearchParams"
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0297: stloc.s 17
+		IL_0299: ldloc.s 17
+		IL_029b: dup
+		IL_029c: ldstr "a=1&a=2"
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_02a6: stloc.3
+		IL_02a7: ldstr "console"
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b6: stloc.s 17
+		IL_02b8: ldloc.3
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02be: volatile.
+		IL_02c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02c5: brfalse IL_02de
 
-		IL_0361: ldstr "URL"
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_036b: br IL_0384
+		IL_02ca: ldstr "getAll"
+		IL_02cf: ldstr "a"
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d9: br IL_02f7
 
-		IL_0370: ldstr "URL"
-		IL_0375: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:112"
-		IL_037a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02de: ldstr "getAll"
+		IL_02e3: ldstr "a"
+		IL_02e8: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:86"
+		IL_02ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0384: stloc.s 16
-		IL_0386: ldloc.s 4
-		IL_0388: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
-		IL_038d: stloc.s 18
-		IL_038f: ldloc.s 16
-		IL_0391: ldloc.s 18
-		IL_0393: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0398: stloc.s 19
-		IL_039a: ldloc.s 19
-		IL_039c: box [System.Runtime]System.Boolean
-		IL_03a1: stloc.s 20
+		IL_02f7: stloc.s 16
+		IL_02f9: ldloc.s 16
+		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0300: volatile.
+		IL_0302: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0307: brfalse IL_0320
+
+		IL_030c: ldstr "join"
+		IL_0311: ldstr "|"
+		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031b: br IL_0339
+
+		IL_0320: ldstr "join"
+		IL_0325: ldstr "|"
+		IL_032a: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:89"
+		IL_032f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0339: stloc.s 16
+		IL_033b: ldloc.s 17
+		IL_033d: ldstr "log"
+		IL_0342: ldstr "params a:"
+		IL_0347: ldloc.s 16
+		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_034e: pop
+		IL_034f: ldstr "console"
+		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_035e: stloc.s 16
+		IL_0360: ldloc.3
+		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0366: volatile.
+		IL_0368: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_036d: brfalse IL_0381
+
+		IL_0372: ldstr "toString"
+		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_037c: br IL_0395
+
+		IL_0381: ldstr "toString"
+		IL_0386: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:97"
+		IL_038b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0395: stloc.s 17
+		IL_0397: ldloc.s 16
+		IL_0399: ldstr "log"
+		IL_039e: ldstr "params string:"
 		IL_03a3: ldloc.s 17
-		IL_03a5: ldstr "log"
-		IL_03aa: ldstr "same URL:"
-		IL_03af: ldloc.s 20
-		IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03b6: pop
-		IL_03b7: ldstr "console"
-		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03c6: stloc.s 17
-		IL_03c8: ldstr "globalThis"
-		IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03d2: volatile.
-		IL_03d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03d9: brfalse IL_03ed
+		IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03aa: pop
+		IL_03ab: ldarg.1
+		IL_03ac: ldstr "url"
+		IL_03b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule>(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object)
+		IL_03b6: stloc.s 4
+		IL_03b8: ldstr "console"
+		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c7: stloc.s 17
+		IL_03c9: ldstr "globalThis"
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03d3: volatile.
+		IL_03d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_03da: brfalse IL_03ee
 
-		IL_03de: ldstr "URLSearchParams"
-		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03e8: br IL_0401
+		IL_03df: ldstr "URL"
+		IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03e9: br IL_0402
 
-		IL_03ed: ldstr "URLSearchParams"
-		IL_03f2: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:125"
-		IL_03f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03ee: ldstr "URL"
+		IL_03f3: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:112"
+		IL_03f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0401: stloc.s 18
-		IL_0403: ldloc.s 4
-		IL_0405: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URLSearchParams()
-		IL_040a: stloc.s 16
-		IL_040c: ldloc.s 18
-		IL_040e: ldloc.s 16
-		IL_0410: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0415: stloc.s 19
-		IL_0417: ldloc.s 19
-		IL_0419: box [System.Runtime]System.Boolean
-		IL_041e: stloc.s 20
-		IL_0420: ldloc.s 17
-		IL_0422: ldstr "log"
-		IL_0427: ldstr "same params:"
-		IL_042c: ldloc.s 20
-		IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0433: pop
-		IL_0434: ldstr "console"
-		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0443: stloc.s 17
-		IL_0445: ldstr "URL"
-		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_044f: stloc.s 16
-		IL_0451: ldstr "Function"
-		IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_045b: stloc.s 18
-		IL_045d: ldloc.s 16
-		IL_045f: ldloc.s 18
-		IL_0461: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0466: stloc.s 19
-		IL_0468: ldloc.s 19
-		IL_046a: box [System.Runtime]System.Boolean
-		IL_046f: stloc.s 20
-		IL_0471: ldloc.s 17
-		IL_0473: ldstr "log"
-		IL_0478: ldstr "url fn:"
-		IL_047d: ldloc.s 20
-		IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0484: pop
-		IL_0485: ldstr "console"
-		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0494: stloc.s 17
-		IL_0496: ldstr "URL"
-		IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_04a5: stloc.s 18
-		IL_04a7: ldstr "Function"
-		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04b1: volatile.
-		IL_04b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_04b8: brfalse IL_04cc
+		IL_0402: stloc.s 16
+		IL_0404: ldloc.s 4
+		IL_0406: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
+		IL_040b: stloc.s 18
+		IL_040d: ldloc.s 16
+		IL_040f: ldloc.s 18
+		IL_0411: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0416: stloc.s 19
+		IL_0418: ldloc.s 19
+		IL_041a: box [System.Runtime]System.Boolean
+		IL_041f: stloc.s 20
+		IL_0421: ldloc.s 17
+		IL_0423: ldstr "log"
+		IL_0428: ldstr "same URL:"
+		IL_042d: ldloc.s 20
+		IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0434: pop
+		IL_0435: ldstr "console"
+		IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0444: stloc.s 17
+		IL_0446: ldstr "globalThis"
+		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0450: volatile.
+		IL_0452: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0457: brfalse IL_046b
 
-		IL_04bd: ldstr "prototype"
-		IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04c7: br IL_04e0
+		IL_045c: ldstr "URLSearchParams"
+		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0466: br IL_047f
 
-		IL_04cc: ldstr "prototype"
-		IL_04d1: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:153"
-		IL_04d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_046b: ldstr "URLSearchParams"
+		IL_0470: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:125"
+		IL_0475: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04e0: stloc.s 16
-		IL_04e2: ldloc.s 18
-		IL_04e4: ldloc.s 16
-		IL_04e6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04eb: stloc.s 19
-		IL_04ed: ldloc.s 19
-		IL_04ef: box [System.Runtime]System.Boolean
-		IL_04f4: stloc.s 20
-		IL_04f6: ldloc.s 17
-		IL_04f8: ldstr "log"
-		IL_04fd: ldstr "url proto:"
-		IL_0502: ldloc.s 20
-		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0509: pop
-		IL_050a: ldstr "console"
-		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0519: stloc.s 17
-		IL_051b: ldstr "URL"
-		IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0525: volatile.
-		IL_0527: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_052c: brfalse IL_0540
+		IL_047f: stloc.s 18
+		IL_0481: ldloc.s 4
+		IL_0483: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URLSearchParams()
+		IL_0488: stloc.s 16
+		IL_048a: ldloc.s 18
+		IL_048c: ldloc.s 16
+		IL_048e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0493: stloc.s 19
+		IL_0495: ldloc.s 19
+		IL_0497: box [System.Runtime]System.Boolean
+		IL_049c: stloc.s 20
+		IL_049e: ldloc.s 17
+		IL_04a0: ldstr "log"
+		IL_04a5: ldstr "same params:"
+		IL_04aa: ldloc.s 20
+		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04b1: pop
+		IL_04b2: ldstr "console"
+		IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04c1: stloc.s 17
+		IL_04c3: ldstr "URL"
+		IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04cd: stloc.s 16
+		IL_04cf: ldstr "Function"
+		IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04d9: stloc.s 18
+		IL_04db: ldloc.s 16
+		IL_04dd: ldloc.s 18
+		IL_04df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_04e4: stloc.s 19
+		IL_04e6: ldloc.s 19
+		IL_04e8: box [System.Runtime]System.Boolean
+		IL_04ed: stloc.s 20
+		IL_04ef: ldloc.s 17
+		IL_04f1: ldstr "log"
+		IL_04f6: ldstr "url fn:"
+		IL_04fb: ldloc.s 20
+		IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0502: pop
+		IL_0503: ldstr "console"
+		IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0512: stloc.s 17
+		IL_0514: ldstr "URL"
+		IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0523: stloc.s 18
+		IL_0525: ldstr "Function"
+		IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_052f: volatile.
+		IL_0531: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0536: brfalse IL_054a
 
-		IL_0531: ldstr "prototype"
-		IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_053b: br IL_0554
+		IL_053b: ldstr "prototype"
+		IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0545: br IL_055e
 
-		IL_0540: ldstr "prototype"
-		IL_0545: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:165"
-		IL_054a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_054f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_054a: ldstr "prototype"
+		IL_054f: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:153"
+		IL_0554: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0554: stloc.s 16
-		IL_0556: ldloc.s 16
-		IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_055d: stloc.s 16
-		IL_055f: ldstr "Object"
-		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0569: volatile.
-		IL_056b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0570: brfalse IL_0584
+		IL_055e: stloc.s 16
+		IL_0560: ldloc.s 18
+		IL_0562: ldloc.s 16
+		IL_0564: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0569: stloc.s 19
+		IL_056b: ldloc.s 19
+		IL_056d: box [System.Runtime]System.Boolean
+		IL_0572: stloc.s 20
+		IL_0574: ldloc.s 17
+		IL_0576: ldstr "log"
+		IL_057b: ldstr "url proto:"
+		IL_0580: ldloc.s 20
+		IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0587: pop
+		IL_0588: ldstr "console"
+		IL_058d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0597: stloc.s 17
+		IL_0599: ldstr "URL"
+		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05a3: volatile.
+		IL_05a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_05aa: brfalse IL_05be
 
-		IL_0575: ldstr "prototype"
-		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_057f: br IL_0598
+		IL_05af: ldstr "prototype"
+		IL_05b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05b9: br IL_05d2
 
-		IL_0584: ldstr "prototype"
-		IL_0589: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:170"
-		IL_058e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05be: ldstr "prototype"
+		IL_05c3: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:165"
+		IL_05c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_05cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0598: stloc.s 18
-		IL_059a: ldloc.s 16
-		IL_059c: ldloc.s 18
-		IL_059e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05a3: stloc.s 19
-		IL_05a5: ldloc.s 19
-		IL_05a7: box [System.Runtime]System.Boolean
-		IL_05ac: stloc.s 20
-		IL_05ae: ldloc.s 17
-		IL_05b0: ldstr "log"
-		IL_05b5: ldstr "url proto parent:"
-		IL_05ba: ldloc.s 20
-		IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_05c1: pop
-		IL_05c2: ldstr "console"
-		IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05d1: stloc.s 17
-		IL_05d3: ldloc.1
-		IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_05d9: stloc.s 18
-		IL_05db: ldstr "URL"
-		IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05e5: volatile.
-		IL_05e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_05ec: brfalse IL_0600
+		IL_05d2: stloc.s 16
+		IL_05d4: ldloc.s 16
+		IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_05db: stloc.s 16
+		IL_05dd: ldstr "Object"
+		IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05e7: volatile.
+		IL_05e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_05ee: brfalse IL_0602
 
-		IL_05f1: ldstr "prototype"
-		IL_05f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05fb: br IL_0614
+		IL_05f3: ldstr "prototype"
+		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05fd: br IL_0616
 
-		IL_0600: ldstr "prototype"
-		IL_0605: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:183"
-		IL_060a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0602: ldstr "prototype"
+		IL_0607: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:170"
+		IL_060c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0614: stloc.s 16
-		IL_0616: ldloc.s 18
+		IL_0616: stloc.s 18
 		IL_0618: ldloc.s 16
-		IL_061a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_061f: stloc.s 19
-		IL_0621: ldloc.s 19
-		IL_0623: box [System.Runtime]System.Boolean
-		IL_0628: stloc.s 20
-		IL_062a: ldloc.s 17
-		IL_062c: ldstr "log"
-		IL_0631: ldstr "url instance proto:"
-		IL_0636: ldloc.s 20
-		IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_063d: pop
-		IL_063e: ldstr "console"
-		IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_064d: stloc.s 17
-		IL_064f: volatile.
-		IL_0651: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0656: brfalse IL_066b
+		IL_061a: ldloc.s 18
+		IL_061c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0621: stloc.s 19
+		IL_0623: ldloc.s 19
+		IL_0625: box [System.Runtime]System.Boolean
+		IL_062a: stloc.s 20
+		IL_062c: ldloc.s 17
+		IL_062e: ldstr "log"
+		IL_0633: ldstr "url proto parent:"
+		IL_0638: ldloc.s 20
+		IL_063a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_063f: pop
+		IL_0640: ldstr "console"
+		IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_064f: stloc.s 17
+		IL_0651: ldloc.1
+		IL_0652: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0657: stloc.s 18
+		IL_0659: ldstr "URL"
+		IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0663: volatile.
+		IL_0665: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_066a: brfalse IL_067e
 
-		IL_065b: ldloc.1
-		IL_065c: ldstr "constructor"
-		IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0666: br IL_0680
+		IL_066f: ldstr "prototype"
+		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0679: br IL_0692
 
-		IL_066b: ldloc.1
-		IL_066c: ldstr "constructor"
-		IL_0671: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:193"
-		IL_0676: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_067e: ldstr "prototype"
+		IL_0683: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:183"
+		IL_0688: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0680: stloc.s 16
-		IL_0682: ldstr "URL"
-		IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_068c: stloc.s 18
-		IL_068e: ldloc.s 16
-		IL_0690: ldloc.s 18
-		IL_0692: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0697: stloc.s 19
-		IL_0699: ldloc.s 19
-		IL_069b: box [System.Runtime]System.Boolean
-		IL_06a0: stloc.s 20
-		IL_06a2: ldloc.s 17
-		IL_06a4: ldstr "log"
-		IL_06a9: ldstr "url instance ctor:"
-		IL_06ae: ldloc.s 20
-		IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06b5: pop
-		IL_06b6: ldstr "console"
-		IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06c5: stloc.s 17
-		IL_06c7: ldstr "URL"
-		IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06d1: stloc.s 18
-		IL_06d3: ldloc.1
-		IL_06d4: ldloc.s 18
-		IL_06d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_06db: stloc.s 19
-		IL_06dd: ldloc.s 19
-		IL_06df: box [System.Runtime]System.Boolean
-		IL_06e4: stloc.s 20
-		IL_06e6: ldloc.s 17
-		IL_06e8: ldstr "log"
-		IL_06ed: ldstr "url instanceof:"
-		IL_06f2: ldloc.s 20
-		IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06f9: pop
-		IL_06fa: ldstr "URL"
-		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0704: ldstr "prototype"
-		IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_070e: stloc.s 5
-		IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0715: stloc.s 17
-		IL_0717: ldloc.s 17
-		IL_0719: ldstr "urlPrototypeDescriptor"
-		IL_071e: ldloc.s 5
-		IL_0720: ldc.i4.0
-		IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_0726: pop
-		IL_0727: ldstr "console"
-		IL_072c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0731: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0736: stloc.s 17
-		IL_0738: volatile.
-		IL_073a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_073f: brfalse IL_0755
+		IL_0692: stloc.s 16
+		IL_0694: ldloc.s 18
+		IL_0696: ldloc.s 16
+		IL_0698: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_069d: stloc.s 19
+		IL_069f: ldloc.s 19
+		IL_06a1: box [System.Runtime]System.Boolean
+		IL_06a6: stloc.s 20
+		IL_06a8: ldloc.s 17
+		IL_06aa: ldstr "log"
+		IL_06af: ldstr "url instance proto:"
+		IL_06b4: ldloc.s 20
+		IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_06bb: pop
+		IL_06bc: ldstr "console"
+		IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06cb: stloc.s 17
+		IL_06cd: volatile.
+		IL_06cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_06d4: brfalse IL_06e9
 
-		IL_0744: ldloc.s 5
-		IL_0746: ldstr "writable"
-		IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0750: br IL_076b
+		IL_06d9: ldloc.1
+		IL_06da: ldstr "constructor"
+		IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06e4: br IL_06fe
 
-		IL_0755: ldloc.s 5
-		IL_0757: ldstr "writable"
-		IL_075c: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:225"
-		IL_0761: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06e9: ldloc.1
+		IL_06ea: ldstr "constructor"
+		IL_06ef: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:193"
+		IL_06f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_06f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_076b: stloc.s 18
-		IL_076d: ldloc.s 17
-		IL_076f: ldstr "log"
-		IL_0774: ldstr "url descriptor writable:"
-		IL_0779: ldloc.s 18
-		IL_077b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0780: pop
-		IL_0781: ldstr "console"
-		IL_0786: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_078b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0790: stloc.s 18
-		IL_0792: volatile.
-		IL_0794: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0799: brfalse IL_07af
+		IL_06fe: stloc.s 16
+		IL_0700: ldstr "URL"
+		IL_0705: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_070a: stloc.s 18
+		IL_070c: ldloc.s 16
+		IL_070e: ldloc.s 18
+		IL_0710: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0715: stloc.s 19
+		IL_0717: ldloc.s 19
+		IL_0719: box [System.Runtime]System.Boolean
+		IL_071e: stloc.s 20
+		IL_0720: ldloc.s 17
+		IL_0722: ldstr "log"
+		IL_0727: ldstr "url instance ctor:"
+		IL_072c: ldloc.s 20
+		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0733: pop
+		IL_0734: ldstr "console"
+		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_073e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0743: stloc.s 17
+		IL_0745: ldstr "URL"
+		IL_074a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_074f: stloc.s 18
+		IL_0751: ldloc.1
+		IL_0752: ldloc.s 18
+		IL_0754: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0759: stloc.s 19
+		IL_075b: ldloc.s 19
+		IL_075d: box [System.Runtime]System.Boolean
+		IL_0762: stloc.s 20
+		IL_0764: ldloc.s 17
+		IL_0766: ldstr "log"
+		IL_076b: ldstr "url instanceof:"
+		IL_0770: ldloc.s 20
+		IL_0772: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0777: pop
+		IL_0778: ldstr "URL"
+		IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0782: ldstr "prototype"
+		IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_078c: stloc.s 5
+		IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_0793: stloc.s 17
+		IL_0795: ldloc.s 17
+		IL_0797: ldstr "urlPrototypeDescriptor"
+		IL_079c: ldloc.s 5
+		IL_079e: ldc.i4.0
+		IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_07a4: pop
+		IL_07a5: ldstr "console"
+		IL_07aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07b4: stloc.s 17
+		IL_07b6: volatile.
+		IL_07b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_07bd: brfalse IL_07d3
 
-		IL_079e: ldloc.s 5
-		IL_07a0: ldstr "enumerable"
-		IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07aa: br IL_07c5
+		IL_07c2: ldloc.s 5
+		IL_07c4: ldstr "writable"
+		IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07ce: br IL_07e9
 
-		IL_07af: ldloc.s 5
-		IL_07b1: ldstr "enumerable"
-		IL_07b6: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:233"
-		IL_07bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_07c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07d3: ldloc.s 5
+		IL_07d5: ldstr "writable"
+		IL_07da: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:225"
+		IL_07df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_07e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07c5: stloc.s 17
-		IL_07c7: ldloc.s 18
-		IL_07c9: ldstr "log"
-		IL_07ce: ldstr "url descriptor enumerable:"
-		IL_07d3: ldloc.s 17
-		IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_07da: pop
-		IL_07db: ldstr "console"
-		IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07ea: stloc.s 17
-		IL_07ec: volatile.
-		IL_07ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_07f3: brfalse IL_0809
+		IL_07e9: stloc.s 18
+		IL_07eb: ldloc.s 17
+		IL_07ed: ldstr "log"
+		IL_07f2: ldstr "url descriptor writable:"
+		IL_07f7: ldloc.s 18
+		IL_07f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_07fe: pop
+		IL_07ff: ldstr "console"
+		IL_0804: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_080e: stloc.s 18
+		IL_0810: volatile.
+		IL_0812: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0817: brfalse IL_082d
 
-		IL_07f8: ldloc.s 5
-		IL_07fa: ldstr "configurable"
-		IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0804: br IL_081f
+		IL_081c: ldloc.s 5
+		IL_081e: ldstr "enumerable"
+		IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0828: br IL_0843
 
-		IL_0809: ldloc.s 5
-		IL_080b: ldstr "configurable"
-		IL_0810: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:241"
-		IL_0815: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_081a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_082d: ldloc.s 5
+		IL_082f: ldstr "enumerable"
+		IL_0834: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:233"
+		IL_0839: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_081f: stloc.s 18
-		IL_0821: ldloc.s 17
-		IL_0823: ldstr "log"
-		IL_0828: ldstr "url descriptor configurable:"
-		IL_082d: ldloc.s 18
-		IL_082f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0834: pop
-		IL_0835: ldstr "console"
-		IL_083a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_083f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0844: stloc.s 18
-		IL_0846: ldstr "URLSearchParams"
-		IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0850: stloc.s 17
-		IL_0852: ldstr "Function"
-		IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_085c: stloc.s 16
-		IL_085e: ldloc.s 17
-		IL_0860: ldloc.s 16
-		IL_0862: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0867: stloc.s 19
-		IL_0869: ldloc.s 19
-		IL_086b: box [System.Runtime]System.Boolean
-		IL_0870: stloc.s 20
-		IL_0872: ldloc.s 18
-		IL_0874: ldstr "log"
-		IL_0879: ldstr "params fn:"
-		IL_087e: ldloc.s 20
-		IL_0880: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0885: pop
-		IL_0886: ldstr "console"
-		IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0895: stloc.s 18
-		IL_0897: ldstr "URLSearchParams"
-		IL_089c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_08a6: stloc.s 16
-		IL_08a8: ldstr "Function"
-		IL_08ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08b2: volatile.
-		IL_08b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_08b9: brfalse IL_08cd
+		IL_0843: stloc.s 17
+		IL_0845: ldloc.s 18
+		IL_0847: ldstr "log"
+		IL_084c: ldstr "url descriptor enumerable:"
+		IL_0851: ldloc.s 17
+		IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0858: pop
+		IL_0859: ldstr "console"
+		IL_085e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0863: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0868: stloc.s 17
+		IL_086a: volatile.
+		IL_086c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0871: brfalse IL_0887
 
-		IL_08be: ldstr "prototype"
-		IL_08c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08c8: br IL_08e1
+		IL_0876: ldloc.s 5
+		IL_0878: ldstr "configurable"
+		IL_087d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0882: br IL_089d
 
-		IL_08cd: ldstr "prototype"
-		IL_08d2: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:266"
-		IL_08d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_08dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0887: ldloc.s 5
+		IL_0889: ldstr "configurable"
+		IL_088e: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:241"
+		IL_0893: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0898: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_08e1: stloc.s 17
-		IL_08e3: ldloc.s 16
-		IL_08e5: ldloc.s 17
-		IL_08e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_08ec: stloc.s 19
-		IL_08ee: ldloc.s 19
-		IL_08f0: box [System.Runtime]System.Boolean
-		IL_08f5: stloc.s 20
-		IL_08f7: ldloc.s 18
-		IL_08f9: ldstr "log"
-		IL_08fe: ldstr "params proto:"
-		IL_0903: ldloc.s 20
-		IL_0905: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_090a: pop
-		IL_090b: ldstr "console"
-		IL_0910: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0915: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_091a: stloc.s 18
-		IL_091c: ldstr "URLSearchParams"
-		IL_0921: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0926: volatile.
-		IL_0928: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_092d: brfalse IL_0941
+		IL_089d: stloc.s 18
+		IL_089f: ldloc.s 17
+		IL_08a1: ldstr "log"
+		IL_08a6: ldstr "url descriptor configurable:"
+		IL_08ab: ldloc.s 18
+		IL_08ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_08b2: pop
+		IL_08b3: ldstr "console"
+		IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08c2: stloc.s 18
+		IL_08c4: ldstr "URLSearchParams"
+		IL_08c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08ce: stloc.s 17
+		IL_08d0: ldstr "Function"
+		IL_08d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08da: stloc.s 16
+		IL_08dc: ldloc.s 17
+		IL_08de: ldloc.s 16
+		IL_08e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_08e5: stloc.s 19
+		IL_08e7: ldloc.s 19
+		IL_08e9: box [System.Runtime]System.Boolean
+		IL_08ee: stloc.s 20
+		IL_08f0: ldloc.s 18
+		IL_08f2: ldstr "log"
+		IL_08f7: ldstr "params fn:"
+		IL_08fc: ldloc.s 20
+		IL_08fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0903: pop
+		IL_0904: ldstr "console"
+		IL_0909: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_090e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0913: stloc.s 18
+		IL_0915: ldstr "URLSearchParams"
+		IL_091a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_091f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0924: stloc.s 16
+		IL_0926: ldstr "Function"
+		IL_092b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0930: volatile.
+		IL_0932: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0937: brfalse IL_094b
 
-		IL_0932: ldstr "prototype"
-		IL_0937: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_093c: br IL_0955
+		IL_093c: ldstr "prototype"
+		IL_0941: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0946: br IL_095f
 
-		IL_0941: ldstr "prototype"
-		IL_0946: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:278"
-		IL_094b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0950: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_094b: ldstr "prototype"
+		IL_0950: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:266"
+		IL_0955: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_095a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0955: stloc.s 17
-		IL_0957: ldloc.s 17
-		IL_0959: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_095e: stloc.s 17
-		IL_0960: ldstr "Object"
-		IL_0965: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_096a: volatile.
-		IL_096c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0971: brfalse IL_0985
+		IL_095f: stloc.s 17
+		IL_0961: ldloc.s 16
+		IL_0963: ldloc.s 17
+		IL_0965: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_096a: stloc.s 19
+		IL_096c: ldloc.s 19
+		IL_096e: box [System.Runtime]System.Boolean
+		IL_0973: stloc.s 20
+		IL_0975: ldloc.s 18
+		IL_0977: ldstr "log"
+		IL_097c: ldstr "params proto:"
+		IL_0981: ldloc.s 20
+		IL_0983: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0988: pop
+		IL_0989: ldstr "console"
+		IL_098e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0993: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0998: stloc.s 18
+		IL_099a: ldstr "URLSearchParams"
+		IL_099f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_09a4: volatile.
+		IL_09a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_09ab: brfalse IL_09bf
 
-		IL_0976: ldstr "prototype"
-		IL_097b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0980: br IL_0999
+		IL_09b0: ldstr "prototype"
+		IL_09b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09ba: br IL_09d3
 
-		IL_0985: ldstr "prototype"
-		IL_098a: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:283"
-		IL_098f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0994: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09bf: ldstr "prototype"
+		IL_09c4: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:278"
+		IL_09c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_09ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0999: stloc.s 16
-		IL_099b: ldloc.s 17
-		IL_099d: ldloc.s 16
-		IL_099f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_09a4: stloc.s 19
-		IL_09a6: ldloc.s 19
-		IL_09a8: box [System.Runtime]System.Boolean
-		IL_09ad: stloc.s 20
-		IL_09af: ldloc.s 18
-		IL_09b1: ldstr "log"
-		IL_09b6: ldstr "params proto parent:"
-		IL_09bb: ldloc.s 20
-		IL_09bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_09c2: pop
-		IL_09c3: ldstr "console"
-		IL_09c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_09cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_09d2: stloc.s 18
-		IL_09d4: ldloc.3
-		IL_09d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_09da: stloc.s 16
-		IL_09dc: ldstr "URLSearchParams"
-		IL_09e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_09e6: volatile.
-		IL_09e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_09ed: brfalse IL_0a01
+		IL_09d3: stloc.s 17
+		IL_09d5: ldloc.s 17
+		IL_09d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_09dc: stloc.s 17
+		IL_09de: ldstr "Object"
+		IL_09e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_09e8: volatile.
+		IL_09ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_09ef: brfalse IL_0a03
 
-		IL_09f2: ldstr "prototype"
-		IL_09f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09fc: br IL_0a15
+		IL_09f4: ldstr "prototype"
+		IL_09f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09fe: br IL_0a17
 
-		IL_0a01: ldstr "prototype"
-		IL_0a06: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:296"
-		IL_0a0b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0a10: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0a03: ldstr "prototype"
+		IL_0a08: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:283"
+		IL_0a0d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0a12: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a15: stloc.s 17
-		IL_0a17: ldloc.s 16
+		IL_0a17: stloc.s 16
 		IL_0a19: ldloc.s 17
-		IL_0a1b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0a20: stloc.s 19
-		IL_0a22: ldloc.s 19
-		IL_0a24: box [System.Runtime]System.Boolean
-		IL_0a29: stloc.s 20
-		IL_0a2b: ldloc.s 18
-		IL_0a2d: ldstr "log"
-		IL_0a32: ldstr "params instance proto:"
-		IL_0a37: ldloc.s 20
-		IL_0a39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0a3e: pop
-		IL_0a3f: ldstr "console"
-		IL_0a44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0a49: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0a4e: stloc.s 18
-		IL_0a50: volatile.
-		IL_0a52: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0a57: brfalse IL_0a6c
+		IL_0a1b: ldloc.s 16
+		IL_0a1d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0a22: stloc.s 19
+		IL_0a24: ldloc.s 19
+		IL_0a26: box [System.Runtime]System.Boolean
+		IL_0a2b: stloc.s 20
+		IL_0a2d: ldloc.s 18
+		IL_0a2f: ldstr "log"
+		IL_0a34: ldstr "params proto parent:"
+		IL_0a39: ldloc.s 20
+		IL_0a3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0a40: pop
+		IL_0a41: ldstr "console"
+		IL_0a46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0a50: stloc.s 18
+		IL_0a52: ldloc.3
+		IL_0a53: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0a58: stloc.s 16
+		IL_0a5a: ldstr "URLSearchParams"
+		IL_0a5f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a64: volatile.
+		IL_0a66: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0a6b: brfalse IL_0a7f
 
-		IL_0a5c: ldloc.3
-		IL_0a5d: ldstr "constructor"
-		IL_0a62: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a67: br IL_0a81
+		IL_0a70: ldstr "prototype"
+		IL_0a75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a7a: br IL_0a93
 
-		IL_0a6c: ldloc.3
-		IL_0a6d: ldstr "constructor"
-		IL_0a72: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:306"
-		IL_0a77: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0a7c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0a7f: ldstr "prototype"
+		IL_0a84: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:296"
+		IL_0a89: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0a8e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a81: stloc.s 17
-		IL_0a83: ldstr "URLSearchParams"
-		IL_0a88: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0a8d: stloc.s 16
-		IL_0a8f: ldloc.s 17
-		IL_0a91: ldloc.s 16
-		IL_0a93: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0a98: stloc.s 19
-		IL_0a9a: ldloc.s 19
-		IL_0a9c: box [System.Runtime]System.Boolean
-		IL_0aa1: stloc.s 20
-		IL_0aa3: ldloc.s 18
-		IL_0aa5: ldstr "log"
-		IL_0aaa: ldstr "params instance ctor:"
-		IL_0aaf: ldloc.s 20
-		IL_0ab1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0ab6: pop
-		IL_0ab7: ldstr "console"
-		IL_0abc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0ac1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0ac6: stloc.s 18
-		IL_0ac8: ldstr "URLSearchParams"
-		IL_0acd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0ad2: stloc.s 16
-		IL_0ad4: ldloc.3
-		IL_0ad5: ldloc.s 16
-		IL_0ad7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0adc: stloc.s 19
-		IL_0ade: ldloc.s 19
-		IL_0ae0: box [System.Runtime]System.Boolean
-		IL_0ae5: stloc.s 20
-		IL_0ae7: ldloc.s 18
-		IL_0ae9: ldstr "log"
-		IL_0aee: ldstr "params instanceof:"
-		IL_0af3: ldloc.s 20
-		IL_0af5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0afa: pop
-		IL_0afb: ldstr "URLSearchParams"
-		IL_0b00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b05: ldstr "prototype"
-		IL_0b0a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0b0f: stloc.s 6
-		IL_0b11: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0b16: stloc.s 18
-		IL_0b18: ldloc.s 18
-		IL_0b1a: ldstr "paramsPrototypeDescriptor"
-		IL_0b1f: ldloc.s 6
-		IL_0b21: ldc.i4.0
-		IL_0b22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_0b27: pop
-		IL_0b28: ldstr "console"
-		IL_0b2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b37: stloc.s 18
-		IL_0b39: volatile.
-		IL_0b3b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0b40: brfalse IL_0b56
+		IL_0a93: stloc.s 17
+		IL_0a95: ldloc.s 16
+		IL_0a97: ldloc.s 17
+		IL_0a99: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0a9e: stloc.s 19
+		IL_0aa0: ldloc.s 19
+		IL_0aa2: box [System.Runtime]System.Boolean
+		IL_0aa7: stloc.s 20
+		IL_0aa9: ldloc.s 18
+		IL_0aab: ldstr "log"
+		IL_0ab0: ldstr "params instance proto:"
+		IL_0ab5: ldloc.s 20
+		IL_0ab7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0abc: pop
+		IL_0abd: ldstr "console"
+		IL_0ac2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0ac7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0acc: stloc.s 18
+		IL_0ace: volatile.
+		IL_0ad0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0ad5: brfalse IL_0aea
 
-		IL_0b45: ldloc.s 6
-		IL_0b47: ldstr "writable"
-		IL_0b4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b51: br IL_0b6c
+		IL_0ada: ldloc.3
+		IL_0adb: ldstr "constructor"
+		IL_0ae0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ae5: br IL_0aff
 
-		IL_0b56: ldloc.s 6
-		IL_0b58: ldstr "writable"
-		IL_0b5d: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:338"
-		IL_0b62: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0b67: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0aea: ldloc.3
+		IL_0aeb: ldstr "constructor"
+		IL_0af0: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:306"
+		IL_0af5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0afa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0b6c: stloc.s 16
-		IL_0b6e: ldloc.s 18
-		IL_0b70: ldstr "log"
-		IL_0b75: ldstr "params descriptor writable:"
-		IL_0b7a: ldloc.s 16
-		IL_0b7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0b81: pop
-		IL_0b82: ldstr "console"
-		IL_0b87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b91: stloc.s 16
-		IL_0b93: volatile.
-		IL_0b95: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0b9a: brfalse IL_0bb0
+		IL_0aff: stloc.s 17
+		IL_0b01: ldstr "URLSearchParams"
+		IL_0b06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b0b: stloc.s 16
+		IL_0b0d: ldloc.s 17
+		IL_0b0f: ldloc.s 16
+		IL_0b11: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0b16: stloc.s 19
+		IL_0b18: ldloc.s 19
+		IL_0b1a: box [System.Runtime]System.Boolean
+		IL_0b1f: stloc.s 20
+		IL_0b21: ldloc.s 18
+		IL_0b23: ldstr "log"
+		IL_0b28: ldstr "params instance ctor:"
+		IL_0b2d: ldloc.s 20
+		IL_0b2f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0b34: pop
+		IL_0b35: ldstr "console"
+		IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b3f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b44: stloc.s 18
+		IL_0b46: ldstr "URLSearchParams"
+		IL_0b4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b50: stloc.s 16
+		IL_0b52: ldloc.3
+		IL_0b53: ldloc.s 16
+		IL_0b55: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0b5a: stloc.s 19
+		IL_0b5c: ldloc.s 19
+		IL_0b5e: box [System.Runtime]System.Boolean
+		IL_0b63: stloc.s 20
+		IL_0b65: ldloc.s 18
+		IL_0b67: ldstr "log"
+		IL_0b6c: ldstr "params instanceof:"
+		IL_0b71: ldloc.s 20
+		IL_0b73: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0b78: pop
+		IL_0b79: ldstr "URLSearchParams"
+		IL_0b7e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b83: ldstr "prototype"
+		IL_0b88: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0b8d: stloc.s 6
+		IL_0b8f: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_0b94: stloc.s 18
+		IL_0b96: ldloc.s 18
+		IL_0b98: ldstr "paramsPrototypeDescriptor"
+		IL_0b9d: ldloc.s 6
+		IL_0b9f: ldc.i4.0
+		IL_0ba0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_0ba5: pop
+		IL_0ba6: ldstr "console"
+		IL_0bab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0bb0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0bb5: stloc.s 18
+		IL_0bb7: volatile.
+		IL_0bb9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0bbe: brfalse IL_0bd4
 
-		IL_0b9f: ldloc.s 6
-		IL_0ba1: ldstr "enumerable"
-		IL_0ba6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0bab: br IL_0bc6
+		IL_0bc3: ldloc.s 6
+		IL_0bc5: ldstr "writable"
+		IL_0bca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0bcf: br IL_0bea
 
-		IL_0bb0: ldloc.s 6
-		IL_0bb2: ldstr "enumerable"
-		IL_0bb7: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:346"
-		IL_0bbc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0bc1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0bd4: ldloc.s 6
+		IL_0bd6: ldstr "writable"
+		IL_0bdb: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:338"
+		IL_0be0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0be5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0bc6: stloc.s 18
-		IL_0bc8: ldloc.s 16
-		IL_0bca: ldstr "log"
-		IL_0bcf: ldstr "params descriptor enumerable:"
-		IL_0bd4: ldloc.s 18
-		IL_0bd6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0bdb: pop
-		IL_0bdc: ldstr "console"
-		IL_0be1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0be6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0beb: stloc.s 18
-		IL_0bed: volatile.
-		IL_0bef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0bf4: brfalse IL_0c0a
+		IL_0bea: stloc.s 16
+		IL_0bec: ldloc.s 18
+		IL_0bee: ldstr "log"
+		IL_0bf3: ldstr "params descriptor writable:"
+		IL_0bf8: ldloc.s 16
+		IL_0bfa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0bff: pop
+		IL_0c00: ldstr "console"
+		IL_0c05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0c0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0c0f: stloc.s 16
+		IL_0c11: volatile.
+		IL_0c13: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0c18: brfalse IL_0c2e
 
-		IL_0bf9: ldloc.s 6
-		IL_0bfb: ldstr "configurable"
-		IL_0c00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c05: br IL_0c20
+		IL_0c1d: ldloc.s 6
+		IL_0c1f: ldstr "enumerable"
+		IL_0c24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c29: br IL_0c44
 
-		IL_0c0a: ldloc.s 6
-		IL_0c0c: ldstr "configurable"
-		IL_0c11: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:354"
-		IL_0c16: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0c1b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0c2e: ldloc.s 6
+		IL_0c30: ldstr "enumerable"
+		IL_0c35: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:346"
+		IL_0c3a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0c3f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0c20: stloc.s 16
-		IL_0c22: ldloc.s 18
-		IL_0c24: ldstr "log"
-		IL_0c29: ldstr "params descriptor configurable:"
-		IL_0c2e: ldloc.s 16
-		IL_0c30: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0c35: pop
+		IL_0c44: stloc.s 18
+		IL_0c46: ldloc.s 16
+		IL_0c48: ldstr "log"
+		IL_0c4d: ldstr "params descriptor enumerable:"
+		IL_0c52: ldloc.s 18
+		IL_0c54: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0c59: pop
+		IL_0c5a: ldstr "console"
+		IL_0c5f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0c64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0c69: stloc.s 18
+		IL_0c6b: volatile.
+		IL_0c6d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0c72: brfalse IL_0c88
+
+		IL_0c77: ldloc.s 6
+		IL_0c79: ldstr "configurable"
+		IL_0c7e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c83: br IL_0c9e
+
+		IL_0c88: ldloc.s 6
+		IL_0c8a: ldstr "configurable"
+		IL_0c8f: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:354"
+		IL_0c94: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0c99: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0c9e: stloc.s 16
+		IL_0ca0: ldloc.s 18
+		IL_0ca2: ldstr "log"
+		IL_0ca7: ldstr "params descriptor configurable:"
+		IL_0cac: ldloc.s 16
+		IL_0cae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0cb3: pop
 		.try
 		{
-			IL_0c36: nop
-			IL_0c37: ldstr "URL"
-			IL_0c3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0c41: stloc.s 7
-			IL_0c43: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_0c48: stloc.s 16
-			IL_0c4a: ldloc.s 16
-			IL_0c4c: ldstr "urlCtor"
-			IL_0c51: ldloc.s 7
-			IL_0c53: ldc.i4.0
-			IL_0c54: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-			IL_0c59: pop
-			IL_0c5a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0c5f: stloc.s 21
-			IL_0c61: ldloc.s 7
-			IL_0c63: ldloc.s 21
-			IL_0c65: ldstr "https://example.com/"
-			IL_0c6a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0c6f: pop
-			IL_0c70: ldstr "console"
-			IL_0c75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0c7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c7f: ldstr "log"
-			IL_0c84: ldstr "url call: no-throw"
-			IL_0c89: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0c8e: pop
-			IL_0c8f: leave IL_0d73
+			IL_0cb4: nop
+			IL_0cb5: ldstr "URL"
+			IL_0cba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0cbf: stloc.s 7
+			IL_0cc1: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+			IL_0cc6: stloc.s 16
+			IL_0cc8: ldloc.s 16
+			IL_0cca: ldstr "urlCtor"
+			IL_0ccf: ldloc.s 7
+			IL_0cd1: ldc.i4.0
+			IL_0cd2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+			IL_0cd7: pop
+			IL_0cd8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0cdd: stloc.s 21
+			IL_0cdf: ldloc.s 7
+			IL_0ce1: ldloc.s 21
+			IL_0ce3: ldstr "https://example.com/"
+			IL_0ce8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0ced: pop
+			IL_0cee: ldstr "console"
+			IL_0cf3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0cf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0cfd: volatile.
+			IL_0cff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0d04: brfalse IL_0d1d
+
+			IL_0d09: ldstr "log"
+			IL_0d0e: ldstr "url call: no-throw"
+			IL_0d13: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0d18: br IL_0d36
+
+			IL_0d1d: ldstr "log"
+			IL_0d22: ldstr "url call: no-throw"
+			IL_0d27: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:376"
+			IL_0d2c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0d31: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0d36: pop
+			IL_0d37: leave IL_0e1b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0c94: stloc.s 8
-			IL_0c96: ldloc.s 8
-			IL_0c98: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0c9d: dup
-			IL_0c9e: brtrue IL_0cb4
+			IL_0d3c: stloc.s 8
+			IL_0d3e: ldloc.s 8
+			IL_0d40: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0d45: dup
+			IL_0d46: brtrue IL_0d5c
 
-			IL_0ca3: pop
-			IL_0ca4: ldloc.s 8
-			IL_0ca6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0cab: dup
-			IL_0cac: brtrue IL_0cc0
+			IL_0d4b: pop
+			IL_0d4c: ldloc.s 8
+			IL_0d4e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0d53: dup
+			IL_0d54: brtrue IL_0d68
 
-			IL_0cb1: pop
-			IL_0cb2: rethrow
+			IL_0d59: pop
+			IL_0d5a: rethrow
 
-			IL_0cb4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0cb9: stloc.s 9
-			IL_0cbb: br IL_0cc2
+			IL_0d5c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0d61: stloc.s 9
+			IL_0d63: br IL_0d6a
 
-			IL_0cc0: stloc.s 9
+			IL_0d68: stloc.s 9
 
-			IL_0cc2: ldloc.s 9
-			IL_0cc4: stloc.s 10
-			IL_0cc6: ldstr "console"
-			IL_0ccb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0cd0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0cd5: stloc.s 16
-			IL_0cd7: volatile.
-			IL_0cd9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_0cde: brfalse IL_0cf4
+			IL_0d6a: ldloc.s 9
+			IL_0d6c: stloc.s 10
+			IL_0d6e: ldstr "console"
+			IL_0d73: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0d78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0d7d: stloc.s 16
+			IL_0d7f: volatile.
+			IL_0d81: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0d86: brfalse IL_0d9c
 
-			IL_0ce3: ldloc.s 10
-			IL_0ce5: ldstr "name"
-			IL_0cea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cef: br IL_0d0a
+			IL_0d8b: ldloc.s 10
+			IL_0d8d: ldstr "name"
+			IL_0d92: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d97: br IL_0db2
 
-			IL_0cf4: ldloc.s 10
-			IL_0cf6: ldstr "name"
-			IL_0cfb: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:390"
-			IL_0d00: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_0d05: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0d9c: ldloc.s 10
+			IL_0d9e: ldstr "name"
+			IL_0da3: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:390"
+			IL_0da8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0dad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0d0a: stloc.s 18
-			IL_0d0c: ldloc.s 18
-			IL_0d0e: ldstr ": "
-			IL_0d13: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0d18: stloc.s 22
-			IL_0d1a: volatile.
-			IL_0d1c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-			IL_0d21: brfalse IL_0d37
+			IL_0db2: stloc.s 18
+			IL_0db4: ldloc.s 18
+			IL_0db6: ldstr ": "
+			IL_0dbb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0dc0: stloc.s 22
+			IL_0dc2: volatile.
+			IL_0dc4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0dc9: brfalse IL_0ddf
 
-			IL_0d26: ldloc.s 10
-			IL_0d28: ldstr "message"
-			IL_0d2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d32: br IL_0d4d
+			IL_0dce: ldloc.s 10
+			IL_0dd0: ldstr "message"
+			IL_0dd5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dda: br IL_0df5
 
-			IL_0d37: ldloc.s 10
-			IL_0d39: ldstr "message"
-			IL_0d3e: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:394"
-			IL_0d43: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-			IL_0d48: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0ddf: ldloc.s 10
+			IL_0de1: ldstr "message"
+			IL_0de6: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:394"
+			IL_0deb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0df0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0d4d: stloc.s 18
-			IL_0d4f: ldloc.s 22
-			IL_0d51: ldloc.s 18
-			IL_0d53: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0d58: stloc.s 22
-			IL_0d5a: ldloc.s 16
-			IL_0d5c: ldstr "log"
-			IL_0d61: ldstr "url call:"
-			IL_0d66: ldloc.s 22
-			IL_0d68: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0d6d: pop
-			IL_0d6e: leave IL_0d73
+			IL_0df5: stloc.s 18
+			IL_0df7: ldloc.s 22
+			IL_0df9: ldloc.s 18
+			IL_0dfb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0e00: stloc.s 22
+			IL_0e02: ldloc.s 16
+			IL_0e04: ldstr "log"
+			IL_0e09: ldstr "url call:"
+			IL_0e0e: ldloc.s 22
+			IL_0e10: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0e15: pop
+			IL_0e16: leave IL_0e1b
 		} // end handler
 		.try
 		{
-			IL_0d73: nop
-			IL_0d74: ldstr "URLSearchParams"
-			IL_0d79: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0d7e: stloc.s 11
-			IL_0d80: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_0d85: stloc.s 16
-			IL_0d87: ldloc.s 16
-			IL_0d89: ldstr "paramsCtor"
-			IL_0d8e: ldloc.s 11
-			IL_0d90: ldc.i4.0
-			IL_0d91: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-			IL_0d96: pop
-			IL_0d97: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0d9c: stloc.s 21
-			IL_0d9e: ldloc.s 11
-			IL_0da0: ldloc.s 21
-			IL_0da2: ldstr "a=1"
-			IL_0da7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0dac: pop
-			IL_0dad: ldstr "console"
-			IL_0db2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0db7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0dbc: ldstr "log"
-			IL_0dc1: ldstr "params call: no-throw"
-			IL_0dc6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0dcb: pop
-			IL_0dcc: leave IL_0eb0
+			IL_0e1b: nop
+			IL_0e1c: ldstr "URLSearchParams"
+			IL_0e21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0e26: stloc.s 11
+			IL_0e28: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+			IL_0e2d: stloc.s 16
+			IL_0e2f: ldloc.s 16
+			IL_0e31: ldstr "paramsCtor"
+			IL_0e36: ldloc.s 11
+			IL_0e38: ldc.i4.0
+			IL_0e39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+			IL_0e3e: pop
+			IL_0e3f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0e44: stloc.s 21
+			IL_0e46: ldloc.s 11
+			IL_0e48: ldloc.s 21
+			IL_0e4a: ldstr "a=1"
+			IL_0e4f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0e54: pop
+			IL_0e55: ldstr "console"
+			IL_0e5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0e5f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0e64: volatile.
+			IL_0e66: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0e6b: brfalse IL_0e84
+
+			IL_0e70: ldstr "log"
+			IL_0e75: ldstr "params call: no-throw"
+			IL_0e7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0e7f: br IL_0e9d
+
+			IL_0e84: ldstr "log"
+			IL_0e89: ldstr "params call: no-throw"
+			IL_0e8e: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:421"
+			IL_0e93: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0e98: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0e9d: pop
+			IL_0e9e: leave IL_0f82
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0dd1: stloc.s 12
-			IL_0dd3: ldloc.s 12
-			IL_0dd5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0dda: dup
-			IL_0ddb: brtrue IL_0df1
+			IL_0ea3: stloc.s 12
+			IL_0ea5: ldloc.s 12
+			IL_0ea7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0eac: dup
+			IL_0ead: brtrue IL_0ec3
 
-			IL_0de0: pop
-			IL_0de1: ldloc.s 12
-			IL_0de3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0de8: dup
-			IL_0de9: brtrue IL_0dfd
+			IL_0eb2: pop
+			IL_0eb3: ldloc.s 12
+			IL_0eb5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0eba: dup
+			IL_0ebb: brtrue IL_0ecf
 
-			IL_0dee: pop
-			IL_0def: rethrow
+			IL_0ec0: pop
+			IL_0ec1: rethrow
 
-			IL_0df1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0df6: stloc.s 13
-			IL_0df8: br IL_0dff
+			IL_0ec3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0ec8: stloc.s 13
+			IL_0eca: br IL_0ed1
 
-			IL_0dfd: stloc.s 13
+			IL_0ecf: stloc.s 13
 
-			IL_0dff: ldloc.s 13
-			IL_0e01: stloc.s 14
-			IL_0e03: ldstr "console"
-			IL_0e08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0e0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0e12: stloc.s 16
-			IL_0e14: volatile.
-			IL_0e16: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_0e1b: brfalse IL_0e31
+			IL_0ed1: ldloc.s 13
+			IL_0ed3: stloc.s 14
+			IL_0ed5: ldstr "console"
+			IL_0eda: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0edf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0ee4: stloc.s 16
+			IL_0ee6: volatile.
+			IL_0ee8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0eed: brfalse IL_0f03
 
-			IL_0e20: ldloc.s 14
-			IL_0e22: ldstr "name"
-			IL_0e27: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e2c: br IL_0e47
+			IL_0ef2: ldloc.s 14
+			IL_0ef4: ldstr "name"
+			IL_0ef9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0efe: br IL_0f19
 
-			IL_0e31: ldloc.s 14
-			IL_0e33: ldstr "name"
-			IL_0e38: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:435"
-			IL_0e3d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_0e42: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0f03: ldloc.s 14
+			IL_0f05: ldstr "name"
+			IL_0f0a: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:435"
+			IL_0f0f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0f14: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e47: stloc.s 18
-			IL_0e49: ldloc.s 18
-			IL_0e4b: ldstr ": "
-			IL_0e50: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0e55: stloc.s 22
-			IL_0e57: volatile.
-			IL_0e59: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_0e5e: brfalse IL_0e74
+			IL_0f19: stloc.s 18
+			IL_0f1b: ldloc.s 18
+			IL_0f1d: ldstr ": "
+			IL_0f22: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0f27: stloc.s 22
+			IL_0f29: volatile.
+			IL_0f2b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0f30: brfalse IL_0f46
 
-			IL_0e63: ldloc.s 14
-			IL_0e65: ldstr "message"
-			IL_0e6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e6f: br IL_0e8a
+			IL_0f35: ldloc.s 14
+			IL_0f37: ldstr "message"
+			IL_0f3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f41: br IL_0f5c
 
-			IL_0e74: ldloc.s 14
-			IL_0e76: ldstr "message"
-			IL_0e7b: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:439"
-			IL_0e80: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_0e85: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0f46: ldloc.s 14
+			IL_0f48: ldstr "message"
+			IL_0f4d: ldstr "Global_Url_And_SearchParams:Modules.Global_Url_And_SearchParams:__js_module_init__:439"
+			IL_0f52: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0f57: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e8a: stloc.s 18
-			IL_0e8c: ldloc.s 22
-			IL_0e8e: ldloc.s 18
-			IL_0e90: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0e95: stloc.s 22
-			IL_0e97: ldloc.s 16
-			IL_0e99: ldstr "log"
-			IL_0e9e: ldstr "params call:"
-			IL_0ea3: ldloc.s 22
-			IL_0ea5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0eaa: pop
-			IL_0eab: leave IL_0eb0
+			IL_0f5c: stloc.s 18
+			IL_0f5e: ldloc.s 22
+			IL_0f60: ldloc.s 18
+			IL_0f62: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0f67: stloc.s 22
+			IL_0f69: ldloc.s 16
+			IL_0f6b: ldstr "log"
+			IL_0f70: ldstr "params call:"
+			IL_0f75: ldloc.s 22
+			IL_0f77: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0f7c: pop
+			IL_0f7d: leave IL_0f82
 		} // end handler
 
-		IL_0eb0: ldnull
-		IL_0eb1: stloc.s 15
-		IL_0eb3: ret
+		IL_0f82: ldnull
+		IL_0f83: stloc.s 15
+		IL_0f85: ret
 	} // end of method Global_Url_And_SearchParams::__js_module_init__
 
 } // end of class Modules.Global_Url_And_SearchParams
@@ -1377,6 +1437,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
 	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_Parse_And_Base.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_Parse_And_Base.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1139 (0x473)
+		// Code size: 1223 (0x4c7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Url_Parse_And_Base/Scope,
@@ -379,100 +379,124 @@
 		IL_033b: stloc.s 4
 		IL_033d: ldloc.s 4
 		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0344: ldstr "get"
-		IL_0349: ldstr "topic"
-		IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0353: stloc.s 4
-		IL_0355: ldloc.s 5
-		IL_0357: ldstr "topic:"
-		IL_035c: ldloc.s 4
-		IL_035e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0363: pop
-		IL_0364: ldloc.1
-		IL_0365: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
-		IL_036a: stloc.s 4
-		IL_036c: ldloc.s 4
-		IL_036e: dup
-		IL_036f: ldstr "../guide?lang=en"
-		IL_0374: ldstr "https://example.com/docs/start/"
-		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_037e: stloc.3
-		IL_037f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0384: stloc.s 5
-		IL_0386: volatile.
-		IL_0388: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_038d: brfalse IL_03a2
+		IL_0344: volatile.
+		IL_0346: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_034b: brfalse IL_0364
 
-		IL_0392: ldloc.3
-		IL_0393: ldstr "href"
-		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_039d: br IL_03b7
+		IL_0350: ldstr "get"
+		IL_0355: ldstr "topic"
+		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_035f: br IL_037d
 
-		IL_03a2: ldloc.3
-		IL_03a3: ldstr "href"
-		IL_03a8: ldstr "Require_Url_Parse_And_Base:Modules.Require_Url_Parse_And_Base:__js_module_init__:92"
-		IL_03ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0364: ldstr "get"
+		IL_0369: ldstr "topic"
+		IL_036e: ldstr "Require_Url_Parse_And_Base:Modules.Require_Url_Parse_And_Base:__js_module_init__:80"
+		IL_0373: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03b7: stloc.s 4
-		IL_03b9: ldloc.s 5
-		IL_03bb: ldstr "based href:"
-		IL_03c0: ldloc.s 4
-		IL_03c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03c7: pop
-		IL_03c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03cd: stloc.s 5
-		IL_03cf: volatile.
-		IL_03d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_03d6: brfalse IL_03eb
+		IL_037d: stloc.s 4
+		IL_037f: ldloc.s 5
+		IL_0381: ldstr "topic:"
+		IL_0386: ldloc.s 4
+		IL_0388: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_038d: pop
+		IL_038e: ldloc.1
+		IL_038f: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
+		IL_0394: stloc.s 4
+		IL_0396: ldloc.s 4
+		IL_0398: dup
+		IL_0399: ldstr "../guide?lang=en"
+		IL_039e: ldstr "https://example.com/docs/start/"
+		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+		IL_03a8: stloc.3
+		IL_03a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03ae: stloc.s 5
+		IL_03b0: volatile.
+		IL_03b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_03b7: brfalse IL_03cc
 
-		IL_03db: ldloc.3
-		IL_03dc: ldstr "pathname"
-		IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03e6: br IL_0400
+		IL_03bc: ldloc.3
+		IL_03bd: ldstr "href"
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03c7: br IL_03e1
 
-		IL_03eb: ldloc.3
-		IL_03ec: ldstr "pathname"
-		IL_03f1: ldstr "Require_Url_Parse_And_Base:Modules.Require_Url_Parse_And_Base:__js_module_init__:98"
-		IL_03f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03cc: ldloc.3
+		IL_03cd: ldstr "href"
+		IL_03d2: ldstr "Require_Url_Parse_And_Base:Modules.Require_Url_Parse_And_Base:__js_module_init__:92"
+		IL_03d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0400: stloc.s 4
-		IL_0402: ldloc.s 5
-		IL_0404: ldstr "based path:"
-		IL_0409: ldloc.s 4
-		IL_040b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0410: pop
-		IL_0411: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0416: stloc.s 5
-		IL_0418: volatile.
-		IL_041a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_041f: brfalse IL_0434
+		IL_03e1: stloc.s 4
+		IL_03e3: ldloc.s 5
+		IL_03e5: ldstr "based href:"
+		IL_03ea: ldloc.s 4
+		IL_03ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03f1: pop
+		IL_03f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03f7: stloc.s 5
+		IL_03f9: volatile.
+		IL_03fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0400: brfalse IL_0415
 
-		IL_0424: ldloc.3
-		IL_0425: ldstr "searchParams"
-		IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_042f: br IL_0449
+		IL_0405: ldloc.3
+		IL_0406: ldstr "pathname"
+		IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0410: br IL_042a
 
-		IL_0434: ldloc.3
-		IL_0435: ldstr "searchParams"
-		IL_043a: ldstr "Require_Url_Parse_And_Base:Modules.Require_Url_Parse_And_Base:__js_module_init__:104"
-		IL_043f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0415: ldloc.3
+		IL_0416: ldstr "pathname"
+		IL_041b: ldstr "Require_Url_Parse_And_Base:Modules.Require_Url_Parse_And_Base:__js_module_init__:98"
+		IL_0420: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0449: stloc.s 4
-		IL_044b: ldloc.s 4
-		IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0452: ldstr "get"
-		IL_0457: ldstr "lang"
-		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0461: stloc.s 4
-		IL_0463: ldloc.s 5
-		IL_0465: ldstr "based lang:"
-		IL_046a: ldloc.s 4
-		IL_046c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0471: pop
-		IL_0472: ret
+		IL_042a: stloc.s 4
+		IL_042c: ldloc.s 5
+		IL_042e: ldstr "based path:"
+		IL_0433: ldloc.s 4
+		IL_0435: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_043a: pop
+		IL_043b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0440: stloc.s 5
+		IL_0442: volatile.
+		IL_0444: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0449: brfalse IL_045e
+
+		IL_044e: ldloc.3
+		IL_044f: ldstr "searchParams"
+		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0459: br IL_0473
+
+		IL_045e: ldloc.3
+		IL_045f: ldstr "searchParams"
+		IL_0464: ldstr "Require_Url_Parse_And_Base:Modules.Require_Url_Parse_And_Base:__js_module_init__:104"
+		IL_0469: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0473: stloc.s 4
+		IL_0475: ldloc.s 4
+		IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_047c: volatile.
+		IL_047e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0483: brfalse IL_049c
+
+		IL_0488: ldstr "get"
+		IL_048d: ldstr "lang"
+		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0497: br IL_04b5
+
+		IL_049c: ldstr "get"
+		IL_04a1: ldstr "lang"
+		IL_04a6: ldstr "Require_Url_Parse_And_Base:Modules.Require_Url_Parse_And_Base:__js_module_init__:107"
+		IL_04ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_04b5: stloc.s 4
+		IL_04b7: ldloc.s 5
+		IL_04b9: ldstr "based lang:"
+		IL_04be: ldloc.s 4
+		IL_04c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_04c5: pop
+		IL_04c6: ret
 	} // end of method Require_Url_Parse_And_Base::__js_module_init__
 
 } // end of class Modules.Require_Url_Parse_And_Base
@@ -516,6 +540,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
@@ -401,7 +401,7 @@
 			IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0017: stloc.1
 			IL_0018: volatile.
-			IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_001f: brfalse IL_003e
 
 			IL_0024: ldarg.1
@@ -416,7 +416,7 @@
 			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0049: ldstr "tag"
 			IL_004e: ldstr "Require_Url_SearchParams_Mutate:<TwoPhaseDummy_M5>:__js_call__:10"
-			IL_0053: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0053: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_005d: stloc.2
@@ -655,7 +655,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1434 (0x59a)
+		// Code size: 1810 (0x712)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Url_SearchParams_Mutate/Scope,
@@ -707,423 +707,533 @@
 		IL_0061: stloc.s 6
 		IL_0063: ldloc.s 6
 		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006a: ldstr "get"
-		IL_006f: ldstr "q"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0079: stloc.s 6
-		IL_007b: ldloc.s 7
-		IL_007d: ldstr "initial q:"
-		IL_0082: ldloc.s 6
-		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0089: pop
-		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008f: stloc.s 7
-		IL_0091: volatile.
-		IL_0093: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0098: brfalse IL_00ad
+		IL_006a: volatile.
+		IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0071: brfalse IL_008a
 
-		IL_009d: ldloc.2
-		IL_009e: ldstr "searchParams"
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a8: br IL_00c2
+		IL_0076: ldstr "get"
+		IL_007b: ldstr "q"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0085: br IL_00a3
 
-		IL_00ad: ldloc.2
-		IL_00ae: ldstr "searchParams"
-		IL_00b3: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:26"
-		IL_00b8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_008a: ldstr "get"
+		IL_008f: ldstr "q"
+		IL_0094: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:20"
+		IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00c2: stloc.s 6
-		IL_00c4: ldloc.s 6
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: ldstr "getAll"
-		IL_00d0: ldstr "q"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00da: stloc.s 6
-		IL_00dc: ldloc.s 6
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e3: ldstr "join"
-		IL_00e8: ldstr "|"
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f2: stloc.s 6
-		IL_00f4: ldloc.s 7
-		IL_00f6: ldstr "all q:"
-		IL_00fb: ldloc.s 6
-		IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0102: pop
-		IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0108: stloc.s 7
-		IL_010a: volatile.
-		IL_010c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0111: brfalse IL_0126
+		IL_00a3: stloc.s 6
+		IL_00a5: ldloc.s 7
+		IL_00a7: ldstr "initial q:"
+		IL_00ac: ldloc.s 6
+		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00b3: pop
+		IL_00b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b9: stloc.s 7
+		IL_00bb: volatile.
+		IL_00bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_00c2: brfalse IL_00d7
 
-		IL_0116: ldloc.2
-		IL_0117: ldstr "searchParams"
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0121: br IL_013b
+		IL_00c7: ldloc.2
+		IL_00c8: ldstr "searchParams"
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d2: br IL_00ec
 
-		IL_0126: ldloc.2
-		IL_0127: ldstr "searchParams"
-		IL_012c: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:38"
-		IL_0131: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00d7: ldloc.2
+		IL_00d8: ldstr "searchParams"
+		IL_00dd: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:26"
+		IL_00e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_013b: stloc.s 6
-		IL_013d: ldloc.s 6
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0144: ldstr "has"
-		IL_0149: ldstr "mode"
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0153: stloc.s 6
-		IL_0155: ldloc.s 7
-		IL_0157: ldstr "has mode:"
-		IL_015c: ldloc.s 6
-		IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0163: pop
-		IL_0164: volatile.
-		IL_0166: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_016b: brfalse IL_0180
+		IL_00ec: stloc.s 6
+		IL_00ee: ldloc.s 6
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f5: volatile.
+		IL_00f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_00fc: brfalse IL_0115
 
-		IL_0170: ldloc.2
-		IL_0171: ldstr "searchParams"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017b: br IL_0195
+		IL_0101: ldstr "getAll"
+		IL_0106: ldstr "q"
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0110: br IL_012e
 
-		IL_0180: ldloc.2
-		IL_0181: ldstr "searchParams"
-		IL_0186: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:45"
-		IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0115: ldstr "getAll"
+		IL_011a: ldstr "q"
+		IL_011f: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:29"
+		IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0195: stloc.s 6
-		IL_0197: ldloc.s 6
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019e: ldstr "append"
-		IL_01a3: ldstr "mode"
-		IL_01a8: ldstr "fast"
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01b2: pop
-		IL_01b3: volatile.
-		IL_01b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_01ba: brfalse IL_01cf
+		IL_012e: stloc.s 6
+		IL_0130: ldloc.s 6
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0137: volatile.
+		IL_0139: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_013e: brfalse IL_0157
 
-		IL_01bf: ldloc.2
-		IL_01c0: ldstr "searchParams"
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ca: br IL_01e4
+		IL_0143: ldstr "join"
+		IL_0148: ldstr "|"
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0152: br IL_0170
 
-		IL_01cf: ldloc.2
-		IL_01d0: ldstr "searchParams"
-		IL_01d5: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:52"
-		IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0157: ldstr "join"
+		IL_015c: ldstr "|"
+		IL_0161: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:32"
+		IL_0166: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01e4: stloc.s 6
-		IL_01e6: ldloc.s 6
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ed: ldstr "set"
-		IL_01f2: ldstr "q"
-		IL_01f7: ldstr "done now"
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0201: pop
-		IL_0202: volatile.
-		IL_0204: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0209: brfalse IL_021e
+		IL_0170: stloc.s 6
+		IL_0172: ldloc.s 7
+		IL_0174: ldstr "all q:"
+		IL_0179: ldloc.s 6
+		IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0180: pop
+		IL_0181: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0186: stloc.s 7
+		IL_0188: volatile.
+		IL_018a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_018f: brfalse IL_01a4
 
-		IL_020e: ldloc.2
-		IL_020f: ldstr "searchParams"
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0219: br IL_0233
+		IL_0194: ldloc.2
+		IL_0195: ldstr "searchParams"
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019f: br IL_01b9
 
-		IL_021e: ldloc.2
-		IL_021f: ldstr "searchParams"
-		IL_0224: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:59"
-		IL_0229: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01a4: ldloc.2
+		IL_01a5: ldstr "searchParams"
+		IL_01aa: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:38"
+		IL_01af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0233: stloc.s 6
-		IL_0235: ldloc.s 6
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023c: ldstr "append"
-		IL_0241: ldstr "empty"
-		IL_0246: ldstr ""
-		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0250: pop
-		IL_0251: volatile.
-		IL_0253: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0258: brfalse IL_026d
+		IL_01b9: stloc.s 6
+		IL_01bb: ldloc.s 6
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c2: volatile.
+		IL_01c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_01c9: brfalse IL_01e2
 
-		IL_025d: ldloc.2
-		IL_025e: ldstr "searchParams"
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0268: br IL_0282
+		IL_01ce: ldstr "has"
+		IL_01d3: ldstr "mode"
+		IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01dd: br IL_01fb
 
-		IL_026d: ldloc.2
-		IL_026e: ldstr "searchParams"
-		IL_0273: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:66"
-		IL_0278: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01e2: ldstr "has"
+		IL_01e7: ldstr "mode"
+		IL_01ec: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:41"
+		IL_01f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0282: stloc.s 6
-		IL_0284: ldloc.s 6
-		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028b: stloc.s 6
-		IL_028d: ldc.i4.1
-		IL_028e: newarr [System.Runtime]System.Object
-		IL_0293: dup
-		IL_0294: ldc.i4.0
-		IL_0295: ldloc.0
-		IL_0296: stelem.ref
-		IL_0297: stloc.s 8
-		IL_0299: newobj instance void Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L14C29/FunctionObject::.ctor()
-		IL_029e: ldc.i4.2
-		IL_029f: conv.r8
-		IL_02a0: ldstr ""
-		IL_02a5: ldc.i4.0
-		IL_02a6: ldc.i4.0
-		IL_02a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L14C29/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L14C29/FunctionObject>(!!0)
-		IL_02b1: stloc.s 9
-		IL_02b3: ldloc.s 6
-		IL_02b5: ldstr "forEach"
-		IL_02ba: ldloc.s 9
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c1: pop
-		IL_02c2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02c7: dup
-		IL_02c8: ldstr "tag"
-		IL_02cd: ldstr "ctx"
-		IL_02d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02d7: stloc.3
-		IL_02d8: volatile.
-		IL_02da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_02df: brfalse IL_02f4
+		IL_01fb: stloc.s 6
+		IL_01fd: ldloc.s 7
+		IL_01ff: ldstr "has mode:"
+		IL_0204: ldloc.s 6
+		IL_0206: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_020b: pop
+		IL_020c: volatile.
+		IL_020e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0213: brfalse IL_0228
 
-		IL_02e4: ldloc.2
-		IL_02e5: ldstr "searchParams"
-		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ef: br IL_0309
+		IL_0218: ldloc.2
+		IL_0219: ldstr "searchParams"
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0223: br IL_023d
 
-		IL_02f4: ldloc.2
-		IL_02f5: ldstr "searchParams"
-		IL_02fa: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:77"
-		IL_02ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0228: ldloc.2
+		IL_0229: ldstr "searchParams"
+		IL_022e: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:45"
+		IL_0233: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0309: stloc.s 6
-		IL_030b: ldloc.s 6
-		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0312: stloc.s 6
-		IL_0314: ldc.i4.1
-		IL_0315: newarr [System.Runtime]System.Object
-		IL_031a: dup
-		IL_031b: ldc.i4.0
-		IL_031c: ldloc.0
-		IL_031d: stelem.ref
-		IL_031e: stloc.s 8
-		IL_0320: newobj instance void Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject::.ctor()
-		IL_0325: ldc.i4.2
-		IL_0326: conv.r8
-		IL_0327: ldstr ""
-		IL_032c: ldc.i4.0
-		IL_032d: ldc.i4.1
-		IL_032e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0333: stloc.s 10
-		IL_0335: ldloc.s 6
-		IL_0337: ldstr "forEach"
-		IL_033c: ldloc.s 10
-		IL_033e: ldloc.3
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0344: pop
-		IL_0345: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_034a: stloc.s 7
-		IL_034c: volatile.
-		IL_034e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0353: brfalse IL_0368
+		IL_023d: stloc.s 6
+		IL_023f: ldloc.s 6
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0246: ldstr "append"
+		IL_024b: ldstr "mode"
+		IL_0250: ldstr "fast"
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_025a: pop
+		IL_025b: volatile.
+		IL_025d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0262: brfalse IL_0277
 
-		IL_0358: ldloc.2
-		IL_0359: ldstr "search"
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0363: br IL_037d
+		IL_0267: ldloc.2
+		IL_0268: ldstr "searchParams"
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0272: br IL_028c
 
-		IL_0368: ldloc.2
-		IL_0369: ldstr "search"
-		IL_036e: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:86"
-		IL_0373: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0277: ldloc.2
+		IL_0278: ldstr "searchParams"
+		IL_027d: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:52"
+		IL_0282: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_037d: stloc.s 6
-		IL_037f: ldloc.s 7
-		IL_0381: ldstr "search:"
-		IL_0386: ldloc.s 6
-		IL_0388: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_038d: pop
-		IL_038e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0393: stloc.s 7
-		IL_0395: volatile.
-		IL_0397: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_039c: brfalse IL_03b1
+		IL_028c: stloc.s 6
+		IL_028e: ldloc.s 6
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0295: ldstr "set"
+		IL_029a: ldstr "q"
+		IL_029f: ldstr "done now"
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02a9: pop
+		IL_02aa: volatile.
+		IL_02ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_02b1: brfalse IL_02c6
 
-		IL_03a1: ldloc.2
-		IL_03a2: ldstr "href"
-		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03ac: br IL_03c6
+		IL_02b6: ldloc.2
+		IL_02b7: ldstr "searchParams"
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02c1: br IL_02db
 
-		IL_03b1: ldloc.2
-		IL_03b2: ldstr "href"
-		IL_03b7: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:92"
-		IL_03bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02c6: ldloc.2
+		IL_02c7: ldstr "searchParams"
+		IL_02cc: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:59"
+		IL_02d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03c6: stloc.s 6
-		IL_03c8: ldloc.s 7
-		IL_03ca: ldstr "href:"
-		IL_03cf: ldloc.s 6
-		IL_03d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03d6: pop
-		IL_03d7: ldloc.1
-		IL_03d8: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URLSearchParams()
-		IL_03dd: stloc.s 6
-		IL_03df: ldloc.s 6
-		IL_03e1: dup
-		IL_03e2: ldstr "alpha=1&beta=two+words"
-		IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_03ec: stloc.s 4
-		IL_03ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03f3: stloc.s 7
-		IL_03f5: ldloc.s 4
-		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03fc: volatile.
-		IL_03fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0403: brfalse IL_0417
+		IL_02db: stloc.s 6
+		IL_02dd: ldloc.s 6
+		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e4: ldstr "append"
+		IL_02e9: ldstr "empty"
+		IL_02ee: ldstr ""
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02f8: pop
+		IL_02f9: volatile.
+		IL_02fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0300: brfalse IL_0315
 
-		IL_0408: ldstr "toString"
-		IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0412: br IL_042b
+		IL_0305: ldloc.2
+		IL_0306: ldstr "searchParams"
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0310: br IL_032a
 
-		IL_0417: ldstr "toString"
-		IL_041c: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:103"
-		IL_0421: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0315: ldloc.2
+		IL_0316: ldstr "searchParams"
+		IL_031b: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:66"
+		IL_0320: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_042b: stloc.s 6
-		IL_042d: ldloc.s 7
-		IL_042f: ldstr "copy:"
-		IL_0434: ldloc.s 6
-		IL_0436: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_043b: pop
-		IL_043c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0441: stloc.s 7
-		IL_0443: ldloc.s 4
-		IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_044a: ldstr "get"
-		IL_044f: ldstr "beta"
-		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0459: stloc.s 6
-		IL_045b: ldloc.s 7
-		IL_045d: ldstr "copy beta:"
-		IL_0462: ldloc.s 6
-		IL_0464: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0469: pop
-		IL_046a: ldloc.1
-		IL_046b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URLSearchParams()
-		IL_0470: stloc.s 6
-		IL_0472: ldloc.s 6
-		IL_0474: dup
-		IL_0475: ldstr "a=1"
-		IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_047f: stloc.s 6
-		IL_0481: ldloc.0
-		IL_0482: ldloc.s 6
-		IL_0484: stfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
-		IL_0489: ldloc.0
-		IL_048a: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
-		IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0494: stloc.s 6
-		IL_0496: ldc.i4.1
-		IL_0497: newarr [System.Runtime]System.Object
-		IL_049c: dup
-		IL_049d: ldc.i4.0
-		IL_049e: ldloc.0
-		IL_049f: stelem.ref
-		IL_04a0: stloc.s 8
-		IL_04a2: ldloc.s 8
-		IL_04a4: ldc.i4.0
-		IL_04a5: ldelem.ref
-		IL_04a6: castclass Modules.Require_Url_SearchParams_Mutate/Scope
-		IL_04ab: newobj instance void Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/FunctionObject::.ctor(class Modules.Require_Url_SearchParams_Mutate/Scope)
-		IL_04b0: ldc.i4.2
-		IL_04b1: conv.r8
-		IL_04b2: ldstr ""
-		IL_04b7: ldc.i4.0
-		IL_04b8: ldc.i4.0
-		IL_04b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/FunctionObject>(!!0)
-		IL_04c3: stloc.s 11
-		IL_04c5: ldloc.s 6
-		IL_04c7: ldstr "forEach"
-		IL_04cc: ldloc.s 11
-		IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04d3: pop
-		IL_04d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04d9: stloc.s 7
-		IL_04db: ldloc.0
-		IL_04dc: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
-		IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04e6: volatile.
-		IL_04e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_04ed: brfalse IL_0501
+		IL_032a: stloc.s 6
+		IL_032c: ldloc.s 6
+		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0333: stloc.s 6
+		IL_0335: ldc.i4.1
+		IL_0336: newarr [System.Runtime]System.Object
+		IL_033b: dup
+		IL_033c: ldc.i4.0
+		IL_033d: ldloc.0
+		IL_033e: stelem.ref
+		IL_033f: stloc.s 8
+		IL_0341: newobj instance void Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L14C29/FunctionObject::.ctor()
+		IL_0346: ldc.i4.2
+		IL_0347: conv.r8
+		IL_0348: ldstr ""
+		IL_034d: ldc.i4.0
+		IL_034e: ldc.i4.0
+		IL_034f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L14C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0354: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L14C29/FunctionObject>(!!0)
+		IL_0359: stloc.s 9
+		IL_035b: volatile.
+		IL_035d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0362: brfalse IL_037a
 
-		IL_04f2: ldstr "toString"
-		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_04fc: br IL_0515
+		IL_0367: ldloc.s 6
+		IL_0369: ldstr "forEach"
+		IL_036e: ldloc.s 9
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0375: br IL_0392
 
-		IL_0501: ldstr "toString"
-		IL_0506: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:128"
-		IL_050b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_037a: ldloc.s 6
+		IL_037c: ldstr "forEach"
+		IL_0381: ldloc.s 9
+		IL_0383: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:70"
+		IL_0388: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0515: stloc.s 6
-		IL_0517: ldloc.s 7
-		IL_0519: ldstr "mutating final:"
-		IL_051e: ldloc.s 6
-		IL_0520: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0525: pop
-		IL_0526: ldloc.1
-		IL_0527: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URLSearchParams()
-		IL_052c: stloc.s 6
-		IL_052e: ldloc.s 6
-		IL_0530: dup
-		IL_0531: ldstr "bad=%&plus=a+b%"
-		IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_053b: stloc.s 5
-		IL_053d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0542: stloc.s 7
-		IL_0544: ldloc.s 5
-		IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_054b: ldstr "get"
-		IL_0550: ldstr "bad"
-		IL_0555: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_055a: stloc.s 6
-		IL_055c: ldloc.s 7
-		IL_055e: ldstr "malformed bad:"
-		IL_0563: ldloc.s 6
-		IL_0565: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_056a: pop
-		IL_056b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0570: stloc.s 7
-		IL_0572: ldloc.s 5
-		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0579: ldstr "get"
-		IL_057e: ldstr "plus"
-		IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0588: stloc.s 6
-		IL_058a: ldloc.s 7
-		IL_058c: ldstr "malformed plus:"
-		IL_0591: ldloc.s 6
-		IL_0593: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0598: pop
-		IL_0599: ret
+		IL_0392: pop
+		IL_0393: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0398: dup
+		IL_0399: ldstr "tag"
+		IL_039e: ldstr "ctx"
+		IL_03a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03a8: stloc.3
+		IL_03a9: volatile.
+		IL_03ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_03b0: brfalse IL_03c5
+
+		IL_03b5: ldloc.2
+		IL_03b6: ldstr "searchParams"
+		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03c0: br IL_03da
+
+		IL_03c5: ldloc.2
+		IL_03c6: ldstr "searchParams"
+		IL_03cb: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:77"
+		IL_03d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_03da: stloc.s 6
+		IL_03dc: ldloc.s 6
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03e3: stloc.s 6
+		IL_03e5: ldc.i4.1
+		IL_03e6: newarr [System.Runtime]System.Object
+		IL_03eb: dup
+		IL_03ec: ldc.i4.0
+		IL_03ed: ldloc.0
+		IL_03ee: stelem.ref
+		IL_03ef: stloc.s 8
+		IL_03f1: newobj instance void Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject::.ctor()
+		IL_03f6: ldc.i4.2
+		IL_03f7: conv.r8
+		IL_03f8: ldstr ""
+		IL_03fd: ldc.i4.0
+		IL_03fe: ldc.i4.1
+		IL_03ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0404: stloc.s 10
+		IL_0406: ldloc.s 6
+		IL_0408: ldstr "forEach"
+		IL_040d: ldloc.s 10
+		IL_040f: ldloc.3
+		IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0415: pop
+		IL_0416: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_041b: stloc.s 7
+		IL_041d: volatile.
+		IL_041f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0424: brfalse IL_0439
+
+		IL_0429: ldloc.2
+		IL_042a: ldstr "search"
+		IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0434: br IL_044e
+
+		IL_0439: ldloc.2
+		IL_043a: ldstr "search"
+		IL_043f: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:86"
+		IL_0444: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_044e: stloc.s 6
+		IL_0450: ldloc.s 7
+		IL_0452: ldstr "search:"
+		IL_0457: ldloc.s 6
+		IL_0459: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_045e: pop
+		IL_045f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0464: stloc.s 7
+		IL_0466: volatile.
+		IL_0468: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_046d: brfalse IL_0482
+
+		IL_0472: ldloc.2
+		IL_0473: ldstr "href"
+		IL_0478: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_047d: br IL_0497
+
+		IL_0482: ldloc.2
+		IL_0483: ldstr "href"
+		IL_0488: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:92"
+		IL_048d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0497: stloc.s 6
+		IL_0499: ldloc.s 7
+		IL_049b: ldstr "href:"
+		IL_04a0: ldloc.s 6
+		IL_04a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_04a7: pop
+		IL_04a8: ldloc.1
+		IL_04a9: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URLSearchParams()
+		IL_04ae: stloc.s 6
+		IL_04b0: ldloc.s 6
+		IL_04b2: dup
+		IL_04b3: ldstr "alpha=1&beta=two+words"
+		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_04bd: stloc.s 4
+		IL_04bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04c4: stloc.s 7
+		IL_04c6: ldloc.s 4
+		IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04cd: volatile.
+		IL_04cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_04d4: brfalse IL_04e8
+
+		IL_04d9: ldstr "toString"
+		IL_04de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_04e3: br IL_04fc
+
+		IL_04e8: ldstr "toString"
+		IL_04ed: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:103"
+		IL_04f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_04fc: stloc.s 6
+		IL_04fe: ldloc.s 7
+		IL_0500: ldstr "copy:"
+		IL_0505: ldloc.s 6
+		IL_0507: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_050c: pop
+		IL_050d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0512: stloc.s 7
+		IL_0514: ldloc.s 4
+		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_051b: volatile.
+		IL_051d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0522: brfalse IL_053b
+
+		IL_0527: ldstr "get"
+		IL_052c: ldstr "beta"
+		IL_0531: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0536: br IL_0554
+
+		IL_053b: ldstr "get"
+		IL_0540: ldstr "beta"
+		IL_0545: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:110"
+		IL_054a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_054f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0554: stloc.s 6
+		IL_0556: ldloc.s 7
+		IL_0558: ldstr "copy beta:"
+		IL_055d: ldloc.s 6
+		IL_055f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0564: pop
+		IL_0565: ldloc.1
+		IL_0566: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URLSearchParams()
+		IL_056b: stloc.s 6
+		IL_056d: ldloc.s 6
+		IL_056f: dup
+		IL_0570: ldstr "a=1"
+		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_057a: stloc.s 6
+		IL_057c: ldloc.0
+		IL_057d: ldloc.s 6
+		IL_057f: stfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
+		IL_0584: ldloc.0
+		IL_0585: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
+		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_058f: stloc.s 6
+		IL_0591: ldc.i4.1
+		IL_0592: newarr [System.Runtime]System.Object
+		IL_0597: dup
+		IL_0598: ldc.i4.0
+		IL_0599: ldloc.0
+		IL_059a: stelem.ref
+		IL_059b: stloc.s 8
+		IL_059d: ldloc.s 8
+		IL_059f: ldc.i4.0
+		IL_05a0: ldelem.ref
+		IL_05a1: castclass Modules.Require_Url_SearchParams_Mutate/Scope
+		IL_05a6: newobj instance void Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/FunctionObject::.ctor(class Modules.Require_Url_SearchParams_Mutate/Scope)
+		IL_05ab: ldc.i4.2
+		IL_05ac: conv.r8
+		IL_05ad: ldstr ""
+		IL_05b2: ldc.i4.0
+		IL_05b3: ldc.i4.0
+		IL_05b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/FunctionObject>(!!0)
+		IL_05be: stloc.s 11
+		IL_05c0: volatile.
+		IL_05c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_05c7: brfalse IL_05df
+
+		IL_05cc: ldloc.s 6
+		IL_05ce: ldstr "forEach"
+		IL_05d3: ldloc.s 11
+		IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05da: br IL_05f7
+
+		IL_05df: ldloc.s 6
+		IL_05e1: ldstr "forEach"
+		IL_05e6: ldloc.s 11
+		IL_05e8: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:122"
+		IL_05ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_05f7: pop
+		IL_05f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05fd: stloc.s 7
+		IL_05ff: ldloc.0
+		IL_0600: ldfld object Modules.Require_Url_SearchParams_Mutate/Scope::mutating
+		IL_0605: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_060a: volatile.
+		IL_060c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0611: brfalse IL_0625
+
+		IL_0616: ldstr "toString"
+		IL_061b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0620: br IL_0639
+
+		IL_0625: ldstr "toString"
+		IL_062a: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:128"
+		IL_062f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0634: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0639: stloc.s 6
+		IL_063b: ldloc.s 7
+		IL_063d: ldstr "mutating final:"
+		IL_0642: ldloc.s 6
+		IL_0644: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0649: pop
+		IL_064a: ldloc.1
+		IL_064b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URLSearchParams()
+		IL_0650: stloc.s 6
+		IL_0652: ldloc.s 6
+		IL_0654: dup
+		IL_0655: ldstr "bad=%&plus=a+b%"
+		IL_065a: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_065f: stloc.s 5
+		IL_0661: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0666: stloc.s 7
+		IL_0668: ldloc.s 5
+		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_066f: volatile.
+		IL_0671: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0676: brfalse IL_068f
+
+		IL_067b: ldstr "get"
+		IL_0680: ldstr "bad"
+		IL_0685: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_068a: br IL_06a8
+
+		IL_068f: ldstr "get"
+		IL_0694: ldstr "bad"
+		IL_0699: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:140"
+		IL_069e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_06a8: stloc.s 6
+		IL_06aa: ldloc.s 7
+		IL_06ac: ldstr "malformed bad:"
+		IL_06b1: ldloc.s 6
+		IL_06b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_06b8: pop
+		IL_06b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06be: stloc.s 7
+		IL_06c0: ldloc.s 5
+		IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06c7: volatile.
+		IL_06c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_06ce: brfalse IL_06e7
+
+		IL_06d3: ldstr "get"
+		IL_06d8: ldstr "plus"
+		IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06e2: br IL_0700
+
+		IL_06e7: ldstr "get"
+		IL_06ec: ldstr "plus"
+		IL_06f1: ldstr "Require_Url_SearchParams_Mutate:Modules.Require_Url_SearchParams_Mutate:__js_module_init__:147"
+		IL_06f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0700: stloc.s 6
+		IL_0702: ldloc.s 7
+		IL_0704: ldstr "malformed plus:"
+		IL_0709: ldloc.s 6
+		IL_070b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0710: pop
+		IL_0711: ret
 	} // end of method Require_Url_SearchParams_Mutate::__js_module_init__
 
 } // end of class Modules.Require_Url_SearchParams_Mutate
@@ -1166,6 +1276,15 @@
 	.field assembly static int32 __jroc_dynamicLookup_17
 	.field assembly static int32 __jroc_dynamicLookup_18
 	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_Basic.verified.txt
@@ -397,7 +397,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 159 (0x9f)
+		// Code size: 239 (0xef)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Promisify_Basic/Scope,
@@ -432,44 +432,70 @@
 		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule>(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object)
 		IL_0032: stloc.2
 		IL_0033: nop
-		IL_0034: ldloc.2
-		IL_0035: ldstr "promisify"
-		IL_003a: ldloc.1
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0040: stloc.3
-		IL_0041: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0046: stloc.s 4
-		IL_0048: ldloc.3
-		IL_0049: ldloc.s 4
-		IL_004b: ldc.r8 5
-		IL_0054: box [System.Runtime]System.Double
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005e: stloc.s 5
-		IL_0060: ldloc.s 5
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0067: stloc.s 5
-		IL_0069: ldc.i4.1
-		IL_006a: newarr [System.Runtime]System.Object
-		IL_006f: dup
-		IL_0070: ldc.i4.0
-		IL_0071: ldloc.0
-		IL_0072: stelem.ref
-		IL_0073: stloc.s 4
-		IL_0075: newobj instance void Modules.Require_Util_Promisify_Basic/ArrowFunction_L15C21/FunctionObject::.ctor()
-		IL_007a: ldc.i4.1
-		IL_007b: conv.r8
-		IL_007c: ldstr ""
-		IL_0081: ldc.i4.0
-		IL_0082: ldc.i4.0
-		IL_0083: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_Basic/ArrowFunction_L15C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0088: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_Basic/ArrowFunction_L15C21/FunctionObject>(!!0)
-		IL_008d: stloc.s 6
-		IL_008f: ldloc.s 5
-		IL_0091: ldstr "then"
-		IL_0096: ldloc.s 6
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009d: pop
-		IL_009e: ret
+		IL_0034: volatile.
+		IL_0036: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_003b: brfalse IL_0051
+
+		IL_0040: ldloc.2
+		IL_0041: ldstr "promisify"
+		IL_0046: ldloc.1
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004c: br IL_0067
+
+		IL_0051: ldloc.2
+		IL_0052: ldstr "promisify"
+		IL_0057: ldloc.1
+		IL_0058: ldstr "Require_Util_Promisify_Basic:Modules.Require_Util_Promisify_Basic:__js_module_init__:13"
+		IL_005d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0067: stloc.3
+		IL_0068: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006d: stloc.s 4
+		IL_006f: ldloc.3
+		IL_0070: ldloc.s 4
+		IL_0072: ldc.r8 5
+		IL_007b: box [System.Runtime]System.Double
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0085: stloc.s 5
+		IL_0087: ldloc.s 5
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008e: stloc.s 5
+		IL_0090: ldc.i4.1
+		IL_0091: newarr [System.Runtime]System.Object
+		IL_0096: dup
+		IL_0097: ldc.i4.0
+		IL_0098: ldloc.0
+		IL_0099: stelem.ref
+		IL_009a: stloc.s 4
+		IL_009c: newobj instance void Modules.Require_Util_Promisify_Basic/ArrowFunction_L15C21/FunctionObject::.ctor()
+		IL_00a1: ldc.i4.1
+		IL_00a2: conv.r8
+		IL_00a3: ldstr ""
+		IL_00a8: ldc.i4.0
+		IL_00a9: ldc.i4.0
+		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_Basic/ArrowFunction_L15C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_Basic/ArrowFunction_L15C21/FunctionObject>(!!0)
+		IL_00b4: stloc.s 6
+		IL_00b6: volatile.
+		IL_00b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00bd: brfalse IL_00d5
+
+		IL_00c2: ldloc.s 5
+		IL_00c4: ldstr "then"
+		IL_00c9: ldloc.s 6
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d0: br IL_00ed
+
+		IL_00d5: ldloc.s 5
+		IL_00d7: ldstr "then"
+		IL_00dc: ldloc.s 6
+		IL_00de: ldstr "Require_Util_Promisify_Basic:Modules.Require_Util_Promisify_Basic:__js_module_init__:23"
+		IL_00e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ed: pop
+		IL_00ee: ret
 	} // end of method Require_Util_Promisify_Basic::__js_module_init__
 
 } // end of class Modules.Require_Util_Promisify_Basic
@@ -494,4 +520,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
@@ -520,7 +520,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -531,7 +531,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "message"
 			IL_0028: ldstr "Require_Util_Promisify_ErrorHandling:<TwoPhaseDummy_M6>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -775,7 +775,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -786,7 +786,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "message"
 			IL_0028: ldstr "Require_Util_Promisify_ErrorHandling:<TwoPhaseDummy_M8>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -840,7 +840,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 362 (0x16a)
+		// Code size: 565 (0x235)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Promisify_ErrorHandling/Scope,
@@ -878,124 +878,189 @@
 		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule>(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object)
 		IL_0032: stloc.2
 		IL_0033: nop
-		IL_0034: ldloc.2
-		IL_0035: ldstr "promisify"
-		IL_003a: ldloc.1
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0040: stloc.3
-		IL_0041: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0046: stloc.s 4
-		IL_0048: ldloc.3
-		IL_0049: ldloc.s 4
-		IL_004b: ldc.i4.0
-		IL_004c: box [System.Runtime]System.Boolean
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0056: stloc.s 5
-		IL_0058: ldloc.s 5
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005f: stloc.s 5
-		IL_0061: ldc.i4.1
-		IL_0062: newarr [System.Runtime]System.Object
-		IL_0067: dup
-		IL_0068: ldc.i4.0
-		IL_0069: ldloc.0
-		IL_006a: stelem.ref
-		IL_006b: stloc.s 4
-		IL_006d: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L18C25/FunctionObject::.ctor()
-		IL_0072: ldc.i4.1
-		IL_0073: conv.r8
-		IL_0074: ldstr ""
-		IL_0079: ldc.i4.0
-		IL_007a: ldc.i4.0
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L18C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L18C25/FunctionObject>(!!0)
-		IL_0085: stloc.s 6
-		IL_0087: ldloc.s 5
-		IL_0089: ldstr "then"
-		IL_008e: ldloc.s 6
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: stloc.s 5
-		IL_0097: ldloc.s 5
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.s 5
-		IL_00a0: ldc.i4.1
-		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: dup
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldloc.0
-		IL_00a9: stelem.ref
-		IL_00aa: stloc.s 4
-		IL_00ac: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L20C10/FunctionObject::.ctor()
-		IL_00b1: ldc.i4.1
-		IL_00b2: conv.r8
-		IL_00b3: ldstr ""
-		IL_00b8: ldc.i4.0
-		IL_00b9: ldc.i4.0
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L20C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L20C10/FunctionObject>(!!0)
-		IL_00c4: stloc.s 7
-		IL_00c6: ldloc.s 5
-		IL_00c8: ldstr "catch"
-		IL_00cd: ldloc.s 7
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d4: pop
-		IL_00d5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00da: stloc.s 4
-		IL_00dc: ldloc.3
-		IL_00dd: ldloc.s 4
-		IL_00df: ldc.i4.1
-		IL_00e0: box [System.Runtime]System.Boolean
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00ea: stloc.s 5
-		IL_00ec: ldloc.s 5
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f3: stloc.s 5
-		IL_00f5: ldc.i4.1
-		IL_00f6: newarr [System.Runtime]System.Object
-		IL_00fb: dup
-		IL_00fc: ldc.i4.0
-		IL_00fd: ldloc.0
-		IL_00fe: stelem.ref
-		IL_00ff: stloc.s 4
-		IL_0101: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L25C24/FunctionObject::.ctor()
-		IL_0106: ldc.i4.1
-		IL_0107: conv.r8
-		IL_0108: ldstr ""
-		IL_010d: ldc.i4.0
-		IL_010e: ldc.i4.0
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L25C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L25C24/FunctionObject>(!!0)
-		IL_0119: stloc.s 8
-		IL_011b: ldloc.s 5
-		IL_011d: ldstr "then"
-		IL_0122: ldloc.s 8
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0129: stloc.s 5
-		IL_012b: ldloc.s 5
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0132: stloc.s 5
-		IL_0134: ldc.i4.1
-		IL_0135: newarr [System.Runtime]System.Object
-		IL_013a: dup
-		IL_013b: ldc.i4.0
-		IL_013c: ldloc.0
-		IL_013d: stelem.ref
-		IL_013e: stloc.s 4
-		IL_0140: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L27C10/FunctionObject::.ctor()
-		IL_0145: ldc.i4.1
-		IL_0146: conv.r8
-		IL_0147: ldstr ""
-		IL_014c: ldc.i4.0
-		IL_014d: ldc.i4.0
-		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L27C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0153: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L27C10/FunctionObject>(!!0)
-		IL_0158: stloc.s 9
-		IL_015a: ldloc.s 5
-		IL_015c: ldstr "catch"
-		IL_0161: ldloc.s 9
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0168: pop
-		IL_0169: ret
+		IL_0034: volatile.
+		IL_0036: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_003b: brfalse IL_0051
+
+		IL_0040: ldloc.2
+		IL_0041: ldstr "promisify"
+		IL_0046: ldloc.1
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004c: br IL_0067
+
+		IL_0051: ldloc.2
+		IL_0052: ldstr "promisify"
+		IL_0057: ldloc.1
+		IL_0058: ldstr "Require_Util_Promisify_ErrorHandling:Modules.Require_Util_Promisify_ErrorHandling:__js_module_init__:13"
+		IL_005d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0067: stloc.3
+		IL_0068: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006d: stloc.s 4
+		IL_006f: ldloc.3
+		IL_0070: ldloc.s 4
+		IL_0072: ldc.i4.0
+		IL_0073: box [System.Runtime]System.Boolean
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_007d: stloc.s 5
+		IL_007f: ldloc.s 5
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0086: stloc.s 5
+		IL_0088: ldc.i4.1
+		IL_0089: newarr [System.Runtime]System.Object
+		IL_008e: dup
+		IL_008f: ldc.i4.0
+		IL_0090: ldloc.0
+		IL_0091: stelem.ref
+		IL_0092: stloc.s 4
+		IL_0094: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L18C25/FunctionObject::.ctor()
+		IL_0099: ldc.i4.1
+		IL_009a: conv.r8
+		IL_009b: ldstr ""
+		IL_00a0: ldc.i4.0
+		IL_00a1: ldc.i4.0
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L18C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L18C25/FunctionObject>(!!0)
+		IL_00ac: stloc.s 6
+		IL_00ae: volatile.
+		IL_00b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00b5: brfalse IL_00cd
+
+		IL_00ba: ldloc.s 5
+		IL_00bc: ldstr "then"
+		IL_00c1: ldloc.s 6
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c8: br IL_00e5
+
+		IL_00cd: ldloc.s 5
+		IL_00cf: ldstr "then"
+		IL_00d4: ldloc.s 6
+		IL_00d6: ldstr "Require_Util_Promisify_ErrorHandling:Modules.Require_Util_Promisify_ErrorHandling:__js_module_init__:23"
+		IL_00db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00e5: stloc.s 5
+		IL_00e7: ldloc.s 5
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ee: stloc.s 5
+		IL_00f0: ldc.i4.1
+		IL_00f1: newarr [System.Runtime]System.Object
+		IL_00f6: dup
+		IL_00f7: ldc.i4.0
+		IL_00f8: ldloc.0
+		IL_00f9: stelem.ref
+		IL_00fa: stloc.s 4
+		IL_00fc: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L20C10/FunctionObject::.ctor()
+		IL_0101: ldc.i4.1
+		IL_0102: conv.r8
+		IL_0103: ldstr ""
+		IL_0108: ldc.i4.0
+		IL_0109: ldc.i4.0
+		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L20C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L20C10/FunctionObject>(!!0)
+		IL_0114: stloc.s 7
+		IL_0116: volatile.
+		IL_0118: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_011d: brfalse IL_0135
+
+		IL_0122: ldloc.s 5
+		IL_0124: ldstr "catch"
+		IL_0129: ldloc.s 7
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0130: br IL_014d
+
+		IL_0135: ldloc.s 5
+		IL_0137: ldstr "catch"
+		IL_013c: ldloc.s 7
+		IL_013e: ldstr "Require_Util_Promisify_ErrorHandling:Modules.Require_Util_Promisify_ErrorHandling:__js_module_init__:27"
+		IL_0143: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_014d: pop
+		IL_014e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0153: stloc.s 4
+		IL_0155: ldloc.3
+		IL_0156: ldloc.s 4
+		IL_0158: ldc.i4.1
+		IL_0159: box [System.Runtime]System.Boolean
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0163: stloc.s 5
+		IL_0165: ldloc.s 5
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016c: stloc.s 5
+		IL_016e: ldc.i4.1
+		IL_016f: newarr [System.Runtime]System.Object
+		IL_0174: dup
+		IL_0175: ldc.i4.0
+		IL_0176: ldloc.0
+		IL_0177: stelem.ref
+		IL_0178: stloc.s 4
+		IL_017a: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L25C24/FunctionObject::.ctor()
+		IL_017f: ldc.i4.1
+		IL_0180: conv.r8
+		IL_0181: ldstr ""
+		IL_0186: ldc.i4.0
+		IL_0187: ldc.i4.0
+		IL_0188: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L25C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_018d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L25C24/FunctionObject>(!!0)
+		IL_0192: stloc.s 8
+		IL_0194: volatile.
+		IL_0196: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_019b: brfalse IL_01b3
+
+		IL_01a0: ldloc.s 5
+		IL_01a2: ldstr "then"
+		IL_01a7: ldloc.s 8
+		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ae: br IL_01cb
+
+		IL_01b3: ldloc.s 5
+		IL_01b5: ldstr "then"
+		IL_01ba: ldloc.s 8
+		IL_01bc: ldstr "Require_Util_Promisify_ErrorHandling:Modules.Require_Util_Promisify_ErrorHandling:__js_module_init__:36"
+		IL_01c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01cb: stloc.s 5
+		IL_01cd: ldloc.s 5
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d4: stloc.s 5
+		IL_01d6: ldc.i4.1
+		IL_01d7: newarr [System.Runtime]System.Object
+		IL_01dc: dup
+		IL_01dd: ldc.i4.0
+		IL_01de: ldloc.0
+		IL_01df: stelem.ref
+		IL_01e0: stloc.s 4
+		IL_01e2: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L27C10/FunctionObject::.ctor()
+		IL_01e7: ldc.i4.1
+		IL_01e8: conv.r8
+		IL_01e9: ldstr ""
+		IL_01ee: ldc.i4.0
+		IL_01ef: ldc.i4.0
+		IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L27C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Promisify_ErrorHandling/ArrowFunction_L27C10/FunctionObject>(!!0)
+		IL_01fa: stloc.s 9
+		IL_01fc: volatile.
+		IL_01fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0203: brfalse IL_021b
+
+		IL_0208: ldloc.s 5
+		IL_020a: ldstr "catch"
+		IL_020f: ldloc.s 9
+		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0216: br IL_0233
+
+		IL_021b: ldloc.s 5
+		IL_021d: ldstr "catch"
+		IL_0222: ldloc.s 9
+		IL_0224: ldstr "Require_Util_Promisify_ErrorHandling:Modules.Require_Util_Promisify_ErrorHandling:__js_module_init__:40"
+		IL_0229: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0233: pop
+		IL_0234: ret
 	} // end of method Require_Util_Promisify_ErrorHandling::__js_module_init__
 
 } // end of class Modules.Require_Util_Promisify_ErrorHandling
@@ -1027,6 +1092,11 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_Expanded.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_Expanded.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 405 (0x195)
+		// Code size: 644 (0x284)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_Expanded/Scope,
@@ -137,130 +137,207 @@
 		IL_0026: stloc.3
 		IL_0027: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Map::.ctor()
 		IL_002c: stloc.s 4
-		IL_002e: ldloc.3
-		IL_002f: ldstr "isMap"
-		IL_0034: ldloc.s 4
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_003b: stloc.3
-		IL_003c: ldloc.2
-		IL_003d: ldloc.3
-		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0043: pop
-		IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0049: stloc.2
-		IL_004a: ldloc.1
-		IL_004b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0050: stloc.3
-		IL_0051: ldloc.3
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0057: stloc.3
-		IL_0058: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
-		IL_005d: stloc.s 5
-		IL_005f: ldloc.3
-		IL_0060: ldstr "isSet"
-		IL_0065: ldloc.s 5
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006c: stloc.3
-		IL_006d: ldloc.2
-		IL_006e: ldloc.3
-		IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0074: pop
-		IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007a: stloc.2
-		IL_007b: ldloc.1
-		IL_007c: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0081: stloc.3
-		IL_0082: ldloc.3
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0088: stloc.3
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_008e: stloc.s 6
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0095: stloc.s 7
-		IL_0097: ldloc.s 6
-		IL_0099: ldloc.s 7
-		IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_00a0: stloc.s 8
-		IL_00a2: ldloc.3
-		IL_00a3: ldstr "isProxy"
-		IL_00a8: ldloc.s 8
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00af: stloc.3
-		IL_00b0: ldloc.2
-		IL_00b1: ldloc.3
-		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b7: pop
-		IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bd: stloc.2
-		IL_00be: ldloc.1
-		IL_00bf: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00c4: stloc.3
-		IL_00c5: ldloc.3
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: stloc.3
-		IL_00cc: ldc.r8 3
-		IL_00d5: box [System.Runtime]System.Double
-		IL_00da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_00df: stloc.s 9
-		IL_00e1: ldloc.3
-		IL_00e2: ldstr "isTypedArray"
-		IL_00e7: ldloc.s 9
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ee: stloc.3
-		IL_00ef: ldloc.2
-		IL_00f0: ldloc.3
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f6: pop
-		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fc: stloc.2
-		IL_00fd: ldloc.1
-		IL_00fe: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0103: stloc.3
-		IL_0104: ldloc.3
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010a: ldc.i4.3
-		IL_010b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0110: dup
-		IL_0111: ldc.r8 1
-		IL_011a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_011f: dup
-		IL_0120: ldc.r8 2
-		IL_0129: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_012e: dup
-		IL_012f: ldc.r8 3
-		IL_0138: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0142: stloc.s 10
-		IL_0144: ldstr "isTypedArray"
-		IL_0149: ldloc.s 10
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0150: stloc.3
-		IL_0151: ldloc.2
-		IL_0152: ldloc.3
-		IL_0153: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0158: pop
-		IL_0159: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015e: stloc.2
-		IL_015f: ldloc.1
-		IL_0160: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0165: stloc.3
-		IL_0166: ldloc.3
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016c: stloc.3
-		IL_016d: ldstr "abc"
-		IL_0172: ldstr ""
-		IL_0177: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_017c: stloc.s 11
-		IL_017e: ldloc.3
-		IL_017f: ldstr "isRegExp"
-		IL_0184: ldloc.s 11
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018b: stloc.3
-		IL_018c: ldloc.2
-		IL_018d: ldloc.3
-		IL_018e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0193: pop
-		IL_0194: ret
+		IL_002e: volatile.
+		IL_0030: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0035: brfalse IL_004c
+
+		IL_003a: ldloc.3
+		IL_003b: ldstr "isMap"
+		IL_0040: ldloc.s 4
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0047: br IL_0063
+
+		IL_004c: ldloc.3
+		IL_004d: ldstr "isMap"
+		IL_0052: ldloc.s 4
+		IL_0054: ldstr "Require_Util_Types_Expanded:Modules.Require_Util_Types_Expanded:__js_module_init__:13"
+		IL_0059: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0063: stloc.3
+		IL_0064: ldloc.2
+		IL_0065: ldloc.3
+		IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006b: pop
+		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0071: stloc.2
+		IL_0072: ldloc.1
+		IL_0073: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_0078: stloc.3
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007f: stloc.3
+		IL_0080: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
+		IL_0085: stloc.s 5
+		IL_0087: volatile.
+		IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_008e: brfalse IL_00a5
+
+		IL_0093: ldloc.3
+		IL_0094: ldstr "isSet"
+		IL_0099: ldloc.s 5
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a0: br IL_00bc
+
+		IL_00a5: ldloc.3
+		IL_00a6: ldstr "isSet"
+		IL_00ab: ldloc.s 5
+		IL_00ad: ldstr "Require_Util_Types_Expanded:Modules.Require_Util_Types_Expanded:__js_module_init__:20"
+		IL_00b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00bc: stloc.3
+		IL_00bd: ldloc.2
+		IL_00be: ldloc.3
+		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c4: pop
+		IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ca: stloc.2
+		IL_00cb: ldloc.1
+		IL_00cc: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_00d1: stloc.3
+		IL_00d2: ldloc.3
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d8: stloc.3
+		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00de: stloc.s 6
+		IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00e5: stloc.s 7
+		IL_00e7: ldloc.s 6
+		IL_00e9: ldloc.s 7
+		IL_00eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_00f0: stloc.s 8
+		IL_00f2: volatile.
+		IL_00f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00f9: brfalse IL_0110
+
+		IL_00fe: ldloc.3
+		IL_00ff: ldstr "isProxy"
+		IL_0104: ldloc.s 8
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010b: br IL_0127
+
+		IL_0110: ldloc.3
+		IL_0111: ldstr "isProxy"
+		IL_0116: ldloc.s 8
+		IL_0118: ldstr "Require_Util_Types_Expanded:Modules.Require_Util_Types_Expanded:__js_module_init__:29"
+		IL_011d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0127: stloc.3
+		IL_0128: ldloc.2
+		IL_0129: ldloc.3
+		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_012f: pop
+		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0135: stloc.2
+		IL_0136: ldloc.1
+		IL_0137: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_013c: stloc.3
+		IL_013d: ldloc.3
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0143: stloc.3
+		IL_0144: ldc.r8 3
+		IL_014d: box [System.Runtime]System.Double
+		IL_0152: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_0157: stloc.s 9
+		IL_0159: volatile.
+		IL_015b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0160: brfalse IL_0177
+
+		IL_0165: ldloc.3
+		IL_0166: ldstr "isTypedArray"
+		IL_016b: ldloc.s 9
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0172: br IL_018e
+
+		IL_0177: ldloc.3
+		IL_0178: ldstr "isTypedArray"
+		IL_017d: ldloc.s 9
+		IL_017f: ldstr "Require_Util_Types_Expanded:Modules.Require_Util_Types_Expanded:__js_module_init__:38"
+		IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_018e: stloc.3
+		IL_018f: ldloc.2
+		IL_0190: ldloc.3
+		IL_0191: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0196: pop
+		IL_0197: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019c: stloc.2
+		IL_019d: ldloc.1
+		IL_019e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_01a3: stloc.3
+		IL_01a4: ldloc.3
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01aa: ldc.i4.3
+		IL_01ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01b0: dup
+		IL_01b1: ldc.r8 1
+		IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01bf: dup
+		IL_01c0: ldc.r8 2
+		IL_01c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01ce: dup
+		IL_01cf: ldc.r8 3
+		IL_01d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01dd: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_01e2: stloc.s 10
+		IL_01e4: volatile.
+		IL_01e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01eb: brfalse IL_0201
+
+		IL_01f0: ldstr "isTypedArray"
+		IL_01f5: ldloc.s 10
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01fc: br IL_0217
+
+		IL_0201: ldstr "isTypedArray"
+		IL_0206: ldloc.s 10
+		IL_0208: ldstr "Require_Util_Types_Expanded:Modules.Require_Util_Types_Expanded:__js_module_init__:49"
+		IL_020d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0217: stloc.3
+		IL_0218: ldloc.2
+		IL_0219: ldloc.3
+		IL_021a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_021f: pop
+		IL_0220: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0225: stloc.2
+		IL_0226: ldloc.1
+		IL_0227: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_022c: stloc.3
+		IL_022d: ldloc.3
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0233: stloc.3
+		IL_0234: ldstr "abc"
+		IL_0239: ldstr ""
+		IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0243: stloc.s 11
+		IL_0245: volatile.
+		IL_0247: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_024c: brfalse IL_0263
+
+		IL_0251: ldloc.3
+		IL_0252: ldstr "isRegExp"
+		IL_0257: ldloc.s 11
+		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025e: br IL_027a
+
+		IL_0263: ldloc.3
+		IL_0264: ldstr "isRegExp"
+		IL_0269: ldloc.s 11
+		IL_026b: ldstr "Require_Util_Types_Expanded:Modules.Require_Util_Types_Expanded:__js_module_init__:58"
+		IL_0270: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_027a: stloc.3
+		IL_027b: ldloc.2
+		IL_027c: ldloc.3
+		IL_027d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0282: pop
+		IL_0283: ret
 	} // end of method Require_Util_Types_Expanded::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_Expanded
@@ -285,4 +362,17 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_Generated_Functions.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_Generated_Functions.verified.txt
@@ -566,7 +566,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 439 (0x1b7)
+		// Code size: 629 (0x275)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_Generated_Functions/Scope,
@@ -647,95 +647,155 @@
 		IL_0098: stloc.s 7
 		IL_009a: ldloc.s 7
 		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a1: ldstr "isFunction"
-		IL_00a6: ldloc.1
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ac: stloc.s 7
-		IL_00ae: ldstr "ordinary:"
-		IL_00b3: ldloc.s 7
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00ba: stloc.s 8
-		IL_00bc: ldloc.s 6
-		IL_00be: ldloc.s 8
-		IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c5: pop
-		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cb: stloc.s 6
-		IL_00cd: ldloc.s 4
-		IL_00cf: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00d4: stloc.s 7
-		IL_00d6: ldloc.s 7
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00dd: ldstr "isFunction"
-		IL_00e2: ldloc.2
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e8: stloc.s 7
-		IL_00ea: ldstr "async-function:"
-		IL_00ef: ldloc.s 7
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00f6: stloc.s 8
-		IL_00f8: ldloc.s 6
-		IL_00fa: ldloc.s 8
-		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0101: pop
-		IL_0102: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0107: stloc.s 6
-		IL_0109: ldloc.s 4
-		IL_010b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0110: stloc.s 7
-		IL_0112: ldloc.s 7
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0119: ldstr "isFunction"
-		IL_011e: ldloc.3
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0124: stloc.s 7
-		IL_0126: ldstr "generator-function:"
-		IL_012b: ldloc.s 7
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0132: stloc.s 8
-		IL_0134: ldloc.s 6
-		IL_0136: ldloc.s 8
-		IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013d: pop
-		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0143: stloc.s 6
-		IL_0145: ldloc.s 4
-		IL_0147: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_014c: stloc.s 7
-		IL_014e: ldloc.s 7
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0155: ldstr "isAsyncFunction"
-		IL_015a: ldloc.2
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0160: stloc.s 7
-		IL_0162: ldstr "is-async:"
-		IL_0167: ldloc.s 7
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_016e: stloc.s 8
-		IL_0170: ldloc.s 6
-		IL_0172: ldloc.s 8
-		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0179: pop
-		IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017f: stloc.s 6
-		IL_0181: ldloc.s 4
-		IL_0183: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0188: stloc.s 7
-		IL_018a: ldloc.s 7
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0191: ldstr "isAsyncFunction"
-		IL_0196: ldloc.1
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019c: stloc.s 7
-		IL_019e: ldstr "ordinary-is-async:"
-		IL_01a3: ldloc.s 7
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01aa: stloc.s 8
-		IL_01ac: ldloc.s 6
-		IL_01ae: ldloc.s 8
-		IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b5: pop
-		IL_01b6: ret
+		IL_00a1: volatile.
+		IL_00a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00a8: brfalse IL_00bd
+
+		IL_00ad: ldstr "isFunction"
+		IL_00b2: ldloc.1
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b8: br IL_00d2
+
+		IL_00bd: ldstr "isFunction"
+		IL_00c2: ldloc.1
+		IL_00c3: ldstr "Require_Util_Types_Generated_Functions:Modules.Require_Util_Types_Generated_Functions:__js_module_init__:25"
+		IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d2: stloc.s 7
+		IL_00d4: ldstr "ordinary:"
+		IL_00d9: ldloc.s 7
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00e0: stloc.s 8
+		IL_00e2: ldloc.s 6
+		IL_00e4: ldloc.s 8
+		IL_00e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00eb: pop
+		IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f1: stloc.s 6
+		IL_00f3: ldloc.s 4
+		IL_00f5: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_00fa: stloc.s 7
+		IL_00fc: ldloc.s 7
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0103: volatile.
+		IL_0105: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_010a: brfalse IL_011f
+
+		IL_010f: ldstr "isFunction"
+		IL_0114: ldloc.2
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011a: br IL_0134
+
+		IL_011f: ldstr "isFunction"
+		IL_0124: ldloc.2
+		IL_0125: ldstr "Require_Util_Types_Generated_Functions:Modules.Require_Util_Types_Generated_Functions:__js_module_init__:33"
+		IL_012a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0134: stloc.s 7
+		IL_0136: ldstr "async-function:"
+		IL_013b: ldloc.s 7
+		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0142: stloc.s 8
+		IL_0144: ldloc.s 6
+		IL_0146: ldloc.s 8
+		IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014d: pop
+		IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0153: stloc.s 6
+		IL_0155: ldloc.s 4
+		IL_0157: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_015c: stloc.s 7
+		IL_015e: ldloc.s 7
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0165: volatile.
+		IL_0167: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_016c: brfalse IL_0181
+
+		IL_0171: ldstr "isFunction"
+		IL_0176: ldloc.3
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017c: br IL_0196
+
+		IL_0181: ldstr "isFunction"
+		IL_0186: ldloc.3
+		IL_0187: ldstr "Require_Util_Types_Generated_Functions:Modules.Require_Util_Types_Generated_Functions:__js_module_init__:41"
+		IL_018c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0196: stloc.s 7
+		IL_0198: ldstr "generator-function:"
+		IL_019d: ldloc.s 7
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01a4: stloc.s 8
+		IL_01a6: ldloc.s 6
+		IL_01a8: ldloc.s 8
+		IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01af: pop
+		IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b5: stloc.s 6
+		IL_01b7: ldloc.s 4
+		IL_01b9: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_01be: stloc.s 7
+		IL_01c0: ldloc.s 7
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c7: volatile.
+		IL_01c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01ce: brfalse IL_01e3
+
+		IL_01d3: ldstr "isAsyncFunction"
+		IL_01d8: ldloc.2
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01de: br IL_01f8
+
+		IL_01e3: ldstr "isAsyncFunction"
+		IL_01e8: ldloc.2
+		IL_01e9: ldstr "Require_Util_Types_Generated_Functions:Modules.Require_Util_Types_Generated_Functions:__js_module_init__:49"
+		IL_01ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01f8: stloc.s 7
+		IL_01fa: ldstr "is-async:"
+		IL_01ff: ldloc.s 7
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0206: stloc.s 8
+		IL_0208: ldloc.s 6
+		IL_020a: ldloc.s 8
+		IL_020c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0211: pop
+		IL_0212: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0217: stloc.s 6
+		IL_0219: ldloc.s 4
+		IL_021b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_0220: stloc.s 7
+		IL_0222: ldloc.s 7
+		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0229: volatile.
+		IL_022b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0230: brfalse IL_0245
+
+		IL_0235: ldstr "isAsyncFunction"
+		IL_023a: ldloc.1
+		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0240: br IL_025a
+
+		IL_0245: ldstr "isAsyncFunction"
+		IL_024a: ldloc.1
+		IL_024b: ldstr "Require_Util_Types_Generated_Functions:Modules.Require_Util_Types_Generated_Functions:__js_module_init__:57"
+		IL_0250: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_025a: stloc.s 7
+		IL_025c: ldstr "ordinary-is-async:"
+		IL_0261: ldloc.s 7
+		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0268: stloc.s 8
+		IL_026a: ldloc.s 6
+		IL_026c: ldloc.s 8
+		IL_026e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0273: pop
+		IL_0274: ret
 	} // end of method Require_Util_Types_Generated_Functions::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_Generated_Functions
@@ -760,4 +820,16 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsArray.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsArray.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 281 (0x119)
+		// Code size: 396 (0x18c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_IsArray/Scope,
@@ -157,45 +157,81 @@
 		IL_009d: stloc.s 6
 		IL_009f: ldloc.s 6
 		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a6: ldstr "isArray"
-		IL_00ab: ldloc.2
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b1: stloc.s 6
-		IL_00b3: ldloc.s 5
-		IL_00b5: ldloc.s 6
-		IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bc: pop
-		IL_00bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c2: stloc.s 5
-		IL_00c4: ldloc.1
-		IL_00c5: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00ca: stloc.s 6
-		IL_00cc: ldloc.s 6
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d3: ldstr "isArray"
-		IL_00d8: ldloc.3
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00de: stloc.s 6
-		IL_00e0: ldloc.s 5
-		IL_00e2: ldloc.s 6
-		IL_00e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e9: pop
-		IL_00ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ef: stloc.s 5
-		IL_00f1: ldloc.1
-		IL_00f2: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00f7: stloc.s 6
-		IL_00f9: ldloc.s 6
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0100: ldstr "isArray"
-		IL_0105: ldloc.s 4
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010c: stloc.s 6
-		IL_010e: ldloc.s 5
-		IL_0110: ldloc.s 6
-		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0117: pop
-		IL_0118: ret
+		IL_00a6: volatile.
+		IL_00a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00ad: brfalse IL_00c2
+
+		IL_00b2: ldstr "isArray"
+		IL_00b7: ldloc.2
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bd: br IL_00d7
+
+		IL_00c2: ldstr "isArray"
+		IL_00c7: ldloc.2
+		IL_00c8: ldstr "Require_Util_Types_IsArray:Modules.Require_Util_Types_IsArray:__js_module_init__:27"
+		IL_00cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d7: stloc.s 6
+		IL_00d9: ldloc.s 5
+		IL_00db: ldloc.s 6
+		IL_00dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e2: pop
+		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e8: stloc.s 5
+		IL_00ea: ldloc.1
+		IL_00eb: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_00f0: stloc.s 6
+		IL_00f2: ldloc.s 6
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f9: volatile.
+		IL_00fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0100: brfalse IL_0115
+
+		IL_0105: ldstr "isArray"
+		IL_010a: ldloc.3
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0110: br IL_012a
+
+		IL_0115: ldstr "isArray"
+		IL_011a: ldloc.3
+		IL_011b: ldstr "Require_Util_Types_IsArray:Modules.Require_Util_Types_IsArray:__js_module_init__:33"
+		IL_0120: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_012a: stloc.s 6
+		IL_012c: ldloc.s 5
+		IL_012e: ldloc.s 6
+		IL_0130: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0135: pop
+		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013b: stloc.s 5
+		IL_013d: ldloc.1
+		IL_013e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_0143: stloc.s 6
+		IL_0145: ldloc.s 6
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014c: volatile.
+		IL_014e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0153: brfalse IL_0169
+
+		IL_0158: ldstr "isArray"
+		IL_015d: ldloc.s 4
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0164: br IL_017f
+
+		IL_0169: ldstr "isArray"
+		IL_016e: ldloc.s 4
+		IL_0170: ldstr "Require_Util_Types_IsArray:Modules.Require_Util_Types_IsArray:__js_module_init__:39"
+		IL_0175: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_017f: stloc.s 6
+		IL_0181: ldloc.s 5
+		IL_0183: ldloc.s 6
+		IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_018a: pop
+		IL_018b: ret
 	} // end of method Require_Util_Types_IsArray::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_IsArray
@@ -220,4 +256,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsFunction.verified.txt
@@ -340,7 +340,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 313 (0x139)
+		// Code size: 467 (0x1d3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_IsFunction/Scope,
@@ -410,63 +410,111 @@
 		IL_0086: stloc.s 9
 		IL_0088: ldloc.s 9
 		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008f: ldstr "isFunction"
-		IL_0094: ldloc.1
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009a: stloc.s 9
-		IL_009c: ldloc.s 8
-		IL_009e: ldloc.s 9
-		IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a5: pop
-		IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ab: stloc.s 8
-		IL_00ad: ldloc.2
-		IL_00ae: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00b3: stloc.s 9
-		IL_00b5: ldloc.s 9
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bc: ldstr "isFunction"
-		IL_00c1: ldloc.3
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c7: stloc.s 9
-		IL_00c9: ldloc.s 8
-		IL_00cb: ldloc.s 9
-		IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d2: pop
-		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d8: stloc.s 8
-		IL_00da: ldloc.2
-		IL_00db: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00e0: stloc.s 9
-		IL_00e2: ldloc.s 9
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e9: ldloc.s 4
-		IL_00eb: box [System.Runtime]System.Double
-		IL_00f0: stloc.s 10
-		IL_00f2: ldstr "isFunction"
-		IL_00f7: ldloc.s 10
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fe: stloc.s 9
-		IL_0100: ldloc.s 8
-		IL_0102: ldloc.s 9
-		IL_0104: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0109: pop
-		IL_010a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010f: stloc.s 8
-		IL_0111: ldloc.2
-		IL_0112: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0117: stloc.s 9
-		IL_0119: ldloc.s 9
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0120: ldstr "isFunction"
-		IL_0125: ldloc.s 5
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008f: volatile.
+		IL_0091: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0096: brfalse IL_00ab
+
+		IL_009b: ldstr "isFunction"
+		IL_00a0: ldloc.1
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a6: br IL_00c0
+
+		IL_00ab: ldstr "isFunction"
+		IL_00b0: ldloc.1
+		IL_00b1: ldstr "Require_Util_Types_IsFunction:Modules.Require_Util_Types_IsFunction:__js_module_init__:28"
+		IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00c0: stloc.s 9
+		IL_00c2: ldloc.s 8
+		IL_00c4: ldloc.s 9
+		IL_00c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00cb: pop
+		IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d1: stloc.s 8
+		IL_00d3: ldloc.2
+		IL_00d4: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_00d9: stloc.s 9
+		IL_00db: ldloc.s 9
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e2: volatile.
+		IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00e9: brfalse IL_00fe
+
+		IL_00ee: ldstr "isFunction"
+		IL_00f3: ldloc.3
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f9: br IL_0113
+
+		IL_00fe: ldstr "isFunction"
+		IL_0103: ldloc.3
+		IL_0104: ldstr "Require_Util_Types_IsFunction:Modules.Require_Util_Types_IsFunction:__js_module_init__:34"
+		IL_0109: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0113: stloc.s 9
+		IL_0115: ldloc.s 8
+		IL_0117: ldloc.s 9
+		IL_0119: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011e: pop
+		IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0124: stloc.s 8
+		IL_0126: ldloc.2
+		IL_0127: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
 		IL_012c: stloc.s 9
-		IL_012e: ldloc.s 8
-		IL_0130: ldloc.s 9
-		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0137: pop
-		IL_0138: ret
+		IL_012e: ldloc.s 9
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0135: ldloc.s 4
+		IL_0137: box [System.Runtime]System.Double
+		IL_013c: stloc.s 10
+		IL_013e: volatile.
+		IL_0140: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0145: brfalse IL_015b
+
+		IL_014a: ldstr "isFunction"
+		IL_014f: ldloc.s 10
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0156: br IL_0171
+
+		IL_015b: ldstr "isFunction"
+		IL_0160: ldloc.s 10
+		IL_0162: ldstr "Require_Util_Types_IsFunction:Modules.Require_Util_Types_IsFunction:__js_module_init__:41"
+		IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0171: stloc.s 9
+		IL_0173: ldloc.s 8
+		IL_0175: ldloc.s 9
+		IL_0177: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_017c: pop
+		IL_017d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0182: stloc.s 8
+		IL_0184: ldloc.2
+		IL_0185: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_018a: stloc.s 9
+		IL_018c: ldloc.s 9
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0193: volatile.
+		IL_0195: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_019a: brfalse IL_01b0
+
+		IL_019f: ldstr "isFunction"
+		IL_01a4: ldloc.s 5
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ab: br IL_01c6
+
+		IL_01b0: ldstr "isFunction"
+		IL_01b5: ldloc.s 5
+		IL_01b7: ldstr "Require_Util_Types_IsFunction:Modules.Require_Util_Types_IsFunction:__js_module_init__:47"
+		IL_01bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01c6: stloc.s 9
+		IL_01c8: ldloc.s 8
+		IL_01ca: ldloc.s 9
+		IL_01cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d1: pop
+		IL_01d2: ret
 	} // end of method Require_Util_Types_IsFunction::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_IsFunction
@@ -491,4 +539,15 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsPromise.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsPromise.verified.txt
@@ -322,7 +322,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 279 (0x117)
+		// Code size: 394 (0x18a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_IsPromise/Scope,
@@ -395,48 +395,84 @@
 		IL_0092: stloc.s 9
 		IL_0094: ldloc.s 9
 		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009b: ldstr "isPromise"
-		IL_00a0: ldloc.2
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a6: stloc.s 9
-		IL_00a8: ldloc.s 8
-		IL_00aa: ldloc.s 9
-		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b1: pop
-		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b7: stloc.s 8
-		IL_00b9: ldloc.1
-		IL_00ba: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00bf: stloc.s 9
-		IL_00c1: ldloc.s 9
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c8: ldstr "isPromise"
-		IL_00cd: ldloc.3
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d3: stloc.s 9
-		IL_00d5: ldloc.s 8
-		IL_00d7: ldloc.s 9
-		IL_00d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00de: pop
-		IL_00df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e4: stloc.s 8
-		IL_00e6: ldloc.1
-		IL_00e7: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00ec: stloc.s 9
-		IL_00ee: ldloc.s 9
-		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f5: ldloc.s 4
-		IL_00f7: box [System.Runtime]System.Double
-		IL_00fc: stloc.s 10
-		IL_00fe: ldstr "isPromise"
-		IL_0103: ldloc.s 10
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010a: stloc.s 9
-		IL_010c: ldloc.s 8
-		IL_010e: ldloc.s 9
-		IL_0110: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0115: pop
-		IL_0116: ret
+		IL_009b: volatile.
+		IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a2: brfalse IL_00b7
+
+		IL_00a7: ldstr "isPromise"
+		IL_00ac: ldloc.2
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b2: br IL_00cc
+
+		IL_00b7: ldstr "isPromise"
+		IL_00bc: ldloc.2
+		IL_00bd: ldstr "Require_Util_Types_IsPromise:Modules.Require_Util_Types_IsPromise:__js_module_init__:25"
+		IL_00c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00cc: stloc.s 9
+		IL_00ce: ldloc.s 8
+		IL_00d0: ldloc.s 9
+		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d7: pop
+		IL_00d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00dd: stloc.s 8
+		IL_00df: ldloc.1
+		IL_00e0: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_00e5: stloc.s 9
+		IL_00e7: ldloc.s 9
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ee: volatile.
+		IL_00f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00f5: brfalse IL_010a
+
+		IL_00fa: ldstr "isPromise"
+		IL_00ff: ldloc.3
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0105: br IL_011f
+
+		IL_010a: ldstr "isPromise"
+		IL_010f: ldloc.3
+		IL_0110: ldstr "Require_Util_Types_IsPromise:Modules.Require_Util_Types_IsPromise:__js_module_init__:31"
+		IL_0115: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_011f: stloc.s 9
+		IL_0121: ldloc.s 8
+		IL_0123: ldloc.s 9
+		IL_0125: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_012a: pop
+		IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0130: stloc.s 8
+		IL_0132: ldloc.1
+		IL_0133: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_0138: stloc.s 9
+		IL_013a: ldloc.s 9
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0141: ldloc.s 4
+		IL_0143: box [System.Runtime]System.Double
+		IL_0148: stloc.s 10
+		IL_014a: volatile.
+		IL_014c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0151: brfalse IL_0167
+
+		IL_0156: ldstr "isPromise"
+		IL_015b: ldloc.s 10
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0162: br IL_017d
+
+		IL_0167: ldstr "isPromise"
+		IL_016c: ldloc.s 10
+		IL_016e: ldstr "Require_Util_Types_IsPromise:Modules.Require_Util_Types_IsPromise:__js_module_init__:38"
+		IL_0173: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_017d: stloc.s 9
+		IL_017f: ldloc.s 8
+		IL_0181: ldloc.s 9
+		IL_0183: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0188: pop
+		IL_0189: ret
 	} // end of method Require_Util_Types_IsPromise::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_IsPromise
@@ -461,4 +497,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_TypedBinary.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_TypedBinary.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 908 (0x38c)
+		// Code size: 1342 (0x53e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_TypedBinary/Scope,
@@ -144,249 +144,386 @@
 		IL_0057: stloc.s 5
 		IL_0059: ldloc.s 5
 		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0060: ldstr "isArrayBuffer"
-		IL_0065: ldloc.2
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006b: stloc.s 5
-		IL_006d: ldloc.s 4
-		IL_006f: ldloc.s 5
-		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0076: pop
-		IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.1
-		IL_007f: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0084: stloc.s 5
-		IL_0086: ldloc.s 5
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008d: stloc.s 5
-		IL_008f: ldc.r8 4
-		IL_0098: box [System.Runtime]System.Double
-		IL_009d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_00a2: stloc.s 6
-		IL_00a4: ldloc.s 5
-		IL_00a6: ldstr "isArrayBuffer"
-		IL_00ab: ldloc.s 6
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b2: stloc.s 5
-		IL_00b4: ldloc.s 4
-		IL_00b6: ldloc.s 5
-		IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bd: pop
-		IL_00be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c3: stloc.s 4
-		IL_00c5: ldloc.1
-		IL_00c6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00cb: stloc.s 5
-		IL_00cd: ldloc.s 5
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d4: ldstr "isAnyArrayBuffer"
-		IL_00d9: ldloc.2
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00df: stloc.s 5
-		IL_00e1: ldloc.s 4
-		IL_00e3: ldloc.s 5
-		IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ea: pop
-		IL_00eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f0: stloc.s 4
-		IL_00f2: ldloc.1
-		IL_00f3: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_00f8: stloc.s 5
-		IL_00fa: ldloc.s 5
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0101: ldstr "isDataView"
-		IL_0106: ldloc.3
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010c: stloc.s 5
-		IL_010e: ldloc.s 4
-		IL_0110: ldloc.s 5
-		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0117: pop
-		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011d: stloc.s 4
-		IL_011f: ldloc.1
-		IL_0120: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0125: stloc.s 5
-		IL_0127: ldloc.s 5
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012e: ldstr "isDataView"
-		IL_0133: ldloc.2
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0139: stloc.s 5
-		IL_013b: ldloc.s 4
-		IL_013d: ldloc.s 5
-		IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0144: pop
-		IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014a: stloc.s 4
-		IL_014c: ldloc.1
-		IL_014d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0152: stloc.s 5
-		IL_0154: ldloc.s 5
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015b: stloc.s 5
-		IL_015d: ldc.i4.3
-		IL_015e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0163: dup
-		IL_0164: ldc.r8 1
-		IL_016d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0172: dup
-		IL_0173: ldc.r8 2
-		IL_017c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0181: dup
-		IL_0182: ldc.r8 3
-		IL_018b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0190: stloc.s 7
-		IL_0192: ldloc.s 7
-		IL_0194: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_0199: stloc.s 8
-		IL_019b: ldloc.s 5
-		IL_019d: ldstr "isInt32Array"
-		IL_01a2: ldloc.s 8
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a9: stloc.s 5
-		IL_01ab: ldloc.s 4
-		IL_01ad: ldloc.s 5
-		IL_01af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b4: pop
-		IL_01b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ba: stloc.s 4
-		IL_01bc: ldloc.1
-		IL_01bd: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_01c2: stloc.s 5
-		IL_01c4: ldloc.s 5
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01cb: stloc.s 5
-		IL_01cd: ldc.i4.3
-		IL_01ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01d3: dup
-		IL_01d4: ldc.r8 1
-		IL_01dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01e2: dup
-		IL_01e3: ldc.r8 2
-		IL_01ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01f1: dup
-		IL_01f2: ldc.r8 3
-		IL_01fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0200: stloc.s 7
-		IL_0202: ldloc.s 7
-		IL_0204: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0209: stloc.s 6
-		IL_020b: ldloc.s 5
-		IL_020d: ldstr "isUint8Array"
-		IL_0212: ldloc.s 6
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0219: stloc.s 5
-		IL_021b: ldloc.s 4
-		IL_021d: ldloc.s 5
-		IL_021f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0224: pop
-		IL_0225: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_022a: stloc.s 4
-		IL_022c: ldloc.1
-		IL_022d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_0232: stloc.s 5
-		IL_0234: ldloc.s 5
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023b: ldc.i4.3
-		IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0241: dup
-		IL_0242: ldc.r8 1
-		IL_024b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0250: dup
-		IL_0251: ldc.r8 2
-		IL_025a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_025f: dup
-		IL_0260: ldc.r8 3
-		IL_0269: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_026e: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0273: stloc.s 9
-		IL_0275: ldstr "isUint8Array"
-		IL_027a: ldloc.s 9
-		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0281: stloc.s 5
-		IL_0283: ldloc.s 4
-		IL_0285: ldloc.s 5
-		IL_0287: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_028c: pop
-		IL_028d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0292: stloc.s 4
-		IL_0294: ldloc.1
-		IL_0295: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_029a: stloc.s 5
-		IL_029c: ldloc.s 5
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a3: stloc.s 5
-		IL_02a5: ldc.i4.2
-		IL_02a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02ab: dup
-		IL_02ac: ldc.r8 1.5
-		IL_02b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ba: dup
-		IL_02bb: ldc.r8 2.5
-		IL_02c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02c9: stloc.s 7
-		IL_02cb: ldloc.s 7
-		IL_02cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Float64Array::.ctor(object)
-		IL_02d2: stloc.s 10
-		IL_02d4: ldloc.s 5
-		IL_02d6: ldstr "isFloat64Array"
-		IL_02db: ldloc.s 10
-		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e2: stloc.s 5
-		IL_02e4: ldloc.s 4
-		IL_02e6: ldloc.s 5
-		IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ed: pop
-		IL_02ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f3: stloc.s 4
-		IL_02f5: ldloc.1
-		IL_02f6: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_02fb: stloc.s 5
-		IL_02fd: ldloc.s 5
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0304: stloc.s 5
-		IL_0306: ldc.i4.3
-		IL_0307: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_030c: dup
-		IL_030d: ldc.r8 1
-		IL_0316: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_031b: dup
-		IL_031c: ldc.r8 2
-		IL_0325: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_032a: dup
-		IL_032b: ldc.r8 3
-		IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0339: stloc.s 7
-		IL_033b: ldloc.s 7
-		IL_033d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0342: stloc.s 6
-		IL_0344: ldloc.s 5
-		IL_0346: ldstr "isUint16Array"
-		IL_034b: ldloc.s 6
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0352: stloc.s 5
-		IL_0354: ldloc.s 4
-		IL_0356: ldloc.s 5
-		IL_0358: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_035d: pop
-		IL_035e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0363: stloc.s 4
-		IL_0365: ldloc.1
-		IL_0366: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
-		IL_036b: stloc.s 5
-		IL_036d: ldloc.s 5
-		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0374: ldstr "isSharedArrayBuffer"
-		IL_0379: ldloc.2
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_037f: stloc.s 5
-		IL_0381: ldloc.s 4
-		IL_0383: ldloc.s 5
-		IL_0385: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_038a: pop
-		IL_038b: ret
+		IL_0060: volatile.
+		IL_0062: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0067: brfalse IL_007c
+
+		IL_006c: ldstr "isArrayBuffer"
+		IL_0071: ldloc.2
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0077: br IL_0091
+
+		IL_007c: ldstr "isArrayBuffer"
+		IL_0081: ldloc.2
+		IL_0082: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:24"
+		IL_0087: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0091: stloc.s 5
+		IL_0093: ldloc.s 4
+		IL_0095: ldloc.s 5
+		IL_0097: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009c: pop
+		IL_009d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a2: stloc.s 4
+		IL_00a4: ldloc.1
+		IL_00a5: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_00aa: stloc.s 5
+		IL_00ac: ldloc.s 5
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b3: stloc.s 5
+		IL_00b5: ldc.r8 4
+		IL_00be: box [System.Runtime]System.Double
+		IL_00c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_00c8: stloc.s 6
+		IL_00ca: volatile.
+		IL_00cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00d1: brfalse IL_00e9
+
+		IL_00d6: ldloc.s 5
+		IL_00d8: ldstr "isArrayBuffer"
+		IL_00dd: ldloc.s 6
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e4: br IL_0101
+
+		IL_00e9: ldloc.s 5
+		IL_00eb: ldstr "isArrayBuffer"
+		IL_00f0: ldloc.s 6
+		IL_00f2: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:33"
+		IL_00f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0101: stloc.s 5
+		IL_0103: ldloc.s 4
+		IL_0105: ldloc.s 5
+		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010c: pop
+		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0112: stloc.s 4
+		IL_0114: ldloc.1
+		IL_0115: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_011a: stloc.s 5
+		IL_011c: ldloc.s 5
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0123: volatile.
+		IL_0125: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_012a: brfalse IL_013f
+
+		IL_012f: ldstr "isAnyArrayBuffer"
+		IL_0134: ldloc.2
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_013a: br IL_0154
+
+		IL_013f: ldstr "isAnyArrayBuffer"
+		IL_0144: ldloc.2
+		IL_0145: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:39"
+		IL_014a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0154: stloc.s 5
+		IL_0156: ldloc.s 4
+		IL_0158: ldloc.s 5
+		IL_015a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015f: pop
+		IL_0160: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0165: stloc.s 4
+		IL_0167: ldloc.1
+		IL_0168: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_016d: stloc.s 5
+		IL_016f: ldloc.s 5
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0176: volatile.
+		IL_0178: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_017d: brfalse IL_0192
+
+		IL_0182: ldstr "isDataView"
+		IL_0187: ldloc.3
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018d: br IL_01a7
+
+		IL_0192: ldstr "isDataView"
+		IL_0197: ldloc.3
+		IL_0198: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:45"
+		IL_019d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01a7: stloc.s 5
+		IL_01a9: ldloc.s 4
+		IL_01ab: ldloc.s 5
+		IL_01ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b2: pop
+		IL_01b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b8: stloc.s 4
+		IL_01ba: ldloc.1
+		IL_01bb: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_01c0: stloc.s 5
+		IL_01c2: ldloc.s 5
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c9: volatile.
+		IL_01cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01d0: brfalse IL_01e5
+
+		IL_01d5: ldstr "isDataView"
+		IL_01da: ldloc.2
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e0: br IL_01fa
+
+		IL_01e5: ldstr "isDataView"
+		IL_01ea: ldloc.2
+		IL_01eb: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:51"
+		IL_01f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01fa: stloc.s 5
+		IL_01fc: ldloc.s 4
+		IL_01fe: ldloc.s 5
+		IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0205: pop
+		IL_0206: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_020b: stloc.s 4
+		IL_020d: ldloc.1
+		IL_020e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_0213: stloc.s 5
+		IL_0215: ldloc.s 5
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021c: stloc.s 5
+		IL_021e: ldc.i4.3
+		IL_021f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0224: dup
+		IL_0225: ldc.r8 1
+		IL_022e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0233: dup
+		IL_0234: ldc.r8 2
+		IL_023d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0242: dup
+		IL_0243: ldc.r8 3
+		IL_024c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0251: stloc.s 7
+		IL_0253: ldloc.s 7
+		IL_0255: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_025a: stloc.s 8
+		IL_025c: volatile.
+		IL_025e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0263: brfalse IL_027b
+
+		IL_0268: ldloc.s 5
+		IL_026a: ldstr "isInt32Array"
+		IL_026f: ldloc.s 8
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0276: br IL_0293
+
+		IL_027b: ldloc.s 5
+		IL_027d: ldstr "isInt32Array"
+		IL_0282: ldloc.s 8
+		IL_0284: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:62"
+		IL_0289: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0293: stloc.s 5
+		IL_0295: ldloc.s 4
+		IL_0297: ldloc.s 5
+		IL_0299: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029e: pop
+		IL_029f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a4: stloc.s 4
+		IL_02a6: ldloc.1
+		IL_02a7: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_02ac: stloc.s 5
+		IL_02ae: ldloc.s 5
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b5: stloc.s 5
+		IL_02b7: ldc.i4.3
+		IL_02b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02bd: dup
+		IL_02be: ldc.r8 1
+		IL_02c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02cc: dup
+		IL_02cd: ldc.r8 2
+		IL_02d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02db: dup
+		IL_02dc: ldc.r8 3
+		IL_02e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02ea: stloc.s 7
+		IL_02ec: ldloc.s 7
+		IL_02ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_02f3: stloc.s 6
+		IL_02f5: volatile.
+		IL_02f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02fc: brfalse IL_0314
+
+		IL_0301: ldloc.s 5
+		IL_0303: ldstr "isUint8Array"
+		IL_0308: ldloc.s 6
+		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030f: br IL_032c
+
+		IL_0314: ldloc.s 5
+		IL_0316: ldstr "isUint8Array"
+		IL_031b: ldloc.s 6
+		IL_031d: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:73"
+		IL_0322: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_032c: stloc.s 5
+		IL_032e: ldloc.s 4
+		IL_0330: ldloc.s 5
+		IL_0332: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0337: pop
+		IL_0338: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_033d: stloc.s 4
+		IL_033f: ldloc.1
+		IL_0340: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_0345: stloc.s 5
+		IL_0347: ldloc.s 5
+		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_034e: ldc.i4.3
+		IL_034f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0354: dup
+		IL_0355: ldc.r8 1
+		IL_035e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0363: dup
+		IL_0364: ldc.r8 2
+		IL_036d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0372: dup
+		IL_0373: ldc.r8 3
+		IL_037c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0381: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0386: stloc.s 9
+		IL_0388: volatile.
+		IL_038a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_038f: brfalse IL_03a5
+
+		IL_0394: ldstr "isUint8Array"
+		IL_0399: ldloc.s 9
+		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a0: br IL_03bb
+
+		IL_03a5: ldstr "isUint8Array"
+		IL_03aa: ldloc.s 9
+		IL_03ac: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:84"
+		IL_03b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03bb: stloc.s 5
+		IL_03bd: ldloc.s 4
+		IL_03bf: ldloc.s 5
+		IL_03c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03c6: pop
+		IL_03c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03cc: stloc.s 4
+		IL_03ce: ldloc.1
+		IL_03cf: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_03d4: stloc.s 5
+		IL_03d6: ldloc.s 5
+		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03dd: stloc.s 5
+		IL_03df: ldc.i4.2
+		IL_03e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_03e5: dup
+		IL_03e6: ldc.r8 1.5
+		IL_03ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_03f4: dup
+		IL_03f5: ldc.r8 2.5
+		IL_03fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0403: stloc.s 7
+		IL_0405: ldloc.s 7
+		IL_0407: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Float64Array::.ctor(object)
+		IL_040c: stloc.s 10
+		IL_040e: volatile.
+		IL_0410: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0415: brfalse IL_042d
+
+		IL_041a: ldloc.s 5
+		IL_041c: ldstr "isFloat64Array"
+		IL_0421: ldloc.s 10
+		IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0428: br IL_0445
+
+		IL_042d: ldloc.s 5
+		IL_042f: ldstr "isFloat64Array"
+		IL_0434: ldloc.s 10
+		IL_0436: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:94"
+		IL_043b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0445: stloc.s 5
+		IL_0447: ldloc.s 4
+		IL_0449: ldloc.s 5
+		IL_044b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0450: pop
+		IL_0451: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0456: stloc.s 4
+		IL_0458: ldloc.1
+		IL_0459: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_045e: stloc.s 5
+		IL_0460: ldloc.s 5
+		IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0467: stloc.s 5
+		IL_0469: ldc.i4.3
+		IL_046a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_046f: dup
+		IL_0470: ldc.r8 1
+		IL_0479: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_047e: dup
+		IL_047f: ldc.r8 2
+		IL_0488: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_048d: dup
+		IL_048e: ldc.r8 3
+		IL_0497: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_049c: stloc.s 7
+		IL_049e: ldloc.s 7
+		IL_04a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_04a5: stloc.s 6
+		IL_04a7: volatile.
+		IL_04a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_04ae: brfalse IL_04c6
+
+		IL_04b3: ldloc.s 5
+		IL_04b5: ldstr "isUint16Array"
+		IL_04ba: ldloc.s 6
+		IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04c1: br IL_04de
+
+		IL_04c6: ldloc.s 5
+		IL_04c8: ldstr "isUint16Array"
+		IL_04cd: ldloc.s 6
+		IL_04cf: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:105"
+		IL_04d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_04de: stloc.s 5
+		IL_04e0: ldloc.s 4
+		IL_04e2: ldloc.s 5
+		IL_04e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04e9: pop
+		IL_04ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04ef: stloc.s 4
+		IL_04f1: ldloc.1
+		IL_04f2: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule::get_types()
+		IL_04f7: stloc.s 5
+		IL_04f9: ldloc.s 5
+		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0500: volatile.
+		IL_0502: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0507: brfalse IL_051c
+
+		IL_050c: ldstr "isSharedArrayBuffer"
+		IL_0511: ldloc.2
+		IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0517: br IL_0531
+
+		IL_051c: ldstr "isSharedArrayBuffer"
+		IL_0521: ldloc.2
+		IL_0522: ldstr "Require_Util_Types_TypedBinary:Modules.Require_Util_Types_TypedBinary:__js_module_init__:111"
+		IL_0527: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0531: stloc.s 5
+		IL_0533: ldloc.s 4
+		IL_0535: ldloc.s 5
+		IL_0537: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_053c: pop
+		IL_053d: ret
 	} // end of method Require_Util_Types_TypedBinary::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_TypedBinary
@@ -411,4 +548,22 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -328,7 +328,7 @@
 				IL_0092: call string [System.Runtime]System.String::Concat(string, string)
 				IL_0097: stloc.s 5
 				IL_0099: volatile.
-				IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+				IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 				IL_00a0: brfalse IL_00b5
 
 				IL_00a5: ldloc.2
@@ -339,7 +339,7 @@
 				IL_00b5: ldloc.2
 				IL_00b6: ldstr "name"
 				IL_00bb: ldstr "Require_Zlib_ErrorPaths:<TwoPhaseDummy_M4>:__js_call__:36"
-				IL_00c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+				IL_00c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00ca: stloc.s 6
@@ -355,7 +355,7 @@
 				IL_00e5: call string [System.Runtime]System.String::Concat(string, string)
 				IL_00ea: stloc.s 5
 				IL_00ec: volatile.
-				IL_00ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+				IL_00ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 				IL_00f3: brfalse IL_0108
 
 				IL_00f8: ldloc.2
@@ -366,7 +366,7 @@
 				IL_0108: ldloc.2
 				IL_0109: ldstr "message"
 				IL_010e: ldstr "Require_Zlib_ErrorPaths:<TwoPhaseDummy_M4>:__js_call__:44"
-				IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+				IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 				IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_011d: stloc.s 6
@@ -1124,7 +1124,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1131 (0x46b)
+		// Code size: 1215 (0x4bf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_ErrorPaths/Scope,
@@ -1206,360 +1206,384 @@
 		IL_0089: stloc.s 11
 		IL_008b: ldloc.s 11
 		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0092: ldstr "toString"
-		IL_0097: ldstr "utf8"
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a1: stloc.s 11
-		IL_00a3: ldloc.s 8
-		IL_00a5: ldstr "gzip level -1 roundtrip:"
-		IL_00aa: ldloc.s 11
-		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00b1: pop
-		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b7: stloc.s 8
-		IL_00b9: ldloc.0
-		IL_00ba: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_00bf: stloc.s 7
-		IL_00c1: ldloc.0
-		IL_00c2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
-		IL_00c7: stloc.s 9
-		IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00ce: dup
-		IL_00cf: ldstr "level"
-		IL_00d4: ldc.r8 1.5
-		IL_00dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00e2: stloc.s 10
-		IL_00e4: ldloc.s 9
-		IL_00e6: ldstr "abc"
-		IL_00eb: ldloc.s 10
-		IL_00ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
-		IL_00f2: stloc.s 11
-		IL_00f4: ldloc.s 7
-		IL_00f6: ldloc.s 11
-		IL_00f8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
-		IL_00fd: stloc.s 11
-		IL_00ff: ldloc.s 11
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0106: ldstr "toString"
-		IL_010b: ldstr "utf8"
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0115: stloc.s 11
-		IL_0117: ldloc.s 8
-		IL_0119: ldstr "gzip level 1.5 roundtrip:"
-		IL_011e: ldloc.s 11
-		IL_0120: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0125: pop
-		IL_0126: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_012b: stloc.s 6
-		IL_012d: ldc.i4.1
-		IL_012e: newarr [System.Runtime]System.Object
-		IL_0133: dup
-		IL_0134: ldc.i4.0
-		IL_0135: ldloc.0
-		IL_0136: stelem.ref
-		IL_0137: stloc.s 12
-		IL_0139: ldloc.s 12
-		IL_013b: ldc.i4.0
-		IL_013c: ldelem.ref
-		IL_013d: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0142: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
-		IL_0147: ldc.i4.0
-		IL_0148: conv.r8
-		IL_0149: ldstr ""
-		IL_014e: ldc.i4.0
-		IL_014f: ldc.i4.0
-		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0155: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject>(!!0)
-		IL_015a: stloc.s 13
-		IL_015c: ldloc.1
-		IL_015d: ldloc.s 6
-		IL_015f: ldstr "gzip unsupported option"
-		IL_0164: ldloc.s 13
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_016b: pop
-		IL_016c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0171: stloc.s 6
-		IL_0173: ldc.i4.1
-		IL_0174: newarr [System.Runtime]System.Object
-		IL_0179: dup
-		IL_017a: ldc.i4.0
-		IL_017b: ldloc.0
-		IL_017c: stelem.ref
-		IL_017d: stloc.s 12
-		IL_017f: ldloc.s 12
-		IL_0181: ldc.i4.0
-		IL_0182: ldelem.ref
-		IL_0183: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0188: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
-		IL_018d: ldc.i4.0
-		IL_018e: conv.r8
-		IL_018f: ldstr ""
-		IL_0194: ldc.i4.0
-		IL_0195: ldc.i4.0
-		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_019b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject>(!!0)
-		IL_01a0: stloc.s 14
-		IL_01a2: ldloc.1
-		IL_01a3: ldloc.s 6
-		IL_01a5: ldstr "gunzip unsupported option"
-		IL_01aa: ldloc.s 14
-		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01b1: pop
-		IL_01b2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b7: stloc.s 6
-		IL_01b9: ldc.i4.1
-		IL_01ba: newarr [System.Runtime]System.Object
-		IL_01bf: dup
-		IL_01c0: ldc.i4.0
-		IL_01c1: ldloc.0
-		IL_01c2: stelem.ref
-		IL_01c3: stloc.s 12
-		IL_01c5: ldloc.s 12
-		IL_01c7: ldc.i4.0
-		IL_01c8: ldelem.ref
-		IL_01c9: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_01ce: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
-		IL_01d3: ldc.i4.0
-		IL_01d4: conv.r8
-		IL_01d5: ldstr ""
-		IL_01da: ldc.i4.0
-		IL_01db: ldc.i4.0
-		IL_01dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject>(!!0)
-		IL_01e6: stloc.s 15
-		IL_01e8: ldloc.1
-		IL_01e9: ldloc.s 6
-		IL_01eb: ldstr "gzip bad level"
-		IL_01f0: ldloc.s 15
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01f7: pop
-		IL_01f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01fd: stloc.s 6
-		IL_01ff: ldc.i4.1
-		IL_0200: newarr [System.Runtime]System.Object
-		IL_0205: dup
-		IL_0206: ldc.i4.0
-		IL_0207: ldloc.0
-		IL_0208: stelem.ref
-		IL_0209: stloc.s 12
-		IL_020b: ldloc.s 12
-		IL_020d: ldc.i4.0
-		IL_020e: ldelem.ref
-		IL_020f: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0214: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
-		IL_0219: ldc.i4.0
-		IL_021a: conv.r8
-		IL_021b: ldstr ""
-		IL_0220: ldc.i4.0
-		IL_0221: ldc.i4.0
-		IL_0222: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0227: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject>(!!0)
-		IL_022c: stloc.s 16
-		IL_022e: ldloc.1
-		IL_022f: ldloc.s 6
-		IL_0231: ldstr "gzip NaN level"
-		IL_0236: ldloc.s 16
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_023d: pop
-		IL_023e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0243: stloc.s 6
-		IL_0245: ldc.i4.1
-		IL_0246: newarr [System.Runtime]System.Object
-		IL_024b: dup
-		IL_024c: ldc.i4.0
-		IL_024d: ldloc.0
-		IL_024e: stelem.ref
-		IL_024f: stloc.s 12
-		IL_0251: ldloc.s 12
-		IL_0253: ldc.i4.0
-		IL_0254: ldelem.ref
-		IL_0255: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_025a: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
-		IL_025f: ldc.i4.0
-		IL_0260: conv.r8
-		IL_0261: ldstr ""
-		IL_0266: ldc.i4.0
-		IL_0267: ldc.i4.0
-		IL_0268: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_026d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0)
-		IL_0272: stloc.s 17
-		IL_0274: ldloc.1
-		IL_0275: ldloc.s 6
-		IL_0277: ldstr "gzip Infinity level"
-		IL_027c: ldloc.s 17
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0283: pop
+		IL_0092: volatile.
+		IL_0094: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0099: brfalse IL_00b2
+
+		IL_009e: ldstr "toString"
+		IL_00a3: ldstr "utf8"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ad: br IL_00cb
+
+		IL_00b2: ldstr "toString"
+		IL_00b7: ldstr "utf8"
+		IL_00bc: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:25"
+		IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00cb: stloc.s 11
+		IL_00cd: ldloc.s 8
+		IL_00cf: ldstr "gzip level -1 roundtrip:"
+		IL_00d4: ldloc.s 11
+		IL_00d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00db: pop
+		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e1: stloc.s 8
+		IL_00e3: ldloc.0
+		IL_00e4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_00e9: stloc.s 7
+		IL_00eb: ldloc.0
+		IL_00ec: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+		IL_00f1: stloc.s 9
+		IL_00f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00f8: dup
+		IL_00f9: ldstr "level"
+		IL_00fe: ldc.r8 1.5
+		IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_010c: stloc.s 10
+		IL_010e: ldloc.s 9
+		IL_0110: ldstr "abc"
+		IL_0115: ldloc.s 10
+		IL_0117: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gzipSync(object, object)
+		IL_011c: stloc.s 11
+		IL_011e: ldloc.s 7
+		IL_0120: ldloc.s 11
+		IL_0122: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
+		IL_0127: stloc.s 11
+		IL_0129: ldloc.s 11
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0130: volatile.
+		IL_0132: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0137: brfalse IL_0150
+
+		IL_013c: ldstr "toString"
+		IL_0141: ldstr "utf8"
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014b: br IL_0169
+
+		IL_0150: ldstr "toString"
+		IL_0155: ldstr "utf8"
+		IL_015a: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:39"
+		IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0169: stloc.s 11
+		IL_016b: ldloc.s 8
+		IL_016d: ldstr "gzip level 1.5 roundtrip:"
+		IL_0172: ldloc.s 11
+		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0179: pop
+		IL_017a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017f: stloc.s 6
+		IL_0181: ldc.i4.1
+		IL_0182: newarr [System.Runtime]System.Object
+		IL_0187: dup
+		IL_0188: ldc.i4.0
+		IL_0189: ldloc.0
+		IL_018a: stelem.ref
+		IL_018b: stloc.s 12
+		IL_018d: ldloc.s 12
+		IL_018f: ldc.i4.0
+		IL_0190: ldelem.ref
+		IL_0191: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0196: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_019b: ldc.i4.0
+		IL_019c: conv.r8
+		IL_019d: ldstr ""
+		IL_01a2: ldc.i4.0
+		IL_01a3: ldc.i4.0
+		IL_01a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject>(!!0)
+		IL_01ae: stloc.s 13
+		IL_01b0: ldloc.1
+		IL_01b1: ldloc.s 6
+		IL_01b3: ldstr "gzip unsupported option"
+		IL_01b8: ldloc.s 13
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01bf: pop
+		IL_01c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01c5: stloc.s 6
+		IL_01c7: ldc.i4.1
+		IL_01c8: newarr [System.Runtime]System.Object
+		IL_01cd: dup
+		IL_01ce: ldc.i4.0
+		IL_01cf: ldloc.0
+		IL_01d0: stelem.ref
+		IL_01d1: stloc.s 12
+		IL_01d3: ldloc.s 12
+		IL_01d5: ldc.i4.0
+		IL_01d6: ldelem.ref
+		IL_01d7: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_01dc: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_01e1: ldc.i4.0
+		IL_01e2: conv.r8
+		IL_01e3: ldstr ""
+		IL_01e8: ldc.i4.0
+		IL_01e9: ldc.i4.0
+		IL_01ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject>(!!0)
+		IL_01f4: stloc.s 14
+		IL_01f6: ldloc.1
+		IL_01f7: ldloc.s 6
+		IL_01f9: ldstr "gunzip unsupported option"
+		IL_01fe: ldloc.s 14
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0205: pop
+		IL_0206: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_020b: stloc.s 6
+		IL_020d: ldc.i4.1
+		IL_020e: newarr [System.Runtime]System.Object
+		IL_0213: dup
+		IL_0214: ldc.i4.0
+		IL_0215: ldloc.0
+		IL_0216: stelem.ref
+		IL_0217: stloc.s 12
+		IL_0219: ldloc.s 12
+		IL_021b: ldc.i4.0
+		IL_021c: ldelem.ref
+		IL_021d: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0222: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_0227: ldc.i4.0
+		IL_0228: conv.r8
+		IL_0229: ldstr ""
+		IL_022e: ldc.i4.0
+		IL_022f: ldc.i4.0
+		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject>(!!0)
+		IL_023a: stloc.s 15
+		IL_023c: ldloc.1
+		IL_023d: ldloc.s 6
+		IL_023f: ldstr "gzip bad level"
+		IL_0244: ldloc.s 15
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_024b: pop
+		IL_024c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0251: stloc.s 6
+		IL_0253: ldc.i4.1
+		IL_0254: newarr [System.Runtime]System.Object
+		IL_0259: dup
+		IL_025a: ldc.i4.0
+		IL_025b: ldloc.0
+		IL_025c: stelem.ref
+		IL_025d: stloc.s 12
+		IL_025f: ldloc.s 12
+		IL_0261: ldc.i4.0
+		IL_0262: ldelem.ref
+		IL_0263: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0268: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_026d: ldc.i4.0
+		IL_026e: conv.r8
+		IL_026f: ldstr ""
+		IL_0274: ldc.i4.0
+		IL_0275: ldc.i4.0
+		IL_0276: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_027b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject>(!!0)
+		IL_0280: stloc.s 16
+		IL_0282: ldloc.1
+		IL_0283: ldloc.s 6
+		IL_0285: ldstr "gzip NaN level"
+		IL_028a: ldloc.s 16
+		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0291: pop
+		IL_0292: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0297: stloc.s 6
+		IL_0299: ldc.i4.1
+		IL_029a: newarr [System.Runtime]System.Object
+		IL_029f: dup
+		IL_02a0: ldc.i4.0
+		IL_02a1: ldloc.0
+		IL_02a2: stelem.ref
+		IL_02a3: stloc.s 12
+		IL_02a5: ldloc.s 12
+		IL_02a7: ldc.i4.0
+		IL_02a8: ldelem.ref
+		IL_02a9: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_02ae: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_02b3: ldc.i4.0
+		IL_02b4: conv.r8
+		IL_02b5: ldstr ""
+		IL_02ba: ldc.i4.0
+		IL_02bb: ldc.i4.0
+		IL_02bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0)
+		IL_02c6: stloc.s 17
+		IL_02c8: ldloc.1
+		IL_02c9: ldloc.s 6
+		IL_02cb: ldstr "gzip Infinity level"
+		IL_02d0: ldloc.s 17
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02d7: pop
 		.try
 		{
-			IL_0284: nop
-			IL_0285: ldloc.0
-			IL_0286: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_028b: stloc.s 7
-			IL_028d: ldstr "not gzip"
-			IL_0292: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_0297: stloc.s 18
-			IL_0299: ldloc.s 7
-			IL_029b: ldloc.s 18
-			IL_029d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
-			IL_02a2: pop
-			IL_02a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02a8: stloc.s 8
-			IL_02aa: ldloc.s 8
-			IL_02ac: ldstr "gunzip invalid data threw:"
-			IL_02b1: ldc.i4.0
-			IL_02b2: box [System.Runtime]System.Boolean
-			IL_02b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_02bc: pop
-			IL_02bd: leave IL_0467
+			IL_02d8: nop
+			IL_02d9: ldloc.0
+			IL_02da: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_02df: stloc.s 7
+			IL_02e1: ldstr "not gzip"
+			IL_02e6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_02eb: stloc.s 18
+			IL_02ed: ldloc.s 7
+			IL_02ef: ldloc.s 18
+			IL_02f1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
+			IL_02f6: pop
+			IL_02f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02fc: stloc.s 8
+			IL_02fe: ldloc.s 8
+			IL_0300: ldstr "gunzip invalid data threw:"
+			IL_0305: ldc.i4.0
+			IL_0306: box [System.Runtime]System.Boolean
+			IL_030b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0310: pop
+			IL_0311: leave IL_04bb
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02c2: stloc.2
-			IL_02c3: ldloc.2
-			IL_02c4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02c9: dup
-			IL_02ca: brtrue IL_02df
+			IL_0316: stloc.2
+			IL_0317: ldloc.2
+			IL_0318: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_031d: dup
+			IL_031e: brtrue IL_0333
 
-			IL_02cf: pop
-			IL_02d0: ldloc.2
-			IL_02d1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02d6: dup
-			IL_02d7: brtrue IL_02ea
+			IL_0323: pop
+			IL_0324: ldloc.2
+			IL_0325: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_032a: dup
+			IL_032b: brtrue IL_033e
 
-			IL_02dc: pop
-			IL_02dd: rethrow
+			IL_0330: pop
+			IL_0331: rethrow
 
-			IL_02df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02e4: stloc.3
-			IL_02e5: br IL_02eb
+			IL_0333: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0338: stloc.3
+			IL_0339: br IL_033f
 
-			IL_02ea: stloc.3
+			IL_033e: stloc.3
 
-			IL_02eb: ldloc.3
-			IL_02ec: stloc.s 4
-			IL_02ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02f3: stloc.s 8
-			IL_02f5: ldloc.s 8
-			IL_02f7: ldstr "gunzip invalid data threw:"
-			IL_02fc: ldc.i4.1
-			IL_02fd: box [System.Runtime]System.Boolean
-			IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0307: pop
-			IL_0308: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_030d: stloc.s 8
-			IL_030f: volatile.
-			IL_0311: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_0316: brfalse IL_032c
+			IL_033f: ldloc.3
+			IL_0340: stloc.s 4
+			IL_0342: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0347: stloc.s 8
+			IL_0349: ldloc.s 8
+			IL_034b: ldstr "gunzip invalid data threw:"
+			IL_0350: ldc.i4.1
+			IL_0351: box [System.Runtime]System.Boolean
+			IL_0356: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_035b: pop
+			IL_035c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0361: stloc.s 8
+			IL_0363: volatile.
+			IL_0365: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_036a: brfalse IL_0380
 
-			IL_031b: ldloc.s 4
-			IL_031d: ldstr "name"
-			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0327: br IL_0342
+			IL_036f: ldloc.s 4
+			IL_0371: ldstr "name"
+			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_037b: br IL_0396
 
-			IL_032c: ldloc.s 4
-			IL_032e: ldstr "name"
-			IL_0333: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:102"
-			IL_0338: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0380: ldloc.s 4
+			IL_0382: ldstr "name"
+			IL_0387: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:102"
+			IL_038c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0342: stloc.s 11
-			IL_0344: ldloc.s 8
-			IL_0346: ldstr "gunzip invalid data name:"
-			IL_034b: ldloc.s 11
-			IL_034d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0352: pop
-			IL_0353: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0358: stloc.s 8
-			IL_035a: volatile.
-			IL_035c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_0361: brfalse IL_0377
+			IL_0396: stloc.s 11
+			IL_0398: ldloc.s 8
+			IL_039a: ldstr "gunzip invalid data name:"
+			IL_039f: ldloc.s 11
+			IL_03a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_03a6: pop
+			IL_03a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ac: stloc.s 8
+			IL_03ae: volatile.
+			IL_03b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_03b5: brfalse IL_03cb
 
-			IL_0366: ldloc.s 4
-			IL_0368: ldstr "message"
-			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0372: br IL_038d
-
-			IL_0377: ldloc.s 4
-			IL_0379: ldstr "message"
-			IL_037e: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:108"
-			IL_0383: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_038d: stloc.s 11
-			IL_038f: ldloc.s 11
-			IL_0391: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_0396: stloc.s 19
-			IL_0398: ldloc.s 19
-			IL_039a: ldstr "string"
-			IL_039f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_03a4: stloc.s 20
-			IL_03a6: ldloc.s 20
-			IL_03a8: box [System.Runtime]System.Boolean
-			IL_03ad: stloc.s 21
-			IL_03af: ldloc.s 21
-			IL_03b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03b6: stloc.s 20
-			IL_03b8: ldloc.s 20
-			IL_03ba: brfalse IL_044f
-
-			IL_03bf: volatile.
-			IL_03c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_03c6: brfalse IL_03dc
+			IL_03ba: ldloc.s 4
+			IL_03bc: ldstr "message"
+			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c6: br IL_03e1
 
 			IL_03cb: ldloc.s 4
 			IL_03cd: ldstr "message"
-			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03d7: br IL_03f2
+			IL_03d2: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:108"
+			IL_03d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03dc: ldloc.s 4
-			IL_03de: ldstr "message"
-			IL_03e3: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:116"
-			IL_03e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03e1: stloc.s 11
+			IL_03e3: ldloc.s 11
+			IL_03e5: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_03ea: stloc.s 19
+			IL_03ec: ldloc.s 19
+			IL_03ee: ldstr "string"
+			IL_03f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_03f8: stloc.s 20
+			IL_03fa: ldloc.s 20
+			IL_03fc: box [System.Runtime]System.Boolean
+			IL_0401: stloc.s 21
+			IL_0403: ldloc.s 21
+			IL_0405: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_040a: stloc.s 20
+			IL_040c: ldloc.s 20
+			IL_040e: brfalse IL_04a3
 
-			IL_03f2: stloc.s 11
-			IL_03f4: volatile.
-			IL_03f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_03fb: brfalse IL_0411
+			IL_0413: volatile.
+			IL_0415: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_041a: brfalse IL_0430
 
-			IL_0400: ldloc.s 11
-			IL_0402: ldstr "length"
-			IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_040c: br IL_0427
+			IL_041f: ldloc.s 4
+			IL_0421: ldstr "message"
+			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_042b: br IL_0446
 
-			IL_0411: ldloc.s 11
-			IL_0413: ldstr "length"
-			IL_0418: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:118"
-			IL_041d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0430: ldloc.s 4
+			IL_0432: ldstr "message"
+			IL_0437: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:116"
+			IL_043c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0427: stloc.s 11
-			IL_0429: ldloc.s 11
-			IL_042b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0430: ldc.r8 0.0
-			IL_0439: cgt
-			IL_043b: stloc.s 20
-			IL_043d: ldloc.s 20
-			IL_043f: box [System.Runtime]System.Boolean
-			IL_0444: stloc.s 22
-			IL_0446: ldloc.s 22
-			IL_0448: stloc.s 24
-			IL_044a: br IL_0453
+			IL_0446: stloc.s 11
+			IL_0448: volatile.
+			IL_044a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_044f: brfalse IL_0465
 
-			IL_044f: ldloc.s 21
-			IL_0451: stloc.s 24
+			IL_0454: ldloc.s 11
+			IL_0456: ldstr "length"
+			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0460: br IL_047b
 
-			IL_0453: ldloc.s 8
-			IL_0455: ldstr "gunzip invalid data message length > 0:"
-			IL_045a: ldloc.s 24
-			IL_045c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0461: pop
-			IL_0462: leave IL_0467
+			IL_0465: ldloc.s 11
+			IL_0467: ldstr "length"
+			IL_046c: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:118"
+			IL_0471: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_047b: stloc.s 11
+			IL_047d: ldloc.s 11
+			IL_047f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0484: ldc.r8 0.0
+			IL_048d: cgt
+			IL_048f: stloc.s 20
+			IL_0491: ldloc.s 20
+			IL_0493: box [System.Runtime]System.Boolean
+			IL_0498: stloc.s 22
+			IL_049a: ldloc.s 22
+			IL_049c: stloc.s 24
+			IL_049e: br IL_04a7
+
+			IL_04a3: ldloc.s 21
+			IL_04a5: stloc.s 24
+
+			IL_04a7: ldloc.s 8
+			IL_04a9: ldstr "gunzip invalid data message length > 0:"
+			IL_04ae: ldloc.s 24
+			IL_04b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_04b5: pop
+			IL_04b6: leave IL_04bb
 		} // end handler
 
-		IL_0467: ldnull
-		IL_0468: stloc.s 5
-		IL_046a: ret
+		IL_04bb: ldnull
+		IL_04bc: stloc.s 5
+		IL_04be: ret
 	} // end of method Require_Zlib_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Zlib_ErrorPaths
@@ -1595,6 +1619,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_GzipSync_GunzipSync_RoundTrip.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_GzipSync_GunzipSync_RoundTrip.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 255 (0xff)
+		// Code size: 297 (0x129)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_GzipSync_GunzipSync_RoundTrip/Scope,
@@ -144,60 +144,72 @@
 		IL_0045: stloc.s 6
 		IL_0047: ldloc.s 6
 		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: ldstr "toString"
-		IL_0053: ldstr "utf8"
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005d: stloc.s 4
-		IL_005f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0064: stloc.s 7
-		IL_0066: ldloc.3
-		IL_0067: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
-		IL_006c: box [System.Runtime]System.Boolean
-		IL_0071: stloc.s 8
-		IL_0073: ldloc.s 7
-		IL_0075: ldstr "compressed buffer:"
-		IL_007a: ldloc.s 8
-		IL_007c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0081: pop
-		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0087: stloc.s 7
-		IL_0089: volatile.
-		IL_008b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0090: brfalse IL_00a5
+		IL_004e: volatile.
+		IL_0050: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0055: brfalse IL_006e
 
-		IL_0095: ldloc.3
-		IL_0096: ldstr "length"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a0: br IL_00ba
+		IL_005a: ldstr "toString"
+		IL_005f: ldstr "utf8"
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0069: br IL_0087
 
-		IL_00a5: ldloc.3
-		IL_00a6: ldstr "length"
-		IL_00ab: ldstr "Require_Zlib_GzipSync_GunzipSync_RoundTrip:Modules.Require_Zlib_GzipSync_GunzipSync_RoundTrip:__js_module_init__:32"
-		IL_00b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_006e: ldstr "toString"
+		IL_0073: ldstr "utf8"
+		IL_0078: ldstr "Require_Zlib_GzipSync_GunzipSync_RoundTrip:Modules.Require_Zlib_GzipSync_GunzipSync_RoundTrip:__js_module_init__:20"
+		IL_007d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00ba: stloc.s 6
-		IL_00bc: ldloc.s 6
-		IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00c3: ldc.r8 0.0
-		IL_00cc: cgt
-		IL_00ce: stloc.s 9
-		IL_00d0: ldloc.s 9
-		IL_00d2: box [System.Runtime]System.Boolean
-		IL_00d7: stloc.s 8
-		IL_00d9: ldloc.s 7
-		IL_00db: ldstr "compressed length > 0:"
-		IL_00e0: ldloc.s 8
-		IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00e7: pop
-		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ed: stloc.s 7
-		IL_00ef: ldloc.s 7
-		IL_00f1: ldstr "roundtrip:"
-		IL_00f6: ldloc.s 4
-		IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00fd: pop
-		IL_00fe: ret
+		IL_0087: stloc.s 4
+		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008e: stloc.s 7
+		IL_0090: ldloc.3
+		IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::isBuffer(object)
+		IL_0096: box [System.Runtime]System.Boolean
+		IL_009b: stloc.s 8
+		IL_009d: ldloc.s 7
+		IL_009f: ldstr "compressed buffer:"
+		IL_00a4: ldloc.s 8
+		IL_00a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00ab: pop
+		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b1: stloc.s 7
+		IL_00b3: volatile.
+		IL_00b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00ba: brfalse IL_00cf
+
+		IL_00bf: ldloc.3
+		IL_00c0: ldstr "length"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ca: br IL_00e4
+
+		IL_00cf: ldloc.3
+		IL_00d0: ldstr "length"
+		IL_00d5: ldstr "Require_Zlib_GzipSync_GunzipSync_RoundTrip:Modules.Require_Zlib_GzipSync_GunzipSync_RoundTrip:__js_module_init__:32"
+		IL_00da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_00e4: stloc.s 6
+		IL_00e6: ldloc.s 6
+		IL_00e8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00ed: ldc.r8 0.0
+		IL_00f6: cgt
+		IL_00f8: stloc.s 9
+		IL_00fa: ldloc.s 9
+		IL_00fc: box [System.Runtime]System.Boolean
+		IL_0101: stloc.s 8
+		IL_0103: ldloc.s 7
+		IL_0105: ldstr "compressed length > 0:"
+		IL_010a: ldloc.s 8
+		IL_010c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0111: pop
+		IL_0112: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0117: stloc.s 7
+		IL_0119: ldloc.s 7
+		IL_011b: ldstr "roundtrip:"
+		IL_0120: ldloc.s 4
+		IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0127: pop
+		IL_0128: ret
 	} // end of method Require_Zlib_GzipSync_GunzipSync_RoundTrip::__js_module_init__
 
 } // end of class Modules.Require_Zlib_GzipSync_GunzipSync_RoundTrip
@@ -228,6 +240,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
@@ -854,7 +854,7 @@
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 125 (0x7d)
+			// Code size: 168 (0xa8)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -882,35 +882,48 @@
 			IL_0027: ldloc.2
 			IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer>(!!0)
 			IL_002d: stloc.2
-			IL_002e: ldloc.2
-			IL_002f: ldstr "toString"
-			IL_0034: ldstr "utf8"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_003e: stloc.3
-			IL_003f: ldloc.1
-			IL_0040: ldstr "output:"
-			IL_0045: ldloc.3
-			IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_004b: pop
-			IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0051: stloc.1
-			IL_0052: ldarg.0
-			IL_0053: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
-			IL_0058: ldc.i4.1
-			IL_0059: newarr [System.Runtime]System.Object
-			IL_005e: dup
-			IL_005f: ldc.i4.0
-			IL_0060: ldstr ","
-			IL_0065: stelem.ref
-			IL_0066: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_006b: stloc.s 4
-			IL_006d: ldloc.1
-			IL_006e: ldstr "events:"
-			IL_0073: ldloc.s 4
-			IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_007a: pop
-			IL_007b: ldnull
-			IL_007c: ret
+			IL_002e: volatile.
+			IL_0030: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0035: brfalse IL_004f
+
+			IL_003a: ldloc.2
+			IL_003b: ldstr "toString"
+			IL_0040: ldstr "utf8"
+			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_004a: br IL_0069
+
+			IL_004f: ldloc.2
+			IL_0050: ldstr "toString"
+			IL_0055: ldstr "utf8"
+			IL_005a: ldstr "Require_Zlib_Stream_RoundTrip:<TwoPhaseDummy_M9>:__js_call__:11"
+			IL_005f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0069: stloc.3
+			IL_006a: ldloc.1
+			IL_006b: ldstr "output:"
+			IL_0070: ldloc.3
+			IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0076: pop
+			IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_007c: stloc.1
+			IL_007d: ldarg.0
+			IL_007e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Require_Zlib_Stream_RoundTrip/Scope::events
+			IL_0083: ldc.i4.1
+			IL_0084: newarr [System.Runtime]System.Object
+			IL_0089: dup
+			IL_008a: ldc.i4.0
+			IL_008b: ldstr ","
+			IL_0090: stelem.ref
+			IL_0091: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0096: stloc.s 4
+			IL_0098: ldloc.1
+			IL_0099: ldstr "events:"
+			IL_009e: ldloc.s 4
+			IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00a5: pop
+			IL_00a6: ldnull
+			IL_00a7: ret
 		} // end of method FunctionExpression_L23C22::__js_call__
 
 	} // end of class FunctionExpression_L23C22
@@ -955,7 +968,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 724 (0x2d4)
+		// Code size: 962 (0x3c2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_Stream_RoundTrip/Scope,
@@ -1200,48 +1213,121 @@
 		IL_0240: pop
 		IL_0241: ldloc.3
 		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0247: ldstr "pipe"
-		IL_024c: ldloc.s 4
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0253: stloc.s 7
-		IL_0255: ldloc.s 7
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025c: ldstr "pipe"
-		IL_0261: ldloc.s 5
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0268: stloc.s 7
-		IL_026a: ldloc.s 7
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0271: ldstr "pipe"
-		IL_0276: ldloc.s 6
-		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_027d: pop
-		IL_027e: ldloc.3
-		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0284: ldstr "stream "
-		IL_0289: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_028e: stloc.s 17
-		IL_0290: ldstr "push"
-		IL_0295: ldloc.s 17
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_029c: pop
-		IL_029d: ldloc.3
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a3: ldstr "roundtrip"
-		IL_02a8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_02ad: stloc.s 17
-		IL_02af: ldstr "push"
-		IL_02b4: ldloc.s 17
-		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02bb: pop
-		IL_02bc: ldloc.3
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c2: ldstr "push"
-		IL_02c7: ldc.i4.0
-		IL_02c8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d2: pop
-		IL_02d3: ret
+		IL_0247: volatile.
+		IL_0249: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_024e: brfalse IL_0264
+
+		IL_0253: ldstr "pipe"
+		IL_0258: ldloc.s 4
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025f: br IL_027a
+
+		IL_0264: ldstr "pipe"
+		IL_0269: ldloc.s 4
+		IL_026b: ldstr "Require_Zlib_Stream_RoundTrip:Modules.Require_Zlib_Stream_RoundTrip:__js_module_init__:73"
+		IL_0270: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_027a: stloc.s 7
+		IL_027c: ldloc.s 7
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0283: volatile.
+		IL_0285: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_028a: brfalse IL_02a0
+
+		IL_028f: ldstr "pipe"
+		IL_0294: ldloc.s 5
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029b: br IL_02b6
+
+		IL_02a0: ldstr "pipe"
+		IL_02a5: ldloc.s 5
+		IL_02a7: ldstr "Require_Zlib_Stream_RoundTrip:Modules.Require_Zlib_Stream_RoundTrip:__js_module_init__:75"
+		IL_02ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02b6: stloc.s 7
+		IL_02b8: ldloc.s 7
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02bf: volatile.
+		IL_02c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02c6: brfalse IL_02dc
+
+		IL_02cb: ldstr "pipe"
+		IL_02d0: ldloc.s 6
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d7: br IL_02f2
+
+		IL_02dc: ldstr "pipe"
+		IL_02e1: ldloc.s 6
+		IL_02e3: ldstr "Require_Zlib_Stream_RoundTrip:Modules.Require_Zlib_Stream_RoundTrip:__js_module_init__:77"
+		IL_02e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02f2: pop
+		IL_02f3: ldloc.3
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f9: ldstr "stream "
+		IL_02fe: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0303: stloc.s 17
+		IL_0305: volatile.
+		IL_0307: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_030c: brfalse IL_0322
+
+		IL_0311: ldstr "push"
+		IL_0316: ldloc.s 17
+		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_031d: br IL_0338
+
+		IL_0322: ldstr "push"
+		IL_0327: ldloc.s 17
+		IL_0329: ldstr "Require_Zlib_Stream_RoundTrip:Modules.Require_Zlib_Stream_RoundTrip:__js_module_init__:82"
+		IL_032e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0338: pop
+		IL_0339: ldloc.3
+		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033f: ldstr "roundtrip"
+		IL_0344: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_0349: stloc.s 17
+		IL_034b: volatile.
+		IL_034d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0352: brfalse IL_0368
+
+		IL_0357: ldstr "push"
+		IL_035c: ldloc.s 17
+		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0363: br IL_037e
+
+		IL_0368: ldstr "push"
+		IL_036d: ldloc.s 17
+		IL_036f: ldstr "Require_Zlib_Stream_RoundTrip:Modules.Require_Zlib_Stream_RoundTrip:__js_module_init__:87"
+		IL_0374: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_037e: pop
+		IL_037f: ldloc.3
+		IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0385: volatile.
+		IL_0387: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_038c: brfalse IL_03a6
+
+		IL_0391: ldstr "push"
+		IL_0396: ldc.i4.0
+		IL_0397: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a1: br IL_03c0
+
+		IL_03a6: ldstr "push"
+		IL_03ab: ldc.i4.0
+		IL_03ac: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_03b1: ldstr "Require_Zlib_Stream_RoundTrip:Modules.Require_Zlib_Stream_RoundTrip:__js_module_init__:92"
+		IL_03b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03c0: pop
+		IL_03c1: ret
 	} // end of method Require_Zlib_Stream_RoundTrip::__js_module_init__
 
 } // end of class Modules.Require_Zlib_Stream_RoundTrip
@@ -1266,4 +1352,18 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
@@ -181,7 +181,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -196,7 +196,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
 			IL_0036: ldstr "ObjectLiteral_AccessorDefinitions:<TwoPhaseDummy_M4>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -448,7 +448,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -463,7 +463,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
 			IL_0036: ldstr "ObjectLiteral_AccessorDefinitions:<TwoPhaseDummy_M6>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -706,7 +706,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1256 (0x4e8)
+		// Code size: 1298 (0x512)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_AccessorDefinitions/Scope,
@@ -1012,136 +1012,148 @@
 		IL_0355: ldloc.1
 		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0360: ldstr "join"
-		IL_0365: ldstr ","
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_036f: stloc.s 8
-		IL_0371: ldloc.s 10
-		IL_0373: ldloc.s 8
-		IL_0375: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_037a: pop
-		IL_037b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0380: stloc.s 5
-		IL_0382: ldc.i4.1
-		IL_0383: newarr [System.Runtime]System.Object
-		IL_0388: dup
-		IL_0389: ldc.i4.0
-		IL_038a: ldloc.0
-		IL_038b: stelem.ref
-		IL_038c: stloc.s 6
-		IL_038e: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject::.ctor()
-		IL_0393: ldc.i4.0
-		IL_0394: conv.r8
-		IL_0395: ldstr ""
-		IL_039a: ldc.i4.0
-		IL_039b: ldc.i4.1
-		IL_039c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject>(!!0)
-		IL_03a6: stloc.s 12
-		IL_03a8: ldloc.s 12
-		IL_03aa: ldstr "x"
-		IL_03af: ldstr "get"
-		IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_03b9: stloc.s 8
-		IL_03bb: ldloc.s 5
-		IL_03bd: ldstr "x"
-		IL_03c2: ldloc.s 8
-		IL_03c4: ldnull
-		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_03ca: pop
-		IL_03cb: ldloc.s 5
-		IL_03cd: ldstr "x"
-		IL_03d2: ldc.r8 5
-		IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
-		IL_03e0: pop
-		IL_03e1: ldloc.s 5
-		IL_03e3: stloc.3
-		IL_03e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03e9: stloc.s 10
-		IL_03eb: volatile.
-		IL_03ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_03f2: brfalse IL_0407
+		IL_0360: volatile.
+		IL_0362: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0367: brfalse IL_0380
 
-		IL_03f7: ldloc.3
-		IL_03f8: ldstr "x"
-		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0402: br IL_041c
+		IL_036c: ldstr "join"
+		IL_0371: ldstr ","
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_037b: br IL_0399
 
-		IL_0407: ldloc.3
-		IL_0408: ldstr "x"
-		IL_040d: ldstr "ObjectLiteral_AccessorDefinitions:Modules.ObjectLiteral_AccessorDefinitions:__js_module_init__:103"
-		IL_0412: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0380: ldstr "join"
+		IL_0385: ldstr ","
+		IL_038a: ldstr "ObjectLiteral_AccessorDefinitions:Modules.ObjectLiteral_AccessorDefinitions:__js_module_init__:85"
+		IL_038f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_041c: stloc.s 8
-		IL_041e: ldloc.s 10
-		IL_0420: ldloc.s 8
-		IL_0422: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0427: pop
-		IL_0428: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_042d: stloc.s 5
-		IL_042f: ldc.i4.1
-		IL_0430: newarr [System.Runtime]System.Object
-		IL_0435: dup
-		IL_0436: ldc.i4.0
-		IL_0437: ldloc.0
-		IL_0438: stelem.ref
-		IL_0439: stloc.s 6
-		IL_043b: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject::.ctor()
-		IL_0440: ldc.i4.0
-		IL_0441: conv.r8
-		IL_0442: ldstr ""
-		IL_0447: ldc.i4.0
-		IL_0448: ldc.i4.1
-		IL_0449: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_044e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject>(!!0)
-		IL_0453: stloc.s 13
-		IL_0455: ldloc.s 13
-		IL_0457: ldstr "x"
-		IL_045c: ldstr "get"
-		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
-		IL_0466: stloc.s 8
-		IL_0468: ldloc.s 5
-		IL_046a: ldstr "x"
-		IL_046f: ldloc.s 8
-		IL_0471: ldnull
-		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
-		IL_0477: pop
-		IL_0478: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_047d: dup
-		IL_047e: ldstr "x"
-		IL_0483: ldc.r8 9
-		IL_048c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0491: stloc.s 14
-		IL_0493: ldloc.s 5
-		IL_0495: ldloc.s 14
-		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
-		IL_049c: pop
-		IL_049d: ldloc.s 5
-		IL_049f: stloc.s 4
-		IL_04a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04a6: stloc.s 10
-		IL_04a8: volatile.
-		IL_04aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_04af: brfalse IL_04c5
+		IL_0399: stloc.s 8
+		IL_039b: ldloc.s 10
+		IL_039d: ldloc.s 8
+		IL_039f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03a4: pop
+		IL_03a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03aa: stloc.s 5
+		IL_03ac: ldc.i4.1
+		IL_03ad: newarr [System.Runtime]System.Object
+		IL_03b2: dup
+		IL_03b3: ldc.i4.0
+		IL_03b4: ldloc.0
+		IL_03b5: stelem.ref
+		IL_03b6: stloc.s 6
+		IL_03b8: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject::.ctor()
+		IL_03bd: ldc.i4.0
+		IL_03be: conv.r8
+		IL_03bf: ldstr ""
+		IL_03c4: ldc.i4.0
+		IL_03c5: ldc.i4.1
+		IL_03c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject>(!!0)
+		IL_03d0: stloc.s 12
+		IL_03d2: ldloc.s 12
+		IL_03d4: ldstr "x"
+		IL_03d9: ldstr "get"
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_03e3: stloc.s 8
+		IL_03e5: ldloc.s 5
+		IL_03e7: ldstr "x"
+		IL_03ec: ldloc.s 8
+		IL_03ee: ldnull
+		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_03f4: pop
+		IL_03f5: ldloc.s 5
+		IL_03f7: ldstr "x"
+		IL_03fc: ldc.r8 5
+		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
+		IL_040a: pop
+		IL_040b: ldloc.s 5
+		IL_040d: stloc.3
+		IL_040e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0413: stloc.s 10
+		IL_0415: volatile.
+		IL_0417: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_041c: brfalse IL_0431
 
-		IL_04b4: ldloc.s 4
-		IL_04b6: ldstr "x"
-		IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04c0: br IL_04db
+		IL_0421: ldloc.3
+		IL_0422: ldstr "x"
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_042c: br IL_0446
 
-		IL_04c5: ldloc.s 4
-		IL_04c7: ldstr "x"
-		IL_04cc: ldstr "ObjectLiteral_AccessorDefinitions:Modules.ObjectLiteral_AccessorDefinitions:__js_module_init__:121"
-		IL_04d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0431: ldloc.3
+		IL_0432: ldstr "x"
+		IL_0437: ldstr "ObjectLiteral_AccessorDefinitions:Modules.ObjectLiteral_AccessorDefinitions:__js_module_init__:103"
+		IL_043c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04db: stloc.s 8
-		IL_04dd: ldloc.s 10
-		IL_04df: ldloc.s 8
-		IL_04e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04e6: pop
-		IL_04e7: ret
+		IL_0446: stloc.s 8
+		IL_0448: ldloc.s 10
+		IL_044a: ldloc.s 8
+		IL_044c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0451: pop
+		IL_0452: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0457: stloc.s 5
+		IL_0459: ldc.i4.1
+		IL_045a: newarr [System.Runtime]System.Object
+		IL_045f: dup
+		IL_0460: ldc.i4.0
+		IL_0461: ldloc.0
+		IL_0462: stelem.ref
+		IL_0463: stloc.s 6
+		IL_0465: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject::.ctor()
+		IL_046a: ldc.i4.0
+		IL_046b: conv.r8
+		IL_046c: ldstr ""
+		IL_0471: ldc.i4.0
+		IL_0472: ldc.i4.1
+		IL_0473: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0478: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject>(!!0)
+		IL_047d: stloc.s 13
+		IL_047f: ldloc.s 13
+		IL_0481: ldstr "x"
+		IL_0486: ldstr "get"
+		IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
+		IL_0490: stloc.s 8
+		IL_0492: ldloc.s 5
+		IL_0494: ldstr "x"
+		IL_0499: ldloc.s 8
+		IL_049b: ldnull
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralAccessorProperty(object, object, object, object)
+		IL_04a1: pop
+		IL_04a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04a7: dup
+		IL_04a8: ldstr "x"
+		IL_04ad: ldc.r8 9
+		IL_04b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_04bb: stloc.s 14
+		IL_04bd: ldloc.s 5
+		IL_04bf: ldloc.s 14
+		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
+		IL_04c6: pop
+		IL_04c7: ldloc.s 5
+		IL_04c9: stloc.s 4
+		IL_04cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04d0: stloc.s 10
+		IL_04d2: volatile.
+		IL_04d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_04d9: brfalse IL_04ef
+
+		IL_04de: ldloc.s 4
+		IL_04e0: ldstr "x"
+		IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04ea: br IL_0505
+
+		IL_04ef: ldloc.s 4
+		IL_04f1: ldstr "x"
+		IL_04f6: ldstr "ObjectLiteral_AccessorDefinitions:Modules.ObjectLiteral_AccessorDefinitions:__js_module_init__:121"
+		IL_04fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0505: stloc.s 8
+		IL_0507: ldloc.s 10
+		IL_0509: ldloc.s 8
+		IL_050b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0510: pop
+		IL_0511: ret
 	} // end of method ObjectLiteral_AccessorDefinitions::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_AccessorDefinitions
@@ -1183,6 +1195,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundAccess_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundAccess_Parity.verified.txt
@@ -314,7 +314,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 94 (0x5e)
+			// Code size: 136 (0x88)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -327,33 +327,45 @@
 			IL_0006: ldarg.1
 			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0011: ldstr "join"
-			IL_0016: ldstr ","
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0020: stloc.1
-			IL_0021: volatile.
-			IL_0023: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0028: brfalse IL_003d
+			IL_0011: volatile.
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0018: brfalse IL_0031
 
-			IL_002d: ldarg.1
-			IL_002e: ldstr "num"
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0038: br IL_0052
+			IL_001d: ldstr "join"
+			IL_0022: ldstr ","
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002c: br IL_004a
 
-			IL_003d: ldarg.1
-			IL_003e: ldstr "num"
-			IL_0043: ldstr "ObjectLiteral_EarlyBoundAccess_Parity:<TwoPhaseDummy_M5>:__js_call__:9"
-			IL_0048: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0031: ldstr "join"
+			IL_0036: ldstr ","
+			IL_003b: ldstr "ObjectLiteral_EarlyBoundAccess_Parity:<TwoPhaseDummy_M5>:__js_call__:6"
+			IL_0040: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0052: stloc.2
-			IL_0053: ldloc.0
-			IL_0054: ldloc.1
-			IL_0055: ldloc.2
-			IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_005b: pop
-			IL_005c: ldnull
-			IL_005d: ret
+			IL_004a: stloc.1
+			IL_004b: volatile.
+			IL_004d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0052: brfalse IL_0067
+
+			IL_0057: ldarg.1
+			IL_0058: ldstr "num"
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0062: br IL_007c
+
+			IL_0067: ldarg.1
+			IL_0068: ldstr "num"
+			IL_006d: ldstr "ObjectLiteral_EarlyBoundAccess_Parity:<TwoPhaseDummy_M5>:__js_call__:9"
+			IL_0072: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_007c: stloc.2
+			IL_007d: ldloc.0
+			IL_007e: ldloc.1
+			IL_007f: ldloc.2
+			IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0085: pop
+			IL_0086: ldnull
+			IL_0087: ret
 		} // end of method inspect::__js_call__
 
 	} // end of class inspect
@@ -1520,6 +1532,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
@@ -205,7 +205,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 				IL_0007: brfalse IL_0026
 
 				IL_000c: ldarg.2
@@ -220,7 +220,7 @@
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0031: ldstr "value"
 				IL_0036: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:<TwoPhaseDummy_M7>:__js_call__:3"
-				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0045: stloc.0
@@ -370,7 +370,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 				IL_0007: brfalse IL_0026
 
 				IL_000c: ldarg.2
@@ -385,7 +385,7 @@
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0031: ldstr "value"
 				IL_0036: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:<TwoPhaseDummy_M8>:__js_call__:3"
-				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0045: stloc.0
@@ -672,7 +672,7 @@
 				)
 
 				IL_0000: volatile.
-				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+				IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 				IL_0007: brfalse IL_0026
 
 				IL_000c: ldarg.1
@@ -687,7 +687,7 @@
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 				IL_0031: ldstr "value"
 				IL_0036: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:<TwoPhaseDummy_M10>:__js_call__:3"
-				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0045: stloc.0
@@ -1324,7 +1324,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2466 (0x9a2)
+		// Code size: 2606 (0xa2e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope,
@@ -1407,766 +1407,804 @@
 		IL_007f: stloc.s 16
 		IL_0081: ldloc.2
 		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0087: ldstr "add"
-		IL_008c: ldc.r8 4
-		IL_0095: box [System.Runtime]System.Double
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009f: stloc.s 17
-		IL_00a1: volatile.
-		IL_00a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_00a8: brfalse IL_00bd
+		IL_0087: volatile.
+		IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_008e: brfalse IL_00b0
 
-		IL_00ad: ldloc.3
-		IL_00ae: ldstr "value"
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b8: br IL_00d2
+		IL_0093: ldstr "add"
+		IL_0098: ldc.r8 4
+		IL_00a1: box [System.Runtime]System.Double
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ab: br IL_00d2
 
-		IL_00bd: ldloc.3
-		IL_00be: ldstr "value"
-		IL_00c3: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:33"
+		IL_00b0: ldstr "add"
+		IL_00b5: ldc.r8 4
+		IL_00be: box [System.Runtime]System.Double
+		IL_00c3: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:31"
 		IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00d2: stloc.s 18
-		IL_00d4: ldloc.s 18
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00e0: dup
+		IL_00d2: stloc.s 17
+		IL_00d4: volatile.
+		IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00db: brfalse IL_00f0
+
+		IL_00e0: ldloc.3
 		IL_00e1: ldstr "value"
-		IL_00e6: ldc.r8 10
-		IL_00ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00f4: stloc.s 19
-		IL_00f6: ldstr "call"
-		IL_00fb: ldloc.s 19
-		IL_00fd: ldc.r8 5
-		IL_0106: box [System.Runtime]System.Double
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0110: stloc.s 18
-		IL_0112: ldloc.s 16
-		IL_0114: ldstr "calls"
-		IL_0119: ldloc.s 17
-		IL_011b: ldloc.s 18
-		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0122: pop
-		IL_0123: ldloc.2
-		IL_0124: ldstr "current"
-		IL_0129: ldc.r8 12
-		IL_0132: ldc.i4.1
-		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0138: pop
-		IL_0139: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013e: stloc.s 16
-		IL_0140: volatile.
-		IL_0142: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0147: brfalse IL_015c
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00eb: br IL_0105
 
-		IL_014c: ldloc.2
-		IL_014d: ldstr "value"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0157: br IL_0171
+		IL_00f0: ldloc.3
+		IL_00f1: ldstr "value"
+		IL_00f6: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:33"
+		IL_00fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_015c: ldloc.2
-		IL_015d: ldstr "value"
-		IL_0162: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:49"
-		IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0171: stloc.s 18
+		IL_0105: stloc.s 18
+		IL_0107: ldloc.s 18
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0113: dup
+		IL_0114: ldstr "value"
+		IL_0119: ldc.r8 10
+		IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0127: stloc.s 19
+		IL_0129: ldstr "call"
+		IL_012e: ldloc.s 19
+		IL_0130: ldc.r8 5
+		IL_0139: box [System.Runtime]System.Double
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0143: stloc.s 18
+		IL_0145: ldloc.s 16
+		IL_0147: ldstr "calls"
+		IL_014c: ldloc.s 17
+		IL_014e: ldloc.s 18
+		IL_0150: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0155: pop
+		IL_0156: ldloc.2
+		IL_0157: ldstr "current"
+		IL_015c: ldc.r8 12
+		IL_0165: ldc.i4.1
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_016b: pop
+		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0171: stloc.s 16
 		IL_0173: volatile.
 		IL_0175: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 		IL_017a: brfalse IL_018f
 
 		IL_017f: ldloc.2
-		IL_0180: ldstr "current"
+		IL_0180: ldstr "value"
 		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_018a: br IL_01a4
 
 		IL_018f: ldloc.2
-		IL_0190: ldstr "current"
-		IL_0195: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:51"
+		IL_0190: ldstr "value"
+		IL_0195: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:49"
 		IL_019a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01a4: stloc.s 17
+		IL_01a4: stloc.s 18
 		IL_01a6: volatile.
 		IL_01a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_01ad: brfalse IL_01c3
+		IL_01ad: brfalse IL_01c2
 
-		IL_01b2: ldloc.s 4
-		IL_01b4: ldstr "get"
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01be: br IL_01d9
+		IL_01b2: ldloc.2
+		IL_01b3: ldstr "current"
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01bd: br IL_01d7
 
-		IL_01c3: ldloc.s 4
-		IL_01c5: ldstr "get"
-		IL_01ca: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:53"
-		IL_01cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01c2: ldloc.2
+		IL_01c3: ldstr "current"
+		IL_01c8: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:51"
+		IL_01cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01d9: stloc.s 20
-		IL_01db: ldloc.s 20
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e2: ldstr "call"
-		IL_01e7: ldloc.2
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ed: stloc.s 20
-		IL_01ef: ldloc.s 16
-		IL_01f1: ldc.i4.4
-		IL_01f2: newarr [System.Runtime]System.Object
-		IL_01f7: dup
-		IL_01f8: ldc.i4.0
-		IL_01f9: ldstr "accessors"
-		IL_01fe: stelem.ref
-		IL_01ff: dup
-		IL_0200: ldc.i4.1
-		IL_0201: ldloc.s 18
-		IL_0203: stelem.ref
-		IL_0204: dup
-		IL_0205: ldc.i4.2
-		IL_0206: ldloc.s 17
-		IL_0208: stelem.ref
-		IL_0209: dup
-		IL_020a: ldc.i4.3
-		IL_020b: ldloc.s 20
-		IL_020d: stelem.ref
-		IL_020e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0213: pop
-		IL_0214: volatile.
-		IL_0216: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_021b: brfalse IL_0231
+		IL_01d7: stloc.s 17
+		IL_01d9: volatile.
+		IL_01db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01e0: brfalse IL_01f6
 
-		IL_0220: ldloc.s 4
-		IL_0222: ldstr "set"
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022c: br IL_0247
+		IL_01e5: ldloc.s 4
+		IL_01e7: ldstr "get"
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f1: br IL_020c
 
-		IL_0231: ldloc.s 4
-		IL_0233: ldstr "set"
-		IL_0238: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:59"
-		IL_023d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01f6: ldloc.s 4
+		IL_01f8: ldstr "get"
+		IL_01fd: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:53"
+		IL_0202: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0247: stloc.s 20
-		IL_0249: ldloc.s 20
-		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0250: ldstr "call"
-		IL_0255: ldloc.2
-		IL_0256: ldc.r8 20
-		IL_025f: box [System.Runtime]System.Double
-		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0269: pop
-		IL_026a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_026f: stloc.s 16
-		IL_0271: volatile.
-		IL_0273: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0278: brfalse IL_028d
+		IL_020c: stloc.s 20
+		IL_020e: ldloc.s 20
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0215: volatile.
+		IL_0217: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_021c: brfalse IL_0231
 
-		IL_027d: ldloc.2
-		IL_027e: ldstr "value"
-		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0288: br IL_02a2
+		IL_0221: ldstr "call"
+		IL_0226: ldloc.2
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022c: br IL_0246
 
-		IL_028d: ldloc.2
-		IL_028e: ldstr "value"
-		IL_0293: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:68"
-		IL_0298: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0231: ldstr "call"
+		IL_0236: ldloc.2
+		IL_0237: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:55"
+		IL_023c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02a2: stloc.s 20
-		IL_02a4: ldloc.s 16
-		IL_02a6: ldstr "setter"
-		IL_02ab: ldloc.s 20
-		IL_02ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02b2: pop
-		IL_02b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b8: stloc.s 16
-		IL_02ba: ldloc.2
-		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c0: ldstr "computed"
-		IL_02c5: ldc.r8 1
-		IL_02ce: box [System.Runtime]System.Double
-		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d8: stloc.s 20
-		IL_02da: volatile.
-		IL_02dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_02e1: brfalse IL_02f7
+		IL_0246: stloc.s 20
+		IL_0248: ldloc.s 16
+		IL_024a: ldc.i4.4
+		IL_024b: newarr [System.Runtime]System.Object
+		IL_0250: dup
+		IL_0251: ldc.i4.0
+		IL_0252: ldstr "accessors"
+		IL_0257: stelem.ref
+		IL_0258: dup
+		IL_0259: ldc.i4.1
+		IL_025a: ldloc.s 18
+		IL_025c: stelem.ref
+		IL_025d: dup
+		IL_025e: ldc.i4.2
+		IL_025f: ldloc.s 17
+		IL_0261: stelem.ref
+		IL_0262: dup
+		IL_0263: ldc.i4.3
+		IL_0264: ldloc.s 20
+		IL_0266: stelem.ref
+		IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_026c: pop
+		IL_026d: volatile.
+		IL_026f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0274: brfalse IL_028a
 
-		IL_02e6: ldloc.s 5
-		IL_02e8: ldstr "value"
-		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02f2: br IL_030d
+		IL_0279: ldloc.s 4
+		IL_027b: ldstr "set"
+		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0285: br IL_02a0
 
-		IL_02f7: ldloc.s 5
-		IL_02f9: ldstr "value"
-		IL_02fe: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:78"
-		IL_0303: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_028a: ldloc.s 4
+		IL_028c: ldstr "set"
+		IL_0291: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:59"
+		IL_0296: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_030d: stloc.s 17
-		IL_030f: ldloc.s 17
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0316: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_031b: dup
-		IL_031c: ldstr "value"
-		IL_0321: ldc.r8 30
-		IL_032a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_032f: stloc.s 19
-		IL_0331: ldstr "call"
-		IL_0336: ldloc.s 19
-		IL_0338: ldc.r8 2
-		IL_0341: box [System.Runtime]System.Double
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_034b: stloc.s 17
-		IL_034d: ldloc.s 16
-		IL_034f: ldstr "computed"
-		IL_0354: ldloc.s 20
-		IL_0356: ldloc.s 17
-		IL_0358: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_035d: pop
-		IL_035e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0363: stloc.s 16
-		IL_0365: volatile.
-		IL_0367: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_036c: brfalse IL_0381
+		IL_02a0: stloc.s 20
+		IL_02a2: ldloc.s 20
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a9: ldstr "call"
+		IL_02ae: ldloc.2
+		IL_02af: ldc.r8 20
+		IL_02b8: box [System.Runtime]System.Double
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02c2: pop
+		IL_02c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c8: stloc.s 16
+		IL_02ca: volatile.
+		IL_02cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_02d1: brfalse IL_02e6
 
-		IL_0371: ldloc.3
-		IL_0372: ldstr "value"
-		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_037c: br IL_0396
+		IL_02d6: ldloc.2
+		IL_02d7: ldstr "value"
+		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02e1: br IL_02fb
 
-		IL_0381: ldloc.3
-		IL_0382: ldstr "value"
-		IL_0387: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:90"
-		IL_038c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02e6: ldloc.2
+		IL_02e7: ldstr "value"
+		IL_02ec: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:68"
+		IL_02f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0396: stloc.s 17
-		IL_0398: volatile.
-		IL_039a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_039f: brfalse IL_03b5
+		IL_02fb: stloc.s 20
+		IL_02fd: ldloc.s 16
+		IL_02ff: ldstr "setter"
+		IL_0304: ldloc.s 20
+		IL_0306: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_030b: pop
+		IL_030c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0311: stloc.s 16
+		IL_0313: ldloc.2
+		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0319: volatile.
+		IL_031b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0320: brfalse IL_0342
 
-		IL_03a4: ldloc.s 17
-		IL_03a6: ldstr "name"
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03b0: br IL_03cb
+		IL_0325: ldstr "computed"
+		IL_032a: ldc.r8 1
+		IL_0333: box [System.Runtime]System.Double
+		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_033d: br IL_0364
 
-		IL_03b5: ldloc.s 17
-		IL_03b7: ldstr "name"
-		IL_03bc: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:92"
-		IL_03c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0342: ldstr "computed"
+		IL_0347: ldc.r8 1
+		IL_0350: box [System.Runtime]System.Double
+		IL_0355: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:76"
+		IL_035a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03cb: stloc.s 17
-		IL_03cd: volatile.
-		IL_03cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_03d4: brfalse IL_03e9
+		IL_0364: stloc.s 20
+		IL_0366: volatile.
+		IL_0368: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_036d: brfalse IL_0383
 
-		IL_03d9: ldloc.3
-		IL_03da: ldstr "value"
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03e4: br IL_03fe
+		IL_0372: ldloc.s 5
+		IL_0374: ldstr "value"
+		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_037e: br IL_0399
 
-		IL_03e9: ldloc.3
-		IL_03ea: ldstr "value"
-		IL_03ef: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:94"
-		IL_03f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0383: ldloc.s 5
+		IL_0385: ldstr "value"
+		IL_038a: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:78"
+		IL_038f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03fe: stloc.s 20
-		IL_0400: volatile.
-		IL_0402: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0407: brfalse IL_041d
+		IL_0399: stloc.s 17
+		IL_039b: ldloc.s 17
+		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03a7: dup
+		IL_03a8: ldstr "value"
+		IL_03ad: ldc.r8 30
+		IL_03b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03bb: stloc.s 19
+		IL_03bd: ldstr "call"
+		IL_03c2: ldloc.s 19
+		IL_03c4: ldc.r8 2
+		IL_03cd: box [System.Runtime]System.Double
+		IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03d7: stloc.s 17
+		IL_03d9: ldloc.s 16
+		IL_03db: ldstr "computed"
+		IL_03e0: ldloc.s 20
+		IL_03e2: ldloc.s 17
+		IL_03e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_03e9: pop
+		IL_03ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03ef: stloc.s 16
+		IL_03f1: volatile.
+		IL_03f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_03f8: brfalse IL_040d
 
-		IL_040c: ldloc.s 20
-		IL_040e: ldstr "length"
-		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0418: br IL_0433
+		IL_03fd: ldloc.3
+		IL_03fe: ldstr "value"
+		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0408: br IL_0422
 
-		IL_041d: ldloc.s 20
-		IL_041f: ldstr "length"
-		IL_0424: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:96"
-		IL_0429: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_040d: ldloc.3
+		IL_040e: ldstr "value"
+		IL_0413: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:90"
+		IL_0418: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0433: stloc.s 20
-		IL_0435: volatile.
-		IL_0437: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_043c: brfalse IL_0452
+		IL_0422: stloc.s 17
+		IL_0424: volatile.
+		IL_0426: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_042b: brfalse IL_0441
 
-		IL_0441: ldloc.s 4
-		IL_0443: ldstr "get"
-		IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_044d: br IL_0468
+		IL_0430: ldloc.s 17
+		IL_0432: ldstr "name"
+		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_043c: br IL_0457
 
-		IL_0452: ldloc.s 4
-		IL_0454: ldstr "get"
-		IL_0459: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:98"
-		IL_045e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0441: ldloc.s 17
+		IL_0443: ldstr "name"
+		IL_0448: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:92"
+		IL_044d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0468: stloc.s 18
-		IL_046a: volatile.
-		IL_046c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0471: brfalse IL_0487
+		IL_0457: stloc.s 17
+		IL_0459: volatile.
+		IL_045b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0460: brfalse IL_0475
 
-		IL_0476: ldloc.s 18
-		IL_0478: ldstr "name"
-		IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0482: br IL_049d
+		IL_0465: ldloc.3
+		IL_0466: ldstr "value"
+		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0470: br IL_048a
 
-		IL_0487: ldloc.s 18
-		IL_0489: ldstr "name"
-		IL_048e: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:100"
-		IL_0493: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0475: ldloc.3
+		IL_0476: ldstr "value"
+		IL_047b: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:94"
+		IL_0480: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_049d: stloc.s 18
-		IL_049f: volatile.
-		IL_04a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_04a6: brfalse IL_04bc
+		IL_048a: stloc.s 20
+		IL_048c: volatile.
+		IL_048e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0493: brfalse IL_04a9
 
-		IL_04ab: ldloc.s 4
-		IL_04ad: ldstr "set"
-		IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04b7: br IL_04d2
+		IL_0498: ldloc.s 20
+		IL_049a: ldstr "length"
+		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04a4: br IL_04bf
 
-		IL_04bc: ldloc.s 4
-		IL_04be: ldstr "set"
-		IL_04c3: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:102"
-		IL_04c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04a9: ldloc.s 20
+		IL_04ab: ldstr "length"
+		IL_04b0: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:96"
+		IL_04b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04d2: stloc.s 21
-		IL_04d4: volatile.
-		IL_04d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_04db: brfalse IL_04f1
+		IL_04bf: stloc.s 20
+		IL_04c1: volatile.
+		IL_04c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_04c8: brfalse IL_04de
 
-		IL_04e0: ldloc.s 21
-		IL_04e2: ldstr "name"
-		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ec: br IL_0507
+		IL_04cd: ldloc.s 4
+		IL_04cf: ldstr "get"
+		IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04d9: br IL_04f4
 
-		IL_04f1: ldloc.s 21
-		IL_04f3: ldstr "name"
-		IL_04f8: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:104"
-		IL_04fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0502: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04de: ldloc.s 4
+		IL_04e0: ldstr "get"
+		IL_04e5: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:98"
+		IL_04ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0507: stloc.s 21
-		IL_0509: volatile.
-		IL_050b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0510: brfalse IL_0526
+		IL_04f4: stloc.s 18
+		IL_04f6: volatile.
+		IL_04f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_04fd: brfalse IL_0513
 
-		IL_0515: ldloc.s 5
-		IL_0517: ldstr "value"
-		IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0521: br IL_053c
+		IL_0502: ldloc.s 18
+		IL_0504: ldstr "name"
+		IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050e: br IL_0529
 
-		IL_0526: ldloc.s 5
-		IL_0528: ldstr "value"
-		IL_052d: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:106"
-		IL_0532: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0513: ldloc.s 18
+		IL_0515: ldstr "name"
+		IL_051a: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:100"
+		IL_051f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_053c: stloc.s 22
-		IL_053e: volatile.
-		IL_0540: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0545: brfalse IL_055b
+		IL_0529: stloc.s 18
+		IL_052b: volatile.
+		IL_052d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0532: brfalse IL_0548
 
-		IL_054a: ldloc.s 22
-		IL_054c: ldstr "name"
-		IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0556: br IL_0571
+		IL_0537: ldloc.s 4
+		IL_0539: ldstr "set"
+		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0543: br IL_055e
 
-		IL_055b: ldloc.s 22
-		IL_055d: ldstr "name"
-		IL_0562: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:108"
-		IL_0567: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0548: ldloc.s 4
+		IL_054a: ldstr "set"
+		IL_054f: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:102"
+		IL_0554: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0571: stloc.s 22
-		IL_0573: ldloc.s 16
-		IL_0575: ldc.i4.6
-		IL_0576: newarr [System.Runtime]System.Object
-		IL_057b: dup
-		IL_057c: ldc.i4.0
-		IL_057d: ldstr "metadata"
-		IL_0582: stelem.ref
-		IL_0583: dup
-		IL_0584: ldc.i4.1
-		IL_0585: ldloc.s 17
-		IL_0587: stelem.ref
-		IL_0588: dup
-		IL_0589: ldc.i4.2
-		IL_058a: ldloc.s 20
-		IL_058c: stelem.ref
-		IL_058d: dup
-		IL_058e: ldc.i4.3
-		IL_058f: ldloc.s 18
-		IL_0591: stelem.ref
-		IL_0592: dup
-		IL_0593: ldc.i4.4
-		IL_0594: ldloc.s 21
-		IL_0596: stelem.ref
-		IL_0597: dup
-		IL_0598: ldc.i4.5
-		IL_0599: ldloc.s 22
-		IL_059b: stelem.ref
-		IL_059c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_05a1: pop
-		IL_05a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05a7: stloc.s 16
-		IL_05a9: volatile.
-		IL_05ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_05b0: brfalse IL_05c5
+		IL_055e: stloc.s 21
+		IL_0560: volatile.
+		IL_0562: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0567: brfalse IL_057d
 
-		IL_05b5: ldloc.3
-		IL_05b6: ldstr "value"
-		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05c0: br IL_05da
+		IL_056c: ldloc.s 21
+		IL_056e: ldstr "name"
+		IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0578: br IL_0593
 
-		IL_05c5: ldloc.3
-		IL_05c6: ldstr "value"
-		IL_05cb: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:114"
-		IL_05d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_057d: ldloc.s 21
+		IL_057f: ldstr "name"
+		IL_0584: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:104"
+		IL_0589: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05da: stloc.s 22
-		IL_05dc: volatile.
-		IL_05de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_05e3: brfalse IL_05f8
+		IL_0593: stloc.s 21
+		IL_0595: volatile.
+		IL_0597: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_059c: brfalse IL_05b2
 
-		IL_05e8: ldloc.2
-		IL_05e9: ldstr "add"
-		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05f3: br IL_060d
+		IL_05a1: ldloc.s 5
+		IL_05a3: ldstr "value"
+		IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ad: br IL_05c8
 
-		IL_05f8: ldloc.2
-		IL_05f9: ldstr "add"
-		IL_05fe: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:116"
-		IL_0603: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0608: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05b2: ldloc.s 5
+		IL_05b4: ldstr "value"
+		IL_05b9: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:106"
+		IL_05be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_060d: stloc.s 21
-		IL_060f: ldloc.s 22
-		IL_0611: ldloc.s 21
-		IL_0613: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0618: stloc.s 23
-		IL_061a: ldloc.s 23
-		IL_061c: box [System.Runtime]System.Boolean
-		IL_0621: stloc.s 24
-		IL_0623: volatile.
-		IL_0625: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_062a: brfalse IL_0640
+		IL_05c8: stloc.s 22
+		IL_05ca: volatile.
+		IL_05cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_05d1: brfalse IL_05e7
 
-		IL_062f: ldloc.s 4
-		IL_0631: ldstr "get"
-		IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_063b: br IL_0656
+		IL_05d6: ldloc.s 22
+		IL_05d8: ldstr "name"
+		IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05e2: br IL_05fd
 
-		IL_0640: ldloc.s 4
-		IL_0642: ldstr "get"
-		IL_0647: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:120"
-		IL_064c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05e7: ldloc.s 22
+		IL_05e9: ldstr "name"
+		IL_05ee: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:108"
+		IL_05f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0656: stloc.s 21
-		IL_0658: ldloc.2
-		IL_0659: ldstr "current"
-		IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0663: volatile.
-		IL_0665: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_066a: brfalse IL_067e
+		IL_05fd: stloc.s 22
+		IL_05ff: ldloc.s 16
+		IL_0601: ldc.i4.6
+		IL_0602: newarr [System.Runtime]System.Object
+		IL_0607: dup
+		IL_0608: ldc.i4.0
+		IL_0609: ldstr "metadata"
+		IL_060e: stelem.ref
+		IL_060f: dup
+		IL_0610: ldc.i4.1
+		IL_0611: ldloc.s 17
+		IL_0613: stelem.ref
+		IL_0614: dup
+		IL_0615: ldc.i4.2
+		IL_0616: ldloc.s 20
+		IL_0618: stelem.ref
+		IL_0619: dup
+		IL_061a: ldc.i4.3
+		IL_061b: ldloc.s 18
+		IL_061d: stelem.ref
+		IL_061e: dup
+		IL_061f: ldc.i4.4
+		IL_0620: ldloc.s 21
+		IL_0622: stelem.ref
+		IL_0623: dup
+		IL_0624: ldc.i4.5
+		IL_0625: ldloc.s 22
+		IL_0627: stelem.ref
+		IL_0628: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_062d: pop
+		IL_062e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0633: stloc.s 16
+		IL_0635: volatile.
+		IL_0637: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_063c: brfalse IL_0651
 
-		IL_066f: ldstr "get"
-		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0679: br IL_0692
+		IL_0641: ldloc.3
+		IL_0642: ldstr "value"
+		IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_064c: br IL_0666
 
-		IL_067e: ldstr "get"
-		IL_0683: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:124"
-		IL_0688: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0651: ldloc.3
+		IL_0652: ldstr "value"
+		IL_0657: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:114"
+		IL_065c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0692: stloc.s 22
-		IL_0694: ldloc.s 21
-		IL_0696: ldloc.s 22
-		IL_0698: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_069d: stloc.s 23
-		IL_069f: ldloc.s 23
-		IL_06a1: box [System.Runtime]System.Boolean
-		IL_06a6: stloc.s 25
-		IL_06a8: volatile.
-		IL_06aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_06af: brfalse IL_06c4
+		IL_0666: stloc.s 22
+		IL_0668: volatile.
+		IL_066a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_066f: brfalse IL_0684
 
-		IL_06b4: ldloc.3
-		IL_06b5: ldstr "value"
-		IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06bf: br IL_06d9
+		IL_0674: ldloc.2
+		IL_0675: ldstr "add"
+		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_067f: br IL_0699
 
-		IL_06c4: ldloc.3
-		IL_06c5: ldstr "value"
-		IL_06ca: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:128"
-		IL_06cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_06d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0684: ldloc.2
+		IL_0685: ldstr "add"
+		IL_068a: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:116"
+		IL_068f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06d9: stloc.s 22
-		IL_06db: ldloc.s 22
-		IL_06dd: ldstr "prototype"
-		IL_06e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_06e7: box [System.Runtime]System.Boolean
-		IL_06ec: stloc.s 26
-		IL_06ee: ldloc.s 16
-		IL_06f0: ldc.i4.4
-		IL_06f1: newarr [System.Runtime]System.Object
-		IL_06f6: dup
-		IL_06f7: ldc.i4.0
-		IL_06f8: ldstr "descriptors"
-		IL_06fd: stelem.ref
-		IL_06fe: dup
-		IL_06ff: ldc.i4.1
-		IL_0700: ldloc.s 24
-		IL_0702: stelem.ref
-		IL_0703: dup
-		IL_0704: ldc.i4.2
-		IL_0705: ldloc.s 25
-		IL_0707: stelem.ref
-		IL_0708: dup
-		IL_0709: ldc.i4.3
-		IL_070a: ldloc.s 26
-		IL_070c: stelem.ref
-		IL_070d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0712: pop
-		IL_0713: ldc.i4.0
-		IL_0714: box [System.Runtime]System.Boolean
-		IL_0719: stloc.s 6
+		IL_0699: stloc.s 21
+		IL_069b: ldloc.s 22
+		IL_069d: ldloc.s 21
+		IL_069f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06a4: stloc.s 23
+		IL_06a6: ldloc.s 23
+		IL_06a8: box [System.Runtime]System.Boolean
+		IL_06ad: stloc.s 24
+		IL_06af: volatile.
+		IL_06b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_06b6: brfalse IL_06cc
+
+		IL_06bb: ldloc.s 4
+		IL_06bd: ldstr "get"
+		IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06c7: br IL_06e2
+
+		IL_06cc: ldloc.s 4
+		IL_06ce: ldstr "get"
+		IL_06d3: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:120"
+		IL_06d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06e2: stloc.s 21
+		IL_06e4: ldloc.2
+		IL_06e5: ldstr "current"
+		IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_06ef: volatile.
+		IL_06f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_06f6: brfalse IL_070a
+
+		IL_06fb: ldstr "get"
+		IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0705: br IL_071e
+
+		IL_070a: ldstr "get"
+		IL_070f: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:124"
+		IL_0714: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_071e: stloc.s 22
+		IL_0720: ldloc.s 21
+		IL_0722: ldloc.s 22
+		IL_0724: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0729: stloc.s 23
+		IL_072b: ldloc.s 23
+		IL_072d: box [System.Runtime]System.Boolean
+		IL_0732: stloc.s 25
+		IL_0734: volatile.
+		IL_0736: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_073b: brfalse IL_0750
+
+		IL_0740: ldloc.3
+		IL_0741: ldstr "value"
+		IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_074b: br IL_0765
+
+		IL_0750: ldloc.3
+		IL_0751: ldstr "value"
+		IL_0756: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:128"
+		IL_075b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0765: stloc.s 22
+		IL_0767: ldloc.s 22
+		IL_0769: ldstr "prototype"
+		IL_076e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0773: box [System.Runtime]System.Boolean
+		IL_0778: stloc.s 26
+		IL_077a: ldloc.s 16
+		IL_077c: ldc.i4.4
+		IL_077d: newarr [System.Runtime]System.Object
+		IL_0782: dup
+		IL_0783: ldc.i4.0
+		IL_0784: ldstr "descriptors"
+		IL_0789: stelem.ref
+		IL_078a: dup
+		IL_078b: ldc.i4.1
+		IL_078c: ldloc.s 24
+		IL_078e: stelem.ref
+		IL_078f: dup
+		IL_0790: ldc.i4.2
+		IL_0791: ldloc.s 25
+		IL_0793: stelem.ref
+		IL_0794: dup
+		IL_0795: ldc.i4.3
+		IL_0796: ldloc.s 26
+		IL_0798: stelem.ref
+		IL_0799: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_079e: pop
+		IL_079f: ldc.i4.0
+		IL_07a0: box [System.Runtime]System.Boolean
+		IL_07a5: stloc.s 6
 		.try
 		{
-			IL_071b: nop
-			IL_071c: ldstr "Reflect"
-			IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_072b: stloc.s 22
-			IL_072d: volatile.
-			IL_072f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_0734: brfalse IL_0749
+			IL_07a7: nop
+			IL_07a8: ldstr "Reflect"
+			IL_07ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07b7: stloc.s 22
+			IL_07b9: volatile.
+			IL_07bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_07c0: brfalse IL_07d5
 
-			IL_0739: ldloc.3
-			IL_073a: ldstr "value"
-			IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0744: br IL_075e
+			IL_07c5: ldloc.3
+			IL_07c6: ldstr "value"
+			IL_07cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d0: br IL_07ea
 
-			IL_0749: ldloc.3
-			IL_074a: ldstr "value"
-			IL_074f: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:145"
-			IL_0754: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07d5: ldloc.3
+			IL_07d6: ldstr "value"
+			IL_07db: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:145"
+			IL_07e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_075e: stloc.s 21
-			IL_0760: ldc.i4.0
-			IL_0761: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0766: stloc.s 27
-			IL_0768: ldloc.s 22
-			IL_076a: ldstr "construct"
-			IL_076f: ldloc.s 21
-			IL_0771: ldloc.s 27
-			IL_0773: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0778: pop
-			IL_0779: leave IL_07dd
+			IL_07ea: stloc.s 21
+			IL_07ec: ldc.i4.0
+			IL_07ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_07f2: stloc.s 27
+			IL_07f4: ldloc.s 22
+			IL_07f6: ldstr "construct"
+			IL_07fb: ldloc.s 21
+			IL_07fd: ldloc.s 27
+			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0804: pop
+			IL_0805: leave IL_0869
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_077e: stloc.s 7
-			IL_0780: ldloc.s 7
-			IL_0782: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0787: dup
-			IL_0788: brtrue IL_079e
+			IL_080a: stloc.s 7
+			IL_080c: ldloc.s 7
+			IL_080e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0813: dup
+			IL_0814: brtrue IL_082a
 
-			IL_078d: pop
-			IL_078e: ldloc.s 7
-			IL_0790: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0795: dup
-			IL_0796: brtrue IL_07aa
+			IL_0819: pop
+			IL_081a: ldloc.s 7
+			IL_081c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0821: dup
+			IL_0822: brtrue IL_0836
 
-			IL_079b: pop
-			IL_079c: rethrow
+			IL_0827: pop
+			IL_0828: rethrow
 
-			IL_079e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_07a3: stloc.s 8
-			IL_07a5: br IL_07ac
+			IL_082a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_082f: stloc.s 8
+			IL_0831: br IL_0838
 
-			IL_07aa: stloc.s 8
+			IL_0836: stloc.s 8
 
-			IL_07ac: ldloc.s 8
-			IL_07ae: stloc.s 9
-			IL_07b0: ldloc.s 9
-			IL_07b2: stloc.s 21
-			IL_07b4: ldstr "TypeError"
-			IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07be: stloc.s 22
-			IL_07c0: ldloc.s 21
-			IL_07c2: ldloc.s 22
-			IL_07c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_07c9: stloc.s 23
-			IL_07cb: ldloc.s 23
-			IL_07cd: box [System.Runtime]System.Boolean
-			IL_07d2: stloc.s 26
-			IL_07d4: ldloc.s 26
-			IL_07d6: stloc.s 6
-			IL_07d8: leave IL_07dd
+			IL_0838: ldloc.s 8
+			IL_083a: stloc.s 9
+			IL_083c: ldloc.s 9
+			IL_083e: stloc.s 21
+			IL_0840: ldstr "TypeError"
+			IL_0845: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_084a: stloc.s 22
+			IL_084c: ldloc.s 21
+			IL_084e: ldloc.s 22
+			IL_0850: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0855: stloc.s 23
+			IL_0857: ldloc.s 23
+			IL_0859: box [System.Runtime]System.Boolean
+			IL_085e: stloc.s 26
+			IL_0860: ldloc.s 26
+			IL_0862: stloc.s 6
+			IL_0864: leave IL_0869
 		} // end handler
 
-		IL_07dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07e2: stloc.s 16
-		IL_07e4: ldloc.s 16
-		IL_07e6: ldstr "nonconstructor"
-		IL_07eb: ldloc.s 6
-		IL_07ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_07f2: pop
-		IL_07f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_07f8: stloc.s 19
-		IL_07fa: ldc.i4.1
-		IL_07fb: newarr [System.Runtime]System.Object
-		IL_0800: dup
-		IL_0801: ldc.i4.0
-		IL_0802: ldloc.0
-		IL_0803: stelem.ref
-		IL_0804: stloc.s 15
-		IL_0806: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject::.ctor()
-		IL_080b: ldc.i4.0
-		IL_080c: conv.r8
-		IL_080d: ldstr ""
-		IL_0812: ldc.i4.0
-		IL_0813: ldc.i4.1
-		IL_0814: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0819: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0)
-		IL_081e: stloc.s 28
-		IL_0820: ldloc.s 19
-		IL_0822: ldstr "label"
-		IL_0827: ldloc.s 28
-		IL_0829: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_082e: pop
-		IL_082f: ldloc.s 19
-		IL_0831: stloc.s 10
-		IL_0833: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0838: stloc.s 19
-		IL_083a: ldloc.s 19
-		IL_083c: ldloc.s 10
-		IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetObjectLiteralPrototype(object, object)
-		IL_0843: pop
-		IL_0844: ldc.i4.1
-		IL_0845: newarr [System.Runtime]System.Object
-		IL_084a: dup
-		IL_084b: ldc.i4.0
-		IL_084c: ldloc.0
-		IL_084d: stelem.ref
-		IL_084e: stloc.s 15
-		IL_0850: ldloc.s 19
-		IL_0852: ldloc.s 15
-		IL_0854: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
-		IL_0859: ldc.i4.0
-		IL_085a: conv.r8
-		IL_085b: ldstr ""
-		IL_0860: ldc.i4.1
-		IL_0861: ldc.i4.1
-		IL_0862: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0867: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0)
-		IL_086c: stloc.s 29
-		IL_086e: ldloc.s 19
-		IL_0870: ldstr "label"
-		IL_0875: ldloc.s 29
-		IL_0877: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_087c: pop
-		IL_087d: ldloc.s 19
-		IL_087f: stloc.s 11
-		IL_0881: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0886: stloc.s 16
-		IL_0888: volatile.
-		IL_088a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_088f: brfalse IL_08a5
+		IL_0869: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_086e: stloc.s 16
+		IL_0870: ldloc.s 16
+		IL_0872: ldstr "nonconstructor"
+		IL_0877: ldloc.s 6
+		IL_0879: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_087e: pop
+		IL_087f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0884: stloc.s 19
+		IL_0886: ldc.i4.1
+		IL_0887: newarr [System.Runtime]System.Object
+		IL_088c: dup
+		IL_088d: ldc.i4.0
+		IL_088e: ldloc.0
+		IL_088f: stelem.ref
+		IL_0890: stloc.s 15
+		IL_0892: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject::.ctor()
+		IL_0897: ldc.i4.0
+		IL_0898: conv.r8
+		IL_0899: ldstr ""
+		IL_089e: ldc.i4.0
+		IL_089f: ldc.i4.1
+		IL_08a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0)
+		IL_08aa: stloc.s 28
+		IL_08ac: ldloc.s 19
+		IL_08ae: ldstr "label"
+		IL_08b3: ldloc.s 28
+		IL_08b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_08ba: pop
+		IL_08bb: ldloc.s 19
+		IL_08bd: stloc.s 10
+		IL_08bf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_08c4: stloc.s 19
+		IL_08c6: ldloc.s 19
+		IL_08c8: ldloc.s 10
+		IL_08ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetObjectLiteralPrototype(object, object)
+		IL_08cf: pop
+		IL_08d0: ldc.i4.1
+		IL_08d1: newarr [System.Runtime]System.Object
+		IL_08d6: dup
+		IL_08d7: ldc.i4.0
+		IL_08d8: ldloc.0
+		IL_08d9: stelem.ref
+		IL_08da: stloc.s 15
+		IL_08dc: ldloc.s 19
+		IL_08de: ldloc.s 15
+		IL_08e0: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
+		IL_08e5: ldc.i4.0
+		IL_08e6: conv.r8
+		IL_08e7: ldstr ""
+		IL_08ec: ldc.i4.1
+		IL_08ed: ldc.i4.1
+		IL_08ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0)
+		IL_08f8: stloc.s 29
+		IL_08fa: ldloc.s 19
+		IL_08fc: ldstr "label"
+		IL_0901: ldloc.s 29
+		IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0908: pop
+		IL_0909: ldloc.s 19
+		IL_090b: stloc.s 11
+		IL_090d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0912: stloc.s 16
+		IL_0914: volatile.
+		IL_0916: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_091b: brfalse IL_0931
 
-		IL_0894: ldloc.s 11
-		IL_0896: ldstr "label"
-		IL_089b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_08a0: br IL_08bb
+		IL_0920: ldloc.s 11
+		IL_0922: ldstr "label"
+		IL_0927: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_092c: br IL_0947
 
-		IL_08a5: ldloc.s 11
-		IL_08a7: ldstr "label"
-		IL_08ac: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:189"
-		IL_08b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_08b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0931: ldloc.s 11
+		IL_0933: ldstr "label"
+		IL_0938: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:189"
+		IL_093d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_0942: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_08bb: stloc.s 22
-		IL_08bd: ldloc.s 16
-		IL_08bf: ldstr "super"
-		IL_08c4: ldloc.s 22
-		IL_08c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_08cb: pop
-		IL_08cc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08d1: stloc.s 15
-		IL_08d3: ldloc.1
-		IL_08d4: ldloc.s 15
-		IL_08d6: ldc.r8 0.0
-		IL_08df: box [System.Runtime]System.Double
-		IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_08e9: stloc.s 12
-		IL_08eb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08f0: stloc.s 15
-		IL_08f2: ldloc.1
-		IL_08f3: ldloc.s 15
-		IL_08f5: ldc.r8 0.0
-		IL_08fe: box [System.Runtime]System.Double
-		IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0908: stloc.s 13
-		IL_090a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_090f: stloc.s 16
-		IL_0911: volatile.
-		IL_0913: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_0918: brfalse IL_092e
+		IL_0947: stloc.s 22
+		IL_0949: ldloc.s 16
+		IL_094b: ldstr "super"
+		IL_0950: ldloc.s 22
+		IL_0952: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0957: pop
+		IL_0958: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_095d: stloc.s 15
+		IL_095f: ldloc.1
+		IL_0960: ldloc.s 15
+		IL_0962: ldc.r8 0.0
+		IL_096b: box [System.Runtime]System.Double
+		IL_0970: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0975: stloc.s 12
+		IL_0977: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_097c: stloc.s 15
+		IL_097e: ldloc.1
+		IL_097f: ldloc.s 15
+		IL_0981: ldc.r8 0.0
+		IL_098a: box [System.Runtime]System.Double
+		IL_098f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0994: stloc.s 13
+		IL_0996: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_099b: stloc.s 16
+		IL_099d: volatile.
+		IL_099f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_09a4: brfalse IL_09ba
 
-		IL_091d: ldloc.s 12
-		IL_091f: ldstr "add"
-		IL_0924: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0929: br IL_0944
+		IL_09a9: ldloc.s 12
+		IL_09ab: ldstr "add"
+		IL_09b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09b5: br IL_09d0
 
-		IL_092e: ldloc.s 12
-		IL_0930: ldstr "add"
-		IL_0935: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:207"
-		IL_093a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_093f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09ba: ldloc.s 12
+		IL_09bc: ldstr "add"
+		IL_09c1: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:207"
+		IL_09c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0944: stloc.s 22
-		IL_0946: volatile.
-		IL_0948: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_094d: brfalse IL_0963
+		IL_09d0: stloc.s 22
+		IL_09d2: volatile.
+		IL_09d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_09d9: brfalse IL_09ef
 
-		IL_0952: ldloc.s 13
-		IL_0954: ldstr "add"
-		IL_0959: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_095e: br IL_0979
+		IL_09de: ldloc.s 13
+		IL_09e0: ldstr "add"
+		IL_09e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09ea: br IL_0a05
 
-		IL_0963: ldloc.s 13
-		IL_0965: ldstr "add"
-		IL_096a: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:209"
-		IL_096f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_0974: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09ef: ldloc.s 13
+		IL_09f1: ldstr "add"
+		IL_09f6: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:209"
+		IL_09fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0a00: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0979: stloc.s 21
-		IL_097b: ldloc.s 22
-		IL_097d: ldloc.s 21
-		IL_097f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0984: stloc.s 23
-		IL_0986: ldloc.s 23
-		IL_0988: box [System.Runtime]System.Boolean
-		IL_098d: stloc.s 26
-		IL_098f: ldloc.s 16
-		IL_0991: ldstr "identity"
-		IL_0996: ldloc.s 26
-		IL_0998: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_099d: pop
-		IL_099e: ldnull
-		IL_099f: stloc.s 14
-		IL_09a1: ret
+		IL_0a05: stloc.s 21
+		IL_0a07: ldloc.s 22
+		IL_0a09: ldloc.s 21
+		IL_0a0b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0a10: stloc.s 23
+		IL_0a12: ldloc.s 23
+		IL_0a14: box [System.Runtime]System.Boolean
+		IL_0a19: stloc.s 26
+		IL_0a1b: ldloc.s 16
+		IL_0a1d: ldstr "identity"
+		IL_0a22: ldloc.s 26
+		IL_0a24: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0a29: pop
+		IL_0a2a: ldnull
+		IL_0a2b: stloc.s 14
+		IL_0a2d: ret
 	} // end of method ObjectLiteral_GeneratedMethodFunctionObjects::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_GeneratedMethodFunctionObjects
@@ -2225,6 +2263,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_38
 	.field assembly static int32 __jroc_dynamicLookup_39
 	.field assembly static int32 __jroc_dynamicLookup_40
+	.field assembly static int32 __jroc_dynamicLookup_41
+	.field assembly static int32 __jroc_dynamicLookup_42
+	.field assembly static int32 __jroc_dynamicLookup_43
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_DescriptorAndMutation_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_DescriptorAndMutation_Parity.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1485 (0x5cd)
+		// Code size: 1569 (0x621)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity/Scope,
@@ -294,320 +294,344 @@
 		IL_01ff: ldloc.3
 		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020a: ldstr "join"
-		IL_020f: ldstr ","
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0219: stloc.s 11
-		IL_021b: ldloc.3
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0221: stloc.s 10
-		IL_0223: ldloc.s 8
-		IL_0225: ldloc.s 12
-		IL_0227: ldloc.s 11
-		IL_0229: ldloc.s 10
-		IL_022b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0230: pop
-		IL_0231: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0236: dup
-		IL_0237: ldstr "keep"
-		IL_023c: ldstr "k"
-		IL_0241: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0246: dup
-		IL_0247: ldstr "drop"
-		IL_024c: ldstr "d"
-		IL_0251: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0256: stloc.s 4
-		IL_0258: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_025d: stloc.s 8
-		IL_025f: ldloc.s 4
-		IL_0261: ldstr "drop"
-		IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
-		IL_026b: stloc.s 13
-		IL_026d: ldloc.s 13
-		IL_026f: box [System.Runtime]System.Boolean
-		IL_0274: stloc.s 14
-		IL_0276: volatile.
-		IL_0278: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_027d: brfalse IL_0293
+		IL_020a: volatile.
+		IL_020c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0211: brfalse IL_022a
 
-		IL_0282: ldloc.s 4
-		IL_0284: ldstr "drop"
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028e: br IL_02a9
+		IL_0216: ldstr "join"
+		IL_021b: ldstr ","
+		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0225: br IL_0243
 
-		IL_0293: ldloc.s 4
-		IL_0295: ldstr "drop"
-		IL_029a: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:63"
-		IL_029f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_022a: ldstr "join"
+		IL_022f: ldstr ","
+		IL_0234: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:48"
+		IL_0239: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02a9: stloc.s 10
-		IL_02ab: ldloc.s 10
-		IL_02ad: ldnull
-		IL_02ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02b3: stloc.s 13
-		IL_02b5: ldloc.s 13
-		IL_02b7: box [System.Runtime]System.Boolean
-		IL_02bc: stloc.s 15
-		IL_02be: ldloc.s 4
-		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ca: ldstr "join"
-		IL_02cf: ldstr ","
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d9: stloc.s 10
-		IL_02db: ldloc.s 8
-		IL_02dd: ldloc.s 14
-		IL_02df: ldloc.s 15
-		IL_02e1: ldloc.s 10
-		IL_02e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_02e8: pop
-		IL_02e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ee: stloc.s 8
-		IL_02f0: ldloc.s 4
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_02f7: stloc.s 10
-		IL_02f9: ldloc.s 8
-		IL_02fb: ldloc.s 10
-		IL_02fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0302: pop
-		IL_0303: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0308: dup
-		IL_0309: ldstr "a"
-		IL_030e: ldc.r8 1
-		IL_0317: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_031c: dup
-		IL_031d: ldstr "b"
-		IL_0322: ldstr "two"
-		IL_0327: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_032c: stloc.s 5
-		IL_032e: ldloc.s 5
-		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_0335: pop
-		IL_0336: ldloc.s 5
-		IL_0338: ldstr "a"
-		IL_033d: ldc.r8 100
-		IL_0346: ldc.i4.0
-		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_034c: pop
-		IL_034d: ldloc.s 5
-		IL_034f: ldstr "c"
-		IL_0354: ldc.r8 3
-		IL_035d: ldc.i4.0
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0363: pop
-		IL_0364: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0369: stloc.s 8
-		IL_036b: ldloc.s 5
-		IL_036d: ldstr "a"
-		IL_0372: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
-		IL_0377: stloc.s 13
-		IL_0379: ldloc.s 13
-		IL_037b: box [System.Runtime]System.Boolean
-		IL_0380: stloc.s 15
-		IL_0382: volatile.
-		IL_0384: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0389: brfalse IL_039f
+		IL_0243: stloc.s 11
+		IL_0245: ldloc.3
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_024b: stloc.s 10
+		IL_024d: ldloc.s 8
+		IL_024f: ldloc.s 12
+		IL_0251: ldloc.s 11
+		IL_0253: ldloc.s 10
+		IL_0255: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_025a: pop
+		IL_025b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0260: dup
+		IL_0261: ldstr "keep"
+		IL_0266: ldstr "k"
+		IL_026b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0270: dup
+		IL_0271: ldstr "drop"
+		IL_0276: ldstr "d"
+		IL_027b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0280: stloc.s 4
+		IL_0282: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0287: stloc.s 8
+		IL_0289: ldloc.s 4
+		IL_028b: ldstr "drop"
+		IL_0290: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
+		IL_0295: stloc.s 13
+		IL_0297: ldloc.s 13
+		IL_0299: box [System.Runtime]System.Boolean
+		IL_029e: stloc.s 14
+		IL_02a0: volatile.
+		IL_02a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02a7: brfalse IL_02bd
 
-		IL_038e: ldloc.s 5
-		IL_0390: ldstr "a"
-		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_039a: br IL_03b5
+		IL_02ac: ldloc.s 4
+		IL_02ae: ldstr "drop"
+		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b8: br IL_02d3
 
-		IL_039f: ldloc.s 5
-		IL_03a1: ldstr "a"
-		IL_03a6: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:98"
-		IL_03ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02bd: ldloc.s 4
+		IL_02bf: ldstr "drop"
+		IL_02c4: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:63"
+		IL_02c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03b5: stloc.s 10
-		IL_03b7: volatile.
-		IL_03b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03be: brfalse IL_03d4
+		IL_02d3: stloc.s 10
+		IL_02d5: ldloc.s 10
+		IL_02d7: ldnull
+		IL_02d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02dd: stloc.s 13
+		IL_02df: ldloc.s 13
+		IL_02e1: box [System.Runtime]System.Boolean
+		IL_02e6: stloc.s 15
+		IL_02e8: ldloc.s 4
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f4: volatile.
+		IL_02f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02fb: brfalse IL_0314
 
-		IL_03c3: ldloc.s 5
-		IL_03c5: ldstr "c"
-		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03cf: br IL_03ea
+		IL_0300: ldstr "join"
+		IL_0305: ldstr ","
+		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030f: br IL_032d
 
-		IL_03d4: ldloc.s 5
-		IL_03d6: ldstr "c"
-		IL_03db: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:100"
-		IL_03e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0314: ldstr "join"
+		IL_0319: ldstr ","
+		IL_031e: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:70"
+		IL_0323: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03ea: stloc.s 11
-		IL_03ec: ldloc.s 11
-		IL_03ee: ldnull
-		IL_03ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03f4: stloc.s 13
-		IL_03f6: ldloc.s 13
-		IL_03f8: box [System.Runtime]System.Boolean
-		IL_03fd: stloc.s 14
-		IL_03ff: ldloc.s 5
-		IL_0401: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_0406: box [System.Runtime]System.Boolean
-		IL_040b: stloc.s 16
-		IL_040d: ldloc.s 8
-		IL_040f: ldc.i4.4
-		IL_0410: newarr [System.Runtime]System.Object
-		IL_0415: dup
-		IL_0416: ldc.i4.0
-		IL_0417: ldloc.s 15
-		IL_0419: stelem.ref
-		IL_041a: dup
-		IL_041b: ldc.i4.1
-		IL_041c: ldloc.s 10
-		IL_041e: stelem.ref
-		IL_041f: dup
-		IL_0420: ldc.i4.2
-		IL_0421: ldloc.s 14
-		IL_0423: stelem.ref
-		IL_0424: dup
-		IL_0425: ldc.i4.3
-		IL_0426: ldloc.s 16
-		IL_0428: stelem.ref
-		IL_0429: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_042e: pop
-		IL_042f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0434: stloc.s 8
-		IL_0436: ldloc.s 5
-		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_043d: stloc.s 10
-		IL_043f: ldloc.s 8
-		IL_0441: ldloc.s 10
-		IL_0443: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0448: pop
-		IL_0449: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_044e: dup
-		IL_044f: ldstr "x"
-		IL_0454: ldc.r8 1
-		IL_045d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0462: stloc.s 6
-		IL_0464: ldloc.s 6
-		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.Object::seal(object)
-		IL_046b: pop
-		IL_046c: ldloc.s 6
-		IL_046e: ldstr "x"
-		IL_0473: ldc.r8 2
-		IL_047c: ldc.i4.0
-		IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_032d: stloc.s 10
+		IL_032f: ldloc.s 8
+		IL_0331: ldloc.s 14
+		IL_0333: ldloc.s 15
+		IL_0335: ldloc.s 10
+		IL_0337: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_033c: pop
+		IL_033d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0342: stloc.s 8
+		IL_0344: ldloc.s 4
+		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_034b: stloc.s 10
+		IL_034d: ldloc.s 8
+		IL_034f: ldloc.s 10
+		IL_0351: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0356: pop
+		IL_0357: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_035c: dup
+		IL_035d: ldstr "a"
+		IL_0362: ldc.r8 1
+		IL_036b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0370: dup
+		IL_0371: ldstr "b"
+		IL_0376: ldstr "two"
+		IL_037b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0380: stloc.s 5
+		IL_0382: ldloc.s 5
+		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_0389: pop
+		IL_038a: ldloc.s 5
+		IL_038c: ldstr "a"
+		IL_0391: ldc.r8 100
+		IL_039a: ldc.i4.0
+		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_03a0: pop
+		IL_03a1: ldloc.s 5
+		IL_03a3: ldstr "c"
+		IL_03a8: ldc.r8 3
+		IL_03b1: ldc.i4.0
+		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_03b7: pop
+		IL_03b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03bd: stloc.s 8
+		IL_03bf: ldloc.s 5
+		IL_03c1: ldstr "a"
+		IL_03c6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
+		IL_03cb: stloc.s 13
+		IL_03cd: ldloc.s 13
+		IL_03cf: box [System.Runtime]System.Boolean
+		IL_03d4: stloc.s 15
+		IL_03d6: volatile.
+		IL_03d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_03dd: brfalse IL_03f3
+
+		IL_03e2: ldloc.s 5
+		IL_03e4: ldstr "a"
+		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ee: br IL_0409
+
+		IL_03f3: ldloc.s 5
+		IL_03f5: ldstr "a"
+		IL_03fa: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:98"
+		IL_03ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0409: stloc.s 10
+		IL_040b: volatile.
+		IL_040d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0412: brfalse IL_0428
+
+		IL_0417: ldloc.s 5
+		IL_0419: ldstr "c"
+		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0423: br IL_043e
+
+		IL_0428: ldloc.s 5
+		IL_042a: ldstr "c"
+		IL_042f: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:100"
+		IL_0434: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_043e: stloc.s 11
+		IL_0440: ldloc.s 11
+		IL_0442: ldnull
+		IL_0443: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0448: stloc.s 13
+		IL_044a: ldloc.s 13
+		IL_044c: box [System.Runtime]System.Boolean
+		IL_0451: stloc.s 14
+		IL_0453: ldloc.s 5
+		IL_0455: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_045a: box [System.Runtime]System.Boolean
+		IL_045f: stloc.s 16
+		IL_0461: ldloc.s 8
+		IL_0463: ldc.i4.4
+		IL_0464: newarr [System.Runtime]System.Object
+		IL_0469: dup
+		IL_046a: ldc.i4.0
+		IL_046b: ldloc.s 15
+		IL_046d: stelem.ref
+		IL_046e: dup
+		IL_046f: ldc.i4.1
+		IL_0470: ldloc.s 10
+		IL_0472: stelem.ref
+		IL_0473: dup
+		IL_0474: ldc.i4.2
+		IL_0475: ldloc.s 14
+		IL_0477: stelem.ref
+		IL_0478: dup
+		IL_0479: ldc.i4.3
+		IL_047a: ldloc.s 16
+		IL_047c: stelem.ref
+		IL_047d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_0482: pop
-		IL_0483: ldloc.s 6
-		IL_0485: ldstr "y"
-		IL_048a: ldc.r8 3
-		IL_0493: ldc.i4.0
-		IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0499: pop
-		IL_049a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_049f: stloc.s 8
-		IL_04a1: ldloc.s 6
+		IL_0483: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0488: stloc.s 8
+		IL_048a: ldloc.s 5
+		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0491: stloc.s 10
+		IL_0493: ldloc.s 8
+		IL_0495: ldloc.s 10
+		IL_0497: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_049c: pop
+		IL_049d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04a2: dup
 		IL_04a3: ldstr "x"
-		IL_04a8: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
-		IL_04ad: stloc.s 13
-		IL_04af: ldloc.s 13
-		IL_04b1: box [System.Runtime]System.Boolean
-		IL_04b6: stloc.s 16
-		IL_04b8: volatile.
-		IL_04ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_04bf: brfalse IL_04d5
+		IL_04a8: ldc.r8 1
+		IL_04b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_04b6: stloc.s 6
+		IL_04b8: ldloc.s 6
+		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::seal(object)
+		IL_04bf: pop
+		IL_04c0: ldloc.s 6
+		IL_04c2: ldstr "x"
+		IL_04c7: ldc.r8 2
+		IL_04d0: ldc.i4.0
+		IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_04d6: pop
+		IL_04d7: ldloc.s 6
+		IL_04d9: ldstr "y"
+		IL_04de: ldc.r8 3
+		IL_04e7: ldc.i4.0
+		IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_04ed: pop
+		IL_04ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04f3: stloc.s 8
+		IL_04f5: ldloc.s 6
+		IL_04f7: ldstr "x"
+		IL_04fc: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
+		IL_0501: stloc.s 13
+		IL_0503: ldloc.s 13
+		IL_0505: box [System.Runtime]System.Boolean
+		IL_050a: stloc.s 16
+		IL_050c: volatile.
+		IL_050e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0513: brfalse IL_0529
 
-		IL_04c4: ldloc.s 6
-		IL_04c6: ldstr "x"
-		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04d0: br IL_04eb
+		IL_0518: ldloc.s 6
+		IL_051a: ldstr "x"
+		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0524: br IL_053f
 
-		IL_04d5: ldloc.s 6
-		IL_04d7: ldstr "x"
-		IL_04dc: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:132"
-		IL_04e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0529: ldloc.s 6
+		IL_052b: ldstr "x"
+		IL_0530: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:132"
+		IL_0535: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04eb: stloc.s 10
-		IL_04ed: volatile.
-		IL_04ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_04f4: brfalse IL_050a
+		IL_053f: stloc.s 10
+		IL_0541: volatile.
+		IL_0543: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0548: brfalse IL_055e
 
-		IL_04f9: ldloc.s 6
-		IL_04fb: ldstr "y"
-		IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0505: br IL_0520
+		IL_054d: ldloc.s 6
+		IL_054f: ldstr "y"
+		IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0559: br IL_0574
 
-		IL_050a: ldloc.s 6
-		IL_050c: ldstr "y"
-		IL_0511: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:134"
-		IL_0516: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_055e: ldloc.s 6
+		IL_0560: ldstr "y"
+		IL_0565: ldstr "ObjectLiteral_Inference_DescriptorAndMutation_Parity:Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity:__js_module_init__:134"
+		IL_056a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0520: stloc.s 11
-		IL_0522: ldloc.s 11
-		IL_0524: ldnull
-		IL_0525: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_052a: stloc.s 13
-		IL_052c: ldloc.s 13
-		IL_052e: box [System.Runtime]System.Boolean
-		IL_0533: stloc.s 14
-		IL_0535: ldloc.s 6
-		IL_0537: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
-		IL_053c: box [System.Runtime]System.Boolean
-		IL_0541: stloc.s 15
-		IL_0543: ldloc.s 6
-		IL_0545: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_054a: box [System.Runtime]System.Boolean
-		IL_054f: stloc.s 17
-		IL_0551: ldloc.s 8
-		IL_0553: ldc.i4.5
-		IL_0554: newarr [System.Runtime]System.Object
-		IL_0559: dup
-		IL_055a: ldc.i4.0
-		IL_055b: ldloc.s 16
-		IL_055d: stelem.ref
-		IL_055e: dup
-		IL_055f: ldc.i4.1
-		IL_0560: ldloc.s 10
-		IL_0562: stelem.ref
-		IL_0563: dup
-		IL_0564: ldc.i4.2
-		IL_0565: ldloc.s 14
-		IL_0567: stelem.ref
-		IL_0568: dup
-		IL_0569: ldc.i4.3
-		IL_056a: ldloc.s 15
-		IL_056c: stelem.ref
-		IL_056d: dup
-		IL_056e: ldc.i4.4
-		IL_056f: ldloc.s 17
-		IL_0571: stelem.ref
-		IL_0572: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0577: pop
-		IL_0578: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_057d: dup
-		IL_057e: ldstr "present"
-		IL_0583: ldnull
-		IL_0584: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0589: stloc.s 7
-		IL_058b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0590: stloc.s 8
-		IL_0592: ldstr "present"
-		IL_0597: ldloc.s 7
-		IL_0599: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_059e: stloc.s 13
-		IL_05a0: ldloc.s 13
-		IL_05a2: box [System.Runtime]System.Boolean
-		IL_05a7: stloc.s 17
-		IL_05a9: ldstr "absent"
-		IL_05ae: ldloc.s 7
-		IL_05b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
-		IL_05b5: stloc.s 13
-		IL_05b7: ldloc.s 13
-		IL_05b9: box [System.Runtime]System.Boolean
-		IL_05be: stloc.s 15
-		IL_05c0: ldloc.s 8
-		IL_05c2: ldloc.s 17
-		IL_05c4: ldloc.s 15
-		IL_05c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0574: stloc.s 11
+		IL_0576: ldloc.s 11
+		IL_0578: ldnull
+		IL_0579: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_057e: stloc.s 13
+		IL_0580: ldloc.s 13
+		IL_0582: box [System.Runtime]System.Boolean
+		IL_0587: stloc.s 14
+		IL_0589: ldloc.s 6
+		IL_058b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
+		IL_0590: box [System.Runtime]System.Boolean
+		IL_0595: stloc.s 15
+		IL_0597: ldloc.s 6
+		IL_0599: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_059e: box [System.Runtime]System.Boolean
+		IL_05a3: stloc.s 17
+		IL_05a5: ldloc.s 8
+		IL_05a7: ldc.i4.5
+		IL_05a8: newarr [System.Runtime]System.Object
+		IL_05ad: dup
+		IL_05ae: ldc.i4.0
+		IL_05af: ldloc.s 16
+		IL_05b1: stelem.ref
+		IL_05b2: dup
+		IL_05b3: ldc.i4.1
+		IL_05b4: ldloc.s 10
+		IL_05b6: stelem.ref
+		IL_05b7: dup
+		IL_05b8: ldc.i4.2
+		IL_05b9: ldloc.s 14
+		IL_05bb: stelem.ref
+		IL_05bc: dup
+		IL_05bd: ldc.i4.3
+		IL_05be: ldloc.s 15
+		IL_05c0: stelem.ref
+		IL_05c1: dup
+		IL_05c2: ldc.i4.4
+		IL_05c3: ldloc.s 17
+		IL_05c5: stelem.ref
+		IL_05c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_05cb: pop
-		IL_05cc: ret
+		IL_05cc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_05d1: dup
+		IL_05d2: ldstr "present"
+		IL_05d7: ldnull
+		IL_05d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_05dd: stloc.s 7
+		IL_05df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05e4: stloc.s 8
+		IL_05e6: ldstr "present"
+		IL_05eb: ldloc.s 7
+		IL_05ed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_05f2: stloc.s 13
+		IL_05f4: ldloc.s 13
+		IL_05f6: box [System.Runtime]System.Boolean
+		IL_05fb: stloc.s 17
+		IL_05fd: ldstr "absent"
+		IL_0602: ldloc.s 7
+		IL_0604: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::In(object, object)
+		IL_0609: stloc.s 13
+		IL_060b: ldloc.s 13
+		IL_060d: box [System.Runtime]System.Boolean
+		IL_0612: stloc.s 15
+		IL_0614: ldloc.s 8
+		IL_0616: ldloc.s 17
+		IL_0618: ldloc.s 15
+		IL_061a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_061f: pop
+		IL_0620: ret
 	} // end of method ObjectLiteral_Inference_DescriptorAndMutation_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_Inference_DescriptorAndMutation_Parity
@@ -647,6 +671,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_EnumerationAndJson_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_EnumerationAndJson_Parity.verified.txt
@@ -587,7 +587,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1486 (0x5ce)
+		// Code size: 1737 (0x6c9)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/Scope,
@@ -704,364 +704,437 @@
 		IL_0122: ldloc.s 5
 		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012e: ldstr "join"
-		IL_0133: ldstr ","
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_013d: stloc.s 11
-		IL_013f: ldloc.s 13
-		IL_0141: ldloc.s 11
-		IL_0143: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0148: pop
-		IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014e: stloc.s 13
-		IL_0150: ldloc.s 5
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Object::values(object)
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015c: ldstr "join"
-		IL_0161: ldstr ","
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016b: stloc.s 11
-		IL_016d: ldloc.s 13
-		IL_016f: ldloc.s 11
-		IL_0171: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0176: pop
-		IL_0177: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017c: stloc.s 13
-		IL_017e: ldloc.s 5
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::entries(object)
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018a: stloc.s 11
-		IL_018c: ldc.i4.1
-		IL_018d: newarr [System.Runtime]System.Object
-		IL_0192: dup
-		IL_0193: ldc.i4.0
-		IL_0194: ldloc.0
-		IL_0195: stelem.ref
-		IL_0196: stloc.s 15
-		IL_0198: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject::.ctor()
-		IL_019d: ldc.i4.1
-		IL_019e: conv.r8
-		IL_019f: ldstr ""
-		IL_01a4: ldc.i4.0
-		IL_01a5: ldc.i4.0
-		IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject>(!!0)
-		IL_01b0: stloc.s 16
-		IL_01b2: ldloc.s 11
-		IL_01b4: ldstr "map"
-		IL_01b9: ldloc.s 16
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c0: stloc.s 11
-		IL_01c2: ldloc.s 11
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c9: ldstr "join"
-		IL_01ce: ldstr ","
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d8: stloc.s 11
-		IL_01da: ldloc.s 13
-		IL_01dc: ldloc.s 11
-		IL_01de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e3: pop
-		IL_01e4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01e9: dup
-		IL_01ea: ldstr "b"
-		IL_01ef: ldstr "s1"
-		IL_01f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_01f9: dup
-		IL_01fa: ldstr "2"
-		IL_01ff: ldstr "i2"
-		IL_0204: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0209: dup
-		IL_020a: ldstr "a"
-		IL_020f: ldstr "s2"
-		IL_0214: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0219: dup
-		IL_021a: ldstr "0"
-		IL_021f: ldstr "i0"
-		IL_0224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0229: dup
-		IL_022a: ldstr "1"
-		IL_022f: ldstr "i1"
-		IL_0234: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0239: stloc.s 6
-		IL_023b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0240: stloc.s 13
-		IL_0242: ldloc.s 6
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024e: ldstr "join"
-		IL_0253: ldstr ","
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025d: stloc.s 11
-		IL_025f: ldloc.s 13
-		IL_0261: ldloc.s 11
-		IL_0263: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0268: pop
-		IL_0269: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_026e: stloc.s 13
-		IL_0270: ldloc.s 6
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0277: stloc.s 11
-		IL_0279: ldloc.s 13
-		IL_027b: ldloc.s 11
-		IL_027d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0282: pop
-		IL_0283: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0288: dup
-		IL_0289: ldstr "x"
-		IL_028e: ldc.r8 1
-		IL_0297: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_029c: dup
-		IL_029d: ldstr "y"
-		IL_02a2: ldstr "two"
-		IL_02a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02ac: stloc.s 17
-		IL_02ae: ldc.i4.1
-		IL_02af: newarr [System.Runtime]System.Object
-		IL_02b4: dup
-		IL_02b5: ldc.i4.0
-		IL_02b6: ldloc.0
-		IL_02b7: stelem.ref
-		IL_02b8: stloc.s 15
-		IL_02ba: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject::.ctor()
-		IL_02bf: ldc.i4.0
-		IL_02c0: conv.r8
-		IL_02c1: ldstr ""
-		IL_02c6: ldc.i4.0
-		IL_02c7: ldc.i4.0
-		IL_02c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject>(!!0)
-		IL_02d2: stloc.s 18
-		IL_02d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02d9: dup
-		IL_02da: ldstr "text"
-		IL_02df: ldstr "hello"
-		IL_02e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02e9: dup
-		IL_02ea: ldstr "n"
-		IL_02ef: ldc.r8 42
-		IL_02f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_02fd: dup
-		IL_02fe: ldstr "flag"
-		IL_0303: ldc.i4.1
-		IL_0304: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0309: dup
-		IL_030a: ldstr "boxed"
-		IL_030f: ldc.i4.0
-		IL_0310: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0315: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_031a: dup
-		IL_031b: ldstr "nested"
-		IL_0320: ldloc.s 17
-		IL_0322: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0327: dup
-		IL_0328: ldstr "fn"
-		IL_032d: ldloc.s 18
-		IL_032f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0334: stloc.s 7
-		IL_0336: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_033b: stloc.s 13
-		IL_033d: ldloc.s 7
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0344: stloc.s 11
-		IL_0346: ldloc.s 13
-		IL_0348: ldloc.s 11
-		IL_034a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_034f: pop
-		IL_0350: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0355: stloc.s 13
-		IL_0357: ldloc.s 7
-		IL_0359: ldc.i4.0
-		IL_035a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_012e: volatile.
+		IL_0130: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0135: brfalse IL_014e
+
+		IL_013a: ldstr "join"
+		IL_013f: ldstr ","
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0149: br IL_0167
+
+		IL_014e: ldstr "join"
+		IL_0153: ldstr ","
+		IL_0158: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:42"
+		IL_015d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0167: stloc.s 11
+		IL_0169: ldloc.s 13
+		IL_016b: ldloc.s 11
+		IL_016d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0172: pop
+		IL_0173: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0178: stloc.s 13
+		IL_017a: ldloc.s 5
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::values(object)
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0186: volatile.
+		IL_0188: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_018d: brfalse IL_01a6
+
+		IL_0192: ldstr "join"
+		IL_0197: ldstr ","
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a1: br IL_01bf
+
+		IL_01a6: ldstr "join"
+		IL_01ab: ldstr ","
+		IL_01b0: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:49"
+		IL_01b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01bf: stloc.s 11
+		IL_01c1: ldloc.s 13
+		IL_01c3: ldloc.s 11
+		IL_01c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ca: pop
+		IL_01cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01d0: stloc.s 13
+		IL_01d2: ldloc.s 5
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::entries(object)
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01de: stloc.s 11
+		IL_01e0: ldc.i4.1
+		IL_01e1: newarr [System.Runtime]System.Object
+		IL_01e6: dup
+		IL_01e7: ldc.i4.0
+		IL_01e8: ldloc.0
+		IL_01e9: stelem.ref
+		IL_01ea: stloc.s 15
+		IL_01ec: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject::.ctor()
+		IL_01f1: ldc.i4.1
+		IL_01f2: conv.r8
+		IL_01f3: ldstr ""
+		IL_01f8: ldc.i4.0
+		IL_01f9: ldc.i4.0
+		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject>(!!0)
+		IL_0204: stloc.s 16
+		IL_0206: volatile.
+		IL_0208: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_020d: brfalse IL_0225
+
+		IL_0212: ldloc.s 11
+		IL_0214: ldstr "map"
+		IL_0219: ldloc.s 16
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0220: br IL_023d
+
+		IL_0225: ldloc.s 11
+		IL_0227: ldstr "map"
+		IL_022c: ldloc.s 16
+		IL_022e: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:57"
+		IL_0233: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_023d: stloc.s 11
+		IL_023f: ldloc.s 11
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0246: volatile.
+		IL_0248: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_024d: brfalse IL_0266
+
+		IL_0252: ldstr "join"
+		IL_0257: ldstr ","
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0261: br IL_027f
+
+		IL_0266: ldstr "join"
+		IL_026b: ldstr ","
+		IL_0270: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:60"
+		IL_0275: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_027f: stloc.s 11
+		IL_0281: ldloc.s 13
+		IL_0283: ldloc.s 11
+		IL_0285: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_028a: pop
+		IL_028b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0290: dup
+		IL_0291: ldstr "b"
+		IL_0296: ldstr "s1"
+		IL_029b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02a0: dup
+		IL_02a1: ldstr "2"
+		IL_02a6: ldstr "i2"
+		IL_02ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02b0: dup
+		IL_02b1: ldstr "a"
+		IL_02b6: ldstr "s2"
+		IL_02bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02c0: dup
+		IL_02c1: ldstr "0"
+		IL_02c6: ldstr "i0"
+		IL_02cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02d0: dup
+		IL_02d1: ldstr "1"
+		IL_02d6: ldstr "i1"
+		IL_02db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02e0: stloc.s 6
+		IL_02e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02e7: stloc.s 13
+		IL_02e9: ldloc.s 6
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f5: volatile.
+		IL_02f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02fc: brfalse IL_0315
+
+		IL_0301: ldstr "join"
+		IL_0306: ldstr ","
+		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0310: br IL_032e
+
+		IL_0315: ldstr "join"
+		IL_031a: ldstr ","
+		IL_031f: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:75"
+		IL_0324: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_032e: stloc.s 11
+		IL_0330: ldloc.s 13
+		IL_0332: ldloc.s 11
+		IL_0334: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0339: pop
+		IL_033a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_033f: stloc.s 13
+		IL_0341: ldloc.s 6
+		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0348: stloc.s 11
+		IL_034a: ldloc.s 13
+		IL_034c: ldloc.s 11
+		IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0353: pop
+		IL_0354: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0359: dup
+		IL_035a: ldstr "x"
 		IL_035f: ldc.r8 1
-		IL_0368: box [System.Runtime]System.Double
-		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object, object, object)
-		IL_0372: stloc.s 11
-		IL_0374: ldloc.s 13
-		IL_0376: ldloc.s 11
-		IL_0378: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_037d: pop
-		IL_037e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0383: dup
-		IL_0384: ldstr "a"
-		IL_0389: ldc.r8 1
-		IL_0392: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0397: dup
-		IL_0398: ldstr "b"
-		IL_039d: ldc.r8 2
-		IL_03a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_03ab: stloc.s 8
-		IL_03ad: ldloc.s 8
-		IL_03af: ldstr "a"
-		IL_03b4: ldc.r8 10
-		IL_03bd: ldc.i4.0
-		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_03c3: pop
-		IL_03c4: volatile.
-		IL_03c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_03cb: brfalse IL_03e1
+		IL_0368: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_036d: dup
+		IL_036e: ldstr "y"
+		IL_0373: ldstr "two"
+		IL_0378: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_037d: stloc.s 17
+		IL_037f: ldc.i4.1
+		IL_0380: newarr [System.Runtime]System.Object
+		IL_0385: dup
+		IL_0386: ldc.i4.0
+		IL_0387: ldloc.0
+		IL_0388: stelem.ref
+		IL_0389: stloc.s 15
+		IL_038b: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject::.ctor()
+		IL_0390: ldc.i4.0
+		IL_0391: conv.r8
+		IL_0392: ldstr ""
+		IL_0397: ldc.i4.0
+		IL_0398: ldc.i4.0
+		IL_0399: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_039e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject>(!!0)
+		IL_03a3: stloc.s 18
+		IL_03a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03aa: dup
+		IL_03ab: ldstr "text"
+		IL_03b0: ldstr "hello"
+		IL_03b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03ba: dup
+		IL_03bb: ldstr "n"
+		IL_03c0: ldc.r8 42
+		IL_03c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03ce: dup
+		IL_03cf: ldstr "flag"
+		IL_03d4: ldc.i4.1
+		IL_03d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_03da: dup
+		IL_03db: ldstr "boxed"
+		IL_03e0: ldc.i4.0
+		IL_03e1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_03e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03eb: dup
+		IL_03ec: ldstr "nested"
+		IL_03f1: ldloc.s 17
+		IL_03f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03f8: dup
+		IL_03f9: ldstr "fn"
+		IL_03fe: ldloc.s 18
+		IL_0400: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0405: stloc.s 7
+		IL_0407: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_040c: stloc.s 13
+		IL_040e: ldloc.s 7
+		IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0415: stloc.s 11
+		IL_0417: ldloc.s 13
+		IL_0419: ldloc.s 11
+		IL_041b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0420: pop
+		IL_0421: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0426: stloc.s 13
+		IL_0428: ldloc.s 7
+		IL_042a: ldc.i4.0
+		IL_042b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0430: ldc.r8 1
+		IL_0439: box [System.Runtime]System.Double
+		IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object, object, object)
+		IL_0443: stloc.s 11
+		IL_0445: ldloc.s 13
+		IL_0447: ldloc.s 11
+		IL_0449: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_044e: pop
+		IL_044f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0454: dup
+		IL_0455: ldstr "a"
+		IL_045a: ldc.r8 1
+		IL_0463: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0468: dup
+		IL_0469: ldstr "b"
+		IL_046e: ldc.r8 2
+		IL_0477: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_047c: stloc.s 8
+		IL_047e: ldloc.s 8
+		IL_0480: ldstr "a"
+		IL_0485: ldc.r8 10
+		IL_048e: ldc.i4.0
+		IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0494: pop
+		IL_0495: volatile.
+		IL_0497: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_049c: brfalse IL_04b2
 
-		IL_03d0: ldloc.s 8
-		IL_03d2: ldstr "b"
-		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03dc: br IL_03f7
+		IL_04a1: ldloc.s 8
+		IL_04a3: ldstr "b"
+		IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04ad: br IL_04c8
 
-		IL_03e1: ldloc.s 8
-		IL_03e3: ldstr "b"
-		IL_03e8: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:116"
-		IL_03ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04b2: ldloc.s 8
+		IL_04b4: ldstr "b"
+		IL_04b9: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:116"
+		IL_04be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03f7: stloc.s 11
-		IL_03f9: ldloc.s 11
-		IL_03fb: ldc.r8 5
-		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-		IL_0409: stloc.s 19
-		IL_040b: ldloc.s 8
-		IL_040d: ldstr "b"
-		IL_0412: ldloc.s 19
-		IL_0414: ldc.i4.0
-		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_041a: pop
-		IL_041b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0420: stloc.s 13
-		IL_0422: ldloc.s 8
-		IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0429: stloc.s 11
-		IL_042b: ldloc.s 13
-		IL_042d: ldloc.s 11
-		IL_042f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0434: pop
-		IL_0435: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::.ctor()
-		IL_043a: stloc.s 9
-		IL_043c: ldloc.s 9
-		IL_043e: ldc.r8 1
-		IL_0447: callvirt instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::set_p(float64)
-		IL_044c: ldloc.s 9
-		IL_044e: ldstr "two"
-		IL_0453: callvirt instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::set_q(string)
-		IL_0458: ldloc.s 9
-		IL_045a: ldc.i4.1
-		IL_045b: callvirt instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::set_r(bool)
-		IL_0460: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0465: dup
-		IL_0466: ldstr "p"
-		IL_046b: ldc.r8 1
-		IL_0474: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0479: dup
-		IL_047a: ldstr "q"
-		IL_047f: ldstr "two"
-		IL_0484: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0489: dup
-		IL_048a: ldstr "r"
-		IL_048f: ldc.i4.1
-		IL_0490: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0495: stloc.s 10
-		IL_0497: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_049c: stloc.s 13
-		IL_049e: ldloc.s 9
-		IL_04a0: castclass Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin
-		IL_04a5: callvirt instance float64 Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::get_p()
-		IL_04aa: stloc.s 20
-		IL_04ac: ldloc.s 20
-		IL_04ae: box [System.Runtime]System.Double
-		IL_04b3: stloc.s 21
-		IL_04b5: ldloc.s 9
-		IL_04b7: castclass Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin
-		IL_04bc: callvirt instance string Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::get_q()
-		IL_04c1: stloc.s 14
-		IL_04c3: ldloc.s 9
-		IL_04c5: castclass Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin
-		IL_04ca: callvirt instance bool Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::get_r()
-		IL_04cf: stloc.s 12
-		IL_04d1: ldloc.s 12
-		IL_04d3: box [System.Runtime]System.Boolean
-		IL_04d8: stloc.s 22
-		IL_04da: ldloc.s 13
-		IL_04dc: ldloc.s 21
-		IL_04de: ldloc.s 14
-		IL_04e0: ldloc.s 22
-		IL_04e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_04e7: pop
-		IL_04e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04ed: stloc.s 13
-		IL_04ef: ldloc.s 10
-		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04fb: ldstr "join"
-		IL_0500: ldstr ","
-		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_050a: stloc.s 11
-		IL_050c: volatile.
-		IL_050e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0513: brfalse IL_0529
-
-		IL_0518: ldloc.s 10
-		IL_051a: ldstr "p"
-		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0524: br IL_053f
-
-		IL_0529: ldloc.s 10
-		IL_052b: ldstr "p"
-		IL_0530: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:152"
-		IL_0535: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_053f: stloc.s 23
-		IL_0541: volatile.
-		IL_0543: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0548: brfalse IL_055e
-
-		IL_054d: ldloc.s 10
-		IL_054f: ldstr "q"
-		IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0559: br IL_0574
-
-		IL_055e: ldloc.s 10
-		IL_0560: ldstr "q"
-		IL_0565: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:154"
-		IL_056a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0574: stloc.s 24
-		IL_0576: volatile.
-		IL_0578: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_057d: brfalse IL_0593
-
-		IL_0582: ldloc.s 10
-		IL_0584: ldstr "r"
-		IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_058e: br IL_05a9
-
-		IL_0593: ldloc.s 10
-		IL_0595: ldstr "r"
-		IL_059a: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:156"
-		IL_059f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_05a9: stloc.s 25
+		IL_04c8: stloc.s 11
+		IL_04ca: ldloc.s 11
+		IL_04cc: ldc.r8 5
+		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+		IL_04da: stloc.s 19
+		IL_04dc: ldloc.s 8
+		IL_04de: ldstr "b"
+		IL_04e3: ldloc.s 19
+		IL_04e5: ldc.i4.0
+		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_04eb: pop
+		IL_04ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04f1: stloc.s 13
+		IL_04f3: ldloc.s 8
+		IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_04fa: stloc.s 11
+		IL_04fc: ldloc.s 13
+		IL_04fe: ldloc.s 11
+		IL_0500: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0505: pop
+		IL_0506: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::.ctor()
+		IL_050b: stloc.s 9
+		IL_050d: ldloc.s 9
+		IL_050f: ldc.r8 1
+		IL_0518: callvirt instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::set_p(float64)
+		IL_051d: ldloc.s 9
+		IL_051f: ldstr "two"
+		IL_0524: callvirt instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::set_q(string)
+		IL_0529: ldloc.s 9
+		IL_052b: ldc.i4.1
+		IL_052c: callvirt instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::set_r(bool)
+		IL_0531: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0536: dup
+		IL_0537: ldstr "p"
+		IL_053c: ldc.r8 1
+		IL_0545: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_054a: dup
+		IL_054b: ldstr "q"
+		IL_0550: ldstr "two"
+		IL_0555: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_055a: dup
+		IL_055b: ldstr "r"
+		IL_0560: ldc.i4.1
+		IL_0561: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0566: stloc.s 10
+		IL_0568: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_056d: stloc.s 13
+		IL_056f: ldloc.s 9
+		IL_0571: castclass Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin
+		IL_0576: callvirt instance float64 Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::get_p()
+		IL_057b: stloc.s 20
+		IL_057d: ldloc.s 20
+		IL_057f: box [System.Runtime]System.Double
+		IL_0584: stloc.s 21
+		IL_0586: ldloc.s 9
+		IL_0588: castclass Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin
+		IL_058d: callvirt instance string Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::get_q()
+		IL_0592: stloc.s 14
+		IL_0594: ldloc.s 9
+		IL_0596: castclass Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin
+		IL_059b: callvirt instance bool Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/ObjectLiterals/L44C22_eligibleTwin::get_r()
+		IL_05a0: stloc.s 12
+		IL_05a2: ldloc.s 12
+		IL_05a4: box [System.Runtime]System.Boolean
+		IL_05a9: stloc.s 22
 		IL_05ab: ldloc.s 13
-		IL_05ad: ldc.i4.4
-		IL_05ae: newarr [System.Runtime]System.Object
-		IL_05b3: dup
-		IL_05b4: ldc.i4.0
-		IL_05b5: ldloc.s 11
-		IL_05b7: stelem.ref
-		IL_05b8: dup
-		IL_05b9: ldc.i4.1
-		IL_05ba: ldloc.s 23
-		IL_05bc: stelem.ref
-		IL_05bd: dup
-		IL_05be: ldc.i4.2
-		IL_05bf: ldloc.s 24
-		IL_05c1: stelem.ref
-		IL_05c2: dup
-		IL_05c3: ldc.i4.3
-		IL_05c4: ldloc.s 25
-		IL_05c6: stelem.ref
-		IL_05c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_05cc: pop
-		IL_05cd: ret
+		IL_05ad: ldloc.s 21
+		IL_05af: ldloc.s 14
+		IL_05b1: ldloc.s 22
+		IL_05b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_05b8: pop
+		IL_05b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05be: stloc.s 13
+		IL_05c0: ldloc.s 10
+		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05cc: volatile.
+		IL_05ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_05d3: brfalse IL_05ec
+
+		IL_05d8: ldstr "join"
+		IL_05dd: ldstr ","
+		IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05e7: br IL_0605
+
+		IL_05ec: ldstr "join"
+		IL_05f1: ldstr ","
+		IL_05f6: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:150"
+		IL_05fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0605: stloc.s 11
+		IL_0607: volatile.
+		IL_0609: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_060e: brfalse IL_0624
+
+		IL_0613: ldloc.s 10
+		IL_0615: ldstr "p"
+		IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_061f: br IL_063a
+
+		IL_0624: ldloc.s 10
+		IL_0626: ldstr "p"
+		IL_062b: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:152"
+		IL_0630: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_063a: stloc.s 23
+		IL_063c: volatile.
+		IL_063e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0643: brfalse IL_0659
+
+		IL_0648: ldloc.s 10
+		IL_064a: ldstr "q"
+		IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0654: br IL_066f
+
+		IL_0659: ldloc.s 10
+		IL_065b: ldstr "q"
+		IL_0660: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:154"
+		IL_0665: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_066f: stloc.s 24
+		IL_0671: volatile.
+		IL_0673: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0678: brfalse IL_068e
+
+		IL_067d: ldloc.s 10
+		IL_067f: ldstr "r"
+		IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0689: br IL_06a4
+
+		IL_068e: ldloc.s 10
+		IL_0690: ldstr "r"
+		IL_0695: ldstr "ObjectLiteral_Inference_EnumerationAndJson_Parity:Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity:__js_module_init__:156"
+		IL_069a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06a4: stloc.s 25
+		IL_06a6: ldloc.s 13
+		IL_06a8: ldc.i4.4
+		IL_06a9: newarr [System.Runtime]System.Object
+		IL_06ae: dup
+		IL_06af: ldc.i4.0
+		IL_06b0: ldloc.s 11
+		IL_06b2: stelem.ref
+		IL_06b3: dup
+		IL_06b4: ldc.i4.1
+		IL_06b5: ldloc.s 23
+		IL_06b7: stelem.ref
+		IL_06b8: dup
+		IL_06b9: ldc.i4.2
+		IL_06ba: ldloc.s 24
+		IL_06bc: stelem.ref
+		IL_06bd: dup
+		IL_06be: ldc.i4.3
+		IL_06bf: ldloc.s 25
+		IL_06c1: stelem.ref
+		IL_06c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_06c7: pop
+		IL_06c8: ret
 	} // end of method ObjectLiteral_Inference_EnumerationAndJson_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity
@@ -1095,6 +1168,12 @@
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
@@ -508,7 +508,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -520,16 +520,28 @@
 			IL_0006: ldarg.1
 			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0011: ldstr "join"
-			IL_0016: ldstr ","
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0020: stloc.1
-			IL_0021: ldloc.0
-			IL_0022: ldloc.1
-			IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0028: pop
-			IL_0029: ldnull
-			IL_002a: ret
+			IL_0011: volatile.
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0018: brfalse IL_0031
+
+			IL_001d: ldstr "join"
+			IL_0022: ldstr ","
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002c: br IL_004a
+
+			IL_0031: ldstr "join"
+			IL_0036: ldstr ","
+			IL_003b: ldstr "ObjectLiteral_InferredConstruction_Parity:<TwoPhaseDummy_M6>:__js_call__:6"
+			IL_0040: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_004a: stloc.1
+			IL_004b: ldloc.0
+			IL_004c: ldloc.1
+			IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0052: pop
+			IL_0053: ldnull
+			IL_0054: ret
 		} // end of method leak::__js_call__
 
 	} // end of class leak
@@ -759,7 +771,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1204 (0x4b4)
+		// Code size: 1246 (0x4de)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InferredConstruction_Parity/Scope,
@@ -1063,147 +1075,159 @@
 		IL_0300: ldloc.3
 		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_030b: ldstr "join"
-		IL_0310: ldstr ","
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_031a: stloc.s 20
-		IL_031c: ldloc.s 8
-		IL_031e: ldloc.s 20
-		IL_0320: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0325: pop
-		IL_0326: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_032b: stloc.s 8
-		IL_032d: ldloc.3
-		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0333: stloc.s 20
-		IL_0335: ldloc.s 8
-		IL_0337: ldloc.s 20
-		IL_0339: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_033e: pop
-		IL_033f: ldloc.3
-		IL_0340: ldstr "n"
-		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_034a: stloc.s 4
-		IL_034c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0351: stloc.s 8
-		IL_0353: volatile.
-		IL_0355: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_035a: brfalse IL_0370
+		IL_030b: volatile.
+		IL_030d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0312: brfalse IL_032b
 
-		IL_035f: ldloc.s 4
-		IL_0361: ldstr "value"
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_036b: br IL_0386
+		IL_0317: ldstr "join"
+		IL_031c: ldstr ","
+		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0326: br IL_0344
 
-		IL_0370: ldloc.s 4
-		IL_0372: ldstr "value"
-		IL_0377: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:74"
-		IL_037c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_032b: ldstr "join"
+		IL_0330: ldstr ","
+		IL_0335: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:61"
+		IL_033a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0386: stloc.s 20
-		IL_0388: volatile.
-		IL_038a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_038f: brfalse IL_03a5
+		IL_0344: stloc.s 20
+		IL_0346: ldloc.s 8
+		IL_0348: ldloc.s 20
+		IL_034a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_034f: pop
+		IL_0350: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0355: stloc.s 8
+		IL_0357: ldloc.3
+		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_035d: stloc.s 20
+		IL_035f: ldloc.s 8
+		IL_0361: ldloc.s 20
+		IL_0363: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0368: pop
+		IL_0369: ldloc.3
+		IL_036a: ldstr "n"
+		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0374: stloc.s 4
+		IL_0376: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_037b: stloc.s 8
+		IL_037d: volatile.
+		IL_037f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0384: brfalse IL_039a
 
-		IL_0394: ldloc.s 4
-		IL_0396: ldstr "writable"
-		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03a0: br IL_03bb
+		IL_0389: ldloc.s 4
+		IL_038b: ldstr "value"
+		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0395: br IL_03b0
 
-		IL_03a5: ldloc.s 4
-		IL_03a7: ldstr "writable"
-		IL_03ac: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:76"
-		IL_03b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_039a: ldloc.s 4
+		IL_039c: ldstr "value"
+		IL_03a1: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:74"
+		IL_03a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03bb: stloc.s 19
-		IL_03bd: volatile.
-		IL_03bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_03c4: brfalse IL_03da
+		IL_03b0: stloc.s 20
+		IL_03b2: volatile.
+		IL_03b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_03b9: brfalse IL_03cf
 
-		IL_03c9: ldloc.s 4
-		IL_03cb: ldstr "enumerable"
-		IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d5: br IL_03f0
+		IL_03be: ldloc.s 4
+		IL_03c0: ldstr "writable"
+		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ca: br IL_03e5
 
-		IL_03da: ldloc.s 4
-		IL_03dc: ldstr "enumerable"
-		IL_03e1: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:78"
-		IL_03e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03cf: ldloc.s 4
+		IL_03d1: ldstr "writable"
+		IL_03d6: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:76"
+		IL_03db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03f0: stloc.s 14
-		IL_03f2: volatile.
-		IL_03f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_03f9: brfalse IL_040f
+		IL_03e5: stloc.s 19
+		IL_03e7: volatile.
+		IL_03e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_03ee: brfalse IL_0404
 
-		IL_03fe: ldloc.s 4
-		IL_0400: ldstr "configurable"
-		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_040a: br IL_0425
+		IL_03f3: ldloc.s 4
+		IL_03f5: ldstr "enumerable"
+		IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ff: br IL_041a
 
-		IL_040f: ldloc.s 4
-		IL_0411: ldstr "configurable"
-		IL_0416: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:80"
-		IL_041b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0404: ldloc.s 4
+		IL_0406: ldstr "enumerable"
+		IL_040b: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:78"
+		IL_0410: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0425: stloc.s 21
-		IL_0427: ldloc.s 8
-		IL_0429: ldc.i4.4
-		IL_042a: newarr [System.Runtime]System.Object
-		IL_042f: dup
-		IL_0430: ldc.i4.0
-		IL_0431: ldloc.s 20
-		IL_0433: stelem.ref
-		IL_0434: dup
-		IL_0435: ldc.i4.1
-		IL_0436: ldloc.s 19
-		IL_0438: stelem.ref
-		IL_0439: dup
-		IL_043a: ldc.i4.2
-		IL_043b: ldloc.s 14
-		IL_043d: stelem.ref
-		IL_043e: dup
-		IL_043f: ldc.i4.3
-		IL_0440: ldloc.s 21
-		IL_0442: stelem.ref
-		IL_0443: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0448: pop
-		IL_0449: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_044e: dup
-		IL_044f: ldstr "x"
-		IL_0454: ldc.r8 1
-		IL_045d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0462: stloc.s 5
-		IL_0464: ldnull
-		IL_0465: ldloc.s 5
-		IL_0467: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
-		IL_046c: pop
-		IL_046d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0472: stloc.s 8
-		IL_0474: volatile.
-		IL_0476: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_047b: brfalse IL_0491
+		IL_041a: stloc.s 14
+		IL_041c: volatile.
+		IL_041e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0423: brfalse IL_0439
 
-		IL_0480: ldloc.s 5
-		IL_0482: ldstr "x"
-		IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_048c: br IL_04a7
+		IL_0428: ldloc.s 4
+		IL_042a: ldstr "configurable"
+		IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0434: br IL_044f
 
-		IL_0491: ldloc.s 5
-		IL_0493: ldstr "x"
-		IL_0498: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:92"
-		IL_049d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0439: ldloc.s 4
+		IL_043b: ldstr "configurable"
+		IL_0440: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:80"
+		IL_0445: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04a7: stloc.s 21
-		IL_04a9: ldloc.s 8
-		IL_04ab: ldloc.s 21
-		IL_04ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04b2: pop
-		IL_04b3: ret
+		IL_044f: stloc.s 21
+		IL_0451: ldloc.s 8
+		IL_0453: ldc.i4.4
+		IL_0454: newarr [System.Runtime]System.Object
+		IL_0459: dup
+		IL_045a: ldc.i4.0
+		IL_045b: ldloc.s 20
+		IL_045d: stelem.ref
+		IL_045e: dup
+		IL_045f: ldc.i4.1
+		IL_0460: ldloc.s 19
+		IL_0462: stelem.ref
+		IL_0463: dup
+		IL_0464: ldc.i4.2
+		IL_0465: ldloc.s 14
+		IL_0467: stelem.ref
+		IL_0468: dup
+		IL_0469: ldc.i4.3
+		IL_046a: ldloc.s 21
+		IL_046c: stelem.ref
+		IL_046d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0472: pop
+		IL_0473: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0478: dup
+		IL_0479: ldstr "x"
+		IL_047e: ldc.r8 1
+		IL_0487: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_048c: stloc.s 5
+		IL_048e: ldnull
+		IL_048f: ldloc.s 5
+		IL_0491: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
+		IL_0496: pop
+		IL_0497: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_049c: stloc.s 8
+		IL_049e: volatile.
+		IL_04a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_04a5: brfalse IL_04bb
+
+		IL_04aa: ldloc.s 5
+		IL_04ac: ldstr "x"
+		IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04b6: br IL_04d1
+
+		IL_04bb: ldloc.s 5
+		IL_04bd: ldstr "x"
+		IL_04c2: ldstr "ObjectLiteral_InferredConstruction_Parity:Modules.ObjectLiteral_InferredConstruction_Parity:__js_module_init__:92"
+		IL_04c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04d1: stloc.s 21
+		IL_04d3: ldloc.s 8
+		IL_04d5: ldloc.s 21
+		IL_04d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04dc: pop
+		IL_04dd: ret
 	} // end of method ObjectLiteral_InferredConstruction_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_InferredConstruction_Parity
@@ -1243,6 +1267,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InterproceduralInference_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InterproceduralInference_Parity.verified.txt
@@ -1772,7 +1772,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Code size: 85 (0x55)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -1784,16 +1784,28 @@
 			IL_0006: ldarg.1
 			IL_0007: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 			IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0011: ldstr "join"
-			IL_0016: ldstr ","
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0020: stloc.1
-			IL_0021: ldloc.0
-			IL_0022: ldloc.1
-			IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0028: pop
-			IL_0029: ldnull
-			IL_002a: ret
+			IL_0011: volatile.
+			IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0018: brfalse IL_0031
+
+			IL_001d: ldstr "join"
+			IL_0022: ldstr ","
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002c: br IL_004a
+
+			IL_0031: ldstr "join"
+			IL_0036: ldstr ","
+			IL_003b: ldstr "ObjectLiteral_InterproceduralInference_Parity:<TwoPhaseDummy_M13>:__js_call__:6"
+			IL_0040: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_004a: stloc.1
+			IL_004b: ldloc.0
+			IL_004c: ldloc.1
+			IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0052: pop
+			IL_0053: ldnull
+			IL_0054: ret
 		} // end of method keep::__js_call__
 
 	} // end of class keep
@@ -2372,7 +2384,7 @@
 			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0025: stloc.1
 			IL_0026: volatile.
-			IL_0028: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0028: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_002d: brfalse IL_0042
 
 			IL_0032: ldarg.3
@@ -2383,7 +2395,7 @@
 			IL_0042: ldarg.3
 			IL_0043: ldstr "b"
 			IL_0048: ldstr "ObjectLiteral_InterproceduralInference_Parity:<TwoPhaseDummy_M16>:__js_call__:11"
-			IL_004d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_004d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0057: stloc.2
@@ -3318,6 +3330,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_27
 	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Spread_SkipsNonEnumerable.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Spread_SkipsNonEnumerable.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 309 (0x135)
+		// Code size: 351 (0x15f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_Spread_SkipsNonEnumerable/Scope,
@@ -202,15 +202,27 @@
 		IL_010e: ldloc.2
 		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
 		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0119: ldstr "join"
-		IL_011e: ldstr ","
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0128: stloc.s 5
-		IL_012a: ldloc.s 4
-		IL_012c: ldloc.s 5
-		IL_012e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0133: pop
-		IL_0134: ret
+		IL_0119: volatile.
+		IL_011b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0120: brfalse IL_0139
+
+		IL_0125: ldstr "join"
+		IL_012a: ldstr ","
+		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0134: br IL_0152
+
+		IL_0139: ldstr "join"
+		IL_013e: ldstr ","
+		IL_0143: ldstr "ObjectLiteral_Spread_SkipsNonEnumerable:Modules.ObjectLiteral_Spread_SkipsNonEnumerable:__js_module_init__:37"
+		IL_0148: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0152: stloc.s 5
+		IL_0154: ldloc.s 4
+		IL_0156: ldloc.s 5
+		IL_0158: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015d: pop
+		IL_015e: ret
 	} // end of method ObjectLiteral_Spread_SkipsNonEnumerable::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_Spread_SkipsNonEnumerable
@@ -242,6 +254,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
@@ -746,7 +746,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2279 (0x8e7)
+		// Code size: 2321 (0x911)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope,
@@ -920,639 +920,651 @@
 		IL_0173: ldloc.0
 		IL_0174: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope::log
 		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017e: ldstr "join"
-		IL_0183: ldstr ","
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018d: stloc.s 27
-		IL_018f: ldstr "log="
-		IL_0194: ldloc.s 27
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_019b: stloc.s 28
-		IL_019d: ldloc.s 26
-		IL_019f: ldloc.s 28
-		IL_01a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a6: pop
-		IL_01a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ac: stloc.s 26
-		IL_01ae: volatile.
-		IL_01b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_01b5: brfalse IL_01cb
+		IL_017e: volatile.
+		IL_0180: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0185: brfalse IL_019e
 
-		IL_01ba: ldloc.s 5
-		IL_01bc: ldstr "get"
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c6: br IL_01e1
+		IL_018a: ldstr "join"
+		IL_018f: ldstr ","
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0199: br IL_01b7
 
-		IL_01cb: ldloc.s 5
-		IL_01cd: ldstr "get"
-		IL_01d2: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:59"
-		IL_01d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_019e: ldstr "join"
+		IL_01a3: ldstr ","
+		IL_01a8: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:52"
+		IL_01ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01e1: stloc.s 27
-		IL_01e3: ldloc.s 27
-		IL_01e5: ldloc.1
-		IL_01e6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01eb: stloc.s 29
-		IL_01ed: ldloc.s 29
-		IL_01ef: box [System.Runtime]System.Boolean
-		IL_01f4: stloc.s 30
-		IL_01f6: ldstr "same_get="
-		IL_01fb: ldloc.s 30
-		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0202: stloc.s 28
-		IL_0204: ldloc.s 26
-		IL_0206: ldloc.s 28
-		IL_0208: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_020d: pop
-		IL_020e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0213: stloc.s 26
-		IL_0215: volatile.
-		IL_0217: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_021c: brfalse IL_0232
+		IL_01b7: stloc.s 27
+		IL_01b9: ldstr "log="
+		IL_01be: ldloc.s 27
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01c5: stloc.s 28
+		IL_01c7: ldloc.s 26
+		IL_01c9: ldloc.s 28
+		IL_01cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d0: pop
+		IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01d6: stloc.s 26
+		IL_01d8: volatile.
+		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01df: brfalse IL_01f5
 
-		IL_0221: ldloc.s 5
-		IL_0223: ldstr "set"
-		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022d: br IL_0248
+		IL_01e4: ldloc.s 5
+		IL_01e6: ldstr "get"
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f0: br IL_020b
 
-		IL_0232: ldloc.s 5
-		IL_0234: ldstr "set"
-		IL_0239: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:68"
-		IL_023e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01f5: ldloc.s 5
+		IL_01f7: ldstr "get"
+		IL_01fc: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:59"
+		IL_0201: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0248: stloc.s 27
-		IL_024a: ldloc.s 27
-		IL_024c: ldloc.3
-		IL_024d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0252: stloc.s 29
-		IL_0254: ldloc.s 29
-		IL_0256: box [System.Runtime]System.Boolean
-		IL_025b: stloc.s 30
-		IL_025d: ldstr "same_set="
-		IL_0262: ldloc.s 30
-		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0269: stloc.s 28
-		IL_026b: ldloc.s 26
-		IL_026d: ldloc.s 28
-		IL_026f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0274: pop
-		IL_0275: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_027a: stloc.s 26
-		IL_027c: volatile.
-		IL_027e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0283: brfalse IL_0299
+		IL_020b: stloc.s 27
+		IL_020d: ldloc.s 27
+		IL_020f: ldloc.1
+		IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0215: stloc.s 29
+		IL_0217: ldloc.s 29
+		IL_0219: box [System.Runtime]System.Boolean
+		IL_021e: stloc.s 30
+		IL_0220: ldstr "same_get="
+		IL_0225: ldloc.s 30
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_022c: stloc.s 28
+		IL_022e: ldloc.s 26
+		IL_0230: ldloc.s 28
+		IL_0232: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0237: pop
+		IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023d: stloc.s 26
+		IL_023f: volatile.
+		IL_0241: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0246: brfalse IL_025c
 
-		IL_0288: ldloc.s 5
-		IL_028a: ldstr "enumerable"
-		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0294: br IL_02af
+		IL_024b: ldloc.s 5
+		IL_024d: ldstr "set"
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0257: br IL_0272
 
-		IL_0299: ldloc.s 5
-		IL_029b: ldstr "enumerable"
-		IL_02a0: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:77"
-		IL_02a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_025c: ldloc.s 5
+		IL_025e: ldstr "set"
+		IL_0263: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:68"
+		IL_0268: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02af: stloc.s 27
-		IL_02b1: ldstr "enum="
-		IL_02b6: ldloc.s 27
-		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02bd: stloc.s 28
-		IL_02bf: ldloc.s 26
-		IL_02c1: ldloc.s 28
-		IL_02c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c8: pop
-		IL_02c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ce: stloc.s 26
-		IL_02d0: volatile.
-		IL_02d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02d7: brfalse IL_02ed
+		IL_0272: stloc.s 27
+		IL_0274: ldloc.s 27
+		IL_0276: ldloc.3
+		IL_0277: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_027c: stloc.s 29
+		IL_027e: ldloc.s 29
+		IL_0280: box [System.Runtime]System.Boolean
+		IL_0285: stloc.s 30
+		IL_0287: ldstr "same_set="
+		IL_028c: ldloc.s 30
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0293: stloc.s 28
+		IL_0295: ldloc.s 26
+		IL_0297: ldloc.s 28
+		IL_0299: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029e: pop
+		IL_029f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a4: stloc.s 26
+		IL_02a6: volatile.
+		IL_02a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02ad: brfalse IL_02c3
 
-		IL_02dc: ldloc.s 5
-		IL_02de: ldstr "configurable"
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e8: br IL_0303
+		IL_02b2: ldloc.s 5
+		IL_02b4: ldstr "enumerable"
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02be: br IL_02d9
 
-		IL_02ed: ldloc.s 5
-		IL_02ef: ldstr "configurable"
-		IL_02f4: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:84"
-		IL_02f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02c3: ldloc.s 5
+		IL_02c5: ldstr "enumerable"
+		IL_02ca: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:77"
+		IL_02cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0303: stloc.s 27
-		IL_0305: ldstr "config="
-		IL_030a: ldloc.s 27
-		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0311: stloc.s 28
-		IL_0313: ldloc.s 26
-		IL_0315: ldloc.s 28
-		IL_0317: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_031c: pop
+		IL_02d9: stloc.s 27
+		IL_02db: ldstr "enum="
+		IL_02e0: ldloc.s 27
+		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02e7: stloc.s 28
+		IL_02e9: ldloc.s 26
+		IL_02eb: ldloc.s 28
+		IL_02ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02f2: pop
+		IL_02f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02f8: stloc.s 26
+		IL_02fa: volatile.
+		IL_02fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0301: brfalse IL_0317
+
+		IL_0306: ldloc.s 5
+		IL_0308: ldstr "configurable"
+		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0312: br IL_032d
+
+		IL_0317: ldloc.s 5
+		IL_0319: ldstr "configurable"
+		IL_031e: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:84"
+		IL_0323: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_032d: stloc.s 27
+		IL_032f: ldstr "config="
+		IL_0334: ldloc.s 27
+		IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_033b: stloc.s 28
+		IL_033d: ldloc.s 26
+		IL_033f: ldloc.s 28
+		IL_0341: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0346: pop
 		.try
 		{
-			IL_031d: nop
-			IL_031e: ldloc.s 4
-			IL_0320: ldstr "mixed"
-			IL_0325: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_032a: dup
-			IL_032b: ldstr "value"
-			IL_0330: ldc.r8 1
-			IL_0339: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_033e: dup
-			IL_033f: ldstr "get"
-			IL_0344: ldloc.1
-			IL_0345: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_034f: pop
-			IL_0350: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0355: stloc.s 26
-			IL_0357: ldloc.s 26
-			IL_0359: ldstr "mixed=allowed"
-			IL_035e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0363: pop
-			IL_0364: leave IL_03f4
+			IL_0347: nop
+			IL_0348: ldloc.s 4
+			IL_034a: ldstr "mixed"
+			IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0354: dup
+			IL_0355: ldstr "value"
+			IL_035a: ldc.r8 1
+			IL_0363: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0368: dup
+			IL_0369: ldstr "get"
+			IL_036e: ldloc.1
+			IL_036f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0379: pop
+			IL_037a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_037f: stloc.s 26
+			IL_0381: ldloc.s 26
+			IL_0383: ldstr "mixed=allowed"
+			IL_0388: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_038d: pop
+			IL_038e: leave IL_041e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0369: stloc.s 6
-			IL_036b: ldloc.s 6
-			IL_036d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0372: dup
-			IL_0373: brtrue IL_0389
+			IL_0393: stloc.s 6
+			IL_0395: ldloc.s 6
+			IL_0397: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_039c: dup
+			IL_039d: brtrue IL_03b3
 
-			IL_0378: pop
-			IL_0379: ldloc.s 6
-			IL_037b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0380: dup
-			IL_0381: brtrue IL_0395
+			IL_03a2: pop
+			IL_03a3: ldloc.s 6
+			IL_03a5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03aa: dup
+			IL_03ab: brtrue IL_03bf
 
-			IL_0386: pop
-			IL_0387: rethrow
+			IL_03b0: pop
+			IL_03b1: rethrow
 
-			IL_0389: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_038e: stloc.s 7
-			IL_0390: br IL_0397
+			IL_03b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03b8: stloc.s 7
+			IL_03ba: br IL_03c1
 
-			IL_0395: stloc.s 7
+			IL_03bf: stloc.s 7
 
-			IL_0397: ldloc.s 7
-			IL_0399: stloc.s 8
-			IL_039b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03a0: stloc.s 26
-			IL_03a2: volatile.
-			IL_03a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_03a9: brfalse IL_03bf
+			IL_03c1: ldloc.s 7
+			IL_03c3: stloc.s 8
+			IL_03c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ca: stloc.s 26
+			IL_03cc: volatile.
+			IL_03ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_03d3: brfalse IL_03e9
 
-			IL_03ae: ldloc.s 8
-			IL_03b0: ldstr "name"
-			IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ba: br IL_03d5
+			IL_03d8: ldloc.s 8
+			IL_03da: ldstr "name"
+			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e4: br IL_03ff
 
-			IL_03bf: ldloc.s 8
-			IL_03c1: ldstr "name"
-			IL_03c6: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:110"
-			IL_03cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03e9: ldloc.s 8
+			IL_03eb: ldstr "name"
+			IL_03f0: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:110"
+			IL_03f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03d5: stloc.s 27
-			IL_03d7: ldstr "mixed="
-			IL_03dc: ldloc.s 27
-			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03e3: stloc.s 28
-			IL_03e5: ldloc.s 26
-			IL_03e7: ldloc.s 28
-			IL_03e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03ee: pop
-			IL_03ef: leave IL_03f4
+			IL_03ff: stloc.s 27
+			IL_0401: ldstr "mixed="
+			IL_0406: ldloc.s 27
+			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_040d: stloc.s 28
+			IL_040f: ldloc.s 26
+			IL_0411: ldloc.s 28
+			IL_0413: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0418: pop
+			IL_0419: leave IL_041e
 		} // end handler
 
-		IL_03f4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03f9: stloc.s 9
-		IL_03fb: ldloc.s 9
-		IL_03fd: ldstr "y"
-		IL_0402: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0407: dup
-		IL_0408: ldstr "value"
-		IL_040d: ldc.r8 1
-		IL_0416: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_041b: dup
-		IL_041c: ldstr "enumerable"
-		IL_0421: ldc.i4.1
-		IL_0422: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0427: dup
-		IL_0428: ldstr "configurable"
-		IL_042d: ldc.i4.0
-		IL_042e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0433: dup
-		IL_0434: ldstr "writable"
-		IL_0439: ldc.i4.0
-		IL_043a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0444: pop
+		IL_041e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0423: stloc.s 9
+		IL_0425: ldloc.s 9
+		IL_0427: ldstr "y"
+		IL_042c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0431: dup
+		IL_0432: ldstr "value"
+		IL_0437: ldc.r8 1
+		IL_0440: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0445: dup
+		IL_0446: ldstr "enumerable"
+		IL_044b: ldc.i4.1
+		IL_044c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0451: dup
+		IL_0452: ldstr "configurable"
+		IL_0457: ldc.i4.0
+		IL_0458: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_045d: dup
+		IL_045e: ldstr "writable"
+		IL_0463: ldc.i4.0
+		IL_0464: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_046e: pop
 		.try
 		{
-			IL_0445: nop
-			IL_0446: ldloc.s 9
-			IL_0448: ldstr "y"
-			IL_044d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0452: dup
-			IL_0453: ldstr "value"
-			IL_0458: ldc.r8 2
-			IL_0461: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_046b: pop
-			IL_046c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0471: stloc.s 26
-			IL_0473: ldloc.s 26
-			IL_0475: ldstr "locked_value=allowed"
-			IL_047a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_047f: pop
-			IL_0480: leave IL_0510
+			IL_046f: nop
+			IL_0470: ldloc.s 9
+			IL_0472: ldstr "y"
+			IL_0477: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_047c: dup
+			IL_047d: ldstr "value"
+			IL_0482: ldc.r8 2
+			IL_048b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0495: pop
+			IL_0496: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_049b: stloc.s 26
+			IL_049d: ldloc.s 26
+			IL_049f: ldstr "locked_value=allowed"
+			IL_04a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04a9: pop
+			IL_04aa: leave IL_053a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0485: stloc.s 10
-			IL_0487: ldloc.s 10
-			IL_0489: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_048e: dup
-			IL_048f: brtrue IL_04a5
+			IL_04af: stloc.s 10
+			IL_04b1: ldloc.s 10
+			IL_04b3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04b8: dup
+			IL_04b9: brtrue IL_04cf
 
-			IL_0494: pop
-			IL_0495: ldloc.s 10
-			IL_0497: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_049c: dup
-			IL_049d: brtrue IL_04b1
+			IL_04be: pop
+			IL_04bf: ldloc.s 10
+			IL_04c1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04c6: dup
+			IL_04c7: brtrue IL_04db
 
-			IL_04a2: pop
-			IL_04a3: rethrow
+			IL_04cc: pop
+			IL_04cd: rethrow
 
-			IL_04a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04aa: stloc.s 11
-			IL_04ac: br IL_04b3
+			IL_04cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04d4: stloc.s 11
+			IL_04d6: br IL_04dd
 
-			IL_04b1: stloc.s 11
+			IL_04db: stloc.s 11
 
-			IL_04b3: ldloc.s 11
-			IL_04b5: stloc.s 12
-			IL_04b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04bc: stloc.s 26
-			IL_04be: volatile.
-			IL_04c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_04c5: brfalse IL_04db
+			IL_04dd: ldloc.s 11
+			IL_04df: stloc.s 12
+			IL_04e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04e6: stloc.s 26
+			IL_04e8: volatile.
+			IL_04ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_04ef: brfalse IL_0505
 
-			IL_04ca: ldloc.s 12
-			IL_04cc: ldstr "name"
-			IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04d6: br IL_04f1
+			IL_04f4: ldloc.s 12
+			IL_04f6: ldstr "name"
+			IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0500: br IL_051b
 
-			IL_04db: ldloc.s 12
-			IL_04dd: ldstr "name"
-			IL_04e2: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:151"
-			IL_04e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0505: ldloc.s 12
+			IL_0507: ldstr "name"
+			IL_050c: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:151"
+			IL_0511: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04f1: stloc.s 27
-			IL_04f3: ldstr "locked_value="
-			IL_04f8: ldloc.s 27
-			IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04ff: stloc.s 28
-			IL_0501: ldloc.s 26
-			IL_0503: ldloc.s 28
-			IL_0505: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_050a: pop
-			IL_050b: leave IL_0510
+			IL_051b: stloc.s 27
+			IL_051d: ldstr "locked_value="
+			IL_0522: ldloc.s 27
+			IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0529: stloc.s 28
+			IL_052b: ldloc.s 26
+			IL_052d: ldloc.s 28
+			IL_052f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0534: pop
+			IL_0535: leave IL_053a
 		} // end handler
 		.try
 		{
-			IL_0510: nop
-			IL_0511: ldloc.s 9
-			IL_0513: ldstr "y"
-			IL_0518: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_051d: dup
-			IL_051e: ldstr "get"
-			IL_0523: ldloc.1
-			IL_0524: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_052e: pop
-			IL_052f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0534: stloc.s 26
-			IL_0536: ldloc.s 26
-			IL_0538: ldstr "locked_kind=allowed"
-			IL_053d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0542: pop
-			IL_0543: leave IL_05d3
+			IL_053a: nop
+			IL_053b: ldloc.s 9
+			IL_053d: ldstr "y"
+			IL_0542: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0547: dup
+			IL_0548: ldstr "get"
+			IL_054d: ldloc.1
+			IL_054e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0558: pop
+			IL_0559: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_055e: stloc.s 26
+			IL_0560: ldloc.s 26
+			IL_0562: ldstr "locked_kind=allowed"
+			IL_0567: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_056c: pop
+			IL_056d: leave IL_05fd
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0548: stloc.s 13
-			IL_054a: ldloc.s 13
-			IL_054c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0551: dup
-			IL_0552: brtrue IL_0568
+			IL_0572: stloc.s 13
+			IL_0574: ldloc.s 13
+			IL_0576: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_057b: dup
+			IL_057c: brtrue IL_0592
 
-			IL_0557: pop
-			IL_0558: ldloc.s 13
-			IL_055a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_055f: dup
-			IL_0560: brtrue IL_0574
+			IL_0581: pop
+			IL_0582: ldloc.s 13
+			IL_0584: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0589: dup
+			IL_058a: brtrue IL_059e
 
-			IL_0565: pop
-			IL_0566: rethrow
+			IL_058f: pop
+			IL_0590: rethrow
 
-			IL_0568: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_056d: stloc.s 14
-			IL_056f: br IL_0576
+			IL_0592: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0597: stloc.s 14
+			IL_0599: br IL_05a0
 
-			IL_0574: stloc.s 14
+			IL_059e: stloc.s 14
 
-			IL_0576: ldloc.s 14
-			IL_0578: stloc.s 15
-			IL_057a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_057f: stloc.s 26
-			IL_0581: volatile.
-			IL_0583: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0588: brfalse IL_059e
+			IL_05a0: ldloc.s 14
+			IL_05a2: stloc.s 15
+			IL_05a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05a9: stloc.s 26
+			IL_05ab: volatile.
+			IL_05ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_05b2: brfalse IL_05c8
 
-			IL_058d: ldloc.s 15
-			IL_058f: ldstr "name"
-			IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0599: br IL_05b4
+			IL_05b7: ldloc.s 15
+			IL_05b9: ldstr "name"
+			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05c3: br IL_05de
 
-			IL_059e: ldloc.s 15
-			IL_05a0: ldstr "name"
-			IL_05a5: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:180"
-			IL_05aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_05af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_05c8: ldloc.s 15
+			IL_05ca: ldstr "name"
+			IL_05cf: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:180"
+			IL_05d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_05b4: stloc.s 27
-			IL_05b6: ldstr "locked_kind="
-			IL_05bb: ldloc.s 27
-			IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05c2: stloc.s 28
-			IL_05c4: ldloc.s 26
-			IL_05c6: ldloc.s 28
-			IL_05c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05cd: pop
-			IL_05ce: leave IL_05d3
+			IL_05de: stloc.s 27
+			IL_05e0: ldstr "locked_kind="
+			IL_05e5: ldloc.s 27
+			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05ec: stloc.s 28
+			IL_05ee: ldloc.s 26
+			IL_05f0: ldloc.s 28
+			IL_05f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05f7: pop
+			IL_05f8: leave IL_05fd
 		} // end handler
 
-		IL_05d3: ldloc.s 9
-		IL_05d5: ldstr "y"
-		IL_05da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_05df: stloc.s 16
-		IL_05e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05e6: stloc.s 26
-		IL_05e8: volatile.
-		IL_05ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_05ef: brfalse IL_0605
+		IL_05fd: ldloc.s 9
+		IL_05ff: ldstr "y"
+		IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0609: stloc.s 16
+		IL_060b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0610: stloc.s 26
+		IL_0612: volatile.
+		IL_0614: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0619: brfalse IL_062f
 
-		IL_05f4: ldloc.s 16
-		IL_05f6: ldstr "value"
-		IL_05fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0600: br IL_061b
+		IL_061e: ldloc.s 16
+		IL_0620: ldstr "value"
+		IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_062a: br IL_0645
 
-		IL_0605: ldloc.s 16
-		IL_0607: ldstr "value"
-		IL_060c: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:195"
-		IL_0611: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0616: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_062f: ldloc.s 16
+		IL_0631: ldstr "value"
+		IL_0636: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:195"
+		IL_063b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_061b: stloc.s 27
-		IL_061d: ldstr "locked_final="
-		IL_0622: ldloc.s 27
-		IL_0624: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0629: stloc.s 28
-		IL_062b: ldloc.s 28
-		IL_062d: ldstr ","
-		IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0637: stloc.s 28
-		IL_0639: volatile.
-		IL_063b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0640: brfalse IL_0656
+		IL_0645: stloc.s 27
+		IL_0647: ldstr "locked_final="
+		IL_064c: ldloc.s 27
+		IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0653: stloc.s 28
+		IL_0655: ldloc.s 28
+		IL_0657: ldstr ","
+		IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0661: stloc.s 28
+		IL_0663: volatile.
+		IL_0665: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_066a: brfalse IL_0680
 
-		IL_0645: ldloc.s 16
-		IL_0647: ldstr "writable"
-		IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0651: br IL_066c
+		IL_066f: ldloc.s 16
+		IL_0671: ldstr "writable"
+		IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_067b: br IL_0696
 
-		IL_0656: ldloc.s 16
-		IL_0658: ldstr "writable"
-		IL_065d: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:200"
-		IL_0662: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0667: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0680: ldloc.s 16
+		IL_0682: ldstr "writable"
+		IL_0687: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:200"
+		IL_068c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_066c: stloc.s 27
-		IL_066e: ldloc.s 28
-		IL_0670: ldloc.s 27
-		IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0677: stloc.s 28
-		IL_0679: ldloc.s 28
-		IL_067b: ldstr ","
-		IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0685: stloc.s 28
-		IL_0687: volatile.
-		IL_0689: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_068e: brfalse IL_06a4
+		IL_0696: stloc.s 27
+		IL_0698: ldloc.s 28
+		IL_069a: ldloc.s 27
+		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_06a1: stloc.s 28
+		IL_06a3: ldloc.s 28
+		IL_06a5: ldstr ","
+		IL_06aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_06af: stloc.s 28
+		IL_06b1: volatile.
+		IL_06b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_06b8: brfalse IL_06ce
 
-		IL_0693: ldloc.s 16
-		IL_0695: ldstr "configurable"
-		IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_069f: br IL_06ba
+		IL_06bd: ldloc.s 16
+		IL_06bf: ldstr "configurable"
+		IL_06c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06c9: br IL_06e4
 
-		IL_06a4: ldloc.s 16
-		IL_06a6: ldstr "configurable"
-		IL_06ab: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:205"
-		IL_06b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06ce: ldloc.s 16
+		IL_06d0: ldstr "configurable"
+		IL_06d5: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:205"
+		IL_06da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_06df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06ba: stloc.s 27
-		IL_06bc: ldloc.s 28
-		IL_06be: ldloc.s 27
-		IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_06c5: stloc.s 28
-		IL_06c7: ldloc.s 26
-		IL_06c9: ldloc.s 28
-		IL_06cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06d0: pop
+		IL_06e4: stloc.s 27
+		IL_06e6: ldloc.s 28
+		IL_06e8: ldloc.s 27
+		IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_06ef: stloc.s 28
+		IL_06f1: ldloc.s 26
+		IL_06f3: ldloc.s 28
+		IL_06f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06fa: pop
 		.try
 		{
-			IL_06d1: nop
-			IL_06d2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_06d7: ldstr "primitive"
-			IL_06dc: ldstr "not-an-object"
-			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_06e6: pop
-			IL_06e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06ec: stloc.s 26
-			IL_06ee: ldloc.s 26
-			IL_06f0: ldstr "primitive=allowed"
-			IL_06f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06fa: pop
-			IL_06fb: leave IL_078b
+			IL_06fb: nop
+			IL_06fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0701: ldstr "primitive"
+			IL_0706: ldstr "not-an-object"
+			IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0710: pop
+			IL_0711: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0716: stloc.s 26
+			IL_0718: ldloc.s 26
+			IL_071a: ldstr "primitive=allowed"
+			IL_071f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0724: pop
+			IL_0725: leave IL_07b5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0700: stloc.s 17
-			IL_0702: ldloc.s 17
-			IL_0704: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0709: dup
-			IL_070a: brtrue IL_0720
+			IL_072a: stloc.s 17
+			IL_072c: ldloc.s 17
+			IL_072e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0733: dup
+			IL_0734: brtrue IL_074a
 
-			IL_070f: pop
-			IL_0710: ldloc.s 17
-			IL_0712: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0717: dup
-			IL_0718: brtrue IL_072c
+			IL_0739: pop
+			IL_073a: ldloc.s 17
+			IL_073c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0741: dup
+			IL_0742: brtrue IL_0756
 
-			IL_071d: pop
-			IL_071e: rethrow
+			IL_0747: pop
+			IL_0748: rethrow
 
-			IL_0720: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0725: stloc.s 18
-			IL_0727: br IL_072e
+			IL_074a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_074f: stloc.s 18
+			IL_0751: br IL_0758
 
-			IL_072c: stloc.s 18
+			IL_0756: stloc.s 18
 
-			IL_072e: ldloc.s 18
-			IL_0730: stloc.s 19
-			IL_0732: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0737: stloc.s 26
-			IL_0739: volatile.
-			IL_073b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0740: brfalse IL_0756
+			IL_0758: ldloc.s 18
+			IL_075a: stloc.s 19
+			IL_075c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0761: stloc.s 26
+			IL_0763: volatile.
+			IL_0765: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_076a: brfalse IL_0780
 
-			IL_0745: ldloc.s 19
-			IL_0747: ldstr "name"
-			IL_074c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0751: br IL_076c
+			IL_076f: ldloc.s 19
+			IL_0771: ldstr "name"
+			IL_0776: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_077b: br IL_0796
 
-			IL_0756: ldloc.s 19
-			IL_0758: ldstr "name"
-			IL_075d: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:231"
-			IL_0762: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0780: ldloc.s 19
+			IL_0782: ldstr "name"
+			IL_0787: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:231"
+			IL_078c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0791: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_076c: stloc.s 27
-			IL_076e: ldstr "primitive="
-			IL_0773: ldloc.s 27
-			IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_077a: stloc.s 28
-			IL_077c: ldloc.s 26
-			IL_077e: ldloc.s 28
-			IL_0780: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0785: pop
-			IL_0786: leave IL_078b
+			IL_0796: stloc.s 27
+			IL_0798: ldstr "primitive="
+			IL_079d: ldloc.s 27
+			IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_07a4: stloc.s 28
+			IL_07a6: ldloc.s 26
+			IL_07a8: ldloc.s 28
+			IL_07aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07af: pop
+			IL_07b0: leave IL_07b5
 		} // end handler
 
-		IL_078b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0790: dup
-		IL_0791: ldstr "enumerable"
-		IL_0796: ldc.i4.1
-		IL_0797: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_079c: dup
-		IL_079d: ldstr "configurable"
-		IL_07a2: ldc.i4.1
-		IL_07a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_07a8: dup
-		IL_07a9: ldstr "value"
-		IL_07ae: ldc.r8 33
-		IL_07b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
-		IL_07c1: stloc.s 20
-		IL_07c3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_07c8: stloc.s 21
-		IL_07ca: ldloc.s 21
-		IL_07cc: ldstr "proto"
-		IL_07d1: ldloc.s 20
-		IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_07d8: pop
-		IL_07d9: ldloc.s 21
-		IL_07db: ldstr "proto"
-		IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_07e5: stloc.s 22
-		IL_07e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07ec: stloc.s 26
-		IL_07ee: volatile.
-		IL_07f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_07f5: brfalse IL_080b
+		IL_07b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_07ba: dup
+		IL_07bb: ldstr "enumerable"
+		IL_07c0: ldc.i4.1
+		IL_07c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_07c6: dup
+		IL_07c7: ldstr "configurable"
+		IL_07cc: ldc.i4.1
+		IL_07cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_07d2: dup
+		IL_07d3: ldstr "value"
+		IL_07d8: ldc.r8 33
+		IL_07e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
+		IL_07eb: stloc.s 20
+		IL_07ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_07f2: stloc.s 21
+		IL_07f4: ldloc.s 21
+		IL_07f6: ldstr "proto"
+		IL_07fb: ldloc.s 20
+		IL_07fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0802: pop
+		IL_0803: ldloc.s 21
+		IL_0805: ldstr "proto"
+		IL_080a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_080f: stloc.s 22
+		IL_0811: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0816: stloc.s 26
+		IL_0818: volatile.
+		IL_081a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_081f: brfalse IL_0835
 
-		IL_07fa: ldloc.s 21
-		IL_07fc: ldstr "proto"
-		IL_0801: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0806: br IL_0821
+		IL_0824: ldloc.s 21
+		IL_0826: ldstr "proto"
+		IL_082b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0830: br IL_084b
 
-		IL_080b: ldloc.s 21
-		IL_080d: ldstr "proto"
-		IL_0812: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:259"
-		IL_0817: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_081c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0835: ldloc.s 21
+		IL_0837: ldstr "proto"
+		IL_083c: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:259"
+		IL_0841: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0846: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0821: stloc.s 27
-		IL_0823: ldstr "proto_value="
-		IL_0828: ldloc.s 27
-		IL_082a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_082f: stloc.s 28
-		IL_0831: ldloc.s 26
-		IL_0833: ldloc.s 28
-		IL_0835: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_083a: pop
-		IL_083b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0840: stloc.s 26
-		IL_0842: volatile.
-		IL_0844: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0849: brfalse IL_085f
+		IL_084b: stloc.s 27
+		IL_084d: ldstr "proto_value="
+		IL_0852: ldloc.s 27
+		IL_0854: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0859: stloc.s 28
+		IL_085b: ldloc.s 26
+		IL_085d: ldloc.s 28
+		IL_085f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0864: pop
+		IL_0865: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_086a: stloc.s 26
+		IL_086c: volatile.
+		IL_086e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0873: brfalse IL_0889
 
-		IL_084e: ldloc.s 22
-		IL_0850: ldstr "enumerable"
-		IL_0855: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_085a: br IL_0875
+		IL_0878: ldloc.s 22
+		IL_087a: ldstr "enumerable"
+		IL_087f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0884: br IL_089f
 
-		IL_085f: ldloc.s 22
-		IL_0861: ldstr "enumerable"
-		IL_0866: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:266"
-		IL_086b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0870: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0889: ldloc.s 22
+		IL_088b: ldstr "enumerable"
+		IL_0890: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:266"
+		IL_0895: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_089a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0875: stloc.s 27
-		IL_0877: ldstr "proto_enum="
-		IL_087c: ldloc.s 27
-		IL_087e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0883: stloc.s 28
-		IL_0885: ldloc.s 26
-		IL_0887: ldloc.s 28
-		IL_0889: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_088e: pop
-		IL_088f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0894: stloc.s 26
-		IL_0896: volatile.
-		IL_0898: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_089d: brfalse IL_08b3
+		IL_089f: stloc.s 27
+		IL_08a1: ldstr "proto_enum="
+		IL_08a6: ldloc.s 27
+		IL_08a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_08ad: stloc.s 28
+		IL_08af: ldloc.s 26
+		IL_08b1: ldloc.s 28
+		IL_08b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08b8: pop
+		IL_08b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08be: stloc.s 26
+		IL_08c0: volatile.
+		IL_08c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_08c7: brfalse IL_08dd
 
-		IL_08a2: ldloc.s 22
-		IL_08a4: ldstr "configurable"
-		IL_08a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08ae: br IL_08c9
+		IL_08cc: ldloc.s 22
+		IL_08ce: ldstr "configurable"
+		IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08d8: br IL_08f3
 
-		IL_08b3: ldloc.s 22
-		IL_08b5: ldstr "configurable"
-		IL_08ba: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:273"
-		IL_08bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_08c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_08dd: ldloc.s 22
+		IL_08df: ldstr "configurable"
+		IL_08e4: ldstr "Object_DefineProperty_AccessorTransitions_And_Invariants:Modules.Object_DefineProperty_AccessorTransitions_And_Invariants:__js_module_init__:273"
+		IL_08e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_08ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_08c9: stloc.s 27
-		IL_08cb: ldstr "proto_config="
-		IL_08d0: ldloc.s 27
-		IL_08d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_08d7: stloc.s 28
-		IL_08d9: ldloc.s 26
-		IL_08db: ldloc.s 28
-		IL_08dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08e2: pop
-		IL_08e3: ldnull
-		IL_08e4: stloc.s 23
-		IL_08e6: ret
+		IL_08f3: stloc.s 27
+		IL_08f5: ldstr "proto_config="
+		IL_08fa: ldloc.s 27
+		IL_08fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0901: stloc.s 28
+		IL_0903: ldloc.s 26
+		IL_0905: ldloc.s 28
+		IL_0907: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_090c: pop
+		IL_090d: ldnull
+		IL_090e: stloc.s 23
+		IL_0910: ret
 	} // end of method Object_DefineProperty_AccessorTransitions_And_Invariants::__js_module_init__
 
 } // end of class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants
@@ -1597,6 +1609,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_19
 	.field assembly static int32 __jroc_dynamicLookup_20
 	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Keys_Basic.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Keys_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 286 (0x11e)
+		// Code size: 328 (0x148)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_Keys_Basic/Scope,
@@ -185,19 +185,31 @@
 		IL_00ee: stloc.3
 		IL_00ef: ldloc.2
 		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f5: ldstr "join"
-		IL_00fa: ldstr ","
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0104: stloc.s 4
-		IL_0106: ldstr "keys="
-		IL_010b: ldloc.s 4
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0112: stloc.s 5
-		IL_0114: ldloc.3
-		IL_0115: ldloc.s 5
-		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_011c: pop
-		IL_011d: ret
+		IL_00f5: volatile.
+		IL_00f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00fc: brfalse IL_0115
+
+		IL_0101: ldstr "join"
+		IL_0106: ldstr ","
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0110: br IL_012e
+
+		IL_0115: ldstr "join"
+		IL_011a: ldstr ","
+		IL_011f: ldstr "Object_Keys_Basic:Modules.Object_Keys_Basic:__js_module_init__:32"
+		IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_012e: stloc.s 4
+		IL_0130: ldstr "keys="
+		IL_0135: ldloc.s 4
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_013c: stloc.s 5
+		IL_013e: ldloc.3
+		IL_013f: ldloc.s 5
+		IL_0141: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0146: pop
+		IL_0147: ret
 	} // end of method Object_Keys_Basic::__js_module_init__
 
 } // end of class Modules.Object_Keys_Basic
@@ -228,6 +240,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_OwnPropertyKeyOrdering.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_OwnPropertyKeyOrdering.verified.txt
@@ -143,7 +143,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1014 (0x3f6)
+		// Code size: 1140 (0x474)
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Object_OwnPropertyKeyOrdering/Scope,
@@ -352,153 +352,189 @@
 		IL_0219: stloc.s 19
 		IL_021b: ldloc.s 4
 		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0222: ldstr "join"
-		IL_0227: ldstr ","
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0231: stloc.s 14
-		IL_0233: ldstr "names="
-		IL_0238: ldloc.s 14
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_023f: stloc.s 18
-		IL_0241: ldloc.s 19
-		IL_0243: ldloc.s 18
-		IL_0245: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024a: pop
-		IL_024b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0250: stloc.s 19
-		IL_0252: ldloc.s 5
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0259: ldstr "join"
-		IL_025e: ldstr ","
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0268: stloc.s 14
-		IL_026a: ldstr "keys="
-		IL_026f: ldloc.s 14
-		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0276: stloc.s 18
-		IL_0278: ldloc.s 19
-		IL_027a: ldloc.s 18
-		IL_027c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0281: pop
-		IL_0282: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0287: stloc.s 19
-		IL_0289: ldloc.s 6
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0290: ldstr "join"
-		IL_0295: ldstr ","
-		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_029f: stloc.s 14
-		IL_02a1: ldstr "values="
-		IL_02a6: ldloc.s 14
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02ad: stloc.s 18
-		IL_02af: ldloc.s 19
-		IL_02b1: ldloc.s 18
-		IL_02b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b8: pop
-		IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02be: stloc.s 19
-		IL_02c0: ldloc.s 11
-		IL_02c2: ldc.i4.1
-		IL_02c3: newarr [System.Runtime]System.Object
-		IL_02c8: dup
-		IL_02c9: ldc.i4.0
-		IL_02ca: ldstr ","
-		IL_02cf: stelem.ref
-		IL_02d0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_02d5: stloc.s 20
-		IL_02d7: ldstr "entries="
-		IL_02dc: ldloc.s 20
-		IL_02de: call string [System.Runtime]System.String::Concat(string, string)
-		IL_02e3: stloc.s 20
-		IL_02e5: ldloc.s 19
-		IL_02e7: ldloc.s 20
-		IL_02e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ee: pop
-		IL_02ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f4: stloc.s 19
-		IL_02f6: ldloc.s 8
-		IL_02f8: ldc.i4.1
-		IL_02f9: newarr [System.Runtime]System.Object
-		IL_02fe: dup
-		IL_02ff: ldc.i4.0
-		IL_0300: ldstr ","
-		IL_0305: stelem.ref
-		IL_0306: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_030b: stloc.s 20
-		IL_030d: ldstr "forin="
-		IL_0312: ldloc.s 20
-		IL_0314: call string [System.Runtime]System.String::Concat(string, string)
-		IL_0319: stloc.s 20
-		IL_031b: ldloc.s 19
-		IL_031d: ldloc.s 20
-		IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0324: pop
-		IL_0325: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_032a: stloc.s 19
-		IL_032c: ldloc.s 13
-		IL_032e: ldc.r8 0.0
-		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_033c: stloc.s 14
-		IL_033e: ldloc.s 14
-		IL_0340: ldloc.1
-		IL_0341: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0346: stloc.s 15
-		IL_0348: ldloc.s 15
-		IL_034a: box [System.Runtime]System.Boolean
-		IL_034f: stloc.s 21
-		IL_0351: ldstr "symbols="
-		IL_0356: ldloc.s 21
-		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_035d: stloc.s 18
-		IL_035f: ldloc.s 18
-		IL_0361: ldstr ","
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_036b: stloc.s 18
-		IL_036d: ldloc.s 13
-		IL_036f: ldc.r8 1
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_037d: stloc.s 14
-		IL_037f: ldloc.s 14
-		IL_0381: ldloc.2
-		IL_0382: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0387: stloc.s 15
-		IL_0389: ldloc.s 15
-		IL_038b: box [System.Runtime]System.Boolean
-		IL_0390: stloc.s 21
-		IL_0392: ldloc.s 18
-		IL_0394: ldloc.s 21
-		IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_039b: stloc.s 18
-		IL_039d: ldloc.s 18
-		IL_039f: ldstr ","
-		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_03a9: stloc.s 18
-		IL_03ab: volatile.
-		IL_03ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_03b2: brfalse IL_03c8
+		IL_0222: volatile.
+		IL_0224: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0229: brfalse IL_0242
 
-		IL_03b7: ldloc.s 13
-		IL_03b9: ldstr "length"
-		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03c3: br IL_03de
+		IL_022e: ldstr "join"
+		IL_0233: ldstr ","
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023d: br IL_025b
 
-		IL_03c8: ldloc.s 13
-		IL_03ca: ldstr "length"
-		IL_03cf: ldstr "Object_OwnPropertyKeyOrdering:Modules.Object_OwnPropertyKeyOrdering:__js_module_init__:165"
-		IL_03d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0242: ldstr "join"
+		IL_0247: ldstr ","
+		IL_024c: ldstr "Object_OwnPropertyKeyOrdering:Modules.Object_OwnPropertyKeyOrdering:__js_module_init__:114"
+		IL_0251: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03de: stloc.s 14
-		IL_03e0: ldloc.s 18
-		IL_03e2: ldloc.s 14
+		IL_025b: stloc.s 14
+		IL_025d: ldstr "names="
+		IL_0262: ldloc.s 14
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0269: stloc.s 18
+		IL_026b: ldloc.s 19
+		IL_026d: ldloc.s 18
+		IL_026f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0274: pop
+		IL_0275: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_027a: stloc.s 19
+		IL_027c: ldloc.s 5
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0283: volatile.
+		IL_0285: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_028a: brfalse IL_02a3
+
+		IL_028f: ldstr "join"
+		IL_0294: ldstr ","
+		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029e: br IL_02bc
+
+		IL_02a3: ldstr "join"
+		IL_02a8: ldstr ","
+		IL_02ad: ldstr "Object_OwnPropertyKeyOrdering:Modules.Object_OwnPropertyKeyOrdering:__js_module_init__:122"
+		IL_02b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02bc: stloc.s 14
+		IL_02be: ldstr "keys="
+		IL_02c3: ldloc.s 14
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02ca: stloc.s 18
+		IL_02cc: ldloc.s 19
+		IL_02ce: ldloc.s 18
+		IL_02d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d5: pop
+		IL_02d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02db: stloc.s 19
+		IL_02dd: ldloc.s 6
+		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e4: volatile.
+		IL_02e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_02eb: brfalse IL_0304
+
+		IL_02f0: ldstr "join"
+		IL_02f5: ldstr ","
+		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ff: br IL_031d
+
+		IL_0304: ldstr "join"
+		IL_0309: ldstr ","
+		IL_030e: ldstr "Object_OwnPropertyKeyOrdering:Modules.Object_OwnPropertyKeyOrdering:__js_module_init__:130"
+		IL_0313: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_031d: stloc.s 14
+		IL_031f: ldstr "values="
+		IL_0324: ldloc.s 14
+		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_032b: stloc.s 18
+		IL_032d: ldloc.s 19
+		IL_032f: ldloc.s 18
+		IL_0331: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0336: pop
+		IL_0337: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_033c: stloc.s 19
+		IL_033e: ldloc.s 11
+		IL_0340: ldc.i4.1
+		IL_0341: newarr [System.Runtime]System.Object
+		IL_0346: dup
+		IL_0347: ldc.i4.0
+		IL_0348: ldstr ","
+		IL_034d: stelem.ref
+		IL_034e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0353: stloc.s 20
+		IL_0355: ldstr "entries="
+		IL_035a: ldloc.s 20
+		IL_035c: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0361: stloc.s 20
+		IL_0363: ldloc.s 19
+		IL_0365: ldloc.s 20
+		IL_0367: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_036c: pop
+		IL_036d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0372: stloc.s 19
+		IL_0374: ldloc.s 8
+		IL_0376: ldc.i4.1
+		IL_0377: newarr [System.Runtime]System.Object
+		IL_037c: dup
+		IL_037d: ldc.i4.0
+		IL_037e: ldstr ","
+		IL_0383: stelem.ref
+		IL_0384: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0389: stloc.s 20
+		IL_038b: ldstr "forin="
+		IL_0390: ldloc.s 20
+		IL_0392: call string [System.Runtime]System.String::Concat(string, string)
+		IL_0397: stloc.s 20
+		IL_0399: ldloc.s 19
+		IL_039b: ldloc.s 20
+		IL_039d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03a2: pop
+		IL_03a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a8: stloc.s 19
+		IL_03aa: ldloc.s 13
+		IL_03ac: ldc.r8 0.0
+		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03ba: stloc.s 14
+		IL_03bc: ldloc.s 14
+		IL_03be: ldloc.1
+		IL_03bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_03c4: stloc.s 15
+		IL_03c6: ldloc.s 15
+		IL_03c8: box [System.Runtime]System.Boolean
+		IL_03cd: stloc.s 21
+		IL_03cf: ldstr "symbols="
+		IL_03d4: ldloc.s 21
+		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03db: stloc.s 18
+		IL_03dd: ldloc.s 18
+		IL_03df: ldstr ","
 		IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 		IL_03e9: stloc.s 18
-		IL_03eb: ldloc.s 19
-		IL_03ed: ldloc.s 18
-		IL_03ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03f4: pop
-		IL_03f5: ret
+		IL_03eb: ldloc.s 13
+		IL_03ed: ldc.r8 1
+		IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03fb: stloc.s 14
+		IL_03fd: ldloc.s 14
+		IL_03ff: ldloc.2
+		IL_0400: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0405: stloc.s 15
+		IL_0407: ldloc.s 15
+		IL_0409: box [System.Runtime]System.Boolean
+		IL_040e: stloc.s 21
+		IL_0410: ldloc.s 18
+		IL_0412: ldloc.s 21
+		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0419: stloc.s 18
+		IL_041b: ldloc.s 18
+		IL_041d: ldstr ","
+		IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0427: stloc.s 18
+		IL_0429: volatile.
+		IL_042b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0430: brfalse IL_0446
+
+		IL_0435: ldloc.s 13
+		IL_0437: ldstr "length"
+		IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0441: br IL_045c
+
+		IL_0446: ldloc.s 13
+		IL_0448: ldstr "length"
+		IL_044d: ldstr "Object_OwnPropertyKeyOrdering:Modules.Object_OwnPropertyKeyOrdering:__js_module_init__:165"
+		IL_0452: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_045c: stloc.s 14
+		IL_045e: ldloc.s 18
+		IL_0460: ldloc.s 14
+		IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0467: stloc.s 18
+		IL_0469: ldloc.s 19
+		IL_046b: ldloc.s 18
+		IL_046d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0472: pop
+		IL_0473: ret
 	} // end of method Object_OwnPropertyKeyOrdering::__js_module_init__
 
 } // end of class Modules.Object_OwnPropertyKeyOrdering
@@ -529,6 +565,9 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 857 (0x359)
+		// Code size: 971 (0x3cb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf/Scope,
@@ -273,111 +273,147 @@
 		IL_01ff: stloc.3
 		IL_0200: ldloc.3
 		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0206: ldstr "call"
-		IL_020b: ldloc.1
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0211: stloc.3
-		IL_0212: ldstr "Object"
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_021c: volatile.
-		IL_021e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0223: brfalse IL_0237
+		IL_0206: volatile.
+		IL_0208: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_020d: brfalse IL_0222
 
-		IL_0228: ldstr "prototype"
-		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0232: br IL_024b
+		IL_0212: ldstr "call"
+		IL_0217: ldloc.1
+		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021d: br IL_0237
 
-		IL_0237: ldstr "prototype"
-		IL_023c: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:55"
-		IL_0241: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0222: ldstr "call"
+		IL_0227: ldloc.1
+		IL_0228: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:51"
+		IL_022d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_024b: stloc.s 4
-		IL_024d: volatile.
-		IL_024f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0254: brfalse IL_026a
+		IL_0237: stloc.3
+		IL_0238: ldstr "Object"
+		IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0242: volatile.
+		IL_0244: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0249: brfalse IL_025d
 
-		IL_0259: ldloc.s 4
-		IL_025b: ldstr "toString"
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0265: br IL_0280
+		IL_024e: ldstr "prototype"
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0258: br IL_0271
 
-		IL_026a: ldloc.s 4
-		IL_026c: ldstr "toString"
-		IL_0271: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:57"
-		IL_0276: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_025d: ldstr "prototype"
+		IL_0262: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:55"
+		IL_0267: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0280: stloc.s 4
-		IL_0282: ldloc.s 4
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0289: ldstr "call"
-		IL_028e: ldloc.1
-		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0294: stloc.s 4
-		IL_0296: ldloc.3
-		IL_0297: ldloc.s 4
-		IL_0299: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_029e: stloc.s 5
-		IL_02a0: ldloc.s 5
-		IL_02a2: box [System.Runtime]System.Boolean
-		IL_02a7: stloc.s 6
-		IL_02a9: ldloc.2
-		IL_02aa: ldloc.s 6
-		IL_02ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b1: pop
-		IL_02b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b7: stloc.2
-		IL_02b8: ldstr "Object"
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02c2: volatile.
-		IL_02c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02c9: brfalse IL_02dd
+		IL_0271: stloc.s 4
+		IL_0273: volatile.
+		IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_027a: brfalse IL_0290
 
-		IL_02ce: ldstr "prototype"
-		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d8: br IL_02f1
+		IL_027f: ldloc.s 4
+		IL_0281: ldstr "toString"
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028b: br IL_02a6
 
-		IL_02dd: ldstr "prototype"
-		IL_02e2: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:68"
-		IL_02e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0290: ldloc.s 4
+		IL_0292: ldstr "toString"
+		IL_0297: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:57"
+		IL_029c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02f1: stloc.s 4
-		IL_02f3: volatile.
-		IL_02f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02fa: brfalse IL_0310
+		IL_02a6: stloc.s 4
+		IL_02a8: ldloc.s 4
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02af: volatile.
+		IL_02b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02b6: brfalse IL_02cb
 
-		IL_02ff: ldloc.s 4
-		IL_0301: ldstr "valueOf"
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_030b: br IL_0326
+		IL_02bb: ldstr "call"
+		IL_02c0: ldloc.1
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c6: br IL_02e0
 
-		IL_0310: ldloc.s 4
-		IL_0312: ldstr "valueOf"
-		IL_0317: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:70"
-		IL_031c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02cb: ldstr "call"
+		IL_02d0: ldloc.1
+		IL_02d1: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:59"
+		IL_02d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0326: stloc.s 4
-		IL_0328: ldloc.s 4
-		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_032f: ldstr "call"
-		IL_0334: ldloc.1
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_033a: stloc.s 4
-		IL_033c: ldloc.s 4
-		IL_033e: ldloc.1
-		IL_033f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0344: stloc.s 5
-		IL_0346: ldloc.s 5
-		IL_0348: box [System.Runtime]System.Boolean
-		IL_034d: stloc.s 6
-		IL_034f: ldloc.2
-		IL_0350: ldloc.s 6
-		IL_0352: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0357: pop
-		IL_0358: ret
+		IL_02e0: stloc.s 4
+		IL_02e2: ldloc.3
+		IL_02e3: ldloc.s 4
+		IL_02e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02ea: stloc.s 5
+		IL_02ec: ldloc.s 5
+		IL_02ee: box [System.Runtime]System.Boolean
+		IL_02f3: stloc.s 6
+		IL_02f5: ldloc.2
+		IL_02f6: ldloc.s 6
+		IL_02f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02fd: pop
+		IL_02fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0303: stloc.2
+		IL_0304: ldstr "Object"
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_030e: volatile.
+		IL_0310: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0315: brfalse IL_0329
+
+		IL_031a: ldstr "prototype"
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0324: br IL_033d
+
+		IL_0329: ldstr "prototype"
+		IL_032e: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:68"
+		IL_0333: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_033d: stloc.s 4
+		IL_033f: volatile.
+		IL_0341: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0346: brfalse IL_035c
+
+		IL_034b: ldloc.s 4
+		IL_034d: ldstr "valueOf"
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0357: br IL_0372
+
+		IL_035c: ldloc.s 4
+		IL_035e: ldstr "valueOf"
+		IL_0363: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:70"
+		IL_0368: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0372: stloc.s 4
+		IL_0374: ldloc.s 4
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_037b: volatile.
+		IL_037d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0382: brfalse IL_0397
+
+		IL_0387: ldstr "call"
+		IL_038c: ldloc.1
+		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0392: br IL_03ac
+
+		IL_0397: ldstr "call"
+		IL_039c: ldloc.1
+		IL_039d: ldstr "Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf:__js_module_init__:72"
+		IL_03a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03ac: stloc.s 4
+		IL_03ae: ldloc.s 4
+		IL_03b0: ldloc.1
+		IL_03b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_03b6: stloc.s 5
+		IL_03b8: ldloc.s 5
+		IL_03ba: box [System.Runtime]System.Boolean
+		IL_03bf: stloc.s 6
+		IL_03c1: ldloc.2
+		IL_03c2: ldloc.s 6
+		IL_03c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03c9: pop
+		IL_03ca: ret
 	} // end of method Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf::__js_module_init__
 
 } // end of class Modules.Object_Prototype_PropertyIsEnumerable_ToLocaleString_ValueOf
@@ -417,6 +453,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_ToString_Basic.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_ToString_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 737 (0x2e1)
+		// Code size: 949 (0x3b5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_Prototype_ToString_Basic/Scope,
@@ -151,196 +151,258 @@
 		IL_0078: stloc.2
 		IL_0079: ldloc.2
 		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007f: ldstr "call"
-		IL_0084: ldnull
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: stloc.2
-		IL_008b: ldloc.1
-		IL_008c: ldloc.2
-		IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0092: pop
-		IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0098: stloc.1
-		IL_0099: ldstr "Object"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00a3: volatile.
-		IL_00a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00aa: brfalse IL_00be
+		IL_007f: volatile.
+		IL_0081: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0086: brfalse IL_009b
 
-		IL_00af: ldstr "prototype"
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b9: br IL_00d2
+		IL_008b: ldstr "call"
+		IL_0090: ldnull
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0096: br IL_00b0
 
-		IL_00be: ldstr "prototype"
-		IL_00c3: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:20"
-		IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_009b: ldstr "call"
+		IL_00a0: ldnull
+		IL_00a1: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:13"
+		IL_00a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00d2: stloc.2
-		IL_00d3: volatile.
-		IL_00d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_00da: brfalse IL_00ef
+		IL_00b0: stloc.2
+		IL_00b1: ldloc.1
+		IL_00b2: ldloc.2
+		IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b8: pop
+		IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00be: stloc.1
+		IL_00bf: ldstr "Object"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c9: volatile.
+		IL_00cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00d0: brfalse IL_00e4
 
-		IL_00df: ldloc.2
-		IL_00e0: ldstr "toString"
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ea: br IL_0104
+		IL_00d5: ldstr "prototype"
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00df: br IL_00f8
 
-		IL_00ef: ldloc.2
-		IL_00f0: ldstr "toString"
-		IL_00f5: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:22"
-		IL_00fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00e4: ldstr "prototype"
+		IL_00e9: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:20"
+		IL_00ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0104: stloc.2
+		IL_00f8: stloc.2
+		IL_00f9: volatile.
+		IL_00fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0100: brfalse IL_0115
+
 		IL_0105: ldloc.2
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010b: ldstr "call"
-		IL_0110: ldc.i4.0
-		IL_0111: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011b: stloc.2
-		IL_011c: ldloc.1
-		IL_011d: ldloc.2
-		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0123: pop
-		IL_0124: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0129: stloc.1
-		IL_012a: ldstr "Object"
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0134: volatile.
-		IL_0136: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_013b: brfalse IL_014f
+		IL_0106: ldstr "toString"
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0110: br IL_012a
 
-		IL_0140: ldstr "prototype"
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014a: br IL_0163
+		IL_0115: ldloc.2
+		IL_0116: ldstr "toString"
+		IL_011b: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:22"
+		IL_0120: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_014f: ldstr "prototype"
-		IL_0154: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:33"
-		IL_0159: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_012a: stloc.2
+		IL_012b: ldloc.2
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0131: volatile.
+		IL_0133: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0138: brfalse IL_0152
 
-		IL_0163: stloc.2
-		IL_0164: volatile.
-		IL_0166: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_016b: brfalse IL_0180
+		IL_013d: ldstr "call"
+		IL_0142: ldc.i4.0
+		IL_0143: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014d: br IL_016c
 
-		IL_0170: ldloc.2
-		IL_0171: ldstr "toString"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017b: br IL_0195
+		IL_0152: ldstr "call"
+		IL_0157: ldc.i4.0
+		IL_0158: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_015d: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:26"
+		IL_0162: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0180: ldloc.2
-		IL_0181: ldstr "toString"
-		IL_0186: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:35"
-		IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_016c: stloc.2
+		IL_016d: ldloc.1
+		IL_016e: ldloc.2
+		IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0174: pop
+		IL_0175: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017a: stloc.1
+		IL_017b: ldstr "Object"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0185: volatile.
+		IL_0187: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_018c: brfalse IL_01a0
 
-		IL_0195: stloc.2
-		IL_0196: ldloc.2
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019c: ldstr "call"
-		IL_01a1: ldc.r8 1
-		IL_01aa: box [System.Runtime]System.Double
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0191: ldstr "prototype"
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019b: br IL_01b4
+
+		IL_01a0: ldstr "prototype"
+		IL_01a5: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:33"
+		IL_01aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
 		IL_01b4: stloc.2
-		IL_01b5: ldloc.1
-		IL_01b6: ldloc.2
-		IL_01b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01bc: pop
-		IL_01bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c2: stloc.1
-		IL_01c3: ldstr "Object"
-		IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01cd: volatile.
-		IL_01cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01d4: brfalse IL_01e8
+		IL_01b5: volatile.
+		IL_01b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01bc: brfalse IL_01d1
 
-		IL_01d9: ldstr "prototype"
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e3: br IL_01fc
+		IL_01c1: ldloc.2
+		IL_01c2: ldstr "toString"
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01cc: br IL_01e6
 
-		IL_01e8: ldstr "prototype"
-		IL_01ed: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:46"
-		IL_01f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01d1: ldloc.2
+		IL_01d2: ldstr "toString"
+		IL_01d7: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:35"
+		IL_01dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01fc: stloc.2
-		IL_01fd: volatile.
-		IL_01ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0204: brfalse IL_0219
+		IL_01e6: stloc.2
+		IL_01e7: ldloc.2
+		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ed: volatile.
+		IL_01ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01f4: brfalse IL_0216
 
-		IL_0209: ldloc.2
-		IL_020a: ldstr "toString"
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0214: br IL_022e
+		IL_01f9: ldstr "call"
+		IL_01fe: ldc.r8 1
+		IL_0207: box [System.Runtime]System.Double
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0211: br IL_0238
 
-		IL_0219: ldloc.2
-		IL_021a: ldstr "toString"
-		IL_021f: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:48"
-		IL_0224: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0216: ldstr "call"
+		IL_021b: ldc.r8 1
+		IL_0224: box [System.Runtime]System.Double
+		IL_0229: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:39"
+		IL_022e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_022e: stloc.2
-		IL_022f: ldloc.2
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0235: ldstr "call"
-		IL_023a: ldstr "x"
-		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0244: stloc.2
-		IL_0245: ldloc.1
-		IL_0246: ldloc.2
-		IL_0247: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024c: pop
-		IL_024d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0252: stloc.1
-		IL_0253: ldstr "Object"
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_025d: volatile.
-		IL_025f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0264: brfalse IL_0278
+		IL_0238: stloc.2
+		IL_0239: ldloc.1
+		IL_023a: ldloc.2
+		IL_023b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0240: pop
+		IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0246: stloc.1
+		IL_0247: ldstr "Object"
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0251: volatile.
+		IL_0253: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0258: brfalse IL_026c
 
-		IL_0269: ldstr "prototype"
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0273: br IL_028c
+		IL_025d: ldstr "prototype"
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0267: br IL_0280
 
-		IL_0278: ldstr "prototype"
-		IL_027d: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:58"
-		IL_0282: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_026c: ldstr "prototype"
+		IL_0271: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:46"
+		IL_0276: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_028c: stloc.2
-		IL_028d: volatile.
-		IL_028f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0294: brfalse IL_02a9
+		IL_0280: stloc.2
+		IL_0281: volatile.
+		IL_0283: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0288: brfalse IL_029d
 
-		IL_0299: ldloc.2
-		IL_029a: ldstr "toString"
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a4: br IL_02be
+		IL_028d: ldloc.2
+		IL_028e: ldstr "toString"
+		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0298: br IL_02b2
 
-		IL_02a9: ldloc.2
-		IL_02aa: ldstr "toString"
-		IL_02af: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:60"
-		IL_02b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_029d: ldloc.2
+		IL_029e: ldstr "toString"
+		IL_02a3: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:48"
+		IL_02a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02be: stloc.2
-		IL_02bf: ldloc.2
-		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c5: ldc.i4.0
-		IL_02c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02cb: stloc.3
-		IL_02cc: ldstr "call"
-		IL_02d1: ldloc.3
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d7: stloc.2
-		IL_02d8: ldloc.1
-		IL_02d9: ldloc.2
-		IL_02da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02df: pop
-		IL_02e0: ret
+		IL_02b2: stloc.2
+		IL_02b3: ldloc.2
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b9: volatile.
+		IL_02bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_02c0: brfalse IL_02d9
+
+		IL_02c5: ldstr "call"
+		IL_02ca: ldstr "x"
+		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d4: br IL_02f2
+
+		IL_02d9: ldstr "call"
+		IL_02de: ldstr "x"
+		IL_02e3: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:51"
+		IL_02e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02f2: stloc.2
+		IL_02f3: ldloc.1
+		IL_02f4: ldloc.2
+		IL_02f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02fa: pop
+		IL_02fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0300: stloc.1
+		IL_0301: ldstr "Object"
+		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_030b: volatile.
+		IL_030d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0312: brfalse IL_0326
+
+		IL_0317: ldstr "prototype"
+		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0321: br IL_033a
+
+		IL_0326: ldstr "prototype"
+		IL_032b: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:58"
+		IL_0330: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_033a: stloc.2
+		IL_033b: volatile.
+		IL_033d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0342: brfalse IL_0357
+
+		IL_0347: ldloc.2
+		IL_0348: ldstr "toString"
+		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0352: br IL_036c
+
+		IL_0357: ldloc.2
+		IL_0358: ldstr "toString"
+		IL_035d: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:60"
+		IL_0362: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_036c: stloc.2
+		IL_036d: ldloc.2
+		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0373: ldc.i4.0
+		IL_0374: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0379: stloc.3
+		IL_037a: volatile.
+		IL_037c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0381: brfalse IL_0396
+
+		IL_0386: ldstr "call"
+		IL_038b: ldloc.3
+		IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0391: br IL_03ab
+
+		IL_0396: ldstr "call"
+		IL_039b: ldloc.3
+		IL_039c: ldstr "Object_Prototype_ToString_Basic:Modules.Object_Prototype_ToString_Basic:__js_module_init__:63"
+		IL_03a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03ab: stloc.2
+		IL_03ac: ldloc.1
+		IL_03ad: ldloc.2
+		IL_03ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03b3: pop
+		IL_03b4: ret
 	} // end of method Object_Prototype_ToString_Basic::__js_module_init__
 
 } // end of class Modules.Object_Prototype_ToString_Basic
@@ -380,6 +442,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_ToString_SymbolToStringTag_Custom.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_ToString_SymbolToStringTag_Custom.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 528 (0x210)
+		// Code size: 642 (0x282)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_Prototype_ToString_SymbolToStringTag_Custom/Scope,
@@ -178,103 +178,139 @@
 		IL_00c5: stloc.s 4
 		IL_00c7: ldloc.s 4
 		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ce: ldstr "call"
-		IL_00d3: ldloc.1
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d9: stloc.s 4
-		IL_00db: ldloc.s 5
-		IL_00dd: ldloc.s 4
-		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e4: pop
-		IL_00e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ea: stloc.s 5
-		IL_00ec: ldstr "Object"
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f6: volatile.
-		IL_00f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00fd: brfalse IL_0111
+		IL_00ce: volatile.
+		IL_00d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d5: brfalse IL_00ea
 
-		IL_0102: ldstr "prototype"
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010c: br IL_0125
+		IL_00da: ldstr "call"
+		IL_00df: ldloc.1
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e5: br IL_00ff
 
-		IL_0111: ldstr "prototype"
-		IL_0116: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:38"
-		IL_011b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00ea: ldstr "call"
+		IL_00ef: ldloc.1
+		IL_00f0: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:31"
+		IL_00f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0125: stloc.s 4
-		IL_0127: volatile.
-		IL_0129: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_012e: brfalse IL_0144
+		IL_00ff: stloc.s 4
+		IL_0101: ldloc.s 5
+		IL_0103: ldloc.s 4
+		IL_0105: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010a: pop
+		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0110: stloc.s 5
+		IL_0112: ldstr "Object"
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_011c: volatile.
+		IL_011e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0123: brfalse IL_0137
 
-		IL_0133: ldloc.s 4
-		IL_0135: ldstr "toString"
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013f: br IL_015a
+		IL_0128: ldstr "prototype"
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0132: br IL_014b
 
-		IL_0144: ldloc.s 4
-		IL_0146: ldstr "toString"
-		IL_014b: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:40"
-		IL_0150: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0137: ldstr "prototype"
+		IL_013c: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:38"
+		IL_0141: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_015a: stloc.s 4
-		IL_015c: ldloc.s 4
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0163: ldstr "call"
-		IL_0168: ldloc.2
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016e: stloc.s 4
-		IL_0170: ldloc.s 5
-		IL_0172: ldloc.s 4
-		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0179: pop
-		IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017f: stloc.s 5
-		IL_0181: ldstr "Object"
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018b: volatile.
-		IL_018d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0192: brfalse IL_01a6
+		IL_014b: stloc.s 4
+		IL_014d: volatile.
+		IL_014f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0154: brfalse IL_016a
 
-		IL_0197: ldstr "prototype"
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a1: br IL_01ba
+		IL_0159: ldloc.s 4
+		IL_015b: ldstr "toString"
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0165: br IL_0180
 
-		IL_01a6: ldstr "prototype"
-		IL_01ab: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:49"
-		IL_01b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_016a: ldloc.s 4
+		IL_016c: ldstr "toString"
+		IL_0171: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:40"
+		IL_0176: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0180: stloc.s 4
+		IL_0182: ldloc.s 4
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0189: volatile.
+		IL_018b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0190: brfalse IL_01a5
+
+		IL_0195: ldstr "call"
+		IL_019a: ldloc.2
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a0: br IL_01ba
+
+		IL_01a5: ldstr "call"
+		IL_01aa: ldloc.2
+		IL_01ab: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:42"
+		IL_01b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
 		IL_01ba: stloc.s 4
-		IL_01bc: volatile.
-		IL_01be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01c3: brfalse IL_01d9
+		IL_01bc: ldloc.s 5
+		IL_01be: ldloc.s 4
+		IL_01c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c5: pop
+		IL_01c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cb: stloc.s 5
+		IL_01cd: ldstr "Object"
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d7: volatile.
+		IL_01d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01de: brfalse IL_01f2
 
-		IL_01c8: ldloc.s 4
-		IL_01ca: ldstr "toString"
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d4: br IL_01ef
+		IL_01e3: ldstr "prototype"
+		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ed: br IL_0206
 
-		IL_01d9: ldloc.s 4
-		IL_01db: ldstr "toString"
-		IL_01e0: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:51"
-		IL_01e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01f2: ldstr "prototype"
+		IL_01f7: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:49"
+		IL_01fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01ef: stloc.s 4
-		IL_01f1: ldloc.s 4
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f8: ldstr "call"
-		IL_01fd: ldloc.3
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0203: stloc.s 4
-		IL_0205: ldloc.s 5
-		IL_0207: ldloc.s 4
-		IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_020e: pop
-		IL_020f: ret
+		IL_0206: stloc.s 4
+		IL_0208: volatile.
+		IL_020a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_020f: brfalse IL_0225
+
+		IL_0214: ldloc.s 4
+		IL_0216: ldstr "toString"
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0220: br IL_023b
+
+		IL_0225: ldloc.s 4
+		IL_0227: ldstr "toString"
+		IL_022c: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:51"
+		IL_0231: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_023b: stloc.s 4
+		IL_023d: ldloc.s 4
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0244: volatile.
+		IL_0246: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_024b: brfalse IL_0260
+
+		IL_0250: ldstr "call"
+		IL_0255: ldloc.3
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025b: br IL_0275
+
+		IL_0260: ldstr "call"
+		IL_0265: ldloc.3
+		IL_0266: ldstr "Object_Prototype_ToString_SymbolToStringTag_Custom:Modules.Object_Prototype_ToString_SymbolToStringTag_Custom:__js_module_init__:53"
+		IL_026b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0275: stloc.s 4
+		IL_0277: ldloc.s 5
+		IL_0279: ldloc.s 4
+		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0280: pop
+		IL_0281: ret
 	} // end of method Object_Prototype_ToString_SymbolToStringTag_Custom::__js_module_init__
 
 } // end of class Modules.Object_Prototype_ToString_SymbolToStringTag_Custom
@@ -310,6 +346,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Values_Basic.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Values_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 286 (0x11e)
+		// Code size: 328 (0x148)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_Values_Basic/Scope,
@@ -185,19 +185,31 @@
 		IL_00ee: stloc.3
 		IL_00ef: ldloc.2
 		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f5: ldstr "join"
-		IL_00fa: ldstr ","
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0104: stloc.s 4
-		IL_0106: ldstr "values="
-		IL_010b: ldloc.s 4
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0112: stloc.s 5
-		IL_0114: ldloc.3
-		IL_0115: ldloc.s 5
-		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_011c: pop
-		IL_011d: ret
+		IL_00f5: volatile.
+		IL_00f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00fc: brfalse IL_0115
+
+		IL_0101: ldstr "join"
+		IL_0106: ldstr ","
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0110: br IL_012e
+
+		IL_0115: ldstr "join"
+		IL_011a: ldstr ","
+		IL_011f: ldstr "Object_Values_Basic:Modules.Object_Values_Basic:__js_module_init__:32"
+		IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_012e: stloc.s 4
+		IL_0130: ldstr "values="
+		IL_0135: ldloc.s 4
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_013c: stloc.s 5
+		IL_013e: ldloc.3
+		IL_013f: ldloc.s 5
+		IL_0141: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0146: pop
+		IL_0147: ret
 	} // end of method Object_Values_Basic::__js_module_init__
 
 } // end of class Modules.Object_Values_Basic
@@ -228,6 +240,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_AllRejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_AllRejected.verified.txt
@@ -187,7 +187,7 @@
 			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0015: stloc.1
 			IL_0016: volatile.
-			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_001d: brfalse IL_0032
 
 			IL_0022: ldloc.1
@@ -198,7 +198,7 @@
 			IL_0032: ldloc.1
 			IL_0033: ldstr "status"
 			IL_0038: ldstr "Promise_AllSettled_AllRejected:<TwoPhaseDummy_M4>:__js_call__:7"
-			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0047: stloc.1
@@ -207,7 +207,7 @@
 			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0057: stloc.2
 			IL_0058: volatile.
-			IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_005f: brfalse IL_0074
 
 			IL_0064: ldloc.2
@@ -218,7 +218,7 @@
 			IL_0074: ldloc.2
 			IL_0075: ldstr "reason"
 			IL_007a: ldstr "Promise_AllSettled_AllRejected:<TwoPhaseDummy_M4>:__js_call__:13"
-			IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0089: stloc.2
@@ -250,7 +250,7 @@
 			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_00c4: stloc.2
 			IL_00c5: volatile.
-			IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_00cc: brfalse IL_00e1
 
 			IL_00d1: ldloc.2
@@ -261,7 +261,7 @@
 			IL_00e1: ldloc.2
 			IL_00e2: ldstr "status"
 			IL_00e7: ldstr "Promise_AllSettled_AllRejected:<TwoPhaseDummy_M4>:__js_call__:22"
-			IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00f6: stloc.2
@@ -270,7 +270,7 @@
 			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0106: stloc.1
 			IL_0107: volatile.
-			IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_010e: brfalse IL_0123
 
 			IL_0113: ldloc.1
@@ -281,7 +281,7 @@
 			IL_0123: ldloc.1
 			IL_0124: ldstr "reason"
 			IL_0129: ldstr "Promise_AllSettled_AllRejected:<TwoPhaseDummy_M4>:__js_call__:28"
-			IL_012e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_012e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0138: stloc.1
@@ -343,7 +343,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 113 (0x71)
+		// Code size: 153 (0x99)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_AllSettled_AllRejected/Scope,
@@ -390,12 +390,25 @@
 		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_AllSettled_AllRejected/ArrowFunction_L6C35/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_AllSettled_AllRejected/ArrowFunction_L6C35/FunctionObject>(!!0)
 		IL_0060: stloc.s 5
-		IL_0062: ldloc.3
-		IL_0063: ldstr "then"
-		IL_0068: ldloc.s 5
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006f: pop
-		IL_0070: ret
+		IL_0062: volatile.
+		IL_0064: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0069: brfalse IL_0080
+
+		IL_006e: ldloc.3
+		IL_006f: ldstr "then"
+		IL_0074: ldloc.s 5
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007b: br IL_0097
+
+		IL_0080: ldloc.3
+		IL_0081: ldstr "then"
+		IL_0086: ldloc.s 5
+		IL_0088: ldstr "Promise_AllSettled_AllRejected:Modules.Promise_AllSettled_AllRejected:__js_module_init__:17"
+		IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0097: pop
+		IL_0098: ret
 	} // end of method Promise_AllSettled_AllRejected::__js_module_init__
 
 } // end of class Modules.Promise_AllSettled_AllRejected
@@ -429,6 +442,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_AllResolved.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_AllResolved.verified.txt
@@ -187,7 +187,7 @@
 			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0015: stloc.1
 			IL_0016: volatile.
-			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_001d: brfalse IL_0032
 
 			IL_0022: ldloc.1
@@ -198,7 +198,7 @@
 			IL_0032: ldloc.1
 			IL_0033: ldstr "status"
 			IL_0038: ldstr "Promise_AllSettled_AllResolved:<TwoPhaseDummy_M4>:__js_call__:7"
-			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0047: stloc.1
@@ -207,7 +207,7 @@
 			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0057: stloc.2
 			IL_0058: volatile.
-			IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_005f: brfalse IL_0074
 
 			IL_0064: ldloc.2
@@ -218,7 +218,7 @@
 			IL_0074: ldloc.2
 			IL_0075: ldstr "value"
 			IL_007a: ldstr "Promise_AllSettled_AllResolved:<TwoPhaseDummy_M4>:__js_call__:13"
-			IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0089: stloc.2
@@ -250,7 +250,7 @@
 			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_00c4: stloc.2
 			IL_00c5: volatile.
-			IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_00cc: brfalse IL_00e1
 
 			IL_00d1: ldloc.2
@@ -261,7 +261,7 @@
 			IL_00e1: ldloc.2
 			IL_00e2: ldstr "status"
 			IL_00e7: ldstr "Promise_AllSettled_AllResolved:<TwoPhaseDummy_M4>:__js_call__:22"
-			IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00f6: stloc.2
@@ -270,7 +270,7 @@
 			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0106: stloc.1
 			IL_0107: volatile.
-			IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_010e: brfalse IL_0123
 
 			IL_0113: ldloc.1
@@ -281,7 +281,7 @@
 			IL_0123: ldloc.1
 			IL_0124: ldstr "value"
 			IL_0129: ldstr "Promise_AllSettled_AllResolved:<TwoPhaseDummy_M4>:__js_call__:28"
-			IL_012e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_012e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0138: stloc.1
@@ -313,7 +313,7 @@
 			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0173: stloc.1
 			IL_0174: volatile.
-			IL_0176: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0176: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_017b: brfalse IL_0190
 
 			IL_0180: ldloc.1
@@ -324,7 +324,7 @@
 			IL_0190: ldloc.1
 			IL_0191: ldstr "status"
 			IL_0196: ldstr "Promise_AllSettled_AllResolved:<TwoPhaseDummy_M4>:__js_call__:37"
-			IL_019b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_019b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01a5: stloc.1
@@ -333,7 +333,7 @@
 			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_01b5: stloc.2
 			IL_01b6: volatile.
-			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_01bd: brfalse IL_01d2
 
 			IL_01c2: ldloc.2
@@ -344,7 +344,7 @@
 			IL_01d2: ldloc.2
 			IL_01d3: ldstr "value"
 			IL_01d8: ldstr "Promise_AllSettled_AllResolved:<TwoPhaseDummy_M4>:__js_call__:43"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01e7: stloc.2
@@ -406,7 +406,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 160 (0xa0)
+		// Code size: 201 (0xc9)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_AllSettled_AllResolved/Scope,
@@ -463,12 +463,25 @@
 		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_AllSettled_AllResolved/ArrowFunction_L7C39/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_AllSettled_AllResolved/ArrowFunction_L7C39/FunctionObject>(!!0)
 		IL_008e: stloc.s 6
-		IL_0090: ldloc.s 4
-		IL_0092: ldstr "then"
-		IL_0097: ldloc.s 6
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009e: pop
-		IL_009f: ret
+		IL_0090: volatile.
+		IL_0092: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0097: brfalse IL_00af
+
+		IL_009c: ldloc.s 4
+		IL_009e: ldstr "then"
+		IL_00a3: ldloc.s 6
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00aa: br IL_00c7
+
+		IL_00af: ldloc.s 4
+		IL_00b1: ldstr "then"
+		IL_00b6: ldloc.s 6
+		IL_00b8: ldstr "Promise_AllSettled_AllResolved:Modules.Promise_AllSettled_AllResolved:__js_module_init__:24"
+		IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00c7: pop
+		IL_00c8: ret
 	} // end of method Promise_AllSettled_AllResolved::__js_module_init__
 
 } // end of class Modules.Promise_AllSettled_AllResolved
@@ -504,6 +517,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_EmptyArray.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_EmptyArray.verified.txt
@@ -182,7 +182,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -193,7 +193,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "length"
 			IL_0028: ldstr "Promise_AllSettled_EmptyArray:<TwoPhaseDummy_M4>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -239,7 +239,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 74 (0x4a)
+		// Code size: 113 (0x71)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_AllSettled_EmptyArray/Scope,
@@ -272,12 +272,25 @@
 		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_AllSettled_EmptyArray/ArrowFunction_L3C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_AllSettled_EmptyArray/ArrowFunction_L3C29/FunctionObject>(!!0)
 		IL_003b: stloc.3
-		IL_003c: ldloc.1
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.3
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: pop
-		IL_0049: ret
+		IL_003c: volatile.
+		IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0043: brfalse IL_0059
+
+		IL_0048: ldloc.1
+		IL_0049: ldstr "then"
+		IL_004e: ldloc.3
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: br IL_006f
+
+		IL_0059: ldloc.1
+		IL_005a: ldstr "then"
+		IL_005f: ldloc.3
+		IL_0060: ldstr "Promise_AllSettled_EmptyArray:Modules.Promise_AllSettled_EmptyArray:__js_module_init__:9"
+		IL_0065: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006f: pop
+		IL_0070: ret
 	} // end of method Promise_AllSettled_EmptyArray::__js_module_init__
 
 } // end of class Modules.Promise_AllSettled_EmptyArray
@@ -308,6 +321,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_MixedResults.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_MixedResults.verified.txt
@@ -187,7 +187,7 @@
 			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0015: stloc.1
 			IL_0016: volatile.
-			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_001d: brfalse IL_0032
 
 			IL_0022: ldloc.1
@@ -198,7 +198,7 @@
 			IL_0032: ldloc.1
 			IL_0033: ldstr "status"
 			IL_0038: ldstr "Promise_AllSettled_MixedResults:<TwoPhaseDummy_M4>:__js_call__:7"
-			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0047: stloc.1
@@ -207,7 +207,7 @@
 			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0057: stloc.2
 			IL_0058: volatile.
-			IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_005f: brfalse IL_0074
 
 			IL_0064: ldloc.2
@@ -218,7 +218,7 @@
 			IL_0074: ldloc.2
 			IL_0075: ldstr "value"
 			IL_007a: ldstr "Promise_AllSettled_MixedResults:<TwoPhaseDummy_M4>:__js_call__:13"
-			IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0089: stloc.2
@@ -250,7 +250,7 @@
 			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_00c4: stloc.2
 			IL_00c5: volatile.
-			IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_00cc: brfalse IL_00e1
 
 			IL_00d1: ldloc.2
@@ -261,7 +261,7 @@
 			IL_00e1: ldloc.2
 			IL_00e2: ldstr "status"
 			IL_00e7: ldstr "Promise_AllSettled_MixedResults:<TwoPhaseDummy_M4>:__js_call__:22"
-			IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00f6: stloc.2
@@ -270,7 +270,7 @@
 			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0106: stloc.1
 			IL_0107: volatile.
-			IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_010e: brfalse IL_0123
 
 			IL_0113: ldloc.1
@@ -281,7 +281,7 @@
 			IL_0123: ldloc.1
 			IL_0124: ldstr "reason"
 			IL_0129: ldstr "Promise_AllSettled_MixedResults:<TwoPhaseDummy_M4>:__js_call__:28"
-			IL_012e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_012e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0138: stloc.1
@@ -313,7 +313,7 @@
 			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0173: stloc.1
 			IL_0174: volatile.
-			IL_0176: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0176: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_017b: brfalse IL_0190
 
 			IL_0180: ldloc.1
@@ -324,7 +324,7 @@
 			IL_0190: ldloc.1
 			IL_0191: ldstr "status"
 			IL_0196: ldstr "Promise_AllSettled_MixedResults:<TwoPhaseDummy_M4>:__js_call__:37"
-			IL_019b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_019b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01a5: stloc.1
@@ -333,7 +333,7 @@
 			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_01b5: stloc.2
 			IL_01b6: volatile.
-			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_01bd: brfalse IL_01d2
 
 			IL_01c2: ldloc.2
@@ -344,7 +344,7 @@
 			IL_01d2: ldloc.2
 			IL_01d3: ldstr "value"
 			IL_01d8: ldstr "Promise_AllSettled_MixedResults:<TwoPhaseDummy_M4>:__js_call__:43"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01e7: stloc.2
@@ -406,7 +406,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 151 (0x97)
+		// Code size: 192 (0xc0)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_AllSettled_MixedResults/Scope,
@@ -462,12 +462,25 @@
 		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_AllSettled_MixedResults/ArrowFunction_L7C39/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_AllSettled_MixedResults/ArrowFunction_L7C39/FunctionObject>(!!0)
 		IL_0085: stloc.s 6
-		IL_0087: ldloc.s 4
-		IL_0089: ldstr "then"
-		IL_008e: ldloc.s 6
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: pop
-		IL_0096: ret
+		IL_0087: volatile.
+		IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_008e: brfalse IL_00a6
+
+		IL_0093: ldloc.s 4
+		IL_0095: ldstr "then"
+		IL_009a: ldloc.s 6
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a1: br IL_00be
+
+		IL_00a6: ldloc.s 4
+		IL_00a8: ldstr "then"
+		IL_00ad: ldloc.s 6
+		IL_00af: ldstr "Promise_AllSettled_MixedResults:Modules.Promise_AllSettled_MixedResults:__js_module_init__:23"
+		IL_00b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00be: pop
+		IL_00bf: ret
 	} // end of method Promise_AllSettled_MixedResults::__js_module_init__
 
 } // end of class Modules.Promise_AllSettled_MixedResults
@@ -503,6 +516,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_MixedValues.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_MixedValues.verified.txt
@@ -187,7 +187,7 @@
 			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0015: stloc.1
 			IL_0016: volatile.
-			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_001d: brfalse IL_0032
 
 			IL_0022: ldloc.1
@@ -198,7 +198,7 @@
 			IL_0032: ldloc.1
 			IL_0033: ldstr "status"
 			IL_0038: ldstr "Promise_AllSettled_MixedValues:<TwoPhaseDummy_M4>:__js_call__:7"
-			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0047: stloc.1
@@ -207,7 +207,7 @@
 			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0057: stloc.2
 			IL_0058: volatile.
-			IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_005f: brfalse IL_0074
 
 			IL_0064: ldloc.2
@@ -218,7 +218,7 @@
 			IL_0074: ldloc.2
 			IL_0075: ldstr "value"
 			IL_007a: ldstr "Promise_AllSettled_MixedValues:<TwoPhaseDummy_M4>:__js_call__:13"
-			IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0089: stloc.2
@@ -250,7 +250,7 @@
 			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_00c4: stloc.2
 			IL_00c5: volatile.
-			IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_00cc: brfalse IL_00e1
 
 			IL_00d1: ldloc.2
@@ -261,7 +261,7 @@
 			IL_00e1: ldloc.2
 			IL_00e2: ldstr "status"
 			IL_00e7: ldstr "Promise_AllSettled_MixedValues:<TwoPhaseDummy_M4>:__js_call__:22"
-			IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00f6: stloc.2
@@ -270,7 +270,7 @@
 			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0106: stloc.1
 			IL_0107: volatile.
-			IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_010e: brfalse IL_0123
 
 			IL_0113: ldloc.1
@@ -281,7 +281,7 @@
 			IL_0123: ldloc.1
 			IL_0124: ldstr "value"
 			IL_0129: ldstr "Promise_AllSettled_MixedValues:<TwoPhaseDummy_M4>:__js_call__:28"
-			IL_012e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_012e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0138: stloc.1
@@ -313,7 +313,7 @@
 			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_0173: stloc.1
 			IL_0174: volatile.
-			IL_0176: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0176: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_017b: brfalse IL_0190
 
 			IL_0180: ldloc.1
@@ -324,7 +324,7 @@
 			IL_0190: ldloc.1
 			IL_0191: ldstr "status"
 			IL_0196: ldstr "Promise_AllSettled_MixedValues:<TwoPhaseDummy_M4>:__js_call__:37"
-			IL_019b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_019b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01a5: stloc.1
@@ -333,7 +333,7 @@
 			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_01b5: stloc.2
 			IL_01b6: volatile.
-			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_01bd: brfalse IL_01d2
 
 			IL_01c2: ldloc.2
@@ -344,7 +344,7 @@
 			IL_01d2: ldloc.2
 			IL_01d3: ldstr "value"
 			IL_01d8: ldstr "Promise_AllSettled_MixedValues:<TwoPhaseDummy_M4>:__js_call__:43"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01e7: stloc.2
@@ -406,7 +406,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 127 (0x7f)
+		// Code size: 168 (0xa8)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_AllSettled_MixedValues/Scope,
@@ -458,12 +458,25 @@
 		IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_AllSettled_MixedValues/ArrowFunction_L7C43/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_AllSettled_MixedValues/ArrowFunction_L7C43/FunctionObject>(!!0)
 		IL_006d: stloc.s 6
-		IL_006f: ldloc.s 4
-		IL_0071: ldstr "then"
-		IL_0076: ldloc.s 6
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007d: pop
-		IL_007e: ret
+		IL_006f: volatile.
+		IL_0071: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0076: brfalse IL_008e
+
+		IL_007b: ldloc.s 4
+		IL_007d: ldstr "then"
+		IL_0082: ldloc.s 6
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0089: br IL_00a6
+
+		IL_008e: ldloc.s 4
+		IL_0090: ldstr "then"
+		IL_0095: ldloc.s 6
+		IL_0097: ldstr "Promise_AllSettled_MixedValues:Modules.Promise_AllSettled_MixedValues:__js_module_init__:19"
+		IL_009c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a6: pop
+		IL_00a7: ret
 	} // end of method Promise_AllSettled_MixedValues::__js_module_init__
 
 } // end of class Modules.Promise_AllSettled_MixedValues
@@ -499,6 +512,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_NullIterable.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_AllSettled_NullIterable.verified.txt
@@ -300,7 +300,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -311,7 +311,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "name"
 			IL_0028: ldstr "Promise_AllSettled_NullIterable:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -357,7 +357,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 132 (0x84)
+		// Code size: 211 (0xd3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_AllSettled_NullIterable/Scope,
@@ -391,36 +391,62 @@
 		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_AllSettled_NullIterable/ArrowFunction_L4C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_AllSettled_NullIterable/ArrowFunction_L4C11/FunctionObject>(!!0)
 		IL_003b: stloc.3
-		IL_003c: ldloc.1
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.3
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: stloc.1
-		IL_0049: ldloc.1
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.1
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: stloc.2
-		IL_005b: newobj instance void Modules.Promise_AllSettled_NullIterable/ArrowFunction_L7C12/FunctionObject::.ctor()
-		IL_0060: ldc.i4.1
-		IL_0061: conv.r8
-		IL_0062: ldstr ""
-		IL_0067: ldc.i4.0
-		IL_0068: ldc.i4.0
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_AllSettled_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_AllSettled_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0)
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.1
-		IL_0076: ldstr "catch"
-		IL_007b: ldloc.s 4
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ret
+		IL_003c: volatile.
+		IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0043: brfalse IL_0059
+
+		IL_0048: ldloc.1
+		IL_0049: ldstr "then"
+		IL_004e: ldloc.3
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: br IL_006f
+
+		IL_0059: ldloc.1
+		IL_005a: ldstr "then"
+		IL_005f: ldloc.3
+		IL_0060: ldstr "Promise_AllSettled_NullIterable:Modules.Promise_AllSettled_NullIterable:__js_module_init__:10"
+		IL_0065: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006f: stloc.1
+		IL_0070: ldloc.1
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0076: stloc.1
+		IL_0077: ldc.i4.1
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldloc.0
+		IL_0080: stelem.ref
+		IL_0081: stloc.2
+		IL_0082: newobj instance void Modules.Promise_AllSettled_NullIterable/ArrowFunction_L7C12/FunctionObject::.ctor()
+		IL_0087: ldc.i4.1
+		IL_0088: conv.r8
+		IL_0089: ldstr ""
+		IL_008e: ldc.i4.0
+		IL_008f: ldc.i4.0
+		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_AllSettled_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_AllSettled_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0)
+		IL_009a: stloc.s 4
+		IL_009c: volatile.
+		IL_009e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a3: brfalse IL_00ba
+
+		IL_00a8: ldloc.1
+		IL_00a9: ldstr "catch"
+		IL_00ae: ldloc.s 4
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b5: br IL_00d1
+
+		IL_00ba: ldloc.1
+		IL_00bb: ldstr "catch"
+		IL_00c0: ldloc.s 4
+		IL_00c2: ldstr "Promise_AllSettled_NullIterable:Modules.Promise_AllSettled_NullIterable:__js_module_init__:14"
+		IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d1: pop
+		IL_00d2: ret
 	} // end of method Promise_AllSettled_NullIterable::__js_module_init__
 
 } // end of class Modules.Promise_AllSettled_NullIterable
@@ -451,6 +477,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_AllResolved.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_AllResolved.verified.txt
@@ -253,7 +253,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 160 (0xa0)
+		// Code size: 201 (0xc9)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_All_AllResolved/Scope,
@@ -310,12 +310,25 @@
 		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_AllResolved/ArrowFunction_L7C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_AllResolved/ArrowFunction_L7C32/FunctionObject>(!!0)
 		IL_008e: stloc.s 6
-		IL_0090: ldloc.s 4
-		IL_0092: ldstr "then"
-		IL_0097: ldloc.s 6
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009e: pop
-		IL_009f: ret
+		IL_0090: volatile.
+		IL_0092: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0097: brfalse IL_00af
+
+		IL_009c: ldloc.s 4
+		IL_009e: ldstr "then"
+		IL_00a3: ldloc.s 6
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00aa: br IL_00c7
+
+		IL_00af: ldloc.s 4
+		IL_00b1: ldstr "then"
+		IL_00b6: ldloc.s 6
+		IL_00b8: ldstr "Promise_All_AllResolved:Modules.Promise_All_AllResolved:__js_module_init__:24"
+		IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00c7: pop
+		IL_00c8: ret
 	} // end of method Promise_All_AllResolved::__js_module_init__
 
 } // end of class Modules.Promise_All_AllResolved
@@ -340,4 +353,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_EmptyArray.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_EmptyArray.verified.txt
@@ -182,7 +182,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -193,7 +193,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "length"
 			IL_0028: ldstr "Promise_All_EmptyArray:<TwoPhaseDummy_M4>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -239,7 +239,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 74 (0x4a)
+		// Code size: 113 (0x71)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_All_EmptyArray/Scope,
@@ -272,12 +272,25 @@
 		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_EmptyArray/ArrowFunction_L3C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_EmptyArray/ArrowFunction_L3C22/FunctionObject>(!!0)
 		IL_003b: stloc.3
-		IL_003c: ldloc.1
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.3
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: pop
-		IL_0049: ret
+		IL_003c: volatile.
+		IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0043: brfalse IL_0059
+
+		IL_0048: ldloc.1
+		IL_0049: ldstr "then"
+		IL_004e: ldloc.3
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: br IL_006f
+
+		IL_0059: ldloc.1
+		IL_005a: ldstr "then"
+		IL_005f: ldloc.3
+		IL_0060: ldstr "Promise_All_EmptyArray:Modules.Promise_All_EmptyArray:__js_module_init__:9"
+		IL_0065: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006f: pop
+		IL_0070: ret
 	} // end of method Promise_All_EmptyArray::__js_module_init__
 
 } // end of class Modules.Promise_All_EmptyArray
@@ -308,6 +321,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_MixedValues.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_MixedValues.verified.txt
@@ -253,7 +253,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 127 (0x7f)
+		// Code size: 168 (0xa8)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_All_MixedValues/Scope,
@@ -305,12 +305,25 @@
 		IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_MixedValues/ArrowFunction_L7C36/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_MixedValues/ArrowFunction_L7C36/FunctionObject>(!!0)
 		IL_006d: stloc.s 6
-		IL_006f: ldloc.s 4
-		IL_0071: ldstr "then"
-		IL_0076: ldloc.s 6
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007d: pop
-		IL_007e: ret
+		IL_006f: volatile.
+		IL_0071: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0076: brfalse IL_008e
+
+		IL_007b: ldloc.s 4
+		IL_007d: ldstr "then"
+		IL_0082: ldloc.s 6
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0089: br IL_00a6
+
+		IL_008e: ldloc.s 4
+		IL_0090: ldstr "then"
+		IL_0095: ldloc.s 6
+		IL_0097: ldstr "Promise_All_MixedValues:Modules.Promise_All_MixedValues:__js_module_init__:19"
+		IL_009c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a6: pop
+		IL_00a7: ret
 	} // end of method Promise_All_MixedValues::__js_module_init__
 
 } // end of class Modules.Promise_All_MixedValues
@@ -335,4 +348,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_NullIterable.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_NullIterable.verified.txt
@@ -300,7 +300,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -311,7 +311,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "name"
 			IL_0028: ldstr "Promise_All_NullIterable:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -357,7 +357,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 132 (0x84)
+		// Code size: 211 (0xd3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_All_NullIterable/Scope,
@@ -391,36 +391,62 @@
 		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_NullIterable/ArrowFunction_L4C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_NullIterable/ArrowFunction_L4C11/FunctionObject>(!!0)
 		IL_003b: stloc.3
-		IL_003c: ldloc.1
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.3
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: stloc.1
-		IL_0049: ldloc.1
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.1
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: stloc.2
-		IL_005b: newobj instance void Modules.Promise_All_NullIterable/ArrowFunction_L7C12/FunctionObject::.ctor()
-		IL_0060: ldc.i4.1
-		IL_0061: conv.r8
-		IL_0062: ldstr ""
-		IL_0067: ldc.i4.0
-		IL_0068: ldc.i4.0
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0)
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.1
-		IL_0076: ldstr "catch"
-		IL_007b: ldloc.s 4
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ret
+		IL_003c: volatile.
+		IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0043: brfalse IL_0059
+
+		IL_0048: ldloc.1
+		IL_0049: ldstr "then"
+		IL_004e: ldloc.3
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: br IL_006f
+
+		IL_0059: ldloc.1
+		IL_005a: ldstr "then"
+		IL_005f: ldloc.3
+		IL_0060: ldstr "Promise_All_NullIterable:Modules.Promise_All_NullIterable:__js_module_init__:10"
+		IL_0065: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006f: stloc.1
+		IL_0070: ldloc.1
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0076: stloc.1
+		IL_0077: ldc.i4.1
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldloc.0
+		IL_0080: stelem.ref
+		IL_0081: stloc.2
+		IL_0082: newobj instance void Modules.Promise_All_NullIterable/ArrowFunction_L7C12/FunctionObject::.ctor()
+		IL_0087: ldc.i4.1
+		IL_0088: conv.r8
+		IL_0089: ldstr ""
+		IL_008e: ldc.i4.0
+		IL_008f: ldc.i4.0
+		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0)
+		IL_009a: stloc.s 4
+		IL_009c: volatile.
+		IL_009e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a3: brfalse IL_00ba
+
+		IL_00a8: ldloc.1
+		IL_00a9: ldstr "catch"
+		IL_00ae: ldloc.s 4
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b5: br IL_00d1
+
+		IL_00ba: ldloc.1
+		IL_00bb: ldstr "catch"
+		IL_00c0: ldloc.s 4
+		IL_00c2: ldstr "Promise_All_NullIterable:Modules.Promise_All_NullIterable:__js_module_init__:14"
+		IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d1: pop
+		IL_00d2: ret
 	} // end of method Promise_All_NullIterable::__js_module_init__
 
 } // end of class Modules.Promise_All_NullIterable
@@ -451,6 +477,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_OneRejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_OneRejected.verified.txt
@@ -340,7 +340,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 214 (0xd6)
+		// Code size: 296 (0x128)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_All_OneRejected/Scope,
@@ -397,36 +397,62 @@
 		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_OneRejected/ArrowFunction_L8C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_OneRejected/ArrowFunction_L8C11/FunctionObject>(!!0)
 		IL_0085: stloc.s 6
-		IL_0087: ldloc.s 4
-		IL_0089: ldstr "then"
-		IL_008e: ldloc.s 6
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.s 4
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.s 4
-		IL_00a0: ldc.i4.1
-		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: dup
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldloc.0
-		IL_00a9: stelem.ref
-		IL_00aa: stloc.s 5
-		IL_00ac: newobj instance void Modules.Promise_All_OneRejected/ArrowFunction_L11C12/FunctionObject::.ctor()
-		IL_00b1: ldc.i4.1
-		IL_00b2: conv.r8
-		IL_00b3: ldstr ""
-		IL_00b8: ldc.i4.0
-		IL_00b9: ldc.i4.0
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_OneRejected/ArrowFunction_L11C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_OneRejected/ArrowFunction_L11C12/FunctionObject>(!!0)
-		IL_00c4: stloc.s 7
-		IL_00c6: ldloc.s 4
-		IL_00c8: ldstr "catch"
-		IL_00cd: ldloc.s 7
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d4: pop
-		IL_00d5: ret
+		IL_0087: volatile.
+		IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_008e: brfalse IL_00a6
+
+		IL_0093: ldloc.s 4
+		IL_0095: ldstr "then"
+		IL_009a: ldloc.s 6
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a1: br IL_00be
+
+		IL_00a6: ldloc.s 4
+		IL_00a8: ldstr "then"
+		IL_00ad: ldloc.s 6
+		IL_00af: ldstr "Promise_All_OneRejected:Modules.Promise_All_OneRejected:__js_module_init__:23"
+		IL_00b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00be: stloc.s 4
+		IL_00c0: ldloc.s 4
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c7: stloc.s 4
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldloc.0
+		IL_00d2: stelem.ref
+		IL_00d3: stloc.s 5
+		IL_00d5: newobj instance void Modules.Promise_All_OneRejected/ArrowFunction_L11C12/FunctionObject::.ctor()
+		IL_00da: ldc.i4.1
+		IL_00db: conv.r8
+		IL_00dc: ldstr ""
+		IL_00e1: ldc.i4.0
+		IL_00e2: ldc.i4.0
+		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_OneRejected/ArrowFunction_L11C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_OneRejected/ArrowFunction_L11C12/FunctionObject>(!!0)
+		IL_00ed: stloc.s 7
+		IL_00ef: volatile.
+		IL_00f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00f6: brfalse IL_010e
+
+		IL_00fb: ldloc.s 4
+		IL_00fd: ldstr "catch"
+		IL_0102: ldloc.s 7
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0109: br IL_0126
+
+		IL_010e: ldloc.s 4
+		IL_0110: ldstr "catch"
+		IL_0115: ldloc.s 7
+		IL_0117: ldstr "Promise_All_OneRejected:Modules.Promise_All_OneRejected:__js_module_init__:27"
+		IL_011c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0126: pop
+		IL_0127: ret
 	} // end of method Promise_All_OneRejected::__js_module_init__
 
 } // end of class Modules.Promise_All_OneRejected
@@ -451,4 +477,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_OrderPreserved.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_All_OrderPreserved.verified.txt
@@ -610,7 +610,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 238 (0xee)
+		// Code size: 279 (0x117)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_All_OrderPreserved/Scope,
@@ -715,12 +715,25 @@
 		IL_00d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_All_OrderPreserved/ArrowFunction_L16C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_All_OrderPreserved/ArrowFunction_L16C32/FunctionObject>(!!0)
 		IL_00dc: stloc.s 9
-		IL_00de: ldloc.s 8
-		IL_00e0: ldstr "then"
-		IL_00e5: ldloc.s 9
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ec: pop
-		IL_00ed: ret
+		IL_00de: volatile.
+		IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00e5: brfalse IL_00fd
+
+		IL_00ea: ldloc.s 8
+		IL_00ec: ldstr "then"
+		IL_00f1: ldloc.s 9
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f8: br IL_0115
+
+		IL_00fd: ldloc.s 8
+		IL_00ff: ldstr "then"
+		IL_0104: ldloc.s 9
+		IL_0106: ldstr "Promise_All_OrderPreserved:Modules.Promise_All_OrderPreserved:__js_module_init__:24"
+		IL_010b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0115: pop
+		IL_0116: ret
 	} // end of method Promise_All_OrderPreserved::__js_module_init__
 
 } // end of class Modules.Promise_All_OrderPreserved
@@ -745,4 +758,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_AllRejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_AllRejected.verified.txt
@@ -300,7 +300,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -311,7 +311,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "name"
 			IL_0028: ldstr "Promise_Any_AllRejected:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -323,7 +323,7 @@
 			IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_004a: stloc.0
 			IL_004b: volatile.
-			IL_004d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_004d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0052: brfalse IL_0067
 
 			IL_0057: ldarg.1
@@ -334,12 +334,12 @@
 			IL_0067: ldarg.1
 			IL_0068: ldstr "errors"
 			IL_006d: ldstr "Promise_Any_AllRejected:<TwoPhaseDummy_M5>:__js_call__:12"
-			IL_0072: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+			IL_0072: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_007c: stloc.1
 			IL_007d: volatile.
-			IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_0084: brfalse IL_0099
 
 			IL_0089: ldloc.1
@@ -350,7 +350,7 @@
 			IL_0099: ldloc.1
 			IL_009a: ldstr "length"
 			IL_009f: ldstr "Promise_Any_AllRejected:<TwoPhaseDummy_M5>:__js_call__:14"
-			IL_00a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_00a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00ae: stloc.1
@@ -396,7 +396,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 196 (0xc4)
+		// Code size: 278 (0x116)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_Any_AllRejected/Scope,
@@ -451,36 +451,62 @@
 		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_AllRejected/ArrowFunction_L8C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_AllRejected/ArrowFunction_L8C11/FunctionObject>(!!0)
 		IL_0073: stloc.s 6
-		IL_0075: ldloc.s 4
-		IL_0077: ldstr "then"
-		IL_007c: ldloc.s 6
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0083: stloc.s 4
-		IL_0085: ldloc.s 4
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008c: stloc.s 4
-		IL_008e: ldc.i4.1
-		IL_008f: newarr [System.Runtime]System.Object
-		IL_0094: dup
-		IL_0095: ldc.i4.0
-		IL_0096: ldloc.0
-		IL_0097: stelem.ref
-		IL_0098: stloc.s 5
-		IL_009a: newobj instance void Modules.Promise_Any_AllRejected/ArrowFunction_L11C12/FunctionObject::.ctor()
-		IL_009f: ldc.i4.1
-		IL_00a0: conv.r8
-		IL_00a1: ldstr ""
-		IL_00a6: ldc.i4.0
-		IL_00a7: ldc.i4.0
-		IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_AllRejected/ArrowFunction_L11C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_AllRejected/ArrowFunction_L11C12/FunctionObject>(!!0)
-		IL_00b2: stloc.s 7
-		IL_00b4: ldloc.s 4
-		IL_00b6: ldstr "catch"
-		IL_00bb: ldloc.s 7
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c2: pop
-		IL_00c3: ret
+		IL_0075: volatile.
+		IL_0077: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_007c: brfalse IL_0094
+
+		IL_0081: ldloc.s 4
+		IL_0083: ldstr "then"
+		IL_0088: ldloc.s 6
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008f: br IL_00ac
+
+		IL_0094: ldloc.s 4
+		IL_0096: ldstr "then"
+		IL_009b: ldloc.s 6
+		IL_009d: ldstr "Promise_Any_AllRejected:Modules.Promise_Any_AllRejected:__js_module_init__:21"
+		IL_00a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ac: stloc.s 4
+		IL_00ae: ldloc.s 4
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b5: stloc.s 4
+		IL_00b7: ldc.i4.1
+		IL_00b8: newarr [System.Runtime]System.Object
+		IL_00bd: dup
+		IL_00be: ldc.i4.0
+		IL_00bf: ldloc.0
+		IL_00c0: stelem.ref
+		IL_00c1: stloc.s 5
+		IL_00c3: newobj instance void Modules.Promise_Any_AllRejected/ArrowFunction_L11C12/FunctionObject::.ctor()
+		IL_00c8: ldc.i4.1
+		IL_00c9: conv.r8
+		IL_00ca: ldstr ""
+		IL_00cf: ldc.i4.0
+		IL_00d0: ldc.i4.0
+		IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_AllRejected/ArrowFunction_L11C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_AllRejected/ArrowFunction_L11C12/FunctionObject>(!!0)
+		IL_00db: stloc.s 7
+		IL_00dd: volatile.
+		IL_00df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00e4: brfalse IL_00fc
+
+		IL_00e9: ldloc.s 4
+		IL_00eb: ldstr "catch"
+		IL_00f0: ldloc.s 7
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f7: br IL_0114
+
+		IL_00fc: ldloc.s 4
+		IL_00fe: ldstr "catch"
+		IL_0103: ldloc.s 7
+		IL_0105: ldstr "Promise_Any_AllRejected:Modules.Promise_Any_AllRejected:__js_module_init__:25"
+		IL_010a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0114: pop
+		IL_0115: ret
 	} // end of method Promise_Any_AllRejected::__js_module_init__
 
 } // end of class Modules.Promise_Any_AllRejected
@@ -513,6 +539,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_EmptyArray.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_EmptyArray.verified.txt
@@ -300,7 +300,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -311,7 +311,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "name"
 			IL_0028: ldstr "Promise_Any_EmptyArray:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -357,7 +357,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 132 (0x84)
+		// Code size: 211 (0xd3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Any_EmptyArray/Scope,
@@ -391,36 +391,62 @@
 		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_EmptyArray/ArrowFunction_L4C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_EmptyArray/ArrowFunction_L4C11/FunctionObject>(!!0)
 		IL_003b: stloc.3
-		IL_003c: ldloc.1
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.3
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: stloc.1
-		IL_0049: ldloc.1
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.1
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: stloc.2
-		IL_005b: newobj instance void Modules.Promise_Any_EmptyArray/ArrowFunction_L7C12/FunctionObject::.ctor()
-		IL_0060: ldc.i4.1
-		IL_0061: conv.r8
-		IL_0062: ldstr ""
-		IL_0067: ldc.i4.0
-		IL_0068: ldc.i4.0
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_EmptyArray/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_EmptyArray/ArrowFunction_L7C12/FunctionObject>(!!0)
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.1
-		IL_0076: ldstr "catch"
-		IL_007b: ldloc.s 4
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ret
+		IL_003c: volatile.
+		IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0043: brfalse IL_0059
+
+		IL_0048: ldloc.1
+		IL_0049: ldstr "then"
+		IL_004e: ldloc.3
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: br IL_006f
+
+		IL_0059: ldloc.1
+		IL_005a: ldstr "then"
+		IL_005f: ldloc.3
+		IL_0060: ldstr "Promise_Any_EmptyArray:Modules.Promise_Any_EmptyArray:__js_module_init__:9"
+		IL_0065: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006f: stloc.1
+		IL_0070: ldloc.1
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0076: stloc.1
+		IL_0077: ldc.i4.1
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldloc.0
+		IL_0080: stelem.ref
+		IL_0081: stloc.2
+		IL_0082: newobj instance void Modules.Promise_Any_EmptyArray/ArrowFunction_L7C12/FunctionObject::.ctor()
+		IL_0087: ldc.i4.1
+		IL_0088: conv.r8
+		IL_0089: ldstr ""
+		IL_008e: ldc.i4.0
+		IL_008f: ldc.i4.0
+		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_EmptyArray/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_EmptyArray/ArrowFunction_L7C12/FunctionObject>(!!0)
+		IL_009a: stloc.s 4
+		IL_009c: volatile.
+		IL_009e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a3: brfalse IL_00ba
+
+		IL_00a8: ldloc.1
+		IL_00a9: ldstr "catch"
+		IL_00ae: ldloc.s 4
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b5: br IL_00d1
+
+		IL_00ba: ldloc.1
+		IL_00bb: ldstr "catch"
+		IL_00c0: ldloc.s 4
+		IL_00c2: ldstr "Promise_Any_EmptyArray:Modules.Promise_Any_EmptyArray:__js_module_init__:13"
+		IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d1: pop
+		IL_00d2: ret
 	} // end of method Promise_Any_EmptyArray::__js_module_init__
 
 } // end of class Modules.Promise_Any_EmptyArray
@@ -451,6 +477,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_FirstResolved.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_FirstResolved.verified.txt
@@ -222,7 +222,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 160 (0xa0)
+		// Code size: 201 (0xc9)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_Any_FirstResolved/Scope,
@@ -279,12 +279,25 @@
 		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_FirstResolved/ArrowFunction_L7C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_FirstResolved/ArrowFunction_L7C32/FunctionObject>(!!0)
 		IL_008e: stloc.s 6
-		IL_0090: ldloc.s 4
-		IL_0092: ldstr "then"
-		IL_0097: ldloc.s 6
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009e: pop
-		IL_009f: ret
+		IL_0090: volatile.
+		IL_0092: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0097: brfalse IL_00af
+
+		IL_009c: ldloc.s 4
+		IL_009e: ldstr "then"
+		IL_00a3: ldloc.s 6
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00aa: br IL_00c7
+
+		IL_00af: ldloc.s 4
+		IL_00b1: ldstr "then"
+		IL_00b6: ldloc.s 6
+		IL_00b8: ldstr "Promise_Any_FirstResolved:Modules.Promise_Any_FirstResolved:__js_module_init__:24"
+		IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00c7: pop
+		IL_00c8: ret
 	} // end of method Promise_Any_FirstResolved::__js_module_init__
 
 } // end of class Modules.Promise_Any_FirstResolved
@@ -309,4 +322,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_NullIterable.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_NullIterable.verified.txt
@@ -300,7 +300,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -311,7 +311,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "name"
 			IL_0028: ldstr "Promise_Any_NullIterable:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -357,7 +357,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 132 (0x84)
+		// Code size: 211 (0xd3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Any_NullIterable/Scope,
@@ -391,36 +391,62 @@
 		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_NullIterable/ArrowFunction_L4C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_NullIterable/ArrowFunction_L4C11/FunctionObject>(!!0)
 		IL_003b: stloc.3
-		IL_003c: ldloc.1
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.3
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: stloc.1
-		IL_0049: ldloc.1
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.1
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: stloc.2
-		IL_005b: newobj instance void Modules.Promise_Any_NullIterable/ArrowFunction_L7C12/FunctionObject::.ctor()
-		IL_0060: ldc.i4.1
-		IL_0061: conv.r8
-		IL_0062: ldstr ""
-		IL_0067: ldc.i4.0
-		IL_0068: ldc.i4.0
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0)
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.1
-		IL_0076: ldstr "catch"
-		IL_007b: ldloc.s 4
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ret
+		IL_003c: volatile.
+		IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0043: brfalse IL_0059
+
+		IL_0048: ldloc.1
+		IL_0049: ldstr "then"
+		IL_004e: ldloc.3
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: br IL_006f
+
+		IL_0059: ldloc.1
+		IL_005a: ldstr "then"
+		IL_005f: ldloc.3
+		IL_0060: ldstr "Promise_Any_NullIterable:Modules.Promise_Any_NullIterable:__js_module_init__:10"
+		IL_0065: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006f: stloc.1
+		IL_0070: ldloc.1
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0076: stloc.1
+		IL_0077: ldc.i4.1
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldloc.0
+		IL_0080: stelem.ref
+		IL_0081: stloc.2
+		IL_0082: newobj instance void Modules.Promise_Any_NullIterable/ArrowFunction_L7C12/FunctionObject::.ctor()
+		IL_0087: ldc.i4.1
+		IL_0088: conv.r8
+		IL_0089: ldstr ""
+		IL_008e: ldc.i4.0
+		IL_008f: ldc.i4.0
+		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0)
+		IL_009a: stloc.s 4
+		IL_009c: volatile.
+		IL_009e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a3: brfalse IL_00ba
+
+		IL_00a8: ldloc.1
+		IL_00a9: ldstr "catch"
+		IL_00ae: ldloc.s 4
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b5: br IL_00d1
+
+		IL_00ba: ldloc.1
+		IL_00bb: ldstr "catch"
+		IL_00c0: ldloc.s 4
+		IL_00c2: ldstr "Promise_Any_NullIterable:Modules.Promise_Any_NullIterable:__js_module_init__:14"
+		IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d1: pop
+		IL_00d2: ret
 	} // end of method Promise_Any_NullIterable::__js_module_init__
 
 } // end of class Modules.Promise_Any_NullIterable
@@ -451,6 +477,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_OneResolved.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Any_OneResolved.verified.txt
@@ -222,7 +222,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 133 (0x85)
+		// Code size: 174 (0xae)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_Any_OneResolved/Scope,
@@ -276,12 +276,25 @@
 		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Any_OneResolved/ArrowFunction_L7C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Any_OneResolved/ArrowFunction_L7C32/FunctionObject>(!!0)
 		IL_0073: stloc.s 6
-		IL_0075: ldloc.s 4
-		IL_0077: ldstr "then"
-		IL_007c: ldloc.s 6
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0083: pop
-		IL_0084: ret
+		IL_0075: volatile.
+		IL_0077: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007c: brfalse IL_0094
+
+		IL_0081: ldloc.s 4
+		IL_0083: ldstr "then"
+		IL_0088: ldloc.s 6
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008f: br IL_00ac
+
+		IL_0094: ldloc.s 4
+		IL_0096: ldstr "then"
+		IL_009b: ldloc.s 6
+		IL_009d: ldstr "Promise_Any_OneResolved:Modules.Promise_Any_OneResolved:__js_module_init__:21"
+		IL_00a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ac: pop
+		IL_00ad: ret
 	} // end of method Promise_Any_OneResolved::__js_module_init__
 
 } // end of class Modules.Promise_Any_OneResolved
@@ -306,4 +319,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Callback_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Callback_Function_Objects.verified.txt
@@ -839,7 +839,7 @@
 			IL_000e: ldarg.1
 			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0014: volatile.
-			IL_0016: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0016: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_001b: brfalse IL_002f
 
 			IL_0020: ldstr "next"
@@ -848,12 +848,12 @@
 
 			IL_002f: ldstr "next"
 			IL_0034: ldstr "Promise_Callback_Function_Objects:<TwoPhaseDummy_M7>:__js_call__:8"
-			IL_0039: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0039: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0043: stloc.1
 			IL_0044: volatile.
-			IL_0046: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0046: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_004b: brfalse IL_0060
 
 			IL_0050: ldloc.1
@@ -864,7 +864,7 @@
 			IL_0060: ldloc.1
 			IL_0061: ldstr "value"
 			IL_0066: ldstr "Promise_Callback_Function_Objects:<TwoPhaseDummy_M7>:__js_call__:10"
-			IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0075: stloc.1
@@ -881,7 +881,7 @@
 			IL_0090: ldarg.1
 			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0096: volatile.
-			IL_0098: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0098: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_009d: brfalse IL_00b1
 
 			IL_00a2: ldstr "next"
@@ -890,12 +890,12 @@
 
 			IL_00b1: ldstr "next"
 			IL_00b6: ldstr "Promise_Callback_Function_Objects:<TwoPhaseDummy_M7>:__js_call__:18"
-			IL_00bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_00bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_00c5: stloc.1
 			IL_00c6: volatile.
-			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_00cd: brfalse IL_00e2
 
 			IL_00d2: ldloc.1
@@ -906,7 +906,7 @@
 			IL_00e2: ldloc.1
 			IL_00e3: ldstr "done"
 			IL_00e8: ldstr "Promise_Callback_Function_Objects:<TwoPhaseDummy_M7>:__js_call__:20"
-			IL_00ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_00ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00f7: stloc.1
@@ -1320,7 +1320,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 585 (0x249)
+		// Code size: 790 (0x316)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Callback_Function_Objects/Scope,
@@ -1363,202 +1363,267 @@
 		IL_003a: ldc.i4.1
 		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/ordinaryReaction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0040: stloc.s 7
-		IL_0042: ldloc.s 5
-		IL_0044: ldstr "then"
-		IL_0049: ldloc.s 7
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0050: stloc.s 5
-		IL_0052: ldloc.s 5
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0059: stloc.s 5
-		IL_005b: ldc.i4.1
-		IL_005c: newarr [System.Runtime]System.Object
-		IL_0061: dup
-		IL_0062: ldc.i4.0
-		IL_0063: ldloc.0
-		IL_0064: stelem.ref
-		IL_0065: stloc.s 6
-		IL_0067: ldloc.s 6
-		IL_0069: newobj instance void Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject::.ctor(object[])
-		IL_006e: ldc.i4.1
-		IL_006f: conv.r8
-		IL_0070: ldstr "asyncReaction"
-		IL_0075: ldc.i4.1
-		IL_0076: ldc.i4.1
-		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject>(!!0)
-		IL_0081: stloc.s 8
-		IL_0083: ldloc.s 5
-		IL_0085: ldstr "then"
-		IL_008a: ldloc.s 8
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0091: stloc.s 5
-		IL_0093: ldloc.s 5
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009a: stloc.s 5
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
-		IL_00a6: stloc.s 6
-		IL_00a8: ldloc.s 6
-		IL_00aa: newobj instance void Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject::.ctor(object[])
-		IL_00af: ldc.i4.1
-		IL_00b0: conv.r8
-		IL_00b1: ldstr "generatorReaction"
-		IL_00b6: ldc.i4.1
-		IL_00b7: ldc.i4.1
-		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_00c2: castclass Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject
-		IL_00c7: stloc.s 9
-		IL_00c9: ldloc.s 5
-		IL_00cb: ldstr "then"
-		IL_00d0: ldloc.s 9
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d7: stloc.s 5
-		IL_00d9: ldloc.s 5
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e0: stloc.s 5
-		IL_00e2: ldc.i4.1
-		IL_00e3: newarr [System.Runtime]System.Object
-		IL_00e8: dup
-		IL_00e9: ldc.i4.0
-		IL_00ea: ldloc.0
-		IL_00eb: stelem.ref
-		IL_00ec: stloc.s 6
-		IL_00ee: newobj instance void Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject::.ctor()
-		IL_00f3: ldc.i4.1
-		IL_00f4: conv.r8
-		IL_00f5: ldstr "consumeGenerator"
-		IL_00fa: ldc.i4.1
-		IL_00fb: ldc.i4.1
-		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0101: stloc.s 10
-		IL_0103: ldloc.s 5
-		IL_0105: ldstr "then"
-		IL_010a: ldloc.s 10
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0111: pop
-		IL_0112: ldstr "Promise"
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0121: stloc.s 5
-		IL_0123: ldc.i4.1
-		IL_0124: newarr [System.Runtime]System.Object
-		IL_0129: dup
-		IL_012a: ldc.i4.0
-		IL_012b: ldloc.0
-		IL_012c: stelem.ref
-		IL_012d: stloc.s 6
-		IL_012f: newobj instance void Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject::.ctor()
-		IL_0134: ldc.i4.2
-		IL_0135: conv.r8
-		IL_0136: ldstr "promiseTryCallback"
-		IL_013b: ldc.i4.1
-		IL_013c: ldc.i4.1
-		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0142: stloc.s 11
-		IL_0144: ldloc.s 5
-		IL_0146: ldstr "try"
-		IL_014b: ldloc.s 11
-		IL_014d: ldc.r8 2
-		IL_0156: box [System.Runtime]System.Double
-		IL_015b: ldc.r8 3
-		IL_0164: box [System.Runtime]System.Double
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_016e: stloc.s 5
-		IL_0170: ldloc.s 5
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0177: stloc.s 5
-		IL_0179: ldc.i4.1
-		IL_017a: newarr [System.Runtime]System.Object
-		IL_017f: dup
-		IL_0180: ldc.i4.0
-		IL_0181: ldloc.0
-		IL_0182: stelem.ref
-		IL_0183: stloc.s 6
-		IL_0185: newobj instance void Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject::.ctor()
-		IL_018a: ldc.i4.1
-		IL_018b: conv.r8
-		IL_018c: ldstr ""
-		IL_0191: ldc.i4.0
-		IL_0192: ldc.i4.1
-		IL_0193: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0198: stloc.s 12
-		IL_019a: ldloc.s 5
-		IL_019c: ldstr "then"
-		IL_01a1: ldloc.s 12
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a8: pop
+		IL_0042: volatile.
+		IL_0044: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0049: brfalse IL_0061
+
+		IL_004e: ldloc.s 5
+		IL_0050: ldstr "then"
+		IL_0055: ldloc.s 7
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005c: br IL_0079
+
+		IL_0061: ldloc.s 5
+		IL_0063: ldstr "then"
+		IL_0068: ldloc.s 7
+		IL_006a: ldstr "Promise_Callback_Function_Objects:Modules.Promise_Callback_Function_Objects:__js_module_init__:10"
+		IL_006f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0079: stloc.s 5
+		IL_007b: ldloc.s 5
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0082: stloc.s 5
+		IL_0084: ldc.i4.1
+		IL_0085: newarr [System.Runtime]System.Object
+		IL_008a: dup
+		IL_008b: ldc.i4.0
+		IL_008c: ldloc.0
+		IL_008d: stelem.ref
+		IL_008e: stloc.s 6
+		IL_0090: ldloc.s 6
+		IL_0092: newobj instance void Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject::.ctor(object[])
+		IL_0097: ldc.i4.1
+		IL_0098: conv.r8
+		IL_0099: ldstr "asyncReaction"
+		IL_009e: ldc.i4.1
+		IL_009f: ldc.i4.1
+		IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject>(!!0)
+		IL_00aa: stloc.s 8
+		IL_00ac: volatile.
+		IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_00b3: brfalse IL_00cb
+
+		IL_00b8: ldloc.s 5
+		IL_00ba: ldstr "then"
+		IL_00bf: ldloc.s 8
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c6: br IL_00e3
+
+		IL_00cb: ldloc.s 5
+		IL_00cd: ldstr "then"
+		IL_00d2: ldloc.s 8
+		IL_00d4: ldstr "Promise_Callback_Function_Objects:Modules.Promise_Callback_Function_Objects:__js_module_init__:14"
+		IL_00d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00e3: stloc.s 5
+		IL_00e5: ldloc.s 5
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ec: stloc.s 5
+		IL_00ee: ldc.i4.1
+		IL_00ef: newarr [System.Runtime]System.Object
+		IL_00f4: dup
+		IL_00f5: ldc.i4.0
+		IL_00f6: ldloc.0
+		IL_00f7: stelem.ref
+		IL_00f8: stloc.s 6
+		IL_00fa: ldloc.s 6
+		IL_00fc: newobj instance void Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject::.ctor(object[])
+		IL_0101: ldc.i4.1
+		IL_0102: conv.r8
+		IL_0103: ldstr "generatorReaction"
+		IL_0108: ldc.i4.1
+		IL_0109: ldc.i4.1
+		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
+		IL_0114: castclass Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject
+		IL_0119: stloc.s 9
+		IL_011b: volatile.
+		IL_011d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0122: brfalse IL_013a
+
+		IL_0127: ldloc.s 5
+		IL_0129: ldstr "then"
+		IL_012e: ldloc.s 9
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0135: br IL_0152
+
+		IL_013a: ldloc.s 5
+		IL_013c: ldstr "then"
+		IL_0141: ldloc.s 9
+		IL_0143: ldstr "Promise_Callback_Function_Objects:Modules.Promise_Callback_Function_Objects:__js_module_init__:18"
+		IL_0148: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0152: stloc.s 5
+		IL_0154: ldloc.s 5
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015b: stloc.s 5
+		IL_015d: ldc.i4.1
+		IL_015e: newarr [System.Runtime]System.Object
+		IL_0163: dup
+		IL_0164: ldc.i4.0
+		IL_0165: ldloc.0
+		IL_0166: stelem.ref
+		IL_0167: stloc.s 6
+		IL_0169: newobj instance void Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject::.ctor()
+		IL_016e: ldc.i4.1
+		IL_016f: conv.r8
+		IL_0170: ldstr "consumeGenerator"
+		IL_0175: ldc.i4.1
+		IL_0176: ldc.i4.1
+		IL_0177: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_017c: stloc.s 10
+		IL_017e: volatile.
+		IL_0180: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0185: brfalse IL_019d
+
+		IL_018a: ldloc.s 5
+		IL_018c: ldstr "then"
+		IL_0191: ldloc.s 10
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0198: br IL_01b5
+
+		IL_019d: ldloc.s 5
+		IL_019f: ldstr "then"
+		IL_01a4: ldloc.s 10
+		IL_01a6: ldstr "Promise_Callback_Function_Objects:Modules.Promise_Callback_Function_Objects:__js_module_init__:22"
+		IL_01ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01b5: pop
+		IL_01b6: ldstr "Promise"
+		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c5: stloc.s 5
+		IL_01c7: ldc.i4.1
+		IL_01c8: newarr [System.Runtime]System.Object
+		IL_01cd: dup
+		IL_01ce: ldc.i4.0
+		IL_01cf: ldloc.0
+		IL_01d0: stelem.ref
+		IL_01d1: stloc.s 6
+		IL_01d3: newobj instance void Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject::.ctor()
+		IL_01d8: ldc.i4.2
+		IL_01d9: conv.r8
+		IL_01da: ldstr "promiseTryCallback"
+		IL_01df: ldc.i4.1
+		IL_01e0: ldc.i4.1
+		IL_01e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01e6: stloc.s 11
+		IL_01e8: ldloc.s 5
+		IL_01ea: ldstr "try"
+		IL_01ef: ldloc.s 11
+		IL_01f1: ldc.r8 2
+		IL_01fa: box [System.Runtime]System.Double
+		IL_01ff: ldc.r8 3
+		IL_0208: box [System.Runtime]System.Double
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0212: stloc.s 5
+		IL_0214: ldloc.s 5
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021b: stloc.s 5
+		IL_021d: ldc.i4.1
+		IL_021e: newarr [System.Runtime]System.Object
+		IL_0223: dup
+		IL_0224: ldc.i4.0
+		IL_0225: ldloc.0
+		IL_0226: stelem.ref
+		IL_0227: stloc.s 6
+		IL_0229: newobj instance void Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject::.ctor()
+		IL_022e: ldc.i4.1
+		IL_022f: conv.r8
+		IL_0230: ldstr ""
+		IL_0235: ldc.i4.0
+		IL_0236: ldc.i4.1
+		IL_0237: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_023c: stloc.s 12
+		IL_023e: volatile.
+		IL_0240: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0245: brfalse IL_025d
+
+		IL_024a: ldloc.s 5
+		IL_024c: ldstr "then"
+		IL_0251: ldloc.s 12
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0258: br IL_0275
+
+		IL_025d: ldloc.s 5
+		IL_025f: ldstr "then"
+		IL_0264: ldloc.s 12
+		IL_0266: ldstr "Promise_Callback_Function_Objects:Modules.Promise_Callback_Function_Objects:__js_module_init__:37"
+		IL_026b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0275: pop
 		.try
 		{
-			IL_01a9: nop
-			IL_01aa: ldc.r8 42
-			IL_01b3: box [System.Runtime]System.Double
-			IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
-			IL_01bd: pop
-			IL_01be: leave IL_0245
+			IL_0276: nop
+			IL_0277: ldc.r8 42
+			IL_0280: box [System.Runtime]System.Double
+			IL_0285: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Promise::.ctor(object)
+			IL_028a: pop
+			IL_028b: leave IL_0312
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01c3: stloc.1
-			IL_01c4: ldloc.1
-			IL_01c5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01ca: dup
-			IL_01cb: brtrue IL_01e0
+			IL_0290: stloc.1
+			IL_0291: ldloc.1
+			IL_0292: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0297: dup
+			IL_0298: brtrue IL_02ad
 
-			IL_01d0: pop
-			IL_01d1: ldloc.1
-			IL_01d2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01d7: dup
-			IL_01d8: brtrue IL_01eb
+			IL_029d: pop
+			IL_029e: ldloc.1
+			IL_029f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02a4: dup
+			IL_02a5: brtrue IL_02b8
 
-			IL_01dd: pop
-			IL_01de: rethrow
+			IL_02aa: pop
+			IL_02ab: rethrow
 
-			IL_01e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_01e5: stloc.2
-			IL_01e6: br IL_01ec
+			IL_02ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02b2: stloc.2
+			IL_02b3: br IL_02b9
 
-			IL_01eb: stloc.2
+			IL_02b8: stloc.2
 
-			IL_01ec: ldloc.2
-			IL_01ed: stloc.3
-			IL_01ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01f3: stloc.s 13
-			IL_01f5: volatile.
-			IL_01f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_01fc: brfalse IL_0211
+			IL_02b9: ldloc.2
+			IL_02ba: stloc.3
+			IL_02bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02c0: stloc.s 13
+			IL_02c2: volatile.
+			IL_02c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_02c9: brfalse IL_02de
 
-			IL_0201: ldloc.3
-			IL_0202: ldstr "message"
-			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_020c: br IL_0226
+			IL_02ce: ldloc.3
+			IL_02cf: ldstr "message"
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d9: br IL_02f3
 
-			IL_0211: ldloc.3
-			IL_0212: ldstr "message"
-			IL_0217: ldstr "Promise_Callback_Function_Objects:Modules.Promise_Callback_Function_Objects:__js_module_init__:56"
-			IL_021c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02de: ldloc.3
+			IL_02df: ldstr "message"
+			IL_02e4: ldstr "Promise_Callback_Function_Objects:Modules.Promise_Callback_Function_Objects:__js_module_init__:56"
+			IL_02e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0226: stloc.s 5
-			IL_0228: ldstr "error:"
-			IL_022d: ldloc.s 5
-			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0234: stloc.s 14
-			IL_0236: ldloc.s 13
-			IL_0238: ldloc.s 14
-			IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_023f: pop
-			IL_0240: leave IL_0245
+			IL_02f3: stloc.s 5
+			IL_02f5: ldstr "error:"
+			IL_02fa: ldloc.s 5
+			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0301: stloc.s 14
+			IL_0303: ldloc.s 13
+			IL_0305: ldloc.s 14
+			IL_0307: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_030c: pop
+			IL_030d: leave IL_0312
 		} // end handler
 
-		IL_0245: ldnull
-		IL_0246: stloc.s 4
-		IL_0248: ret
+		IL_0312: ldnull
+		IL_0313: stloc.s 4
+		IL_0315: ret
 	} // end of method Promise_Callback_Function_Objects::__js_module_init__
 
 } // end of class Modules.Promise_Callback_Function_Objects
@@ -1593,6 +1658,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Catch_ReturnsRejectedPromise.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Catch_ReturnsRejectedPromise.verified.txt
@@ -331,7 +331,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 210 (0xd2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Catch_ReturnsRejectedPromise/Scope,
@@ -364,36 +364,62 @@
 		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L3C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L3C30/FunctionObject>(!!0)
 		IL_003a: stloc.3
-		IL_003b: ldloc.1
-		IL_003c: ldstr "catch"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: stloc.1
-		IL_0048: ldloc.1
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.1
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldloc.0
-		IL_0058: stelem.ref
-		IL_0059: stloc.2
-		IL_005a: newobj instance void Modules.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L3C65/FunctionObject::.ctor()
-		IL_005f: ldc.i4.1
-		IL_0060: conv.r8
-		IL_0061: ldstr ""
-		IL_0066: ldc.i4.0
-		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L3C65/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L3C65/FunctionObject>(!!0)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.1
-		IL_0075: ldstr "catch"
-		IL_007a: ldloc.s 4
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: ret
+		IL_003b: volatile.
+		IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0042: brfalse IL_0058
+
+		IL_0047: ldloc.1
+		IL_0048: ldstr "catch"
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0053: br IL_006e
+
+		IL_0058: ldloc.1
+		IL_0059: ldstr "catch"
+		IL_005e: ldloc.3
+		IL_005f: ldstr "Promise_Catch_ReturnsRejectedPromise:Modules.Promise_Catch_ReturnsRejectedPromise:__js_module_init__:9"
+		IL_0064: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006e: stloc.1
+		IL_006f: ldloc.1
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0075: stloc.1
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: stloc.2
+		IL_0081: newobj instance void Modules.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L3C65/FunctionObject::.ctor()
+		IL_0086: ldc.i4.1
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: ldc.i4.0
+		IL_008e: ldc.i4.0
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L3C65/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Catch_ReturnsRejectedPromise/ArrowFunction_L3C65/FunctionObject>(!!0)
+		IL_0099: stloc.s 4
+		IL_009b: volatile.
+		IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a2: brfalse IL_00b9
+
+		IL_00a7: ldloc.1
+		IL_00a8: ldstr "catch"
+		IL_00ad: ldloc.s 4
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: br IL_00d0
+
+		IL_00b9: ldloc.1
+		IL_00ba: ldstr "catch"
+		IL_00bf: ldloc.s 4
+		IL_00c1: ldstr "Promise_Catch_ReturnsRejectedPromise:Modules.Promise_Catch_ReturnsRejectedPromise:__js_module_init__:13"
+		IL_00c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d0: pop
+		IL_00d1: ret
 	} // end of method Promise_Catch_ReturnsRejectedPromise::__js_module_init__
 
 } // end of class Modules.Promise_Catch_ReturnsRejectedPromise
@@ -418,4 +444,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Catch_ReturnsResolvedPromise.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Catch_ReturnsResolvedPromise.verified.txt
@@ -331,7 +331,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 210 (0xd2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Catch_ReturnsResolvedPromise/Scope,
@@ -364,36 +364,62 @@
 		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L3C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L3C29/FunctionObject>(!!0)
 		IL_003a: stloc.3
-		IL_003b: ldloc.1
-		IL_003c: ldstr "catch"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: stloc.1
-		IL_0048: ldloc.1
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.1
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldloc.0
-		IL_0058: stelem.ref
-		IL_0059: stloc.2
-		IL_005a: newobj instance void Modules.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L3C69/FunctionObject::.ctor()
-		IL_005f: ldc.i4.1
-		IL_0060: conv.r8
-		IL_0061: ldstr ""
-		IL_0066: ldc.i4.0
-		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L3C69/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L3C69/FunctionObject>(!!0)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.1
-		IL_0075: ldstr "then"
-		IL_007a: ldloc.s 4
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: ret
+		IL_003b: volatile.
+		IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0042: brfalse IL_0058
+
+		IL_0047: ldloc.1
+		IL_0048: ldstr "catch"
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0053: br IL_006e
+
+		IL_0058: ldloc.1
+		IL_0059: ldstr "catch"
+		IL_005e: ldloc.3
+		IL_005f: ldstr "Promise_Catch_ReturnsResolvedPromise:Modules.Promise_Catch_ReturnsResolvedPromise:__js_module_init__:9"
+		IL_0064: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006e: stloc.1
+		IL_006f: ldloc.1
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0075: stloc.1
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: stloc.2
+		IL_0081: newobj instance void Modules.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L3C69/FunctionObject::.ctor()
+		IL_0086: ldc.i4.1
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: ldc.i4.0
+		IL_008e: ldc.i4.0
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L3C69/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Catch_ReturnsResolvedPromise/ArrowFunction_L3C69/FunctionObject>(!!0)
+		IL_0099: stloc.s 4
+		IL_009b: volatile.
+		IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a2: brfalse IL_00b9
+
+		IL_00a7: ldloc.1
+		IL_00a8: ldstr "then"
+		IL_00ad: ldloc.s 4
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: br IL_00d0
+
+		IL_00b9: ldloc.1
+		IL_00ba: ldstr "then"
+		IL_00bf: ldloc.s 4
+		IL_00c1: ldstr "Promise_Catch_ReturnsResolvedPromise:Modules.Promise_Catch_ReturnsResolvedPromise:__js_module_init__:13"
+		IL_00c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d0: pop
+		IL_00d1: ret
 	} // end of method Promise_Catch_ReturnsResolvedPromise::__js_module_init__
 
 } // end of class Modules.Promise_Catch_ReturnsResolvedPromise
@@ -418,4 +444,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_ExplicitReceiverAbi.verified.txt
@@ -309,7 +309,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -320,7 +320,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "message"
 			IL_0028: ldstr "Promise_ExplicitReceiverAbi:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -761,7 +761,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1994 (0x7ca)
+		// Code size: 2152 (0x868)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_ExplicitReceiverAbi/Scope,
@@ -1011,447 +1011,496 @@
 		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_ExplicitReceiverAbi/ArrowFunction_L17C9/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_ExplicitReceiverAbi/ArrowFunction_L17C9/FunctionObject>(!!0)
 		IL_029c: stloc.s 20
-		IL_029e: ldloc.s 14
-		IL_02a0: ldstr "then"
-		IL_02a5: ldloc.s 20
-		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ac: pop
+		IL_029e: volatile.
+		IL_02a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02a5: brfalse IL_02bd
+
+		IL_02aa: ldloc.s 14
+		IL_02ac: ldstr "then"
+		IL_02b1: ldloc.s 20
+		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b8: br IL_02d5
+
+		IL_02bd: ldloc.s 14
+		IL_02bf: ldstr "then"
+		IL_02c4: ldloc.s 20
+		IL_02c6: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:58"
+		IL_02cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02d5: pop
 		.try
 		{
-			IL_02ad: nop
-			IL_02ae: ldstr "Promise"
-			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02b8: volatile.
-			IL_02ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_02bf: brfalse IL_02d3
+			IL_02d6: nop
+			IL_02d7: ldstr "Promise"
+			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_02e1: volatile.
+			IL_02e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_02e8: brfalse IL_02fc
 
-			IL_02c4: ldstr "prototype"
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ce: br IL_02e7
+			IL_02ed: ldstr "prototype"
+			IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f7: br IL_0310
 
-			IL_02d3: ldstr "prototype"
-			IL_02d8: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:66"
-			IL_02dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02fc: ldstr "prototype"
+			IL_0301: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:66"
+			IL_0306: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02e7: stloc.s 14
-			IL_02e9: volatile.
-			IL_02eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_02f0: brfalse IL_0306
+			IL_0310: stloc.s 14
+			IL_0312: volatile.
+			IL_0314: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0319: brfalse IL_032f
 
-			IL_02f5: ldloc.s 14
-			IL_02f7: ldstr "then"
-			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0301: br IL_031c
-
-			IL_0306: ldloc.s 14
-			IL_0308: ldstr "then"
-			IL_030d: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:68"
-			IL_0312: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_031c: stloc.s 14
 			IL_031e: ldloc.s 14
-			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0325: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_032a: stloc.s 21
-			IL_032c: ldstr "call"
-			IL_0331: ldloc.s 21
-			IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0338: pop
-			IL_0339: leave IL_03aa
+			IL_0320: ldstr "then"
+			IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_032a: br IL_0345
+
+			IL_032f: ldloc.s 14
+			IL_0331: ldstr "then"
+			IL_0336: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:68"
+			IL_033b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0345: stloc.s 14
+			IL_0347: ldloc.s 14
+			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_034e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0353: stloc.s 21
+			IL_0355: volatile.
+			IL_0357: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_035c: brfalse IL_0372
+
+			IL_0361: ldstr "call"
+			IL_0366: ldloc.s 21
+			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_036d: br IL_0388
+
+			IL_0372: ldstr "call"
+			IL_0377: ldloc.s 21
+			IL_0379: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:71"
+			IL_037e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0388: pop
+			IL_0389: leave IL_03fa
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_033e: stloc.s 4
-			IL_0340: ldloc.s 4
-			IL_0342: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0347: dup
-			IL_0348: brtrue IL_035e
+			IL_038e: stloc.s 4
+			IL_0390: ldloc.s 4
+			IL_0392: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0397: dup
+			IL_0398: brtrue IL_03ae
 
-			IL_034d: pop
-			IL_034e: ldloc.s 4
-			IL_0350: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0355: dup
-			IL_0356: brtrue IL_036a
+			IL_039d: pop
+			IL_039e: ldloc.s 4
+			IL_03a0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03a5: dup
+			IL_03a6: brtrue IL_03ba
 
-			IL_035b: pop
-			IL_035c: rethrow
+			IL_03ab: pop
+			IL_03ac: rethrow
 
-			IL_035e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0363: stloc.s 5
-			IL_0365: br IL_036c
+			IL_03ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03b3: stloc.s 5
+			IL_03b5: br IL_03bc
 
-			IL_036a: stloc.s 5
+			IL_03ba: stloc.s 5
 
-			IL_036c: ldloc.s 5
-			IL_036e: stloc.s 6
-			IL_0370: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0375: stloc.s 22
-			IL_0377: ldloc.s 6
-			IL_0379: stloc.s 14
-			IL_037b: ldstr "TypeError"
-			IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0385: stloc.s 23
-			IL_0387: ldloc.s 14
-			IL_0389: ldloc.s 23
-			IL_038b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0390: stloc.s 24
-			IL_0392: ldloc.s 24
-			IL_0394: box [System.Runtime]System.Boolean
-			IL_0399: stloc.s 25
-			IL_039b: ldloc.s 22
-			IL_039d: ldloc.s 25
-			IL_039f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03a4: pop
-			IL_03a5: leave IL_03aa
+			IL_03bc: ldloc.s 5
+			IL_03be: stloc.s 6
+			IL_03c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03c5: stloc.s 22
+			IL_03c7: ldloc.s 6
+			IL_03c9: stloc.s 14
+			IL_03cb: ldstr "TypeError"
+			IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03d5: stloc.s 23
+			IL_03d7: ldloc.s 14
+			IL_03d9: ldloc.s 23
+			IL_03db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_03e0: stloc.s 24
+			IL_03e2: ldloc.s 24
+			IL_03e4: box [System.Runtime]System.Boolean
+			IL_03e9: stloc.s 25
+			IL_03eb: ldloc.s 22
+			IL_03ed: ldloc.s 25
+			IL_03ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03f4: pop
+			IL_03f5: leave IL_03fa
 		} // end handler
 		.try
 		{
-			IL_03aa: nop
-			IL_03ab: ldstr "Promise"
-			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03b5: volatile.
-			IL_03b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_03bc: brfalse IL_03d0
+			IL_03fa: nop
+			IL_03fb: ldstr "Promise"
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0405: volatile.
+			IL_0407: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_040c: brfalse IL_0420
 
-			IL_03c1: ldstr "prototype"
-			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03cb: br IL_03e4
+			IL_0411: ldstr "prototype"
+			IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_041b: br IL_0434
 
-			IL_03d0: ldstr "prototype"
-			IL_03d5: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:98"
-			IL_03da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0420: ldstr "prototype"
+			IL_0425: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:98"
+			IL_042a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03e4: stloc.s 23
-			IL_03e6: volatile.
-			IL_03e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_03ed: brfalse IL_0403
+			IL_0434: stloc.s 23
+			IL_0436: volatile.
+			IL_0438: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_043d: brfalse IL_0453
 
-			IL_03f2: ldloc.s 23
-			IL_03f4: ldstr "catch"
-			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03fe: br IL_0419
+			IL_0442: ldloc.s 23
+			IL_0444: ldstr "catch"
+			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_044e: br IL_0469
 
-			IL_0403: ldloc.s 23
-			IL_0405: ldstr "catch"
-			IL_040a: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:100"
-			IL_040f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0453: ldloc.s 23
+			IL_0455: ldstr "catch"
+			IL_045a: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:100"
+			IL_045f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0419: stloc.s 23
-			IL_041b: ldloc.s 23
-			IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0422: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0427: stloc.s 21
-			IL_0429: ldstr "call"
-			IL_042e: ldloc.s 21
-			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0435: pop
-			IL_0436: leave IL_04a7
+			IL_0469: stloc.s 23
+			IL_046b: ldloc.s 23
+			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0472: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0477: stloc.s 21
+			IL_0479: volatile.
+			IL_047b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0480: brfalse IL_0496
+
+			IL_0485: ldstr "call"
+			IL_048a: ldloc.s 21
+			IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0491: br IL_04ac
+
+			IL_0496: ldstr "call"
+			IL_049b: ldloc.s 21
+			IL_049d: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:103"
+			IL_04a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_04ac: pop
+			IL_04ad: leave IL_051e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_043b: stloc.s 7
-			IL_043d: ldloc.s 7
-			IL_043f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0444: dup
-			IL_0445: brtrue IL_045b
+			IL_04b2: stloc.s 7
+			IL_04b4: ldloc.s 7
+			IL_04b6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04bb: dup
+			IL_04bc: brtrue IL_04d2
 
-			IL_044a: pop
-			IL_044b: ldloc.s 7
-			IL_044d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0452: dup
-			IL_0453: brtrue IL_0467
+			IL_04c1: pop
+			IL_04c2: ldloc.s 7
+			IL_04c4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04c9: dup
+			IL_04ca: brtrue IL_04de
 
-			IL_0458: pop
-			IL_0459: rethrow
+			IL_04cf: pop
+			IL_04d0: rethrow
 
-			IL_045b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0460: stloc.s 8
-			IL_0462: br IL_0469
+			IL_04d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04d7: stloc.s 8
+			IL_04d9: br IL_04e0
 
-			IL_0467: stloc.s 8
+			IL_04de: stloc.s 8
 
-			IL_0469: ldloc.s 8
-			IL_046b: stloc.s 9
-			IL_046d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0472: stloc.s 22
-			IL_0474: ldloc.s 9
-			IL_0476: stloc.s 23
-			IL_0478: ldstr "TypeError"
-			IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0482: stloc.s 14
-			IL_0484: ldloc.s 23
-			IL_0486: ldloc.s 14
-			IL_0488: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_048d: stloc.s 24
-			IL_048f: ldloc.s 24
-			IL_0491: box [System.Runtime]System.Boolean
-			IL_0496: stloc.s 25
-			IL_0498: ldloc.s 22
-			IL_049a: ldloc.s 25
-			IL_049c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04a1: pop
-			IL_04a2: leave IL_04a7
+			IL_04e0: ldloc.s 8
+			IL_04e2: stloc.s 9
+			IL_04e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04e9: stloc.s 22
+			IL_04eb: ldloc.s 9
+			IL_04ed: stloc.s 23
+			IL_04ef: ldstr "TypeError"
+			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04f9: stloc.s 14
+			IL_04fb: ldloc.s 23
+			IL_04fd: ldloc.s 14
+			IL_04ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0504: stloc.s 24
+			IL_0506: ldloc.s 24
+			IL_0508: box [System.Runtime]System.Boolean
+			IL_050d: stloc.s 25
+			IL_050f: ldloc.s 22
+			IL_0511: ldloc.s 25
+			IL_0513: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0518: pop
+			IL_0519: leave IL_051e
 		} // end handler
 		.try
 		{
-			IL_04a7: nop
-			IL_04a8: ldstr "Promise"
-			IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04b2: volatile.
-			IL_04b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_04b9: brfalse IL_04cd
+			IL_051e: nop
+			IL_051f: ldstr "Promise"
+			IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0529: volatile.
+			IL_052b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0530: brfalse IL_0544
 
-			IL_04be: ldstr "prototype"
-			IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04c8: br IL_04e1
+			IL_0535: ldstr "prototype"
+			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_053f: br IL_0558
 
-			IL_04cd: ldstr "prototype"
-			IL_04d2: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:130"
-			IL_04d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0544: ldstr "prototype"
+			IL_0549: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:130"
+			IL_054e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04e1: stloc.s 14
-			IL_04e3: volatile.
-			IL_04e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_04ea: brfalse IL_0500
+			IL_0558: stloc.s 14
+			IL_055a: volatile.
+			IL_055c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0561: brfalse IL_0577
 
-			IL_04ef: ldloc.s 14
-			IL_04f1: ldstr "finally"
-			IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04fb: br IL_0516
+			IL_0566: ldloc.s 14
+			IL_0568: ldstr "finally"
+			IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0572: br IL_058d
 
-			IL_0500: ldloc.s 14
-			IL_0502: ldstr "finally"
-			IL_0507: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:132"
-			IL_050c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0577: ldloc.s 14
+			IL_0579: ldstr "finally"
+			IL_057e: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:132"
+			IL_0583: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0516: stloc.s 14
-			IL_0518: ldloc.s 14
-			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_051f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0524: stloc.s 21
-			IL_0526: ldstr "call"
-			IL_052b: ldloc.s 21
-			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0532: pop
-			IL_0533: leave IL_05a4
+			IL_058d: stloc.s 14
+			IL_058f: ldloc.s 14
+			IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0596: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_059b: stloc.s 21
+			IL_059d: volatile.
+			IL_059f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_05a4: brfalse IL_05ba
+
+			IL_05a9: ldstr "call"
+			IL_05ae: ldloc.s 21
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05b5: br IL_05d0
+
+			IL_05ba: ldstr "call"
+			IL_05bf: ldloc.s 21
+			IL_05c1: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:135"
+			IL_05c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_05cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_05d0: pop
+			IL_05d1: leave IL_0642
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0538: stloc.s 10
-			IL_053a: ldloc.s 10
-			IL_053c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0541: dup
-			IL_0542: brtrue IL_0558
+			IL_05d6: stloc.s 10
+			IL_05d8: ldloc.s 10
+			IL_05da: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05df: dup
+			IL_05e0: brtrue IL_05f6
 
-			IL_0547: pop
-			IL_0548: ldloc.s 10
-			IL_054a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_054f: dup
-			IL_0550: brtrue IL_0564
+			IL_05e5: pop
+			IL_05e6: ldloc.s 10
+			IL_05e8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_05ed: dup
+			IL_05ee: brtrue IL_0602
 
-			IL_0555: pop
-			IL_0556: rethrow
+			IL_05f3: pop
+			IL_05f4: rethrow
 
-			IL_0558: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_055d: stloc.s 11
-			IL_055f: br IL_0566
+			IL_05f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_05fb: stloc.s 11
+			IL_05fd: br IL_0604
 
-			IL_0564: stloc.s 11
+			IL_0602: stloc.s 11
 
-			IL_0566: ldloc.s 11
-			IL_0568: stloc.s 12
-			IL_056a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_056f: stloc.s 22
-			IL_0571: ldloc.s 12
-			IL_0573: stloc.s 14
-			IL_0575: ldstr "TypeError"
-			IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_057f: stloc.s 23
-			IL_0581: ldloc.s 14
-			IL_0583: ldloc.s 23
-			IL_0585: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_058a: stloc.s 24
-			IL_058c: ldloc.s 24
-			IL_058e: box [System.Runtime]System.Boolean
-			IL_0593: stloc.s 25
-			IL_0595: ldloc.s 22
-			IL_0597: ldloc.s 25
-			IL_0599: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_059e: pop
-			IL_059f: leave IL_05a4
+			IL_0604: ldloc.s 11
+			IL_0606: stloc.s 12
+			IL_0608: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_060d: stloc.s 22
+			IL_060f: ldloc.s 12
+			IL_0611: stloc.s 14
+			IL_0613: ldstr "TypeError"
+			IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_061d: stloc.s 23
+			IL_061f: ldloc.s 14
+			IL_0621: ldloc.s 23
+			IL_0623: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0628: stloc.s 24
+			IL_062a: ldloc.s 24
+			IL_062c: box [System.Runtime]System.Boolean
+			IL_0631: stloc.s 25
+			IL_0633: ldloc.s 22
+			IL_0635: ldloc.s 25
+			IL_0637: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_063c: pop
+			IL_063d: leave IL_0642
 		} // end handler
 
-		IL_05a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05a9: stloc.s 22
-		IL_05ab: ldstr "Promise"
-		IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05b5: volatile.
-		IL_05b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_05bc: brfalse IL_05d0
+		IL_0642: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0647: stloc.s 22
+		IL_0649: ldstr "Promise"
+		IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0653: volatile.
+		IL_0655: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_065a: brfalse IL_066e
 
-		IL_05c1: ldstr "prototype"
-		IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05cb: br IL_05e4
+		IL_065f: ldstr "prototype"
+		IL_0664: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0669: br IL_0682
 
-		IL_05d0: ldstr "prototype"
-		IL_05d5: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:160"
-		IL_05da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_05df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_066e: ldstr "prototype"
+		IL_0673: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:160"
+		IL_0678: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05e4: stloc.s 23
-		IL_05e6: volatile.
-		IL_05e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_05ed: brfalse IL_0603
+		IL_0682: stloc.s 23
+		IL_0684: volatile.
+		IL_0686: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_068b: brfalse IL_06a1
 
-		IL_05f2: ldloc.s 23
-		IL_05f4: ldstr "then"
-		IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05fe: br IL_0619
+		IL_0690: ldloc.s 23
+		IL_0692: ldstr "then"
+		IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_069c: br IL_06b7
 
-		IL_0603: ldloc.s 23
-		IL_0605: ldstr "then"
-		IL_060a: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:162"
-		IL_060f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06a1: ldloc.s 23
+		IL_06a3: ldstr "then"
+		IL_06a8: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:162"
+		IL_06ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0619: stloc.s 23
-		IL_061b: volatile.
-		IL_061d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0622: brfalse IL_0638
+		IL_06b7: stloc.s 23
+		IL_06b9: volatile.
+		IL_06bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_06c0: brfalse IL_06d6
 
-		IL_0627: ldloc.s 23
-		IL_0629: ldstr "length"
-		IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0633: br IL_064e
+		IL_06c5: ldloc.s 23
+		IL_06c7: ldstr "length"
+		IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06d1: br IL_06ec
 
-		IL_0638: ldloc.s 23
-		IL_063a: ldstr "length"
-		IL_063f: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:164"
-		IL_0644: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06d6: ldloc.s 23
+		IL_06d8: ldstr "length"
+		IL_06dd: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:164"
+		IL_06e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_064e: stloc.s 23
-		IL_0650: ldloc.s 22
-		IL_0652: ldloc.s 23
-		IL_0654: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0659: pop
-		IL_065a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_065f: stloc.s 22
-		IL_0661: ldstr "Promise"
-		IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_066b: volatile.
-		IL_066d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0672: brfalse IL_0686
+		IL_06ec: stloc.s 23
+		IL_06ee: ldloc.s 22
+		IL_06f0: ldloc.s 23
+		IL_06f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06f7: pop
+		IL_06f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06fd: stloc.s 22
+		IL_06ff: ldstr "Promise"
+		IL_0704: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0709: volatile.
+		IL_070b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0710: brfalse IL_0724
 
-		IL_0677: ldstr "prototype"
-		IL_067c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0681: br IL_069a
+		IL_0715: ldstr "prototype"
+		IL_071a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_071f: br IL_0738
 
-		IL_0686: ldstr "prototype"
-		IL_068b: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:171"
-		IL_0690: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0724: ldstr "prototype"
+		IL_0729: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:171"
+		IL_072e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_069a: stloc.s 23
-		IL_069c: volatile.
-		IL_069e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_06a3: brfalse IL_06b9
+		IL_0738: stloc.s 23
+		IL_073a: volatile.
+		IL_073c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0741: brfalse IL_0757
 
-		IL_06a8: ldloc.s 23
-		IL_06aa: ldstr "catch"
-		IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06b4: br IL_06cf
+		IL_0746: ldloc.s 23
+		IL_0748: ldstr "catch"
+		IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0752: br IL_076d
 
-		IL_06b9: ldloc.s 23
-		IL_06bb: ldstr "catch"
-		IL_06c0: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:173"
-		IL_06c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0757: ldloc.s 23
+		IL_0759: ldstr "catch"
+		IL_075e: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:173"
+		IL_0763: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0768: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06cf: stloc.s 23
-		IL_06d1: volatile.
-		IL_06d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_06d8: brfalse IL_06ee
+		IL_076d: stloc.s 23
+		IL_076f: volatile.
+		IL_0771: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0776: brfalse IL_078c
 
-		IL_06dd: ldloc.s 23
-		IL_06df: ldstr "length"
-		IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06e9: br IL_0704
+		IL_077b: ldloc.s 23
+		IL_077d: ldstr "length"
+		IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0787: br IL_07a2
 
-		IL_06ee: ldloc.s 23
-		IL_06f0: ldstr "length"
-		IL_06f5: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:175"
-		IL_06fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_078c: ldloc.s 23
+		IL_078e: ldstr "length"
+		IL_0793: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:175"
+		IL_0798: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_079d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0704: stloc.s 23
-		IL_0706: ldloc.s 22
-		IL_0708: ldloc.s 23
-		IL_070a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_070f: pop
-		IL_0710: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0715: stloc.s 22
-		IL_0717: ldstr "Promise"
-		IL_071c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0721: volatile.
-		IL_0723: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0728: brfalse IL_073c
+		IL_07a2: stloc.s 23
+		IL_07a4: ldloc.s 22
+		IL_07a6: ldloc.s 23
+		IL_07a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07ad: pop
+		IL_07ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07b3: stloc.s 22
+		IL_07b5: ldstr "Promise"
+		IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07bf: volatile.
+		IL_07c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_07c6: brfalse IL_07da
 
-		IL_072d: ldstr "prototype"
-		IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0737: br IL_0750
+		IL_07cb: ldstr "prototype"
+		IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07d5: br IL_07ee
 
-		IL_073c: ldstr "prototype"
-		IL_0741: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:182"
-		IL_0746: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07da: ldstr "prototype"
+		IL_07df: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:182"
+		IL_07e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_07e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0750: stloc.s 23
-		IL_0752: volatile.
-		IL_0754: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0759: brfalse IL_076f
+		IL_07ee: stloc.s 23
+		IL_07f0: volatile.
+		IL_07f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_07f7: brfalse IL_080d
 
-		IL_075e: ldloc.s 23
-		IL_0760: ldstr "finally"
-		IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_076a: br IL_0785
+		IL_07fc: ldloc.s 23
+		IL_07fe: ldstr "finally"
+		IL_0803: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0808: br IL_0823
 
-		IL_076f: ldloc.s 23
-		IL_0771: ldstr "finally"
-		IL_0776: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:184"
-		IL_077b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0780: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_080d: ldloc.s 23
+		IL_080f: ldstr "finally"
+		IL_0814: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:184"
+		IL_0819: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_081e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0785: stloc.s 23
-		IL_0787: volatile.
-		IL_0789: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_078e: brfalse IL_07a4
+		IL_0823: stloc.s 23
+		IL_0825: volatile.
+		IL_0827: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_082c: brfalse IL_0842
 
-		IL_0793: ldloc.s 23
-		IL_0795: ldstr "length"
-		IL_079a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_079f: br IL_07ba
+		IL_0831: ldloc.s 23
+		IL_0833: ldstr "length"
+		IL_0838: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_083d: br IL_0858
 
-		IL_07a4: ldloc.s 23
-		IL_07a6: ldstr "length"
-		IL_07ab: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:186"
-		IL_07b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_07b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0842: ldloc.s 23
+		IL_0844: ldstr "length"
+		IL_0849: ldstr "Promise_ExplicitReceiverAbi:Modules.Promise_ExplicitReceiverAbi:__js_module_init__:186"
+		IL_084e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07ba: stloc.s 23
-		IL_07bc: ldloc.s 22
-		IL_07be: ldloc.s 23
-		IL_07c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07c5: pop
-		IL_07c6: ldnull
-		IL_07c7: stloc.s 13
-		IL_07c9: ret
+		IL_0858: stloc.s 23
+		IL_085a: ldloc.s 22
+		IL_085c: ldloc.s 23
+		IL_085e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0863: pop
+		IL_0864: ldnull
+		IL_0865: stloc.s 13
+		IL_0867: ret
 	} // end of method Promise_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.Promise_ExplicitReceiverAbi
@@ -1503,6 +1552,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
 	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsRejectedPromise.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsRejectedPromise.verified.txt
@@ -321,7 +321,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 140 (0x8c)
+		// Code size: 219 (0xdb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Finally_ReturnsRejectedPromise/Scope,
@@ -355,36 +355,62 @@
 		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L3C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L3C29/FunctionObject>(!!0)
 		IL_0043: stloc.3
-		IL_0044: ldloc.1
-		IL_0045: ldstr "finally"
-		IL_004a: ldloc.3
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0050: stloc.1
-		IL_0051: ldloc.1
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0057: stloc.1
-		IL_0058: ldc.i4.1
-		IL_0059: newarr [System.Runtime]System.Object
-		IL_005e: dup
-		IL_005f: ldc.i4.0
-		IL_0060: ldloc.0
-		IL_0061: stelem.ref
-		IL_0062: stloc.2
-		IL_0063: newobj instance void Modules.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L3C75/FunctionObject::.ctor()
-		IL_0068: ldc.i4.1
-		IL_0069: conv.r8
-		IL_006a: ldstr ""
-		IL_006f: ldc.i4.0
-		IL_0070: ldc.i4.0
-		IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L3C75/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L3C75/FunctionObject>(!!0)
-		IL_007b: stloc.s 4
-		IL_007d: ldloc.1
-		IL_007e: ldstr "catch"
-		IL_0083: ldloc.s 4
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: pop
-		IL_008b: ret
+		IL_0044: volatile.
+		IL_0046: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_004b: brfalse IL_0061
+
+		IL_0050: ldloc.1
+		IL_0051: ldstr "finally"
+		IL_0056: ldloc.3
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005c: br IL_0077
+
+		IL_0061: ldloc.1
+		IL_0062: ldstr "finally"
+		IL_0067: ldloc.3
+		IL_0068: ldstr "Promise_Finally_ReturnsRejectedPromise:Modules.Promise_Finally_ReturnsRejectedPromise:__js_module_init__:10"
+		IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0077: stloc.1
+		IL_0078: ldloc.1
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007e: stloc.1
+		IL_007f: ldc.i4.1
+		IL_0080: newarr [System.Runtime]System.Object
+		IL_0085: dup
+		IL_0086: ldc.i4.0
+		IL_0087: ldloc.0
+		IL_0088: stelem.ref
+		IL_0089: stloc.2
+		IL_008a: newobj instance void Modules.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L3C75/FunctionObject::.ctor()
+		IL_008f: ldc.i4.1
+		IL_0090: conv.r8
+		IL_0091: ldstr ""
+		IL_0096: ldc.i4.0
+		IL_0097: ldc.i4.0
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L3C75/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsRejectedPromise/ArrowFunction_L3C75/FunctionObject>(!!0)
+		IL_00a2: stloc.s 4
+		IL_00a4: volatile.
+		IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ab: brfalse IL_00c2
+
+		IL_00b0: ldloc.1
+		IL_00b1: ldstr "catch"
+		IL_00b6: ldloc.s 4
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bd: br IL_00d9
+
+		IL_00c2: ldloc.1
+		IL_00c3: ldstr "catch"
+		IL_00c8: ldloc.s 4
+		IL_00ca: ldstr "Promise_Finally_ReturnsRejectedPromise:Modules.Promise_Finally_ReturnsRejectedPromise:__js_module_init__:14"
+		IL_00cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d9: pop
+		IL_00da: ret
 	} // end of method Promise_Finally_ReturnsRejectedPromise::__js_module_init__
 
 } // end of class Modules.Promise_Finally_ReturnsRejectedPromise
@@ -409,4 +435,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsResolvedPromise.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsResolvedPromise.verified.txt
@@ -322,7 +322,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 140 (0x8c)
+		// Code size: 219 (0xdb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Finally_ReturnsResolvedPromise/Scope,
@@ -356,36 +356,62 @@
 		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L3C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L3C29/FunctionObject>(!!0)
 		IL_0043: stloc.3
-		IL_0044: ldloc.1
-		IL_0045: ldstr "finally"
-		IL_004a: ldloc.3
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0050: stloc.1
-		IL_0051: ldloc.1
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0057: stloc.1
-		IL_0058: ldc.i4.1
-		IL_0059: newarr [System.Runtime]System.Object
-		IL_005e: dup
-		IL_005f: ldc.i4.0
-		IL_0060: ldloc.0
-		IL_0061: stelem.ref
-		IL_0062: stloc.2
-		IL_0063: newobj instance void Modules.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L3C62/FunctionObject::.ctor()
-		IL_0068: ldc.i4.1
-		IL_0069: conv.r8
-		IL_006a: ldstr ""
-		IL_006f: ldc.i4.0
-		IL_0070: ldc.i4.0
-		IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L3C62/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L3C62/FunctionObject>(!!0)
-		IL_007b: stloc.s 4
-		IL_007d: ldloc.1
-		IL_007e: ldstr "then"
-		IL_0083: ldloc.s 4
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: pop
-		IL_008b: ret
+		IL_0044: volatile.
+		IL_0046: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_004b: brfalse IL_0061
+
+		IL_0050: ldloc.1
+		IL_0051: ldstr "finally"
+		IL_0056: ldloc.3
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005c: br IL_0077
+
+		IL_0061: ldloc.1
+		IL_0062: ldstr "finally"
+		IL_0067: ldloc.3
+		IL_0068: ldstr "Promise_Finally_ReturnsResolvedPromise:Modules.Promise_Finally_ReturnsResolvedPromise:__js_module_init__:10"
+		IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0077: stloc.1
+		IL_0078: ldloc.1
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007e: stloc.1
+		IL_007f: ldc.i4.1
+		IL_0080: newarr [System.Runtime]System.Object
+		IL_0085: dup
+		IL_0086: ldc.i4.0
+		IL_0087: ldloc.0
+		IL_0088: stelem.ref
+		IL_0089: stloc.2
+		IL_008a: newobj instance void Modules.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L3C62/FunctionObject::.ctor()
+		IL_008f: ldc.i4.1
+		IL_0090: conv.r8
+		IL_0091: ldstr ""
+		IL_0096: ldc.i4.0
+		IL_0097: ldc.i4.0
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L3C62/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsResolvedPromise/ArrowFunction_L3C62/FunctionObject>(!!0)
+		IL_00a2: stloc.s 4
+		IL_00a4: volatile.
+		IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ab: brfalse IL_00c2
+
+		IL_00b0: ldloc.1
+		IL_00b1: ldstr "then"
+		IL_00b6: ldloc.s 4
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bd: br IL_00d9
+
+		IL_00c2: ldloc.1
+		IL_00c3: ldstr "then"
+		IL_00c8: ldloc.s 4
+		IL_00ca: ldstr "Promise_Finally_ReturnsResolvedPromise:Modules.Promise_Finally_ReturnsResolvedPromise:__js_module_init__:14"
+		IL_00cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d9: pop
+		IL_00da: ret
 	} // end of method Promise_Finally_ReturnsResolvedPromise::__js_module_init__
 
 } // end of class Modules.Promise_Finally_ReturnsResolvedPromise
@@ -410,4 +436,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected.verified.txt
@@ -321,7 +321,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 210 (0xd2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected/Scope,
@@ -354,36 +354,62 @@
 		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected/ArrowFunction_L3C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected/ArrowFunction_L3C32/FunctionObject>(!!0)
 		IL_003a: stloc.3
-		IL_003b: ldloc.1
-		IL_003c: ldstr "finally"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: stloc.1
-		IL_0048: ldloc.1
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.1
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldloc.0
-		IL_0058: stelem.ref
-		IL_0059: stloc.2
-		IL_005a: newobj instance void Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected/ArrowFunction_L3C66/FunctionObject::.ctor()
-		IL_005f: ldc.i4.1
-		IL_0060: conv.r8
-		IL_0061: ldstr ""
-		IL_0066: ldc.i4.0
-		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected/ArrowFunction_L3C66/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected/ArrowFunction_L3C66/FunctionObject>(!!0)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.1
-		IL_0075: ldstr "catch"
-		IL_007a: ldloc.s 4
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: ret
+		IL_003b: volatile.
+		IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0042: brfalse IL_0058
+
+		IL_0047: ldloc.1
+		IL_0048: ldstr "finally"
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0053: br IL_006e
+
+		IL_0058: ldloc.1
+		IL_0059: ldstr "finally"
+		IL_005e: ldloc.3
+		IL_005f: ldstr "Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected:Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected:__js_module_init__:9"
+		IL_0064: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006e: stloc.1
+		IL_006f: ldloc.1
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0075: stloc.1
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: stloc.2
+		IL_0081: newobj instance void Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected/ArrowFunction_L3C66/FunctionObject::.ctor()
+		IL_0086: ldc.i4.1
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: ldc.i4.0
+		IL_008e: ldc.i4.0
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected/ArrowFunction_L3C66/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected/ArrowFunction_L3C66/FunctionObject>(!!0)
+		IL_0099: stloc.s 4
+		IL_009b: volatile.
+		IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00a2: brfalse IL_00b9
+
+		IL_00a7: ldloc.1
+		IL_00a8: ldstr "catch"
+		IL_00ad: ldloc.s 4
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: br IL_00d0
+
+		IL_00b9: ldloc.1
+		IL_00ba: ldstr "catch"
+		IL_00bf: ldloc.s 4
+		IL_00c1: ldstr "Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected:Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected:__js_module_init__:13"
+		IL_00c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d0: pop
+		IL_00d1: ret
 	} // end of method Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected::__js_module_init__
 
 } // end of class Modules.Promise_Finally_ReturnsResolvedPromise_PassThrough_Rejected
@@ -408,4 +434,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
@@ -500,7 +500,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 295 (0x127)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/Scope,
@@ -565,36 +565,62 @@
 		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/ArrowFunction_L9C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/ArrowFunction_L9C29/FunctionObject>(!!0)
 		IL_0085: stloc.s 5
-		IL_0087: ldloc.s 4
-		IL_0089: ldstr "finally"
-		IL_008e: ldloc.s 5
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.s 4
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.s 4
-		IL_00a0: ldc.i4.1
-		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: dup
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldloc.0
-		IL_00a9: stelem.ref
-		IL_00aa: stloc.2
-		IL_00ab: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/ArrowFunction_L9C50/FunctionObject::.ctor()
-		IL_00b0: ldc.i4.1
-		IL_00b1: conv.r8
-		IL_00b2: ldstr ""
-		IL_00b7: ldc.i4.0
-		IL_00b8: ldc.i4.0
-		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/ArrowFunction_L9C50/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/ArrowFunction_L9C50/FunctionObject>(!!0)
-		IL_00c3: stloc.s 6
-		IL_00c5: ldloc.s 4
-		IL_00c7: ldstr "then"
-		IL_00cc: ldloc.s 6
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ret
+		IL_0087: volatile.
+		IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_008e: brfalse IL_00a6
+
+		IL_0093: ldloc.s 4
+		IL_0095: ldstr "finally"
+		IL_009a: ldloc.s 5
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a1: br IL_00be
+
+		IL_00a6: ldloc.s 4
+		IL_00a8: ldstr "finally"
+		IL_00ad: ldloc.s 5
+		IL_00af: ldstr "Promise_Finally_ReturnsThenable_PassThrough_Fulfilled:Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled:__js_module_init__:17"
+		IL_00b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00be: stloc.s 4
+		IL_00c0: ldloc.s 4
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c7: stloc.s 4
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldloc.0
+		IL_00d2: stelem.ref
+		IL_00d3: stloc.2
+		IL_00d4: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/ArrowFunction_L9C50/FunctionObject::.ctor()
+		IL_00d9: ldc.i4.1
+		IL_00da: conv.r8
+		IL_00db: ldstr ""
+		IL_00e0: ldc.i4.0
+		IL_00e1: ldc.i4.0
+		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/ArrowFunction_L9C50/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/ArrowFunction_L9C50/FunctionObject>(!!0)
+		IL_00ec: stloc.s 6
+		IL_00ee: volatile.
+		IL_00f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00f5: brfalse IL_010d
+
+		IL_00fa: ldloc.s 4
+		IL_00fc: ldstr "then"
+		IL_0101: ldloc.s 6
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0108: br IL_0125
+
+		IL_010d: ldloc.s 4
+		IL_010f: ldstr "then"
+		IL_0114: ldloc.s 6
+		IL_0116: ldstr "Promise_Finally_ReturnsThenable_PassThrough_Fulfilled:Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled:__js_module_init__:21"
+		IL_011b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0125: pop
+		IL_0126: ret
 	} // end of method Promise_Finally_ReturnsThenable_PassThrough_Fulfilled::__js_module_init__
 
 } // end of class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled
@@ -619,4 +645,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
@@ -500,7 +500,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 204 (0xcc)
+		// Code size: 286 (0x11e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/Scope,
@@ -564,36 +564,62 @@
 		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/ArrowFunction_L9C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/ArrowFunction_L9C32/FunctionObject>(!!0)
 		IL_007c: stloc.s 5
-		IL_007e: ldloc.s 4
-		IL_0080: ldstr "finally"
-		IL_0085: ldloc.s 5
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008c: stloc.s 4
-		IL_008e: ldloc.s 4
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0095: stloc.s 4
-		IL_0097: ldc.i4.1
-		IL_0098: newarr [System.Runtime]System.Object
-		IL_009d: dup
-		IL_009e: ldc.i4.0
-		IL_009f: ldloc.0
-		IL_00a0: stelem.ref
-		IL_00a1: stloc.2
-		IL_00a2: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/ArrowFunction_L9C54/FunctionObject::.ctor()
-		IL_00a7: ldc.i4.1
-		IL_00a8: conv.r8
-		IL_00a9: ldstr ""
-		IL_00ae: ldc.i4.0
-		IL_00af: ldc.i4.0
-		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/ArrowFunction_L9C54/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/ArrowFunction_L9C54/FunctionObject>(!!0)
-		IL_00ba: stloc.s 6
-		IL_00bc: ldloc.s 4
-		IL_00be: ldstr "catch"
-		IL_00c3: ldloc.s 6
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ca: pop
-		IL_00cb: ret
+		IL_007e: volatile.
+		IL_0080: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0085: brfalse IL_009d
+
+		IL_008a: ldloc.s 4
+		IL_008c: ldstr "finally"
+		IL_0091: ldloc.s 5
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0098: br IL_00b5
+
+		IL_009d: ldloc.s 4
+		IL_009f: ldstr "finally"
+		IL_00a4: ldloc.s 5
+		IL_00a6: ldstr "Promise_Finally_ReturnsThenable_PassThrough_Rejected:Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected:__js_module_init__:16"
+		IL_00ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00b5: stloc.s 4
+		IL_00b7: ldloc.s 4
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00be: stloc.s 4
+		IL_00c0: ldc.i4.1
+		IL_00c1: newarr [System.Runtime]System.Object
+		IL_00c6: dup
+		IL_00c7: ldc.i4.0
+		IL_00c8: ldloc.0
+		IL_00c9: stelem.ref
+		IL_00ca: stloc.2
+		IL_00cb: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/ArrowFunction_L9C54/FunctionObject::.ctor()
+		IL_00d0: ldc.i4.1
+		IL_00d1: conv.r8
+		IL_00d2: ldstr ""
+		IL_00d7: ldc.i4.0
+		IL_00d8: ldc.i4.0
+		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/ArrowFunction_L9C54/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/ArrowFunction_L9C54/FunctionObject>(!!0)
+		IL_00e3: stloc.s 6
+		IL_00e5: volatile.
+		IL_00e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00ec: brfalse IL_0104
+
+		IL_00f1: ldloc.s 4
+		IL_00f3: ldstr "catch"
+		IL_00f8: ldloc.s 6
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ff: br IL_011c
+
+		IL_0104: ldloc.s 4
+		IL_0106: ldstr "catch"
+		IL_010b: ldloc.s 6
+		IL_010d: ldstr "Promise_Finally_ReturnsThenable_PassThrough_Rejected:Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected:__js_module_init__:20"
+		IL_0112: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_011c: pop
+		IL_011d: ret
 	} // end of method Promise_Finally_ReturnsThenable_PassThrough_Rejected::__js_module_init__
 
 } // end of class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected
@@ -618,4 +644,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_EmptyArray.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_EmptyArray.verified.txt
@@ -448,7 +448,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 199 (0xc7)
+		// Code size: 318 (0x13e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Race_EmptyArray/Scope,
@@ -483,61 +483,100 @@
 		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_EmptyArray/ArrowFunction_L4C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_EmptyArray/ArrowFunction_L4C11/FunctionObject>(!!0)
 		IL_003b: stloc.3
-		IL_003c: ldloc.1
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.3
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: stloc.1
-		IL_0049: ldloc.1
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.1
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: stloc.2
-		IL_005b: newobj instance void Modules.Promise_Race_EmptyArray/ArrowFunction_L7C12/FunctionObject::.ctor()
-		IL_0060: ldc.i4.1
-		IL_0061: conv.r8
-		IL_0062: ldstr ""
-		IL_0067: ldc.i4.0
-		IL_0068: ldc.i4.0
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_EmptyArray/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_EmptyArray/ArrowFunction_L7C12/FunctionObject>(!!0)
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.1
-		IL_0076: ldstr "catch"
-		IL_007b: ldloc.s 4
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ldstr "done"
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0092: stloc.1
-		IL_0093: ldc.i4.1
-		IL_0094: newarr [System.Runtime]System.Object
-		IL_0099: dup
-		IL_009a: ldc.i4.0
-		IL_009b: ldloc.0
-		IL_009c: stelem.ref
-		IL_009d: stloc.2
-		IL_009e: newobj instance void Modules.Promise_Race_EmptyArray/ArrowFunction_L12C30/FunctionObject::.ctor()
-		IL_00a3: ldc.i4.0
-		IL_00a4: conv.r8
-		IL_00a5: ldstr ""
-		IL_00aa: ldc.i4.0
-		IL_00ab: ldc.i4.0
-		IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_EmptyArray/ArrowFunction_L12C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_EmptyArray/ArrowFunction_L12C30/FunctionObject>(!!0)
-		IL_00b6: stloc.s 5
-		IL_00b8: ldloc.1
-		IL_00b9: ldstr "then"
-		IL_00be: ldloc.s 5
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c5: pop
-		IL_00c6: ret
+		IL_003c: volatile.
+		IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0043: brfalse IL_0059
+
+		IL_0048: ldloc.1
+		IL_0049: ldstr "then"
+		IL_004e: ldloc.3
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: br IL_006f
+
+		IL_0059: ldloc.1
+		IL_005a: ldstr "then"
+		IL_005f: ldloc.3
+		IL_0060: ldstr "Promise_Race_EmptyArray:Modules.Promise_Race_EmptyArray:__js_module_init__:9"
+		IL_0065: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006f: stloc.1
+		IL_0070: ldloc.1
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0076: stloc.1
+		IL_0077: ldc.i4.1
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldloc.0
+		IL_0080: stelem.ref
+		IL_0081: stloc.2
+		IL_0082: newobj instance void Modules.Promise_Race_EmptyArray/ArrowFunction_L7C12/FunctionObject::.ctor()
+		IL_0087: ldc.i4.1
+		IL_0088: conv.r8
+		IL_0089: ldstr ""
+		IL_008e: ldc.i4.0
+		IL_008f: ldc.i4.0
+		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_EmptyArray/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_EmptyArray/ArrowFunction_L7C12/FunctionObject>(!!0)
+		IL_009a: stloc.s 4
+		IL_009c: volatile.
+		IL_009e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a3: brfalse IL_00ba
+
+		IL_00a8: ldloc.1
+		IL_00a9: ldstr "catch"
+		IL_00ae: ldloc.s 4
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b5: br IL_00d1
+
+		IL_00ba: ldloc.1
+		IL_00bb: ldstr "catch"
+		IL_00c0: ldloc.s 4
+		IL_00c2: ldstr "Promise_Race_EmptyArray:Modules.Promise_Race_EmptyArray:__js_module_init__:13"
+		IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d1: pop
+		IL_00d2: ldstr "done"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e1: stloc.1
+		IL_00e2: ldc.i4.1
+		IL_00e3: newarr [System.Runtime]System.Object
+		IL_00e8: dup
+		IL_00e9: ldc.i4.0
+		IL_00ea: ldloc.0
+		IL_00eb: stelem.ref
+		IL_00ec: stloc.2
+		IL_00ed: newobj instance void Modules.Promise_Race_EmptyArray/ArrowFunction_L12C30/FunctionObject::.ctor()
+		IL_00f2: ldc.i4.0
+		IL_00f3: conv.r8
+		IL_00f4: ldstr ""
+		IL_00f9: ldc.i4.0
+		IL_00fa: ldc.i4.0
+		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_EmptyArray/ArrowFunction_L12C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_EmptyArray/ArrowFunction_L12C30/FunctionObject>(!!0)
+		IL_0105: stloc.s 5
+		IL_0107: volatile.
+		IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_010e: brfalse IL_0125
+
+		IL_0113: ldloc.1
+		IL_0114: ldstr "then"
+		IL_0119: ldloc.s 5
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0120: br IL_013c
+
+		IL_0125: ldloc.1
+		IL_0126: ldstr "then"
+		IL_012b: ldloc.s 5
+		IL_012d: ldstr "Promise_Race_EmptyArray:Modules.Promise_Race_EmptyArray:__js_module_init__:20"
+		IL_0132: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_013c: pop
+		IL_013d: ret
 	} // end of method Promise_Race_EmptyArray::__js_module_init__
 
 } // end of class Modules.Promise_Race_EmptyArray
@@ -562,4 +601,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_FirstRejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_FirstRejected.verified.txt
@@ -340,7 +340,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 214 (0xd6)
+		// Code size: 296 (0x128)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_Race_FirstRejected/Scope,
@@ -397,36 +397,62 @@
 		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_FirstRejected/ArrowFunction_L8C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_FirstRejected/ArrowFunction_L8C11/FunctionObject>(!!0)
 		IL_0085: stloc.s 6
-		IL_0087: ldloc.s 4
-		IL_0089: ldstr "then"
-		IL_008e: ldloc.s 6
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.s 4
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.s 4
-		IL_00a0: ldc.i4.1
-		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: dup
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldloc.0
-		IL_00a9: stelem.ref
-		IL_00aa: stloc.s 5
-		IL_00ac: newobj instance void Modules.Promise_Race_FirstRejected/ArrowFunction_L11C12/FunctionObject::.ctor()
-		IL_00b1: ldc.i4.1
-		IL_00b2: conv.r8
-		IL_00b3: ldstr ""
-		IL_00b8: ldc.i4.0
-		IL_00b9: ldc.i4.0
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_FirstRejected/ArrowFunction_L11C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_FirstRejected/ArrowFunction_L11C12/FunctionObject>(!!0)
-		IL_00c4: stloc.s 7
-		IL_00c6: ldloc.s 4
-		IL_00c8: ldstr "catch"
-		IL_00cd: ldloc.s 7
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d4: pop
-		IL_00d5: ret
+		IL_0087: volatile.
+		IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_008e: brfalse IL_00a6
+
+		IL_0093: ldloc.s 4
+		IL_0095: ldstr "then"
+		IL_009a: ldloc.s 6
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a1: br IL_00be
+
+		IL_00a6: ldloc.s 4
+		IL_00a8: ldstr "then"
+		IL_00ad: ldloc.s 6
+		IL_00af: ldstr "Promise_Race_FirstRejected:Modules.Promise_Race_FirstRejected:__js_module_init__:23"
+		IL_00b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00be: stloc.s 4
+		IL_00c0: ldloc.s 4
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c7: stloc.s 4
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldloc.0
+		IL_00d2: stelem.ref
+		IL_00d3: stloc.s 5
+		IL_00d5: newobj instance void Modules.Promise_Race_FirstRejected/ArrowFunction_L11C12/FunctionObject::.ctor()
+		IL_00da: ldc.i4.1
+		IL_00db: conv.r8
+		IL_00dc: ldstr ""
+		IL_00e1: ldc.i4.0
+		IL_00e2: ldc.i4.0
+		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_FirstRejected/ArrowFunction_L11C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_FirstRejected/ArrowFunction_L11C12/FunctionObject>(!!0)
+		IL_00ed: stloc.s 7
+		IL_00ef: volatile.
+		IL_00f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00f6: brfalse IL_010e
+
+		IL_00fb: ldloc.s 4
+		IL_00fd: ldstr "catch"
+		IL_0102: ldloc.s 7
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0109: br IL_0126
+
+		IL_010e: ldloc.s 4
+		IL_0110: ldstr "catch"
+		IL_0115: ldloc.s 7
+		IL_0117: ldstr "Promise_Race_FirstRejected:Modules.Promise_Race_FirstRejected:__js_module_init__:27"
+		IL_011c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0126: pop
+		IL_0127: ret
 	} // end of method Promise_Race_FirstRejected::__js_module_init__
 
 } // end of class Modules.Promise_Race_FirstRejected
@@ -451,4 +477,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_FirstResolved.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_FirstResolved.verified.txt
@@ -222,7 +222,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 160 (0xa0)
+		// Code size: 201 (0xc9)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_Race_FirstResolved/Scope,
@@ -279,12 +279,25 @@
 		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_FirstResolved/ArrowFunction_L7C33/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_FirstResolved/ArrowFunction_L7C33/FunctionObject>(!!0)
 		IL_008e: stloc.s 6
-		IL_0090: ldloc.s 4
-		IL_0092: ldstr "then"
-		IL_0097: ldloc.s 6
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009e: pop
-		IL_009f: ret
+		IL_0090: volatile.
+		IL_0092: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0097: brfalse IL_00af
+
+		IL_009c: ldloc.s 4
+		IL_009e: ldstr "then"
+		IL_00a3: ldloc.s 6
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00aa: br IL_00c7
+
+		IL_00af: ldloc.s 4
+		IL_00b1: ldstr "then"
+		IL_00b6: ldloc.s 6
+		IL_00b8: ldstr "Promise_Race_FirstResolved:Modules.Promise_Race_FirstResolved:__js_module_init__:24"
+		IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00c7: pop
+		IL_00c8: ret
 	} // end of method Promise_Race_FirstResolved::__js_module_init__
 
 } // end of class Modules.Promise_Race_FirstResolved
@@ -309,4 +322,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_MixedValues.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_MixedValues.verified.txt
@@ -222,7 +222,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 108 (0x6c)
+		// Code size: 148 (0x94)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Promise_Race_MixedValues/Scope,
@@ -268,12 +268,25 @@
 		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_MixedValues/ArrowFunction_L6C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_MixedValues/ArrowFunction_L6C32/FunctionObject>(!!0)
 		IL_005b: stloc.s 5
-		IL_005d: ldloc.3
-		IL_005e: ldstr "then"
-		IL_0063: ldloc.s 5
-		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006a: pop
-		IL_006b: ret
+		IL_005d: volatile.
+		IL_005f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0064: brfalse IL_007b
+
+		IL_0069: ldloc.3
+		IL_006a: ldstr "then"
+		IL_006f: ldloc.s 5
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0076: br IL_0092
+
+		IL_007b: ldloc.3
+		IL_007c: ldstr "then"
+		IL_0081: ldloc.s 5
+		IL_0083: ldstr "Promise_Race_MixedValues:Modules.Promise_Race_MixedValues:__js_module_init__:16"
+		IL_0088: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0092: pop
+		IL_0093: ret
 	} // end of method Promise_Race_MixedValues::__js_module_init__
 
 } // end of class Modules.Promise_Race_MixedValues
@@ -298,4 +311,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_NullIterable.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Race_NullIterable.verified.txt
@@ -300,7 +300,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -311,7 +311,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "name"
 			IL_0028: ldstr "Promise_Race_NullIterable:<TwoPhaseDummy_M5>:__js_call__:5"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -357,7 +357,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 132 (0x84)
+		// Code size: 211 (0xd3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Race_NullIterable/Scope,
@@ -391,36 +391,62 @@
 		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_NullIterable/ArrowFunction_L4C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0036: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_NullIterable/ArrowFunction_L4C11/FunctionObject>(!!0)
 		IL_003b: stloc.3
-		IL_003c: ldloc.1
-		IL_003d: ldstr "then"
-		IL_0042: ldloc.3
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0048: stloc.1
-		IL_0049: ldloc.1
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.1
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: stloc.2
-		IL_005b: newobj instance void Modules.Promise_Race_NullIterable/ArrowFunction_L7C12/FunctionObject::.ctor()
-		IL_0060: ldc.i4.1
-		IL_0061: conv.r8
-		IL_0062: ldstr ""
-		IL_0067: ldc.i4.0
-		IL_0068: ldc.i4.0
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0)
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.1
-		IL_0076: ldstr "catch"
-		IL_007b: ldloc.s 4
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0082: pop
-		IL_0083: ret
+		IL_003c: volatile.
+		IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0043: brfalse IL_0059
+
+		IL_0048: ldloc.1
+		IL_0049: ldstr "then"
+		IL_004e: ldloc.3
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0054: br IL_006f
+
+		IL_0059: ldloc.1
+		IL_005a: ldstr "then"
+		IL_005f: ldloc.3
+		IL_0060: ldstr "Promise_Race_NullIterable:Modules.Promise_Race_NullIterable:__js_module_init__:10"
+		IL_0065: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006f: stloc.1
+		IL_0070: ldloc.1
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0076: stloc.1
+		IL_0077: ldc.i4.1
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldloc.0
+		IL_0080: stelem.ref
+		IL_0081: stloc.2
+		IL_0082: newobj instance void Modules.Promise_Race_NullIterable/ArrowFunction_L7C12/FunctionObject::.ctor()
+		IL_0087: ldc.i4.1
+		IL_0088: conv.r8
+		IL_0089: ldstr ""
+		IL_008e: ldc.i4.0
+		IL_008f: ldc.i4.0
+		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Race_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Race_NullIterable/ArrowFunction_L7C12/FunctionObject>(!!0)
+		IL_009a: stloc.s 4
+		IL_009c: volatile.
+		IL_009e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a3: brfalse IL_00ba
+
+		IL_00a8: ldloc.1
+		IL_00a9: ldstr "catch"
+		IL_00ae: ldloc.s 4
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b5: br IL_00d1
+
+		IL_00ba: ldloc.1
+		IL_00bb: ldstr "catch"
+		IL_00c0: ldloc.s 4
+		IL_00c2: ldstr "Promise_Race_NullIterable:Modules.Promise_Race_NullIterable:__js_module_init__:14"
+		IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d1: pop
+		IL_00d2: ret
 	} // end of method Promise_Race_NullIterable::__js_module_init__
 
 } // end of class Modules.Promise_Race_NullIterable
@@ -451,6 +477,8 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Reject_FinallyCatch.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Reject_FinallyCatch.verified.txt
@@ -330,7 +330,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 210 (0xd2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Reject_FinallyCatch/Scope,
@@ -363,36 +363,62 @@
 		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Reject_FinallyCatch/ArrowFunction_L3C53/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Reject_FinallyCatch/ArrowFunction_L3C53/FunctionObject>(!!0)
 		IL_003a: stloc.3
-		IL_003b: ldloc.1
-		IL_003c: ldstr "finally"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: stloc.1
-		IL_0048: ldloc.1
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.1
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldloc.0
-		IL_0058: stelem.ref
-		IL_0059: stloc.2
-		IL_005a: newobj instance void Modules.Promise_Reject_FinallyCatch/ArrowFunction_L3C101/FunctionObject::.ctor()
-		IL_005f: ldc.i4.1
-		IL_0060: conv.r8
-		IL_0061: ldstr ""
-		IL_0066: ldc.i4.0
-		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Reject_FinallyCatch/ArrowFunction_L3C101/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Reject_FinallyCatch/ArrowFunction_L3C101/FunctionObject>(!!0)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.1
-		IL_0075: ldstr "catch"
-		IL_007a: ldloc.s 4
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: ret
+		IL_003b: volatile.
+		IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0042: brfalse IL_0058
+
+		IL_0047: ldloc.1
+		IL_0048: ldstr "finally"
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0053: br IL_006e
+
+		IL_0058: ldloc.1
+		IL_0059: ldstr "finally"
+		IL_005e: ldloc.3
+		IL_005f: ldstr "Promise_Reject_FinallyCatch:Modules.Promise_Reject_FinallyCatch:__js_module_init__:9"
+		IL_0064: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006e: stloc.1
+		IL_006f: ldloc.1
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0075: stloc.1
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: stloc.2
+		IL_0081: newobj instance void Modules.Promise_Reject_FinallyCatch/ArrowFunction_L3C101/FunctionObject::.ctor()
+		IL_0086: ldc.i4.1
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: ldc.i4.0
+		IL_008e: ldc.i4.0
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Reject_FinallyCatch/ArrowFunction_L3C101/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Reject_FinallyCatch/ArrowFunction_L3C101/FunctionObject>(!!0)
+		IL_0099: stloc.s 4
+		IL_009b: volatile.
+		IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00a2: brfalse IL_00b9
+
+		IL_00a7: ldloc.1
+		IL_00a8: ldstr "catch"
+		IL_00ad: ldloc.s 4
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: br IL_00d0
+
+		IL_00b9: ldloc.1
+		IL_00ba: ldstr "catch"
+		IL_00bf: ldloc.s 4
+		IL_00c1: ldstr "Promise_Reject_FinallyCatch:Modules.Promise_Reject_FinallyCatch:__js_module_init__:13"
+		IL_00c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d0: pop
+		IL_00d1: ret
 	} // end of method Promise_Reject_FinallyCatch::__js_module_init__
 
 } // end of class Modules.Promise_Reject_FinallyCatch
@@ -417,4 +443,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThen.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThen.verified.txt
@@ -332,7 +332,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 210 (0xd2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Resolve_FinallyThen/Scope,
@@ -365,36 +365,62 @@
 		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_FinallyThen/ArrowFunction_L3C55/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_FinallyThen/ArrowFunction_L3C55/FunctionObject>(!!0)
 		IL_003a: stloc.3
-		IL_003b: ldloc.1
-		IL_003c: ldstr "finally"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: stloc.1
-		IL_0048: ldloc.1
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.1
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldloc.0
-		IL_0058: stelem.ref
-		IL_0059: stloc.2
-		IL_005a: newobj instance void Modules.Promise_Resolve_FinallyThen/ArrowFunction_L3C114/FunctionObject::.ctor()
-		IL_005f: ldc.i4.1
-		IL_0060: conv.r8
-		IL_0061: ldstr ""
-		IL_0066: ldc.i4.0
-		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_FinallyThen/ArrowFunction_L3C114/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_FinallyThen/ArrowFunction_L3C114/FunctionObject>(!!0)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.1
-		IL_0075: ldstr "then"
-		IL_007a: ldloc.s 4
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: ret
+		IL_003b: volatile.
+		IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0042: brfalse IL_0058
+
+		IL_0047: ldloc.1
+		IL_0048: ldstr "finally"
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0053: br IL_006e
+
+		IL_0058: ldloc.1
+		IL_0059: ldstr "finally"
+		IL_005e: ldloc.3
+		IL_005f: ldstr "Promise_Resolve_FinallyThen:Modules.Promise_Resolve_FinallyThen:__js_module_init__:9"
+		IL_0064: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006e: stloc.1
+		IL_006f: ldloc.1
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0075: stloc.1
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: stloc.2
+		IL_0081: newobj instance void Modules.Promise_Resolve_FinallyThen/ArrowFunction_L3C114/FunctionObject::.ctor()
+		IL_0086: ldc.i4.1
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: ldc.i4.0
+		IL_008e: ldc.i4.0
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_FinallyThen/ArrowFunction_L3C114/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_FinallyThen/ArrowFunction_L3C114/FunctionObject>(!!0)
+		IL_0099: stloc.s 4
+		IL_009b: volatile.
+		IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00a2: brfalse IL_00b9
+
+		IL_00a7: ldloc.1
+		IL_00a8: ldstr "then"
+		IL_00ad: ldloc.s 4
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: br IL_00d0
+
+		IL_00b9: ldloc.1
+		IL_00ba: ldstr "then"
+		IL_00bf: ldloc.s 4
+		IL_00c1: ldstr "Promise_Resolve_FinallyThen:Modules.Promise_Resolve_FinallyThen:__js_module_init__:13"
+		IL_00c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d0: pop
+		IL_00d1: ret
 	} // end of method Promise_Resolve_FinallyThen::__js_module_init__
 
 } // end of class Modules.Promise_Resolve_FinallyThen
@@ -419,4 +445,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThrows.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_FinallyThrows.verified.txt
@@ -459,7 +459,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 189 (0xbd)
+		// Code size: 308 (0x134)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Resolve_FinallyThrows/Scope,
@@ -493,60 +493,99 @@
 		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C55/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C55/FunctionObject>(!!0)
 		IL_003a: stloc.3
-		IL_003b: ldloc.1
-		IL_003c: ldstr "finally"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: stloc.1
-		IL_0048: ldloc.1
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.1
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldloc.0
-		IL_0058: stelem.ref
-		IL_0059: stloc.2
-		IL_005a: newobj instance void Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C96/FunctionObject::.ctor()
-		IL_005f: ldc.i4.1
-		IL_0060: conv.r8
-		IL_0061: ldstr ""
-		IL_0066: ldc.i4.0
-		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C96/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C96/FunctionObject>(!!0)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.1
-		IL_0075: ldstr "then"
-		IL_007a: ldloc.s 4
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: stloc.1
-		IL_0082: ldloc.1
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0088: stloc.1
-		IL_0089: ldc.i4.1
-		IL_008a: newarr [System.Runtime]System.Object
-		IL_008f: dup
-		IL_0090: ldc.i4.0
-		IL_0091: ldloc.0
-		IL_0092: stelem.ref
-		IL_0093: stloc.2
-		IL_0094: newobj instance void Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C147/FunctionObject::.ctor()
-		IL_0099: ldc.i4.1
-		IL_009a: conv.r8
-		IL_009b: ldstr ""
-		IL_00a0: ldc.i4.0
-		IL_00a1: ldc.i4.0
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C147/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C147/FunctionObject>(!!0)
-		IL_00ac: stloc.s 5
-		IL_00ae: ldloc.1
-		IL_00af: ldstr "catch"
-		IL_00b4: ldloc.s 5
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: pop
-		IL_00bc: ret
+		IL_003b: volatile.
+		IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0042: brfalse IL_0058
+
+		IL_0047: ldloc.1
+		IL_0048: ldstr "finally"
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0053: br IL_006e
+
+		IL_0058: ldloc.1
+		IL_0059: ldstr "finally"
+		IL_005e: ldloc.3
+		IL_005f: ldstr "Promise_Resolve_FinallyThrows:Modules.Promise_Resolve_FinallyThrows:__js_module_init__:9"
+		IL_0064: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006e: stloc.1
+		IL_006f: ldloc.1
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0075: stloc.1
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: stloc.2
+		IL_0081: newobj instance void Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C96/FunctionObject::.ctor()
+		IL_0086: ldc.i4.1
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: ldc.i4.0
+		IL_008e: ldc.i4.0
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C96/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C96/FunctionObject>(!!0)
+		IL_0099: stloc.s 4
+		IL_009b: volatile.
+		IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00a2: brfalse IL_00b9
+
+		IL_00a7: ldloc.1
+		IL_00a8: ldstr "then"
+		IL_00ad: ldloc.s 4
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: br IL_00d0
+
+		IL_00b9: ldloc.1
+		IL_00ba: ldstr "then"
+		IL_00bf: ldloc.s 4
+		IL_00c1: ldstr "Promise_Resolve_FinallyThrows:Modules.Promise_Resolve_FinallyThrows:__js_module_init__:13"
+		IL_00c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d0: stloc.1
+		IL_00d1: ldloc.1
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d7: stloc.1
+		IL_00d8: ldc.i4.1
+		IL_00d9: newarr [System.Runtime]System.Object
+		IL_00de: dup
+		IL_00df: ldc.i4.0
+		IL_00e0: ldloc.0
+		IL_00e1: stelem.ref
+		IL_00e2: stloc.2
+		IL_00e3: newobj instance void Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C147/FunctionObject::.ctor()
+		IL_00e8: ldc.i4.1
+		IL_00e9: conv.r8
+		IL_00ea: ldstr ""
+		IL_00ef: ldc.i4.0
+		IL_00f0: ldc.i4.0
+		IL_00f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C147/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_FinallyThrows/ArrowFunction_L3C147/FunctionObject>(!!0)
+		IL_00fb: stloc.s 5
+		IL_00fd: volatile.
+		IL_00ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0104: brfalse IL_011b
+
+		IL_0109: ldloc.1
+		IL_010a: ldstr "catch"
+		IL_010f: ldloc.s 5
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0116: br IL_0132
+
+		IL_011b: ldloc.1
+		IL_011c: ldstr "catch"
+		IL_0121: ldloc.s 5
+		IL_0123: ldstr "Promise_Resolve_FinallyThrows:Modules.Promise_Resolve_FinallyThrows:__js_module_init__:17"
+		IL_0128: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0132: pop
+		IL_0133: ret
 	} // end of method Promise_Resolve_FinallyThrows::__js_module_init__
 
 } // end of class Modules.Promise_Resolve_FinallyThrows
@@ -571,4 +610,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_Then.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_Then.verified.txt
@@ -222,7 +222,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 73 (0x49)
+		// Code size: 112 (0x70)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Resolve_Then/Scope,
@@ -254,12 +254,25 @@
 		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_Then/ArrowFunction_L3C53/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_Then/ArrowFunction_L3C53/FunctionObject>(!!0)
 		IL_003a: stloc.3
-		IL_003b: ldloc.1
-		IL_003c: ldstr "then"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: pop
-		IL_0048: ret
+		IL_003b: volatile.
+		IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0042: brfalse IL_0058
+
+		IL_0047: ldloc.1
+		IL_0048: ldstr "then"
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0053: br IL_006e
+
+		IL_0058: ldloc.1
+		IL_0059: ldstr "then"
+		IL_005e: ldloc.3
+		IL_005f: ldstr "Promise_Resolve_Then:Modules.Promise_Resolve_Then:__js_module_init__:9"
+		IL_0064: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006e: pop
+		IL_006f: ret
 	} // end of method Promise_Resolve_Then::__js_module_init__
 
 } // end of class Modules.Promise_Resolve_Then
@@ -284,4 +297,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_ThenFinally.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Resolve_ThenFinally.verified.txt
@@ -332,7 +332,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 210 (0xd2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Resolve_ThenFinally/Scope,
@@ -365,36 +365,62 @@
 		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_ThenFinally/ArrowFunction_L3C52/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_ThenFinally/ArrowFunction_L3C52/FunctionObject>(!!0)
 		IL_003a: stloc.3
-		IL_003b: ldloc.1
-		IL_003c: ldstr "then"
-		IL_0041: ldloc.3
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0047: stloc.1
-		IL_0048: ldloc.1
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.1
-		IL_004f: ldc.i4.1
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldloc.0
-		IL_0058: stelem.ref
-		IL_0059: stloc.2
-		IL_005a: newobj instance void Modules.Promise_Resolve_ThenFinally/ArrowFunction_L3C105/FunctionObject::.ctor()
-		IL_005f: ldc.i4.0
-		IL_0060: conv.r8
-		IL_0061: ldstr ""
-		IL_0066: ldc.i4.0
-		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_ThenFinally/ArrowFunction_L3C105/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_ThenFinally/ArrowFunction_L3C105/FunctionObject>(!!0)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.1
-		IL_0075: ldstr "finally"
-		IL_007a: ldloc.s 4
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: ret
+		IL_003b: volatile.
+		IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0042: brfalse IL_0058
+
+		IL_0047: ldloc.1
+		IL_0048: ldstr "then"
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0053: br IL_006e
+
+		IL_0058: ldloc.1
+		IL_0059: ldstr "then"
+		IL_005e: ldloc.3
+		IL_005f: ldstr "Promise_Resolve_ThenFinally:Modules.Promise_Resolve_ThenFinally:__js_module_init__:9"
+		IL_0064: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006e: stloc.1
+		IL_006f: ldloc.1
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0075: stloc.1
+		IL_0076: ldc.i4.1
+		IL_0077: newarr [System.Runtime]System.Object
+		IL_007c: dup
+		IL_007d: ldc.i4.0
+		IL_007e: ldloc.0
+		IL_007f: stelem.ref
+		IL_0080: stloc.2
+		IL_0081: newobj instance void Modules.Promise_Resolve_ThenFinally/ArrowFunction_L3C105/FunctionObject::.ctor()
+		IL_0086: ldc.i4.0
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: ldc.i4.0
+		IL_008e: ldc.i4.0
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Resolve_ThenFinally/ArrowFunction_L3C105/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Resolve_ThenFinally/ArrowFunction_L3C105/FunctionObject>(!!0)
+		IL_0099: stloc.s 4
+		IL_009b: volatile.
+		IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00a2: brfalse IL_00b9
+
+		IL_00a7: ldloc.1
+		IL_00a8: ldstr "finally"
+		IL_00ad: ldloc.s 4
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b4: br IL_00d0
+
+		IL_00b9: ldloc.1
+		IL_00ba: ldstr "finally"
+		IL_00bf: ldloc.s 4
+		IL_00c1: ldstr "Promise_Resolve_ThenFinally:Modules.Promise_Resolve_ThenFinally:__js_module_init__:13"
+		IL_00c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d0: pop
+		IL_00d1: ret
 	} // end of method Promise_Resolve_ThenFinally::__js_module_init__
 
 } // end of class Modules.Promise_Resolve_ThenFinally
@@ -419,4 +445,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Scheduling_StarvationTest.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Scheduling_StarvationTest.verified.txt
@@ -486,7 +486,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 143 (0x8f)
+		// Code size: 184 (0xb8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Scheduling_StarvationTest/Scope,
@@ -515,7 +515,7 @@
 			IL_0025: ldloc.3
 			IL_0026: ldc.r8 2048
 			IL_002f: clt
-			IL_0031: brfalse IL_008e
+			IL_0031: brfalse IL_00b7
 
 			IL_0036: ldloc.1
 			IL_0037: box [System.Runtime]System.Double
@@ -538,19 +538,32 @@
 			IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Scheduling_StarvationTest/ArrowFunction_L7C29/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Scheduling_StarvationTest/ArrowFunction_L7C29/FunctionObject>(!!0)
 			IL_006c: stloc.s 6
-			IL_006e: ldloc.s 4
-			IL_0070: ldstr "then"
-			IL_0075: ldloc.s 6
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007c: pop
-			IL_007d: ldloc.1
-			IL_007e: ldc.r8 1
-			IL_0087: add
-			IL_0088: stloc.1
-			IL_0089: br IL_0023
+			IL_006e: volatile.
+			IL_0070: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0075: brfalse IL_008d
+
+			IL_007a: ldloc.s 4
+			IL_007c: ldstr "then"
+			IL_0081: ldloc.s 6
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0088: br IL_00a5
+
+			IL_008d: ldloc.s 4
+			IL_008f: ldstr "then"
+			IL_0094: ldloc.s 6
+			IL_0096: ldstr "Promise_Scheduling_StarvationTest:Modules.Promise_Scheduling_StarvationTest:__js_module_init__:21"
+			IL_009b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_00a5: pop
+			IL_00a6: ldloc.1
+			IL_00a7: ldc.r8 1
+			IL_00b0: add
+			IL_00b1: stloc.1
+			IL_00b2: br IL_0023
 		// end loop
 
-		IL_008e: ret
+		IL_00b7: ret
 	} // end of method Promise_Scheduling_StarvationTest::__js_module_init__
 
 } // end of class Modules.Promise_Scheduling_StarvationTest
@@ -575,4 +588,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Then_ReturnsRejectedPromise.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Then_ReturnsRejectedPromise.verified.txt
@@ -331,7 +331,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 140 (0x8c)
+		// Code size: 219 (0xdb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Then_ReturnsRejectedPromise/Scope,
@@ -365,36 +365,62 @@
 		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L3C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L3C25/FunctionObject>(!!0)
 		IL_0043: stloc.3
-		IL_0044: ldloc.1
-		IL_0045: ldstr "then"
-		IL_004a: ldloc.3
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0050: stloc.1
-		IL_0051: ldloc.1
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0057: stloc.1
-		IL_0058: ldc.i4.1
-		IL_0059: newarr [System.Runtime]System.Object
-		IL_005e: dup
-		IL_005f: ldc.i4.0
-		IL_0060: ldloc.0
-		IL_0061: stelem.ref
-		IL_0062: stloc.2
-		IL_0063: newobj instance void Modules.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L3C71/FunctionObject::.ctor()
-		IL_0068: ldc.i4.1
-		IL_0069: conv.r8
-		IL_006a: ldstr ""
-		IL_006f: ldc.i4.0
-		IL_0070: ldc.i4.0
-		IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L3C71/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L3C71/FunctionObject>(!!0)
-		IL_007b: stloc.s 4
-		IL_007d: ldloc.1
-		IL_007e: ldstr "catch"
-		IL_0083: ldloc.s 4
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: pop
-		IL_008b: ret
+		IL_0044: volatile.
+		IL_0046: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_004b: brfalse IL_0061
+
+		IL_0050: ldloc.1
+		IL_0051: ldstr "then"
+		IL_0056: ldloc.3
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005c: br IL_0077
+
+		IL_0061: ldloc.1
+		IL_0062: ldstr "then"
+		IL_0067: ldloc.3
+		IL_0068: ldstr "Promise_Then_ReturnsRejectedPromise:Modules.Promise_Then_ReturnsRejectedPromise:__js_module_init__:10"
+		IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0077: stloc.1
+		IL_0078: ldloc.1
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007e: stloc.1
+		IL_007f: ldc.i4.1
+		IL_0080: newarr [System.Runtime]System.Object
+		IL_0085: dup
+		IL_0086: ldc.i4.0
+		IL_0087: ldloc.0
+		IL_0088: stelem.ref
+		IL_0089: stloc.2
+		IL_008a: newobj instance void Modules.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L3C71/FunctionObject::.ctor()
+		IL_008f: ldc.i4.1
+		IL_0090: conv.r8
+		IL_0091: ldstr ""
+		IL_0096: ldc.i4.0
+		IL_0097: ldc.i4.0
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L3C71/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Then_ReturnsRejectedPromise/ArrowFunction_L3C71/FunctionObject>(!!0)
+		IL_00a2: stloc.s 4
+		IL_00a4: volatile.
+		IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00ab: brfalse IL_00c2
+
+		IL_00b0: ldloc.1
+		IL_00b1: ldstr "catch"
+		IL_00b6: ldloc.s 4
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bd: br IL_00d9
+
+		IL_00c2: ldloc.1
+		IL_00c3: ldstr "catch"
+		IL_00c8: ldloc.s 4
+		IL_00ca: ldstr "Promise_Then_ReturnsRejectedPromise:Modules.Promise_Then_ReturnsRejectedPromise:__js_module_init__:14"
+		IL_00cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d9: pop
+		IL_00da: ret
 	} // end of method Promise_Then_ReturnsRejectedPromise::__js_module_init__
 
 } // end of class Modules.Promise_Then_ReturnsRejectedPromise
@@ -419,4 +445,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Then_ReturnsResolvedPromise.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Then_ReturnsResolvedPromise.verified.txt
@@ -338,7 +338,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 140 (0x8c)
+		// Code size: 219 (0xdb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Then_ReturnsResolvedPromise/Scope,
@@ -372,36 +372,62 @@
 		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L3C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L3C25/FunctionObject>(!!0)
 		IL_0043: stloc.3
-		IL_0044: ldloc.1
-		IL_0045: ldstr "then"
-		IL_004a: ldloc.3
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0050: stloc.1
-		IL_0051: ldloc.1
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0057: stloc.1
-		IL_0058: ldc.i4.1
-		IL_0059: newarr [System.Runtime]System.Object
-		IL_005e: dup
-		IL_005f: ldc.i4.0
-		IL_0060: ldloc.0
-		IL_0061: stelem.ref
-		IL_0062: stloc.2
-		IL_0063: newobj instance void Modules.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L3C59/FunctionObject::.ctor()
-		IL_0068: ldc.i4.1
-		IL_0069: conv.r8
-		IL_006a: ldstr ""
-		IL_006f: ldc.i4.0
-		IL_0070: ldc.i4.0
-		IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L3C59/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L3C59/FunctionObject>(!!0)
-		IL_007b: stloc.s 4
-		IL_007d: ldloc.1
-		IL_007e: ldstr "then"
-		IL_0083: ldloc.s 4
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008a: pop
-		IL_008b: ret
+		IL_0044: volatile.
+		IL_0046: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_004b: brfalse IL_0061
+
+		IL_0050: ldloc.1
+		IL_0051: ldstr "then"
+		IL_0056: ldloc.3
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005c: br IL_0077
+
+		IL_0061: ldloc.1
+		IL_0062: ldstr "then"
+		IL_0067: ldloc.3
+		IL_0068: ldstr "Promise_Then_ReturnsResolvedPromise:Modules.Promise_Then_ReturnsResolvedPromise:__js_module_init__:10"
+		IL_006d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0077: stloc.1
+		IL_0078: ldloc.1
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007e: stloc.1
+		IL_007f: ldc.i4.1
+		IL_0080: newarr [System.Runtime]System.Object
+		IL_0085: dup
+		IL_0086: ldc.i4.0
+		IL_0087: ldloc.0
+		IL_0088: stelem.ref
+		IL_0089: stloc.2
+		IL_008a: newobj instance void Modules.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L3C59/FunctionObject::.ctor()
+		IL_008f: ldc.i4.1
+		IL_0090: conv.r8
+		IL_0091: ldstr ""
+		IL_0096: ldc.i4.0
+		IL_0097: ldc.i4.0
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L3C59/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Then_ReturnsResolvedPromise/ArrowFunction_L3C59/FunctionObject>(!!0)
+		IL_00a2: stloc.s 4
+		IL_00a4: volatile.
+		IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00ab: brfalse IL_00c2
+
+		IL_00b0: ldloc.1
+		IL_00b1: ldstr "then"
+		IL_00b6: ldloc.s 4
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bd: br IL_00d9
+
+		IL_00c2: ldloc.1
+		IL_00c3: ldstr "then"
+		IL_00c8: ldloc.s 4
+		IL_00ca: ldstr "Promise_Then_ReturnsResolvedPromise:Modules.Promise_Then_ReturnsResolvedPromise:__js_module_init__:14"
+		IL_00cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d9: pop
+		IL_00da: ret
 	} // end of method Promise_Then_ReturnsResolvedPromise::__js_module_init__
 
 } // end of class Modules.Promise_Then_ReturnsResolvedPromise
@@ -426,4 +452,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
@@ -572,7 +572,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 235 (0xeb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Nested/Scope,
@@ -659,12 +659,25 @@
 		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Nested/ArrowFunction_L15C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Thenable_Nested/ArrowFunction_L15C32/FunctionObject>(!!0)
 		IL_00b0: stloc.s 7
-		IL_00b2: ldloc.s 6
-		IL_00b4: ldstr "then"
-		IL_00b9: ldloc.s 7
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_00b2: volatile.
+		IL_00b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00b9: brfalse IL_00d1
+
+		IL_00be: ldloc.s 6
+		IL_00c0: ldstr "then"
+		IL_00c5: ldloc.s 7
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cc: br IL_00e9
+
+		IL_00d1: ldloc.s 6
+		IL_00d3: ldstr "then"
+		IL_00d8: ldloc.s 7
+		IL_00da: ldstr "Promise_Thenable_Nested:Modules.Promise_Thenable_Nested:__js_module_init__:22"
+		IL_00df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00e9: pop
+		IL_00ea: ret
 	} // end of method Promise_Thenable_Nested::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Nested
@@ -689,4 +702,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_6
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_NonFunctionThen.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_NonFunctionThen.verified.txt
@@ -183,7 +183,7 @@
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_000d: brfalse IL_0022
 
 			IL_0012: ldarg.1
@@ -194,7 +194,7 @@
 			IL_0022: ldarg.1
 			IL_0023: ldstr "then"
 			IL_0028: ldstr "Promise_Thenable_NonFunctionThen:<TwoPhaseDummy_M4>:__js_call__:3"
-			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0037: stloc.1
@@ -242,7 +242,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 137 (0x89)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_NonFunctionThen/Scope,
@@ -281,12 +281,25 @@
 		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_NonFunctionThen/ArrowFunction_L5C27/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Thenable_NonFunctionThen/ArrowFunction_L5C27/FunctionObject>(!!0)
 		IL_0050: stloc.s 4
-		IL_0052: ldloc.2
-		IL_0053: ldstr "then"
-		IL_0058: ldloc.s 4
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0052: volatile.
+		IL_0054: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0059: brfalse IL_0070
+
+		IL_005e: ldloc.2
+		IL_005f: ldstr "then"
+		IL_0064: ldloc.s 4
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006b: br IL_0087
+
+		IL_0070: ldloc.2
+		IL_0071: ldstr "then"
+		IL_0076: ldloc.s 4
+		IL_0078: ldstr "Promise_Thenable_NonFunctionThen:Modules.Promise_Thenable_NonFunctionThen:__js_module_init__:12"
+		IL_007d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0087: pop
+		IL_0088: ret
 	} // end of method Promise_Thenable_NonFunctionThen::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_NonFunctionThen
@@ -317,6 +330,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Reject.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Reject.verified.txt
@@ -385,7 +385,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 123 (0x7b)
+		// Code size: 164 (0xa4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Reject/Scope,
@@ -441,12 +441,25 @@
 		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Reject/ArrowFunction_L9C33/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Thenable_Reject/ArrowFunction_L9C33/FunctionObject>(!!0)
 		IL_0069: stloc.s 5
-		IL_006b: ldloc.s 4
-		IL_006d: ldstr "catch"
-		IL_0072: ldloc.s 5
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0079: pop
-		IL_007a: ret
+		IL_006b: volatile.
+		IL_006d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0072: brfalse IL_008a
+
+		IL_0077: ldloc.s 4
+		IL_0079: ldstr "catch"
+		IL_007e: ldloc.s 5
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0085: br IL_00a2
+
+		IL_008a: ldloc.s 4
+		IL_008c: ldstr "catch"
+		IL_0091: ldloc.s 5
+		IL_0093: ldstr "Promise_Thenable_Reject:Modules.Promise_Thenable_Reject:__js_module_init__:15"
+		IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a2: pop
+		IL_00a3: ret
 	} // end of method Promise_Thenable_Reject::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Reject
@@ -471,4 +484,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Delayed.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Delayed.verified.txt
@@ -622,7 +622,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Resolve_Delayed/Scope,
@@ -682,12 +682,25 @@
 		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Delayed/ArrowFunction_L12C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Thenable_Resolve_Delayed/ArrowFunction_L12C32/FunctionObject>(!!0)
 		IL_0071: stloc.s 5
-		IL_0073: ldloc.s 4
-		IL_0075: ldstr "then"
-		IL_007a: ldloc.s 5
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: pop
-		IL_0082: ret
+		IL_0073: volatile.
+		IL_0075: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_007a: brfalse IL_0092
+
+		IL_007f: ldloc.s 4
+		IL_0081: ldstr "then"
+		IL_0086: ldloc.s 5
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008d: br IL_00aa
+
+		IL_0092: ldloc.s 4
+		IL_0094: ldstr "then"
+		IL_0099: ldloc.s 5
+		IL_009b: ldstr "Promise_Thenable_Resolve_Delayed:Modules.Promise_Thenable_Resolve_Delayed:__js_module_init__:15"
+		IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method Promise_Thenable_Resolve_Delayed::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Resolve_Delayed
@@ -712,4 +725,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_8
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Immediate.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Immediate.verified.txt
@@ -386,7 +386,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 123 (0x7b)
+		// Code size: 164 (0xa4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Resolve_Immediate/Scope,
@@ -442,12 +442,25 @@
 		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Immediate/ArrowFunction_L9C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Thenable_Resolve_Immediate/ArrowFunction_L9C32/FunctionObject>(!!0)
 		IL_0069: stloc.s 5
-		IL_006b: ldloc.s 4
-		IL_006d: ldstr "then"
-		IL_0072: ldloc.s 5
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0079: pop
-		IL_007a: ret
+		IL_006b: volatile.
+		IL_006d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0072: brfalse IL_008a
+
+		IL_0077: ldloc.s 4
+		IL_0079: ldstr "then"
+		IL_007e: ldloc.s 5
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0085: br IL_00a2
+
+		IL_008a: ldloc.s 4
+		IL_008c: ldstr "then"
+		IL_0091: ldloc.s 5
+		IL_0093: ldstr "Promise_Thenable_Resolve_Immediate:Modules.Promise_Thenable_Resolve_Immediate:__js_module_init__:15"
+		IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a2: pop
+		IL_00a3: ret
 	} // end of method Promise_Thenable_Resolve_Immediate::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Resolve_Immediate
@@ -472,4 +485,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
@@ -501,7 +501,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 295 (0x127)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Returned_FromHandler/Scope,
@@ -566,36 +566,62 @@
 		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Returned_FromHandler/ArrowFunction_L9C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Thenable_Returned_FromHandler/ArrowFunction_L9C26/FunctionObject>(!!0)
 		IL_0085: stloc.s 5
-		IL_0087: ldloc.s 4
-		IL_0089: ldstr "then"
-		IL_008e: ldloc.s 5
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.s 4
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009e: stloc.s 4
-		IL_00a0: ldc.i4.1
-		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: dup
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldloc.0
-		IL_00a9: stelem.ref
-		IL_00aa: stloc.2
-		IL_00ab: newobj instance void Modules.Promise_Thenable_Returned_FromHandler/ArrowFunction_L9C47/FunctionObject::.ctor()
-		IL_00b0: ldc.i4.1
-		IL_00b1: conv.r8
-		IL_00b2: ldstr ""
-		IL_00b7: ldc.i4.0
-		IL_00b8: ldc.i4.0
-		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Returned_FromHandler/ArrowFunction_L9C47/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Thenable_Returned_FromHandler/ArrowFunction_L9C47/FunctionObject>(!!0)
-		IL_00c3: stloc.s 6
-		IL_00c5: ldloc.s 4
-		IL_00c7: ldstr "then"
-		IL_00cc: ldloc.s 6
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ret
+		IL_0087: volatile.
+		IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_008e: brfalse IL_00a6
+
+		IL_0093: ldloc.s 4
+		IL_0095: ldstr "then"
+		IL_009a: ldloc.s 5
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a1: br IL_00be
+
+		IL_00a6: ldloc.s 4
+		IL_00a8: ldstr "then"
+		IL_00ad: ldloc.s 5
+		IL_00af: ldstr "Promise_Thenable_Returned_FromHandler:Modules.Promise_Thenable_Returned_FromHandler:__js_module_init__:17"
+		IL_00b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00be: stloc.s 4
+		IL_00c0: ldloc.s 4
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c7: stloc.s 4
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldloc.0
+		IL_00d2: stelem.ref
+		IL_00d3: stloc.2
+		IL_00d4: newobj instance void Modules.Promise_Thenable_Returned_FromHandler/ArrowFunction_L9C47/FunctionObject::.ctor()
+		IL_00d9: ldc.i4.1
+		IL_00da: conv.r8
+		IL_00db: ldstr ""
+		IL_00e0: ldc.i4.0
+		IL_00e1: ldc.i4.0
+		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Returned_FromHandler/ArrowFunction_L9C47/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Thenable_Returned_FromHandler/ArrowFunction_L9C47/FunctionObject>(!!0)
+		IL_00ec: stloc.s 6
+		IL_00ee: volatile.
+		IL_00f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00f5: brfalse IL_010d
+
+		IL_00fa: ldloc.s 4
+		IL_00fc: ldstr "then"
+		IL_0101: ldloc.s 6
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0108: br IL_0125
+
+		IL_010d: ldloc.s 4
+		IL_010f: ldstr "then"
+		IL_0114: ldloc.s 6
+		IL_0116: ldstr "Promise_Thenable_Returned_FromHandler:Modules.Promise_Thenable_Returned_FromHandler:__js_module_init__:21"
+		IL_011b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0125: pop
+		IL_0126: ret
 	} // end of method Promise_Thenable_Returned_FromHandler::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Returned_FromHandler
@@ -620,4 +646,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Idempotent.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Idempotent.verified.txt
@@ -351,7 +351,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 191 (0xbf)
+		// Code size: 359 (0x167)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_WithResolvers_Idempotent/Scope,
@@ -391,52 +391,104 @@
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_WithResolvers_Idempotent/ArrowFunction_L6C11/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_WithResolvers_Idempotent/ArrowFunction_L6C11/FunctionObject>(!!0)
 		IL_003f: stloc.s 5
-		IL_0041: ldloc.3
-		IL_0042: ldstr "then"
-		IL_0047: ldloc.s 5
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004e: stloc.3
-		IL_004f: ldloc.3
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0055: stloc.3
-		IL_0056: ldc.i4.1
-		IL_0057: newarr [System.Runtime]System.Object
-		IL_005c: dup
-		IL_005d: ldc.i4.0
-		IL_005e: ldloc.0
-		IL_005f: stelem.ref
-		IL_0060: stloc.s 4
-		IL_0062: newobj instance void Modules.Promise_WithResolvers_Idempotent/ArrowFunction_L7C12/FunctionObject::.ctor()
-		IL_0067: ldc.i4.1
-		IL_0068: conv.r8
-		IL_0069: ldstr ""
-		IL_006e: ldc.i4.0
-		IL_006f: ldc.i4.0
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_WithResolvers_Idempotent/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_WithResolvers_Idempotent/ArrowFunction_L7C12/FunctionObject>(!!0)
-		IL_007a: stloc.s 6
-		IL_007c: ldloc.3
-		IL_007d: ldstr "catch"
-		IL_0082: ldloc.s 6
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0089: pop
-		IL_008a: ldloc.1
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
-		IL_0090: stloc.s 7
-		IL_0092: ldloc.s 7
-		IL_0094: ldstr "resolve"
-		IL_0099: ldstr "first"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a3: pop
-		IL_00a4: ldloc.1
-		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
-		IL_00aa: stloc.s 7
-		IL_00ac: ldloc.s 7
-		IL_00ae: ldstr "reject"
-		IL_00b3: ldstr "second"
+		IL_0041: volatile.
+		IL_0043: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0048: brfalse IL_005f
+
+		IL_004d: ldloc.3
+		IL_004e: ldstr "then"
+		IL_0053: ldloc.s 5
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005a: br IL_0076
+
+		IL_005f: ldloc.3
+		IL_0060: ldstr "then"
+		IL_0065: ldloc.s 5
+		IL_0067: ldstr "Promise_WithResolvers_Idempotent:Modules.Promise_WithResolvers_Idempotent:__js_module_init__:12"
+		IL_006c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0076: stloc.3
+		IL_0077: ldloc.3
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007d: stloc.3
+		IL_007e: ldc.i4.1
+		IL_007f: newarr [System.Runtime]System.Object
+		IL_0084: dup
+		IL_0085: ldc.i4.0
+		IL_0086: ldloc.0
+		IL_0087: stelem.ref
+		IL_0088: stloc.s 4
+		IL_008a: newobj instance void Modules.Promise_WithResolvers_Idempotent/ArrowFunction_L7C12/FunctionObject::.ctor()
+		IL_008f: ldc.i4.1
+		IL_0090: conv.r8
+		IL_0091: ldstr ""
+		IL_0096: ldc.i4.0
+		IL_0097: ldc.i4.0
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_WithResolvers_Idempotent/ArrowFunction_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_WithResolvers_Idempotent/ArrowFunction_L7C12/FunctionObject>(!!0)
+		IL_00a2: stloc.s 6
+		IL_00a4: volatile.
+		IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00ab: brfalse IL_00c2
+
+		IL_00b0: ldloc.3
+		IL_00b1: ldstr "catch"
+		IL_00b6: ldloc.s 6
 		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bd: pop
-		IL_00be: ret
+		IL_00bd: br IL_00d9
+
+		IL_00c2: ldloc.3
+		IL_00c3: ldstr "catch"
+		IL_00c8: ldloc.s 6
+		IL_00ca: ldstr "Promise_WithResolvers_Idempotent:Modules.Promise_WithResolvers_Idempotent:__js_module_init__:16"
+		IL_00cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d9: pop
+		IL_00da: ldloc.1
+		IL_00db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
+		IL_00e0: stloc.s 7
+		IL_00e2: volatile.
+		IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_00e9: brfalse IL_0104
+
+		IL_00ee: ldloc.s 7
+		IL_00f0: ldstr "resolve"
+		IL_00f5: ldstr "first"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ff: br IL_011f
+
+		IL_0104: ldloc.s 7
+		IL_0106: ldstr "resolve"
+		IL_010b: ldstr "first"
+		IL_0110: ldstr "Promise_WithResolvers_Idempotent:Modules.Promise_WithResolvers_Idempotent:__js_module_init__:20"
+		IL_0115: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_011f: pop
+		IL_0120: ldloc.1
+		IL_0121: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
+		IL_0126: stloc.s 7
+		IL_0128: volatile.
+		IL_012a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_012f: brfalse IL_014a
+
+		IL_0134: ldloc.s 7
+		IL_0136: ldstr "reject"
+		IL_013b: ldstr "second"
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0145: br IL_0165
+
+		IL_014a: ldloc.s 7
+		IL_014c: ldstr "reject"
+		IL_0151: ldstr "second"
+		IL_0156: ldstr "Promise_WithResolvers_Idempotent:Modules.Promise_WithResolvers_Idempotent:__js_module_init__:24"
+		IL_015b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0165: pop
+		IL_0166: ret
 	} // end of method Promise_WithResolvers_Idempotent::__js_module_init__
 
 } // end of class Modules.Promise_WithResolvers_Idempotent
@@ -461,4 +513,15 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Reject.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Reject.verified.txt
@@ -221,7 +221,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 106 (0x6a)
+		// Code size: 190 (0xbe)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_WithResolvers_Reject/Scope,
@@ -260,20 +260,46 @@
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_WithResolvers_Reject/ArrowFunction_L5C17/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_WithResolvers_Reject/ArrowFunction_L5C17/FunctionObject>(!!0)
 		IL_003f: stloc.s 5
-		IL_0041: ldloc.3
-		IL_0042: ldstr "catch"
-		IL_0047: ldloc.s 5
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004e: pop
-		IL_004f: ldloc.1
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
-		IL_0055: stloc.s 6
-		IL_0057: ldloc.s 6
-		IL_0059: ldstr "reject"
-		IL_005e: ldstr "rejected"
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0068: pop
-		IL_0069: ret
+		IL_0041: volatile.
+		IL_0043: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0048: brfalse IL_005f
+
+		IL_004d: ldloc.3
+		IL_004e: ldstr "catch"
+		IL_0053: ldloc.s 5
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005a: br IL_0076
+
+		IL_005f: ldloc.3
+		IL_0060: ldstr "catch"
+		IL_0065: ldloc.s 5
+		IL_0067: ldstr "Promise_WithResolvers_Reject:Modules.Promise_WithResolvers_Reject:__js_module_init__:12"
+		IL_006c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0076: pop
+		IL_0077: ldloc.1
+		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
+		IL_007d: stloc.s 6
+		IL_007f: volatile.
+		IL_0081: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0086: brfalse IL_00a1
+
+		IL_008b: ldloc.s 6
+		IL_008d: ldstr "reject"
+		IL_0092: ldstr "rejected"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009c: br IL_00bc
+
+		IL_00a1: ldloc.s 6
+		IL_00a3: ldstr "reject"
+		IL_00a8: ldstr "rejected"
+		IL_00ad: ldstr "Promise_WithResolvers_Reject:Modules.Promise_WithResolvers_Reject:__js_module_init__:16"
+		IL_00b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00bc: pop
+		IL_00bd: ret
 	} // end of method Promise_WithResolvers_Reject::__js_module_init__
 
 } // end of class Modules.Promise_WithResolvers_Reject
@@ -298,4 +324,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Resolve.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_WithResolvers_Resolve.verified.txt
@@ -221,7 +221,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 106 (0x6a)
+		// Code size: 190 (0xbe)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_WithResolvers_Resolve/Scope,
@@ -260,20 +260,46 @@
 		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_WithResolvers_Resolve/ArrowFunction_L5C16/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_WithResolvers_Resolve/ArrowFunction_L5C16/FunctionObject>(!!0)
 		IL_003f: stloc.s 5
-		IL_0041: ldloc.3
-		IL_0042: ldstr "then"
-		IL_0047: ldloc.s 5
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004e: pop
-		IL_004f: ldloc.1
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
-		IL_0055: stloc.s 6
-		IL_0057: ldloc.s 6
-		IL_0059: ldstr "resolve"
-		IL_005e: ldstr "resolved"
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0068: pop
-		IL_0069: ret
+		IL_0041: volatile.
+		IL_0043: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0048: brfalse IL_005f
+
+		IL_004d: ldloc.3
+		IL_004e: ldstr "then"
+		IL_0053: ldloc.s 5
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_005a: br IL_0076
+
+		IL_005f: ldloc.3
+		IL_0060: ldstr "then"
+		IL_0065: ldloc.s 5
+		IL_0067: ldstr "Promise_WithResolvers_Resolve:Modules.Promise_WithResolvers_Resolve:__js_module_init__:12"
+		IL_006c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0076: pop
+		IL_0077: ldloc.1
+		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers>(!!0)
+		IL_007d: stloc.s 6
+		IL_007f: volatile.
+		IL_0081: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0086: brfalse IL_00a1
+
+		IL_008b: ldloc.s 6
+		IL_008d: ldstr "resolve"
+		IL_0092: ldstr "resolved"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009c: br IL_00bc
+
+		IL_00a1: ldloc.s 6
+		IL_00a3: ldstr "resolve"
+		IL_00a8: ldstr "resolved"
+		IL_00ad: ldstr "Promise_WithResolvers_Resolve:Modules.Promise_WithResolvers_Resolve:__js_module_init__:16"
+		IL_00b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00bc: pop
+		IL_00bd: ret
 	} // end of method Promise_WithResolvers_Resolve::__js_module_init__
 
 } // end of class Modules.Promise_WithResolvers_Resolve
@@ -298,4 +324,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
@@ -506,7 +506,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_0007: brfalse IL_001c
 
 			IL_000c: ldarg.2
@@ -517,7 +517,7 @@
 			IL_001c: ldarg.2
 			IL_001d: ldstr "marker"
 			IL_0022: ldstr "Proxy_OwnKeys_And_PrototypeTraps_WithFallback:<TwoPhaseDummy_M6>:__js_call__:4"
-			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0031: stloc.0
@@ -573,7 +573,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 748 (0x2ec)
+		// Code size: 832 (0x340)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope,
@@ -635,44 +635,37 @@
 		IL_0065: ldloc.1
 		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0070: ldstr "join"
-		IL_0075: ldstr ","
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007f: stloc.s 12
-		IL_0081: ldloc.s 11
-		IL_0083: ldloc.s 12
-		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008a: pop
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0090: dup
-		IL_0091: ldstr "marker"
-		IL_0096: ldstr "trapProto"
-		IL_009b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00a0: stloc.s 10
-		IL_00a2: ldloc.0
-		IL_00a3: ldloc.s 10
-		IL_00a5: stfld object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope::trappedPrototype
-		IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00af: stloc.2
-		IL_00b0: ldc.i4.1
-		IL_00b1: newarr [System.Runtime]System.Object
-		IL_00b6: dup
-		IL_00b7: ldc.i4.0
-		IL_00b8: ldloc.0
-		IL_00b9: stelem.ref
-		IL_00ba: stloc.s 8
-		IL_00bc: ldloc.s 8
-		IL_00be: ldc.i4.0
-		IL_00bf: ldelem.ref
-		IL_00c0: castclass Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope
-		IL_00c5: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject::.ctor(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope)
-		IL_00ca: ldc.i4.0
-		IL_00cb: conv.r8
-		IL_00cc: ldstr ""
-		IL_00d1: ldc.i4.0
-		IL_00d2: ldc.i4.1
-		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00d8: stloc.s 13
+		IL_0070: volatile.
+		IL_0072: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0077: brfalse IL_0090
+
+		IL_007c: ldstr "join"
+		IL_0081: ldstr ","
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008b: br IL_00a9
+
+		IL_0090: ldstr "join"
+		IL_0095: ldstr ","
+		IL_009a: ldstr "Proxy_OwnKeys_And_PrototypeTraps_WithFallback:Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback:__js_module_init__:16"
+		IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a9: stloc.s 12
+		IL_00ab: ldloc.s 11
+		IL_00ad: ldloc.s 12
+		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b4: pop
+		IL_00b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00ba: dup
+		IL_00bb: ldstr "marker"
+		IL_00c0: ldstr "trapProto"
+		IL_00c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00ca: stloc.s 10
+		IL_00cc: ldloc.0
+		IL_00cd: ldloc.s 10
+		IL_00cf: stfld object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope::trappedPrototype
+		IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00d9: stloc.2
 		IL_00da: ldc.i4.1
 		IL_00db: newarr [System.Runtime]System.Object
 		IL_00e0: dup
@@ -680,167 +673,198 @@
 		IL_00e2: ldloc.0
 		IL_00e3: stelem.ref
 		IL_00e4: stloc.s 8
-		IL_00e6: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject::.ctor()
-		IL_00eb: ldc.i4.2
-		IL_00ec: conv.r8
-		IL_00ed: ldstr ""
-		IL_00f2: ldc.i4.0
-		IL_00f3: ldc.i4.1
-		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00f9: stloc.s 14
-		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0100: dup
-		IL_0101: ldstr "getPrototypeOf"
-		IL_0106: ldloc.s 13
-		IL_0108: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_010d: dup
-		IL_010e: ldstr "setPrototypeOf"
-		IL_0113: ldloc.s 14
-		IL_0115: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_011a: stloc.s 10
-		IL_011c: ldloc.2
-		IL_011d: ldloc.s 10
-		IL_011f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0124: stloc.3
-		IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012a: stloc.s 11
-		IL_012c: ldloc.3
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0132: volatile.
-		IL_0134: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0139: brfalse IL_014d
+		IL_00e6: ldloc.s 8
+		IL_00e8: ldc.i4.0
+		IL_00e9: ldelem.ref
+		IL_00ea: castclass Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope
+		IL_00ef: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject::.ctor(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope)
+		IL_00f4: ldc.i4.0
+		IL_00f5: conv.r8
+		IL_00f6: ldstr ""
+		IL_00fb: ldc.i4.0
+		IL_00fc: ldc.i4.1
+		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0102: stloc.s 13
+		IL_0104: ldc.i4.1
+		IL_0105: newarr [System.Runtime]System.Object
+		IL_010a: dup
+		IL_010b: ldc.i4.0
+		IL_010c: ldloc.0
+		IL_010d: stelem.ref
+		IL_010e: stloc.s 8
+		IL_0110: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject::.ctor()
+		IL_0115: ldc.i4.2
+		IL_0116: conv.r8
+		IL_0117: ldstr ""
+		IL_011c: ldc.i4.0
+		IL_011d: ldc.i4.1
+		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0123: stloc.s 14
+		IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_012a: dup
+		IL_012b: ldstr "getPrototypeOf"
+		IL_0130: ldloc.s 13
+		IL_0132: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0137: dup
+		IL_0138: ldstr "setPrototypeOf"
+		IL_013d: ldloc.s 14
+		IL_013f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0144: stloc.s 10
+		IL_0146: ldloc.2
+		IL_0147: ldloc.s 10
+		IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_014e: stloc.3
+		IL_014f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0154: stloc.s 11
+		IL_0156: ldloc.3
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_015c: volatile.
+		IL_015e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0163: brfalse IL_0177
 
-		IL_013e: ldstr "marker"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0148: br IL_0161
+		IL_0168: ldstr "marker"
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0172: br IL_018b
 
-		IL_014d: ldstr "marker"
-		IL_0152: ldstr "Proxy_OwnKeys_And_PrototypeTraps_WithFallback:Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback:__js_module_init__:37"
-		IL_0157: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0177: ldstr "marker"
+		IL_017c: ldstr "Proxy_OwnKeys_And_PrototypeTraps_WithFallback:Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback:__js_module_init__:37"
+		IL_0181: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0161: stloc.s 12
-		IL_0163: ldloc.s 11
-		IL_0165: ldloc.s 12
-		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_016c: pop
-		IL_016d: ldloc.3
-		IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0173: dup
-		IL_0174: ldstr "marker"
-		IL_0179: ldstr "setTrap"
-		IL_017e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_0188: pop
-		IL_0189: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018e: stloc.s 11
-		IL_0190: volatile.
-		IL_0192: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0197: brfalse IL_01ac
+		IL_018b: stloc.s 12
+		IL_018d: ldloc.s 11
+		IL_018f: ldloc.s 12
+		IL_0191: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0196: pop
+		IL_0197: ldloc.3
+		IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_019d: dup
+		IL_019e: ldstr "marker"
+		IL_01a3: ldstr "setTrap"
+		IL_01a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_01b2: pop
+		IL_01b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b8: stloc.s 11
+		IL_01ba: volatile.
+		IL_01bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01c1: brfalse IL_01d6
 
-		IL_019c: ldloc.2
-		IL_019d: ldstr "protoMarker"
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a7: br IL_01c1
+		IL_01c6: ldloc.2
+		IL_01c7: ldstr "protoMarker"
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d1: br IL_01eb
 
-		IL_01ac: ldloc.2
-		IL_01ad: ldstr "protoMarker"
-		IL_01b2: ldstr "Proxy_OwnKeys_And_PrototypeTraps_WithFallback:Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback:__js_module_init__:46"
-		IL_01b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01d6: ldloc.2
+		IL_01d7: ldstr "protoMarker"
+		IL_01dc: ldstr "Proxy_OwnKeys_And_PrototypeTraps_WithFallback:Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback:__js_module_init__:46"
+		IL_01e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01c1: stloc.s 12
-		IL_01c3: ldloc.s 11
-		IL_01c5: ldloc.s 12
-		IL_01c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01cc: pop
-		IL_01cd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01d2: stloc.s 4
-		IL_01d4: ldloc.s 4
-		IL_01d6: ldstr "b"
-		IL_01db: ldc.r8 2
-		IL_01e4: ldc.i4.1
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_01ea: pop
-		IL_01eb: ldloc.s 4
-		IL_01ed: ldstr "a"
-		IL_01f2: ldc.r8 1
-		IL_01fb: ldc.i4.1
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0201: pop
-		IL_0202: ldloc.s 4
-		IL_0204: ldc.r8 0.0
-		IL_020d: ldc.r8 0.0
-		IL_0216: ldc.i4.1
-		IL_0217: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-		IL_021c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0221: dup
-		IL_0222: ldstr "from"
-		IL_0227: ldstr "fallbackProto"
-		IL_022c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0231: stloc.s 5
-		IL_0233: ldloc.s 4
-		IL_0235: ldloc.s 5
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_023c: pop
-		IL_023d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0242: stloc.s 10
-		IL_0244: ldloc.s 4
-		IL_0246: ldloc.s 10
-		IL_0248: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_024d: stloc.s 6
-		IL_024f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0254: stloc.s 11
-		IL_0256: ldloc.s 6
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0262: ldstr "join"
-		IL_0267: ldstr ","
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0271: stloc.s 12
-		IL_0273: ldloc.s 11
-		IL_0275: ldloc.s 12
-		IL_0277: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_027c: pop
-		IL_027d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0282: stloc.s 11
-		IL_0284: ldloc.s 6
-		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_028b: stloc.s 12
-		IL_028d: ldloc.s 12
-		IL_028f: ldloc.s 5
-		IL_0291: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0296: stloc.s 15
-		IL_0298: ldloc.s 15
-		IL_029a: box [System.Runtime]System.Boolean
-		IL_029f: stloc.s 16
-		IL_02a1: ldloc.s 11
-		IL_02a3: ldloc.s 16
-		IL_02a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02aa: pop
-		IL_02ab: ldloc.s 6
-		IL_02ad: ldc.i4.0
-		IL_02ae: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_02b8: pop
-		IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02be: stloc.s 11
-		IL_02c0: ldloc.s 4
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_02c7: stloc.s 12
+		IL_01eb: stloc.s 12
+		IL_01ed: ldloc.s 11
+		IL_01ef: ldloc.s 12
+		IL_01f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f6: pop
+		IL_01f7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01fc: stloc.s 4
+		IL_01fe: ldloc.s 4
+		IL_0200: ldstr "b"
+		IL_0205: ldc.r8 2
+		IL_020e: ldc.i4.1
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0214: pop
+		IL_0215: ldloc.s 4
+		IL_0217: ldstr "a"
+		IL_021c: ldc.r8 1
+		IL_0225: ldc.i4.1
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_022b: pop
+		IL_022c: ldloc.s 4
+		IL_022e: ldc.r8 0.0
+		IL_0237: ldc.r8 0.0
+		IL_0240: ldc.i4.1
+		IL_0241: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+		IL_0246: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_024b: dup
+		IL_024c: ldstr "from"
+		IL_0251: ldstr "fallbackProto"
+		IL_0256: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_025b: stloc.s 5
+		IL_025d: ldloc.s 4
+		IL_025f: ldloc.s 5
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0266: pop
+		IL_0267: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_026c: stloc.s 10
+		IL_026e: ldloc.s 4
+		IL_0270: ldloc.s 10
+		IL_0272: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0277: stloc.s 6
+		IL_0279: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_027e: stloc.s 11
+		IL_0280: ldloc.s 6
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028c: volatile.
+		IL_028e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0293: brfalse IL_02ac
+
+		IL_0298: ldstr "join"
+		IL_029d: ldstr ","
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a7: br IL_02c5
+
+		IL_02ac: ldstr "join"
+		IL_02b1: ldstr ","
+		IL_02b6: ldstr "Proxy_OwnKeys_And_PrototypeTraps_WithFallback:Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback:__js_module_init__:78"
+		IL_02bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02c5: stloc.s 12
+		IL_02c7: ldloc.s 11
 		IL_02c9: ldloc.s 12
-		IL_02cb: ldc.i4.0
-		IL_02cc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_02d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02d6: stloc.s 15
-		IL_02d8: ldloc.s 15
-		IL_02da: box [System.Runtime]System.Boolean
-		IL_02df: stloc.s 16
-		IL_02e1: ldloc.s 11
-		IL_02e3: ldloc.s 16
-		IL_02e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ea: pop
-		IL_02eb: ret
+		IL_02cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d0: pop
+		IL_02d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d6: stloc.s 11
+		IL_02d8: ldloc.s 6
+		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_02df: stloc.s 12
+		IL_02e1: ldloc.s 12
+		IL_02e3: ldloc.s 5
+		IL_02e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02ea: stloc.s 15
+		IL_02ec: ldloc.s 15
+		IL_02ee: box [System.Runtime]System.Boolean
+		IL_02f3: stloc.s 16
+		IL_02f5: ldloc.s 11
+		IL_02f7: ldloc.s 16
+		IL_02f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02fe: pop
+		IL_02ff: ldloc.s 6
+		IL_0301: ldc.i4.0
+		IL_0302: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_030c: pop
+		IL_030d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0312: stloc.s 11
+		IL_0314: ldloc.s 4
+		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_031b: stloc.s 12
+		IL_031d: ldloc.s 12
+		IL_031f: ldc.i4.0
+		IL_0320: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0325: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_032a: stloc.s 15
+		IL_032c: ldloc.s 15
+		IL_032e: box [System.Runtime]System.Boolean
+		IL_0333: stloc.s 16
+		IL_0335: ldloc.s 11
+		IL_0337: ldloc.s 16
+		IL_0339: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_033e: pop
+		IL_033f: ret
 	} // end of method Proxy_OwnKeys_And_PrototypeTraps_WithFallback::__js_module_init__
 
 } // end of class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback
@@ -873,6 +897,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -1523,7 +1523,7 @@
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
 			// Header size: 12
-			// Code size: 85 (0x55)
+			// Code size: 127 (0x7f)
 			.maxstack 10
 			.locals init (
 				[0] object
@@ -1550,12 +1550,24 @@
 			IL_003c: stloc.0
 			IL_003d: ldloc.0
 			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0043: ldstr "join"
-			IL_0048: ldstr ","
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0052: stloc.0
-			IL_0053: ldloc.0
-			IL_0054: ret
+			IL_0043: volatile.
+			IL_0045: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_004a: brfalse IL_0063
+
+			IL_004f: ldstr "join"
+			IL_0054: ldstr ","
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_005e: br IL_007c
+
+			IL_0063: ldstr "join"
+			IL_0068: ldstr ","
+			IL_006d: ldstr "Proxy_Revocable_ThrowsAfterRevoke:<TwoPhaseDummy_M11>:__js_call__:7"
+			IL_0072: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_007c: stloc.0
+			IL_007d: ldloc.0
+			IL_007e: ret
 		} // end of method FunctionExpression_L32C17::__js_call__
 
 	} // end of class FunctionExpression_L32C17
@@ -1707,7 +1719,7 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_000d: brfalse IL_0021
 
 			IL_0012: ldstr "proxy"
@@ -1716,7 +1728,7 @@
 
 			IL_0021: ldstr "proxy"
 			IL_0026: ldstr "Proxy_Revocable_ThrowsAfterRevoke:<TwoPhaseDummy_M12>:__js_call__:3"
-			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0035: stloc.0
@@ -1874,7 +1886,7 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 			IL_000d: brfalse IL_0021
 
 			IL_0012: ldstr "proxy"
@@ -1883,7 +1895,7 @@
 
 			IL_0021: ldstr "proxy"
 			IL_0026: ldstr "Proxy_Revocable_ThrowsAfterRevoke:<TwoPhaseDummy_M13>:__js_call__:3"
-			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0035: stloc.0
@@ -2180,7 +2192,7 @@
 				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
 			// Header size: 12
-			// Code size: 38 (0x26)
+			// Code size: 89 (0x59)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -2189,13 +2201,26 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000b: ldstr "proxy"
-			IL_0010: ldc.r8 1
-			IL_0019: box [System.Runtime]System.Double
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0023: stloc.0
-			IL_0024: ldloc.0
-			IL_0025: ret
+			IL_000b: volatile.
+			IL_000d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0012: brfalse IL_0034
+
+			IL_0017: ldstr "proxy"
+			IL_001c: ldc.r8 1
+			IL_0025: box [System.Runtime]System.Double
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_002f: br IL_0056
+
+			IL_0034: ldstr "proxy"
+			IL_0039: ldc.r8 1
+			IL_0042: box [System.Runtime]System.Double
+			IL_0047: ldstr "Proxy_Revocable_ThrowsAfterRevoke:<TwoPhaseDummy_M15>:__js_call__:5"
+			IL_004c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0056: stloc.0
+			IL_0057: ldloc.0
+			IL_0058: ret
 		} // end of method FunctionExpression_L40C17::__js_call__
 
 	} // end of class FunctionExpression_L40C17
@@ -2511,7 +2536,7 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 			IL_000d: brfalse IL_0021
 
 			IL_0012: ldstr "proxy"
@@ -2520,7 +2545,7 @@
 
 			IL_0021: ldstr "proxy"
 			IL_0026: ldstr "Proxy_Revocable_ThrowsAfterRevoke:<TwoPhaseDummy_M17>:__js_call__:3"
-			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0035: stloc.0
@@ -3156,6 +3181,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_30
 	.field assembly static int32 __jroc_dynamicLookup_31
 	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -340,7 +340,7 @@
 				IL_0077: call string [System.Runtime]System.String::Concat(string, string)
 				IL_007c: stloc.s 6
 				IL_007e: volatile.
-				IL_0080: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_0080: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 				IL_0085: brfalse IL_009a
 
 				IL_008a: ldloc.3
@@ -351,7 +351,7 @@
 				IL_009a: ldloc.3
 				IL_009b: ldstr "name"
 				IL_00a0: ldstr "Proxy_Validation_EdgeCases:<TwoPhaseDummy_M4>:__js_call__:28"
-				IL_00a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+				IL_00a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_00af: stloc.s 8
@@ -2988,7 +2988,7 @@
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Code size: 85 (0x55)
 			.maxstack 9
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
@@ -3004,12 +3004,24 @@
 			IL_0012: stloc.1
 			IL_0013: ldloc.1
 			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: ldstr "join"
-			IL_001e: ldstr ","
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0028: stloc.1
-			IL_0029: ldloc.1
-			IL_002a: ret
+			IL_0019: volatile.
+			IL_001b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0020: brfalse IL_0039
+
+			IL_0025: ldstr "join"
+			IL_002a: ldstr ","
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0034: br IL_0052
+
+			IL_0039: ldstr "join"
+			IL_003e: ldstr ","
+			IL_0043: ldstr "Proxy_Validation_EdgeCases:<TwoPhaseDummy_M22>:__js_call__:5"
+			IL_0048: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0052: stloc.1
+			IL_0053: ldloc.1
+			IL_0054: ret
 		} // end of method FunctionExpression_L98C25::__js_call__
 
 	} // end of class FunctionExpression_L98C25
@@ -3288,7 +3300,7 @@
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Code size: 85 (0x55)
 			.maxstack 9
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
@@ -3304,12 +3316,24 @@
 			IL_0012: stloc.1
 			IL_0013: ldloc.1
 			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0019: ldstr "join"
-			IL_001e: ldstr ","
-			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0028: stloc.1
-			IL_0029: ldloc.1
-			IL_002a: ret
+			IL_0019: volatile.
+			IL_001b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0020: brfalse IL_0039
+
+			IL_0025: ldstr "join"
+			IL_002a: ldstr ","
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0034: br IL_0052
+
+			IL_0039: ldstr "join"
+			IL_003e: ldstr ","
+			IL_0043: ldstr "Proxy_Validation_EdgeCases:<TwoPhaseDummy_M24>:__js_call__:5"
+			IL_0048: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0052: stloc.1
+			IL_0053: ldloc.1
+			IL_0054: ret
 		} // end of method FunctionExpression_L108C21::__js_call__
 
 	} // end of class FunctionExpression_L108C21
@@ -3372,7 +3396,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1547 (0x60b)
+		// Code size: 1631 (0x65f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Validation_EdgeCases/Scope,
@@ -3852,173 +3876,197 @@
 		IL_0446: ldloc.3
 		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
 		IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0451: ldstr "join"
-		IL_0456: ldstr ","
-		IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0460: stloc.s 23
-		IL_0462: ldloc.s 22
-		IL_0464: ldloc.s 23
-		IL_0466: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_046b: pop
-		IL_046c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0471: stloc.s 13
-		IL_0473: ldc.i4.1
-		IL_0474: newarr [System.Runtime]System.Object
-		IL_0479: dup
-		IL_047a: ldc.i4.0
-		IL_047b: ldloc.0
-		IL_047c: stelem.ref
-		IL_047d: stloc.s 5
-		IL_047f: ldloc.s 5
-		IL_0481: ldc.i4.0
-		IL_0482: ldelem.ref
-		IL_0483: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0488: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_048d: ldc.i4.0
-		IL_048e: conv.r8
-		IL_048f: ldstr ""
-		IL_0494: ldc.i4.0
-		IL_0495: ldc.i4.1
-		IL_0496: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_049b: stloc.s 29
-		IL_049d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04a2: dup
-		IL_04a3: ldstr "ownKeys"
-		IL_04a8: ldloc.s 29
-		IL_04aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_04af: stloc.s 11
-		IL_04b1: ldloc.s 13
-		IL_04b3: ldloc.s 11
-		IL_04b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_04ba: stloc.s 4
-		IL_04bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04c1: stloc.s 22
-		IL_04c3: ldloc.s 4
-		IL_04c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04cf: ldstr "join"
-		IL_04d4: ldstr ","
-		IL_04d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04de: stloc.s 23
-		IL_04e0: ldloc.s 22
-		IL_04e2: ldloc.s 23
-		IL_04e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04e9: pop
-		IL_04ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04ef: stloc.s 11
-		IL_04f1: ldc.i4.1
-		IL_04f2: newarr [System.Runtime]System.Object
-		IL_04f7: dup
-		IL_04f8: ldc.i4.0
-		IL_04f9: ldloc.0
-		IL_04fa: stelem.ref
-		IL_04fb: stloc.s 5
-		IL_04fd: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject::.ctor()
-		IL_0502: ldc.i4.0
-		IL_0503: conv.r8
-		IL_0504: ldstr ""
-		IL_0509: ldc.i4.0
-		IL_050a: ldc.i4.1
-		IL_050b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0510: stloc.s 30
-		IL_0512: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0517: dup
-		IL_0518: ldstr "ownKeys"
-		IL_051d: ldloc.s 30
-		IL_051f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0524: stloc.s 13
-		IL_0526: ldloc.s 11
-		IL_0528: ldloc.s 13
-		IL_052a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_052f: stloc.s 14
-		IL_0531: ldloc.0
-		IL_0532: ldloc.s 14
-		IL_0534: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
-		IL_0539: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_053e: stloc.s 5
-		IL_0540: ldc.i4.1
-		IL_0541: newarr [System.Runtime]System.Object
-		IL_0546: dup
-		IL_0547: ldc.i4.0
-		IL_0548: ldloc.0
-		IL_0549: stelem.ref
-		IL_054a: stloc.s 6
-		IL_054c: ldloc.s 6
-		IL_054e: ldc.i4.0
-		IL_054f: ldelem.ref
-		IL_0550: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0555: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_055a: ldc.i4.0
-		IL_055b: conv.r8
-		IL_055c: ldstr ""
-		IL_0561: ldc.i4.0
-		IL_0562: ldc.i4.1
-		IL_0563: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0568: stloc.s 31
-		IL_056a: ldloc.1
-		IL_056b: ldloc.s 5
-		IL_056d: ldstr "ownKeys-primitive"
-		IL_0572: ldloc.s 31
-		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0579: pop
-		IL_057a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_057f: stloc.s 13
-		IL_0581: ldc.i4.1
-		IL_0582: newarr [System.Runtime]System.Object
-		IL_0587: dup
-		IL_0588: ldc.i4.0
-		IL_0589: ldloc.0
-		IL_058a: stelem.ref
-		IL_058b: stloc.s 5
-		IL_058d: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject::.ctor()
-		IL_0592: ldc.i4.0
-		IL_0593: conv.r8
-		IL_0594: ldstr ""
-		IL_0599: ldc.i4.0
-		IL_059a: ldc.i4.1
-		IL_059b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05a0: stloc.s 32
-		IL_05a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_05a7: dup
-		IL_05a8: ldstr "ownKeys"
-		IL_05ad: ldloc.s 32
-		IL_05af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_05b4: stloc.s 11
-		IL_05b6: ldloc.s 13
-		IL_05b8: ldloc.s 11
-		IL_05ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_05bf: stloc.s 14
-		IL_05c1: ldloc.0
-		IL_05c2: ldloc.s 14
-		IL_05c4: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
-		IL_05c9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05ce: stloc.s 5
-		IL_05d0: ldc.i4.1
-		IL_05d1: newarr [System.Runtime]System.Object
-		IL_05d6: dup
-		IL_05d7: ldc.i4.0
-		IL_05d8: ldloc.0
-		IL_05d9: stelem.ref
-		IL_05da: stloc.s 6
-		IL_05dc: ldloc.s 6
-		IL_05de: ldc.i4.0
-		IL_05df: ldelem.ref
-		IL_05e0: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_05e5: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_05ea: ldc.i4.0
-		IL_05eb: conv.r8
-		IL_05ec: ldstr ""
-		IL_05f1: ldc.i4.0
-		IL_05f2: ldc.i4.1
-		IL_05f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05f8: stloc.s 33
-		IL_05fa: ldloc.1
-		IL_05fb: ldloc.s 5
-		IL_05fd: ldstr "ownKeys-entry"
-		IL_0602: ldloc.s 33
-		IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0609: pop
-		IL_060a: ret
+		IL_0451: volatile.
+		IL_0453: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0458: brfalse IL_0471
+
+		IL_045d: ldstr "join"
+		IL_0462: ldstr ","
+		IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_046c: br IL_048a
+
+		IL_0471: ldstr "join"
+		IL_0476: ldstr ","
+		IL_047b: ldstr "Proxy_Validation_EdgeCases:Modules.Proxy_Validation_EdgeCases:__js_module_init__:111"
+		IL_0480: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_048a: stloc.s 23
+		IL_048c: ldloc.s 22
+		IL_048e: ldloc.s 23
+		IL_0490: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0495: pop
+		IL_0496: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_049b: stloc.s 13
+		IL_049d: ldc.i4.1
+		IL_049e: newarr [System.Runtime]System.Object
+		IL_04a3: dup
+		IL_04a4: ldc.i4.0
+		IL_04a5: ldloc.0
+		IL_04a6: stelem.ref
+		IL_04a7: stloc.s 5
+		IL_04a9: ldloc.s 5
+		IL_04ab: ldc.i4.0
+		IL_04ac: ldelem.ref
+		IL_04ad: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_04b2: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_04b7: ldc.i4.0
+		IL_04b8: conv.r8
+		IL_04b9: ldstr ""
+		IL_04be: ldc.i4.0
+		IL_04bf: ldc.i4.1
+		IL_04c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04c5: stloc.s 29
+		IL_04c7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04cc: dup
+		IL_04cd: ldstr "ownKeys"
+		IL_04d2: ldloc.s 29
+		IL_04d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_04d9: stloc.s 11
+		IL_04db: ldloc.s 13
+		IL_04dd: ldloc.s 11
+		IL_04df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_04e4: stloc.s 4
+		IL_04e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04eb: stloc.s 22
+		IL_04ed: ldloc.s 4
+		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04f9: volatile.
+		IL_04fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0500: brfalse IL_0519
+
+		IL_0505: ldstr "join"
+		IL_050a: ldstr ","
+		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0514: br IL_0532
+
+		IL_0519: ldstr "join"
+		IL_051e: ldstr ","
+		IL_0523: ldstr "Proxy_Validation_EdgeCases:Modules.Proxy_Validation_EdgeCases:__js_module_init__:125"
+		IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0532: stloc.s 23
+		IL_0534: ldloc.s 22
+		IL_0536: ldloc.s 23
+		IL_0538: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_053d: pop
+		IL_053e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0543: stloc.s 11
+		IL_0545: ldc.i4.1
+		IL_0546: newarr [System.Runtime]System.Object
+		IL_054b: dup
+		IL_054c: ldc.i4.0
+		IL_054d: ldloc.0
+		IL_054e: stelem.ref
+		IL_054f: stloc.s 5
+		IL_0551: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject::.ctor()
+		IL_0556: ldc.i4.0
+		IL_0557: conv.r8
+		IL_0558: ldstr ""
+		IL_055d: ldc.i4.0
+		IL_055e: ldc.i4.1
+		IL_055f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0564: stloc.s 30
+		IL_0566: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_056b: dup
+		IL_056c: ldstr "ownKeys"
+		IL_0571: ldloc.s 30
+		IL_0573: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0578: stloc.s 13
+		IL_057a: ldloc.s 11
+		IL_057c: ldloc.s 13
+		IL_057e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0583: stloc.s 14
+		IL_0585: ldloc.0
+		IL_0586: ldloc.s 14
+		IL_0588: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
+		IL_058d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0592: stloc.s 5
+		IL_0594: ldc.i4.1
+		IL_0595: newarr [System.Runtime]System.Object
+		IL_059a: dup
+		IL_059b: ldc.i4.0
+		IL_059c: ldloc.0
+		IL_059d: stelem.ref
+		IL_059e: stloc.s 6
+		IL_05a0: ldloc.s 6
+		IL_05a2: ldc.i4.0
+		IL_05a3: ldelem.ref
+		IL_05a4: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_05a9: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_05ae: ldc.i4.0
+		IL_05af: conv.r8
+		IL_05b0: ldstr ""
+		IL_05b5: ldc.i4.0
+		IL_05b6: ldc.i4.1
+		IL_05b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05bc: stloc.s 31
+		IL_05be: ldloc.1
+		IL_05bf: ldloc.s 5
+		IL_05c1: ldstr "ownKeys-primitive"
+		IL_05c6: ldloc.s 31
+		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_05cd: pop
+		IL_05ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_05d3: stloc.s 13
+		IL_05d5: ldc.i4.1
+		IL_05d6: newarr [System.Runtime]System.Object
+		IL_05db: dup
+		IL_05dc: ldc.i4.0
+		IL_05dd: ldloc.0
+		IL_05de: stelem.ref
+		IL_05df: stloc.s 5
+		IL_05e1: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject::.ctor()
+		IL_05e6: ldc.i4.0
+		IL_05e7: conv.r8
+		IL_05e8: ldstr ""
+		IL_05ed: ldc.i4.0
+		IL_05ee: ldc.i4.1
+		IL_05ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05f4: stloc.s 32
+		IL_05f6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_05fb: dup
+		IL_05fc: ldstr "ownKeys"
+		IL_0601: ldloc.s 32
+		IL_0603: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0608: stloc.s 11
+		IL_060a: ldloc.s 13
+		IL_060c: ldloc.s 11
+		IL_060e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0613: stloc.s 14
+		IL_0615: ldloc.0
+		IL_0616: ldloc.s 14
+		IL_0618: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
+		IL_061d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0622: stloc.s 5
+		IL_0624: ldc.i4.1
+		IL_0625: newarr [System.Runtime]System.Object
+		IL_062a: dup
+		IL_062b: ldc.i4.0
+		IL_062c: ldloc.0
+		IL_062d: stelem.ref
+		IL_062e: stloc.s 6
+		IL_0630: ldloc.s 6
+		IL_0632: ldc.i4.0
+		IL_0633: ldelem.ref
+		IL_0634: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0639: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_063e: ldc.i4.0
+		IL_063f: conv.r8
+		IL_0640: ldstr ""
+		IL_0645: ldc.i4.0
+		IL_0646: ldc.i4.1
+		IL_0647: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_064c: stloc.s 33
+		IL_064e: ldloc.1
+		IL_064f: ldloc.s 5
+		IL_0651: ldstr "ownKeys-entry"
+		IL_0656: ldloc.s 33
+		IL_0658: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_065d: pop
+		IL_065e: ret
 	} // end of method Proxy_Validation_EdgeCases::__js_module_init__
 
 } // end of class Modules.Proxy_Validation_EdgeCases
@@ -4049,6 +4097,10 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
@@ -609,7 +609,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1060 (0x424)
+		// Code size: 1455 (0x5af)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Algebra_Methods/Scope,
@@ -666,325 +666,455 @@
 		IL_0071: stloc.2
 		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0077: stloc.s 9
-		IL_0079: ldloc.1
-		IL_007a: ldstr "difference"
-		IL_007f: ldloc.2
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0085: stloc.s 10
-		IL_0087: ldloc.s 10
-		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_008e: ldc.i4.1
-		IL_008f: newarr [System.Runtime]System.Object
-		IL_0094: dup
-		IL_0095: ldc.i4.0
-		IL_0096: ldstr ","
-		IL_009b: stelem.ref
-		IL_009c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00a1: stloc.s 11
-		IL_00a3: ldloc.s 9
-		IL_00a5: ldloc.s 11
-		IL_00a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ac: pop
-		IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b2: stloc.s 9
-		IL_00b4: ldloc.1
-		IL_00b5: ldstr "intersection"
-		IL_00ba: ldloc.2
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c0: stloc.s 10
-		IL_00c2: ldloc.s 10
-		IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_00c9: ldc.i4.1
-		IL_00ca: newarr [System.Runtime]System.Object
-		IL_00cf: dup
-		IL_00d0: ldc.i4.0
-		IL_00d1: ldstr ","
-		IL_00d6: stelem.ref
-		IL_00d7: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00dc: stloc.s 11
-		IL_00de: ldloc.s 9
-		IL_00e0: ldloc.s 11
-		IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e7: pop
-		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ed: stloc.s 9
-		IL_00ef: ldloc.1
-		IL_00f0: ldstr "union"
-		IL_00f5: ldloc.2
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fb: stloc.s 10
-		IL_00fd: ldloc.s 10
-		IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0104: ldc.i4.1
-		IL_0105: newarr [System.Runtime]System.Object
-		IL_010a: dup
-		IL_010b: ldc.i4.0
-		IL_010c: ldstr ","
-		IL_0111: stelem.ref
-		IL_0112: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0117: stloc.s 11
-		IL_0119: ldloc.s 9
-		IL_011b: ldloc.s 11
-		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0122: pop
-		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0128: stloc.s 9
-		IL_012a: ldloc.1
-		IL_012b: ldstr "symmetricDifference"
-		IL_0130: ldloc.2
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0136: stloc.s 10
-		IL_0138: ldloc.s 10
-		IL_013a: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_013f: ldc.i4.1
-		IL_0140: newarr [System.Runtime]System.Object
-		IL_0145: dup
-		IL_0146: ldc.i4.0
-		IL_0147: ldstr ","
-		IL_014c: stelem.ref
-		IL_014d: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0152: stloc.s 11
-		IL_0154: ldloc.s 9
-		IL_0156: ldloc.s 11
-		IL_0158: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015d: pop
-		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0163: stloc.s 9
-		IL_0165: ldc.i4.2
-		IL_0166: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_016b: dup
-		IL_016c: ldc.r8 4
-		IL_0175: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_017a: dup
-		IL_017b: ldc.r8 5
-		IL_0184: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0189: stloc.s 8
-		IL_018b: ldloc.s 8
-		IL_018d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_0192: stloc.s 12
-		IL_0194: ldloc.1
-		IL_0195: ldstr "isDisjointFrom"
-		IL_019a: ldloc.s 12
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a1: stloc.s 10
-		IL_01a3: ldloc.s 9
-		IL_01a5: ldloc.s 10
-		IL_01a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ac: pop
-		IL_01ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b2: stloc.s 9
-		IL_01b4: ldloc.1
-		IL_01b5: ldstr "isDisjointFrom"
-		IL_01ba: ldloc.2
-		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c0: stloc.s 10
-		IL_01c2: ldloc.s 9
-		IL_01c4: ldloc.s 10
-		IL_01c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01cb: pop
-		IL_01cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d1: stloc.s 9
-		IL_01d3: ldc.i4.2
-		IL_01d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01d9: dup
-		IL_01da: ldc.r8 1
-		IL_01e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01e8: dup
-		IL_01e9: ldc.r8 2
-		IL_01f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01f7: stloc.s 8
-		IL_01f9: ldloc.s 8
-		IL_01fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_0200: stloc.s 12
-		IL_0202: ldc.i4.3
-		IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0208: dup
-		IL_0209: ldc.r8 1
-		IL_0212: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0217: dup
-		IL_0218: ldc.r8 2
-		IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0226: dup
-		IL_0227: ldc.r8 3
-		IL_0230: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0235: stloc.s 8
-		IL_0237: ldloc.s 8
-		IL_0239: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_023e: stloc.s 13
-		IL_0240: ldloc.s 12
-		IL_0242: ldstr "isSubsetOf"
-		IL_0247: ldloc.s 13
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024e: stloc.s 10
-		IL_0250: ldloc.s 9
-		IL_0252: ldloc.s 10
-		IL_0254: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0259: pop
-		IL_025a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_025f: stloc.s 9
-		IL_0261: ldc.i4.2
-		IL_0262: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0267: dup
-		IL_0268: ldc.r8 1
-		IL_0271: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0276: dup
-		IL_0277: ldc.r8 3
-		IL_0280: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0285: stloc.s 8
-		IL_0287: ldloc.s 8
-		IL_0289: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_028e: stloc.s 13
-		IL_0290: ldloc.1
-		IL_0291: ldstr "isSupersetOf"
-		IL_0296: ldloc.s 13
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_029d: stloc.s 10
-		IL_029f: ldloc.s 9
-		IL_02a1: ldloc.s 10
-		IL_02a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02a8: pop
-		IL_02a9: ldc.i4.1
-		IL_02aa: newarr [System.Runtime]System.Object
-		IL_02af: dup
-		IL_02b0: ldc.i4.0
-		IL_02b1: ldloc.0
-		IL_02b2: stelem.ref
-		IL_02b3: stloc.s 14
-		IL_02b5: newobj instance void Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject::.ctor()
-		IL_02ba: ldc.i4.1
-		IL_02bb: conv.r8
-		IL_02bc: ldstr ""
-		IL_02c1: ldc.i4.0
-		IL_02c2: ldc.i4.1
-		IL_02c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02c8: stloc.s 15
-		IL_02ca: ldc.i4.1
-		IL_02cb: newarr [System.Runtime]System.Object
-		IL_02d0: dup
-		IL_02d1: ldc.i4.0
-		IL_02d2: ldloc.0
-		IL_02d3: stelem.ref
-		IL_02d4: stloc.s 14
-		IL_02d6: ldloc.s 14
-		IL_02d8: newobj instance void Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject::.ctor(object[])
-		IL_02dd: ldc.i4.0
-		IL_02de: conv.r8
-		IL_02df: ldstr ""
-		IL_02e4: ldc.i4.1
-		IL_02e5: ldc.i4.1
-		IL_02e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_02f0: castclass Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject
-		IL_02f5: stloc.s 16
-		IL_02f7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02fc: dup
-		IL_02fd: ldstr "size"
-		IL_0302: ldc.r8 2
-		IL_030b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0310: dup
-		IL_0311: ldstr "has"
-		IL_0316: ldloc.s 15
-		IL_0318: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_031d: dup
-		IL_031e: ldstr "keys"
-		IL_0323: ldloc.s 16
-		IL_0325: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_032a: stloc.3
-		IL_032b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0330: stloc.s 9
-		IL_0332: ldloc.1
-		IL_0333: ldstr "union"
-		IL_0338: ldloc.3
-		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_033e: stloc.s 10
-		IL_0340: ldloc.s 10
-		IL_0342: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0347: ldc.i4.1
-		IL_0348: newarr [System.Runtime]System.Object
-		IL_034d: dup
-		IL_034e: ldc.i4.0
-		IL_034f: ldstr ","
-		IL_0354: stelem.ref
-		IL_0355: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_035a: stloc.s 11
-		IL_035c: ldloc.s 9
-		IL_035e: ldloc.s 11
-		IL_0360: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0365: pop
+		IL_0079: volatile.
+		IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0080: brfalse IL_0096
+
+		IL_0085: ldloc.1
+		IL_0086: ldstr "difference"
+		IL_008b: ldloc.2
+		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0091: br IL_00ac
+
+		IL_0096: ldloc.1
+		IL_0097: ldstr "difference"
+		IL_009c: ldloc.2
+		IL_009d: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:18"
+		IL_00a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ac: stloc.s 10
+		IL_00ae: ldloc.s 10
+		IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_00b5: ldc.i4.1
+		IL_00b6: newarr [System.Runtime]System.Object
+		IL_00bb: dup
+		IL_00bc: ldc.i4.0
+		IL_00bd: ldstr ","
+		IL_00c2: stelem.ref
+		IL_00c3: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_00c8: stloc.s 11
+		IL_00ca: ldloc.s 9
+		IL_00cc: ldloc.s 11
+		IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d3: pop
+		IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d9: stloc.s 9
+		IL_00db: volatile.
+		IL_00dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00e2: brfalse IL_00f8
+
+		IL_00e7: ldloc.1
+		IL_00e8: ldstr "intersection"
+		IL_00ed: ldloc.2
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f3: br IL_010e
+
+		IL_00f8: ldloc.1
+		IL_00f9: ldstr "intersection"
+		IL_00fe: ldloc.2
+		IL_00ff: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:25"
+		IL_0104: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_010e: stloc.s 10
+		IL_0110: ldloc.s 10
+		IL_0112: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0117: ldc.i4.1
+		IL_0118: newarr [System.Runtime]System.Object
+		IL_011d: dup
+		IL_011e: ldc.i4.0
+		IL_011f: ldstr ","
+		IL_0124: stelem.ref
+		IL_0125: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_012a: stloc.s 11
+		IL_012c: ldloc.s 9
+		IL_012e: ldloc.s 11
+		IL_0130: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0135: pop
+		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013b: stloc.s 9
+		IL_013d: volatile.
+		IL_013f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0144: brfalse IL_015a
+
+		IL_0149: ldloc.1
+		IL_014a: ldstr "union"
+		IL_014f: ldloc.2
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0155: br IL_0170
+
+		IL_015a: ldloc.1
+		IL_015b: ldstr "union"
+		IL_0160: ldloc.2
+		IL_0161: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:32"
+		IL_0166: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0170: stloc.s 10
+		IL_0172: ldloc.s 10
+		IL_0174: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0179: ldc.i4.1
+		IL_017a: newarr [System.Runtime]System.Object
+		IL_017f: dup
+		IL_0180: ldc.i4.0
+		IL_0181: ldstr ","
+		IL_0186: stelem.ref
+		IL_0187: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_018c: stloc.s 11
+		IL_018e: ldloc.s 9
+		IL_0190: ldloc.s 11
+		IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0197: pop
+		IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019d: stloc.s 9
+		IL_019f: volatile.
+		IL_01a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01a6: brfalse IL_01bc
+
+		IL_01ab: ldloc.1
+		IL_01ac: ldstr "symmetricDifference"
+		IL_01b1: ldloc.2
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b7: br IL_01d2
+
+		IL_01bc: ldloc.1
+		IL_01bd: ldstr "symmetricDifference"
+		IL_01c2: ldloc.2
+		IL_01c3: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:39"
+		IL_01c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01d2: stloc.s 10
+		IL_01d4: ldloc.s 10
+		IL_01d6: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_01db: ldc.i4.1
+		IL_01dc: newarr [System.Runtime]System.Object
+		IL_01e1: dup
+		IL_01e2: ldc.i4.0
+		IL_01e3: ldstr ","
+		IL_01e8: stelem.ref
+		IL_01e9: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_01ee: stloc.s 11
+		IL_01f0: ldloc.s 9
+		IL_01f2: ldloc.s 11
+		IL_01f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f9: pop
+		IL_01fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ff: stloc.s 9
+		IL_0201: ldc.i4.2
+		IL_0202: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0207: dup
+		IL_0208: ldc.r8 4
+		IL_0211: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0216: dup
+		IL_0217: ldc.r8 5
+		IL_0220: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0225: stloc.s 8
+		IL_0227: ldloc.s 8
+		IL_0229: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_022e: stloc.s 12
+		IL_0230: volatile.
+		IL_0232: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0237: brfalse IL_024e
+
+		IL_023c: ldloc.1
+		IL_023d: ldstr "isDisjointFrom"
+		IL_0242: ldloc.s 12
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0249: br IL_0265
+
+		IL_024e: ldloc.1
+		IL_024f: ldstr "isDisjointFrom"
+		IL_0254: ldloc.s 12
+		IL_0256: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:50"
+		IL_025b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0265: stloc.s 10
+		IL_0267: ldloc.s 9
+		IL_0269: ldloc.s 10
+		IL_026b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0270: pop
+		IL_0271: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0276: stloc.s 9
+		IL_0278: volatile.
+		IL_027a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_027f: brfalse IL_0295
+
+		IL_0284: ldloc.1
+		IL_0285: ldstr "isDisjointFrom"
+		IL_028a: ldloc.2
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0290: br IL_02ab
+
+		IL_0295: ldloc.1
+		IL_0296: ldstr "isDisjointFrom"
+		IL_029b: ldloc.2
+		IL_029c: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:54"
+		IL_02a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02ab: stloc.s 10
+		IL_02ad: ldloc.s 9
+		IL_02af: ldloc.s 10
+		IL_02b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02b6: pop
+		IL_02b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02bc: stloc.s 9
+		IL_02be: ldc.i4.2
+		IL_02bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02c4: dup
+		IL_02c5: ldc.r8 1
+		IL_02ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02d3: dup
+		IL_02d4: ldc.r8 2
+		IL_02dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02e2: stloc.s 8
+		IL_02e4: ldloc.s 8
+		IL_02e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_02eb: stloc.s 12
+		IL_02ed: ldc.i4.3
+		IL_02ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02f3: dup
+		IL_02f4: ldc.r8 1
+		IL_02fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0302: dup
+		IL_0303: ldc.r8 2
+		IL_030c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0311: dup
+		IL_0312: ldc.r8 3
+		IL_031b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0320: stloc.s 8
+		IL_0322: ldloc.s 8
+		IL_0324: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_0329: stloc.s 13
+		IL_032b: volatile.
+		IL_032d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0332: brfalse IL_034a
+
+		IL_0337: ldloc.s 12
+		IL_0339: ldstr "isSubsetOf"
+		IL_033e: ldloc.s 13
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0345: br IL_0362
+
+		IL_034a: ldloc.s 12
+		IL_034c: ldstr "isSubsetOf"
+		IL_0351: ldloc.s 13
+		IL_0353: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:67"
+		IL_0358: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0362: stloc.s 10
+		IL_0364: ldloc.s 9
+		IL_0366: ldloc.s 10
+		IL_0368: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_036d: pop
+		IL_036e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0373: stloc.s 9
+		IL_0375: ldc.i4.2
+		IL_0376: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_037b: dup
+		IL_037c: ldc.r8 1
+		IL_0385: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_038a: dup
+		IL_038b: ldc.r8 3
+		IL_0394: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0399: stloc.s 8
+		IL_039b: ldloc.s 8
+		IL_039d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_03a2: stloc.s 13
+		IL_03a4: volatile.
+		IL_03a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_03ab: brfalse IL_03c2
+
+		IL_03b0: ldloc.1
+		IL_03b1: ldstr "isSupersetOf"
+		IL_03b6: ldloc.s 13
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03bd: br IL_03d9
+
+		IL_03c2: ldloc.1
+		IL_03c3: ldstr "isSupersetOf"
+		IL_03c8: ldloc.s 13
+		IL_03ca: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:75"
+		IL_03cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03d9: stloc.s 10
+		IL_03db: ldloc.s 9
+		IL_03dd: ldloc.s 10
+		IL_03df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03e4: pop
+		IL_03e5: ldc.i4.1
+		IL_03e6: newarr [System.Runtime]System.Object
+		IL_03eb: dup
+		IL_03ec: ldc.i4.0
+		IL_03ed: ldloc.0
+		IL_03ee: stelem.ref
+		IL_03ef: stloc.s 14
+		IL_03f1: newobj instance void Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject::.ctor()
+		IL_03f6: ldc.i4.1
+		IL_03f7: conv.r8
+		IL_03f8: ldstr ""
+		IL_03fd: ldc.i4.0
+		IL_03fe: ldc.i4.1
+		IL_03ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0404: stloc.s 15
+		IL_0406: ldc.i4.1
+		IL_0407: newarr [System.Runtime]System.Object
+		IL_040c: dup
+		IL_040d: ldc.i4.0
+		IL_040e: ldloc.0
+		IL_040f: stelem.ref
+		IL_0410: stloc.s 14
+		IL_0412: ldloc.s 14
+		IL_0414: newobj instance void Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject::.ctor(object[])
+		IL_0419: ldc.i4.0
+		IL_041a: conv.r8
+		IL_041b: ldstr ""
+		IL_0420: ldc.i4.1
+		IL_0421: ldc.i4.1
+		IL_0422: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
+		IL_042c: castclass Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject
+		IL_0431: stloc.s 16
+		IL_0433: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0438: dup
+		IL_0439: ldstr "size"
+		IL_043e: ldc.r8 2
+		IL_0447: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_044c: dup
+		IL_044d: ldstr "has"
+		IL_0452: ldloc.s 15
+		IL_0454: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0459: dup
+		IL_045a: ldstr "keys"
+		IL_045f: ldloc.s 16
+		IL_0461: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0466: stloc.3
+		IL_0467: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_046c: stloc.s 9
+		IL_046e: volatile.
+		IL_0470: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0475: brfalse IL_048b
+
+		IL_047a: ldloc.1
+		IL_047b: ldstr "union"
+		IL_0480: ldloc.3
+		IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0486: br IL_04a1
+
+		IL_048b: ldloc.1
+		IL_048c: ldstr "union"
+		IL_0491: ldloc.3
+		IL_0492: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:87"
+		IL_0497: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_04a1: stloc.s 10
+		IL_04a3: ldloc.s 10
+		IL_04a5: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_04aa: ldc.i4.1
+		IL_04ab: newarr [System.Runtime]System.Object
+		IL_04b0: dup
+		IL_04b1: ldc.i4.0
+		IL_04b2: ldstr ","
+		IL_04b7: stelem.ref
+		IL_04b8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_04bd: stloc.s 11
+		IL_04bf: ldloc.s 9
+		IL_04c1: ldloc.s 11
+		IL_04c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04c8: pop
 		.try
 		{
-			IL_0366: nop
-			IL_0367: ldc.i4.2
-			IL_0368: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_036d: dup
-			IL_036e: ldc.r8 3
-			IL_0377: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_037c: dup
-			IL_037d: ldc.r8 4
-			IL_0386: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_038b: stloc.s 8
-			IL_038d: ldloc.1
-			IL_038e: ldstr "union"
-			IL_0393: ldloc.s 8
-			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_039a: pop
-			IL_039b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03a0: stloc.s 9
-			IL_03a2: ldloc.s 9
-			IL_03a4: ldstr "array did not throw"
-			IL_03a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03ae: pop
-			IL_03af: leave IL_0420
+			IL_04c9: nop
+			IL_04ca: ldc.i4.2
+			IL_04cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_04d0: dup
+			IL_04d1: ldc.r8 3
+			IL_04da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_04df: dup
+			IL_04e0: ldc.r8 4
+			IL_04e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_04ee: stloc.s 8
+			IL_04f0: volatile.
+			IL_04f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_04f7: brfalse IL_050e
+
+			IL_04fc: ldloc.1
+			IL_04fd: ldstr "union"
+			IL_0502: ldloc.s 8
+			IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0509: br IL_0525
+
+			IL_050e: ldloc.1
+			IL_050f: ldstr "union"
+			IL_0514: ldloc.s 8
+			IL_0516: ldstr "Set_Algebra_Methods:Modules.Set_Algebra_Methods:__js_module_init__:99"
+			IL_051b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0525: pop
+			IL_0526: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_052b: stloc.s 9
+			IL_052d: ldloc.s 9
+			IL_052f: ldstr "array did not throw"
+			IL_0534: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0539: pop
+			IL_053a: leave IL_05ab
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03b4: stloc.s 4
-			IL_03b6: ldloc.s 4
-			IL_03b8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03bd: dup
-			IL_03be: brtrue IL_03d4
+			IL_053f: stloc.s 4
+			IL_0541: ldloc.s 4
+			IL_0543: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0548: dup
+			IL_0549: brtrue IL_055f
 
-			IL_03c3: pop
-			IL_03c4: ldloc.s 4
-			IL_03c6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03cb: dup
-			IL_03cc: brtrue IL_03e0
+			IL_054e: pop
+			IL_054f: ldloc.s 4
+			IL_0551: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0556: dup
+			IL_0557: brtrue IL_056b
 
-			IL_03d1: pop
-			IL_03d2: rethrow
+			IL_055c: pop
+			IL_055d: rethrow
 
-			IL_03d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03d9: stloc.s 5
-			IL_03db: br IL_03e2
+			IL_055f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0564: stloc.s 5
+			IL_0566: br IL_056d
 
-			IL_03e0: stloc.s 5
+			IL_056b: stloc.s 5
 
-			IL_03e2: ldloc.s 5
-			IL_03e4: stloc.s 6
-			IL_03e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03eb: stloc.s 9
-			IL_03ed: ldloc.s 6
-			IL_03ef: stloc.s 10
-			IL_03f1: ldstr "TypeError"
-			IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03fb: stloc.s 17
-			IL_03fd: ldloc.s 10
-			IL_03ff: ldloc.s 17
-			IL_0401: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0406: stloc.s 18
-			IL_0408: ldloc.s 18
-			IL_040a: box [System.Runtime]System.Boolean
-			IL_040f: stloc.s 19
-			IL_0411: ldloc.s 9
-			IL_0413: ldloc.s 19
-			IL_0415: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_041a: pop
-			IL_041b: leave IL_0420
+			IL_056d: ldloc.s 5
+			IL_056f: stloc.s 6
+			IL_0571: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0576: stloc.s 9
+			IL_0578: ldloc.s 6
+			IL_057a: stloc.s 10
+			IL_057c: ldstr "TypeError"
+			IL_0581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0586: stloc.s 17
+			IL_0588: ldloc.s 10
+			IL_058a: ldloc.s 17
+			IL_058c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0591: stloc.s 18
+			IL_0593: ldloc.s 18
+			IL_0595: box [System.Runtime]System.Boolean
+			IL_059a: stloc.s 19
+			IL_059c: ldloc.s 9
+			IL_059e: ldloc.s 19
+			IL_05a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05a5: pop
+			IL_05a6: leave IL_05ab
 		} // end handler
 
-		IL_0420: ldnull
-		IL_0421: stloc.s 7
-		IL_0423: ret
+		IL_05ab: ldnull
+		IL_05ac: stloc.s 7
+		IL_05ae: ret
 	} // end of method Set_Algebra_Methods::__js_module_init__
 
 } // end of class Modules.Set_Algebra_Methods
@@ -1009,4 +1139,21 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
@@ -1794,7 +1794,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 785 (0x311)
+		// Code size: 1084 (0x43c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Constructor_Iterable/Scope,
@@ -1872,208 +1872,289 @@
 		IL_009e: pop
 		IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00a4: stloc.s 10
-		IL_00a6: ldloc.2
-		IL_00a7: ldstr "has"
-		IL_00ac: ldc.r8 1
-		IL_00b5: box [System.Runtime]System.Double
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bf: stloc.s 7
-		IL_00c1: ldloc.s 10
-		IL_00c3: ldloc.s 7
-		IL_00c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ca: pop
-		IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d0: stloc.s 10
-		IL_00d2: ldloc.2
-		IL_00d3: ldstr "has"
-		IL_00d8: ldc.r8 3
-		IL_00e1: box [System.Runtime]System.Double
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00eb: stloc.s 7
-		IL_00ed: ldloc.s 10
-		IL_00ef: ldloc.s 7
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f6: pop
-		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fc: stloc.s 10
-		IL_00fe: ldloc.2
-		IL_00ff: ldstr "has"
-		IL_0104: ldc.r8 4
-		IL_010d: box [System.Runtime]System.Double
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0117: stloc.s 7
-		IL_0119: ldloc.s 10
-		IL_011b: ldloc.s 7
-		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0122: pop
-		IL_0123: ldloc.0
-		IL_0124: ldc.i4.0
-		IL_0125: box [System.Runtime]System.Boolean
-		IL_012a: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_012f: ldstr "iterator"
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0139: stloc.s 7
-		IL_013b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0140: stloc.s 8
-		IL_0142: ldc.i4.1
-		IL_0143: newarr [System.Runtime]System.Object
-		IL_0148: dup
-		IL_0149: ldc.i4.0
-		IL_014a: ldloc.0
-		IL_014b: stelem.ref
-		IL_014c: stloc.s 9
-		IL_014e: ldloc.s 8
-		IL_0150: ldloc.s 7
-		IL_0152: ldloc.s 9
-		IL_0154: ldc.i4.0
-		IL_0155: ldelem.ref
-		IL_0156: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_015b: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope)
-		IL_0160: ldc.i4.0
-		IL_0161: conv.r8
-		IL_0162: ldstr ""
-		IL_0167: ldc.i4.0
-		IL_0168: ldc.i4.1
-		IL_0169: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_016e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0)
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0178: pop
-		IL_0179: ldloc.s 8
-		IL_017b: stloc.3
-		IL_017c: ldloc.3
-		IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
-		IL_0182: stloc.s 4
-		IL_0184: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0189: stloc.s 10
-		IL_018b: ldloc.0
-		IL_018c: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
-		IL_0191: stloc.s 7
-		IL_0193: ldloc.s 10
-		IL_0195: ldloc.s 7
-		IL_0197: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019c: pop
-		IL_019d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a2: stloc.s 10
-		IL_01a4: volatile.
-		IL_01a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_01ab: brfalse IL_01c1
+		IL_00a6: volatile.
+		IL_00a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_00ad: brfalse IL_00d0
 
-		IL_01b0: ldloc.s 4
-		IL_01b2: ldstr "size"
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01bc: br IL_01d7
+		IL_00b2: ldloc.2
+		IL_00b3: ldstr "has"
+		IL_00b8: ldc.r8 1
+		IL_00c1: box [System.Runtime]System.Double
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cb: br IL_00f3
 
-		IL_01c1: ldloc.s 4
-		IL_01c3: ldstr "size"
-		IL_01c8: ldstr "Set_Constructor_Iterable:Modules.Set_Constructor_Iterable:__js_module_init__:59"
-		IL_01cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00d0: ldloc.2
+		IL_00d1: ldstr "has"
+		IL_00d6: ldc.r8 1
+		IL_00df: box [System.Runtime]System.Double
+		IL_00e4: ldstr "Set_Constructor_Iterable:Modules.Set_Constructor_Iterable:__js_module_init__:23"
+		IL_00e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01d7: stloc.s 7
-		IL_01d9: ldloc.s 10
-		IL_01db: ldloc.s 7
-		IL_01dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e2: pop
-		IL_01e3: ldloc.0
-		IL_01e4: ldc.i4.0
-		IL_01e5: box [System.Runtime]System.Boolean
-		IL_01ea: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_01ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01f4: stloc.s 8
-		IL_01f6: ldloc.s 8
-		IL_01f8: ldstr "size"
-		IL_01fd: ldc.r8 2
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
-		IL_020b: pop
-		IL_020c: ldc.i4.1
-		IL_020d: newarr [System.Runtime]System.Object
-		IL_0212: dup
-		IL_0213: ldc.i4.0
-		IL_0214: ldloc.0
-		IL_0215: stelem.ref
-		IL_0216: stloc.s 9
-		IL_0218: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject::.ctor()
-		IL_021d: ldc.i4.1
-		IL_021e: conv.r8
-		IL_021f: ldstr ""
-		IL_0224: ldc.i4.0
-		IL_0225: ldc.i4.1
-		IL_0226: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject>(!!0)
-		IL_0230: stloc.s 11
-		IL_0232: ldloc.s 8
-		IL_0234: ldstr "has"
-		IL_0239: ldloc.s 11
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0240: pop
-		IL_0241: ldc.i4.1
-		IL_0242: newarr [System.Runtime]System.Object
-		IL_0247: dup
-		IL_0248: ldc.i4.0
-		IL_0249: ldloc.0
-		IL_024a: stelem.ref
-		IL_024b: stloc.s 9
-		IL_024d: ldloc.s 9
-		IL_024f: ldc.i4.0
-		IL_0250: ldelem.ref
-		IL_0251: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_0256: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope)
-		IL_025b: ldc.i4.0
-		IL_025c: conv.r8
-		IL_025d: ldstr ""
-		IL_0262: ldc.i4.0
-		IL_0263: ldc.i4.1
-		IL_0264: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0269: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject>(!!0)
-		IL_026e: stloc.s 12
-		IL_0270: ldloc.s 8
-		IL_0272: ldstr "keys"
-		IL_0277: ldloc.s 12
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_00f3: stloc.s 7
+		IL_00f5: ldloc.s 10
+		IL_00f7: ldloc.s 7
+		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fe: pop
+		IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0104: stloc.s 10
+		IL_0106: volatile.
+		IL_0108: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_010d: brfalse IL_0130
+
+		IL_0112: ldloc.2
+		IL_0113: ldstr "has"
+		IL_0118: ldc.r8 3
+		IL_0121: box [System.Runtime]System.Double
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012b: br IL_0153
+
+		IL_0130: ldloc.2
+		IL_0131: ldstr "has"
+		IL_0136: ldc.r8 3
+		IL_013f: box [System.Runtime]System.Double
+		IL_0144: ldstr "Set_Constructor_Iterable:Modules.Set_Constructor_Iterable:__js_module_init__:29"
+		IL_0149: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0153: stloc.s 7
+		IL_0155: ldloc.s 10
+		IL_0157: ldloc.s 7
+		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015e: pop
+		IL_015f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0164: stloc.s 10
+		IL_0166: volatile.
+		IL_0168: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_016d: brfalse IL_0190
+
+		IL_0172: ldloc.2
+		IL_0173: ldstr "has"
+		IL_0178: ldc.r8 4
+		IL_0181: box [System.Runtime]System.Double
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018b: br IL_01b3
+
+		IL_0190: ldloc.2
+		IL_0191: ldstr "has"
+		IL_0196: ldc.r8 4
+		IL_019f: box [System.Runtime]System.Double
+		IL_01a4: ldstr "Set_Constructor_Iterable:Modules.Set_Constructor_Iterable:__js_module_init__:35"
+		IL_01a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01b3: stloc.s 7
+		IL_01b5: ldloc.s 10
+		IL_01b7: ldloc.s 7
+		IL_01b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01be: pop
+		IL_01bf: ldloc.0
+		IL_01c0: ldc.i4.0
+		IL_01c1: box [System.Runtime]System.Boolean
+		IL_01c6: stfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_01cb: ldstr "iterator"
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_01d5: stloc.s 7
+		IL_01d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01dc: stloc.s 8
+		IL_01de: ldc.i4.1
+		IL_01df: newarr [System.Runtime]System.Object
+		IL_01e4: dup
+		IL_01e5: ldc.i4.0
+		IL_01e6: ldloc.0
+		IL_01e7: stelem.ref
+		IL_01e8: stloc.s 9
+		IL_01ea: ldloc.s 8
+		IL_01ec: ldloc.s 7
+		IL_01ee: ldloc.s 9
+		IL_01f0: ldc.i4.0
+		IL_01f1: ldelem.ref
+		IL_01f2: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_01f7: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope)
+		IL_01fc: ldc.i4.0
+		IL_01fd: conv.r8
+		IL_01fe: ldstr ""
+		IL_0203: ldc.i4.0
+		IL_0204: ldc.i4.1
+		IL_0205: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_020a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0)
+		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0214: pop
+		IL_0215: ldloc.s 8
+		IL_0217: stloc.3
+		IL_0218: ldloc.3
+		IL_0219: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor(object)
+		IL_021e: stloc.s 4
+		IL_0220: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0225: stloc.s 10
+		IL_0227: ldloc.0
+		IL_0228: ldfld object Modules.Set_Constructor_Iterable/Scope::closedOnNormalCompletion
+		IL_022d: stloc.s 7
+		IL_022f: ldloc.s 10
+		IL_0231: ldloc.s 7
+		IL_0233: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0238: pop
+		IL_0239: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023e: stloc.s 10
+		IL_0240: volatile.
+		IL_0242: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0247: brfalse IL_025d
+
+		IL_024c: ldloc.s 4
+		IL_024e: ldstr "size"
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0258: br IL_0273
+
+		IL_025d: ldloc.s 4
+		IL_025f: ldstr "size"
+		IL_0264: ldstr "Set_Constructor_Iterable:Modules.Set_Constructor_Iterable:__js_module_init__:59"
+		IL_0269: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0273: stloc.s 7
+		IL_0275: ldloc.s 10
+		IL_0277: ldloc.s 7
+		IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_027e: pop
-		IL_027f: ldloc.s 8
-		IL_0281: stloc.s 5
-		IL_0283: ldloc.s 4
-		IL_0285: ldstr "union"
-		IL_028a: ldloc.s 5
-		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0291: stloc.s 6
-		IL_0293: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0298: stloc.s 10
-		IL_029a: ldloc.0
-		IL_029b: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
-		IL_02a0: stloc.s 7
-		IL_02a2: ldloc.s 10
-		IL_02a4: ldloc.s 7
-		IL_02a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ab: pop
-		IL_02ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b1: stloc.s 10
-		IL_02b3: ldloc.s 6
-		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ba: ldstr "has"
-		IL_02bf: ldc.r8 4
-		IL_02c8: box [System.Runtime]System.Double
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d2: stloc.s 7
-		IL_02d4: ldloc.s 10
-		IL_02d6: ldloc.s 7
-		IL_02d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02dd: pop
-		IL_02de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02e3: stloc.s 10
-		IL_02e5: ldloc.s 6
-		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ec: ldstr "has"
-		IL_02f1: ldc.r8 6
-		IL_02fa: box [System.Runtime]System.Double
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0304: stloc.s 7
-		IL_0306: ldloc.s 10
-		IL_0308: ldloc.s 7
-		IL_030a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_030f: pop
-		IL_0310: ret
+		IL_027f: ldloc.0
+		IL_0280: ldc.i4.0
+		IL_0281: box [System.Runtime]System.Boolean
+		IL_0286: stfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_028b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0290: stloc.s 8
+		IL_0292: ldloc.s 8
+		IL_0294: ldstr "size"
+		IL_0299: ldc.r8 2
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
+		IL_02a7: pop
+		IL_02a8: ldc.i4.1
+		IL_02a9: newarr [System.Runtime]System.Object
+		IL_02ae: dup
+		IL_02af: ldc.i4.0
+		IL_02b0: ldloc.0
+		IL_02b1: stelem.ref
+		IL_02b2: stloc.s 9
+		IL_02b4: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject::.ctor()
+		IL_02b9: ldc.i4.1
+		IL_02ba: conv.r8
+		IL_02bb: ldstr ""
+		IL_02c0: ldc.i4.0
+		IL_02c1: ldc.i4.1
+		IL_02c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject>(!!0)
+		IL_02cc: stloc.s 11
+		IL_02ce: ldloc.s 8
+		IL_02d0: ldstr "has"
+		IL_02d5: ldloc.s 11
+		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_02dc: pop
+		IL_02dd: ldc.i4.1
+		IL_02de: newarr [System.Runtime]System.Object
+		IL_02e3: dup
+		IL_02e4: ldc.i4.0
+		IL_02e5: ldloc.0
+		IL_02e6: stelem.ref
+		IL_02e7: stloc.s 9
+		IL_02e9: ldloc.s 9
+		IL_02eb: ldc.i4.0
+		IL_02ec: ldelem.ref
+		IL_02ed: castclass Modules.Set_Constructor_Iterable/Scope
+		IL_02f2: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope)
+		IL_02f7: ldc.i4.0
+		IL_02f8: conv.r8
+		IL_02f9: ldstr ""
+		IL_02fe: ldc.i4.0
+		IL_02ff: ldc.i4.1
+		IL_0300: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0305: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject>(!!0)
+		IL_030a: stloc.s 12
+		IL_030c: ldloc.s 8
+		IL_030e: ldstr "keys"
+		IL_0313: ldloc.s 12
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_031a: pop
+		IL_031b: ldloc.s 8
+		IL_031d: stloc.s 5
+		IL_031f: volatile.
+		IL_0321: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0326: brfalse IL_033e
+
+		IL_032b: ldloc.s 4
+		IL_032d: ldstr "union"
+		IL_0332: ldloc.s 5
+		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0339: br IL_0356
+
+		IL_033e: ldloc.s 4
+		IL_0340: ldstr "union"
+		IL_0345: ldloc.s 5
+		IL_0347: ldstr "Set_Constructor_Iterable:Modules.Set_Constructor_Iterable:__js_module_init__:80"
+		IL_034c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0356: stloc.s 6
+		IL_0358: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_035d: stloc.s 10
+		IL_035f: ldloc.0
+		IL_0360: ldfld object Modules.Set_Constructor_Iterable/Scope::closedDuringNormalization
+		IL_0365: stloc.s 7
+		IL_0367: ldloc.s 10
+		IL_0369: ldloc.s 7
+		IL_036b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0370: pop
+		IL_0371: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0376: stloc.s 10
+		IL_0378: ldloc.s 6
+		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_037f: volatile.
+		IL_0381: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0386: brfalse IL_03a8
+
+		IL_038b: ldstr "has"
+		IL_0390: ldc.r8 4
+		IL_0399: box [System.Runtime]System.Double
+		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a3: br IL_03ca
+
+		IL_03a8: ldstr "has"
+		IL_03ad: ldc.r8 4
+		IL_03b6: box [System.Runtime]System.Double
+		IL_03bb: ldstr "Set_Constructor_Iterable:Modules.Set_Constructor_Iterable:__js_module_init__:91"
+		IL_03c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03ca: stloc.s 7
+		IL_03cc: ldloc.s 10
+		IL_03ce: ldloc.s 7
+		IL_03d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03d5: pop
+		IL_03d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03db: stloc.s 10
+		IL_03dd: ldloc.s 6
+		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03e4: volatile.
+		IL_03e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_03eb: brfalse IL_040d
+
+		IL_03f0: ldstr "has"
+		IL_03f5: ldc.r8 6
+		IL_03fe: box [System.Runtime]System.Double
+		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0408: br IL_042f
+
+		IL_040d: ldstr "has"
+		IL_0412: ldc.r8 6
+		IL_041b: box [System.Runtime]System.Double
+		IL_0420: ldstr "Set_Constructor_Iterable:Modules.Set_Constructor_Iterable:__js_module_init__:98"
+		IL_0425: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_042f: stloc.s 7
+		IL_0431: ldloc.s 10
+		IL_0433: ldloc.s 7
+		IL_0435: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_043a: pop
+		IL_043b: ret
 	} // end of method Set_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Set_Constructor_Iterable
@@ -2105,6 +2186,12 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_27
 	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
+	.field assembly static int32 __jroc_dynamicLookup_32
+	.field assembly static int32 __jroc_dynamicLookup_33
+	.field assembly static int32 __jroc_dynamicLookup_34
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Prototype_Surface.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Prototype_Surface.verified.txt
@@ -143,7 +143,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1984 (0x7c0)
+		// Code size: 2559 (0x9ff)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Constructor_Prototype_Surface/Scope,
@@ -209,554 +209,735 @@
 		IL_00ab: ldloc.s 11
 		IL_00ad: box [System.Runtime]System.Boolean
 		IL_00b2: stloc.s 12
-		IL_00b4: ldloc.s 8
-		IL_00b6: ldstr "log"
-		IL_00bb: ldloc.s 12
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c2: pop
-		IL_00c3: ldstr "console"
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d2: stloc.s 8
-		IL_00d4: ldstr "Set"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00de: volatile.
-		IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00e5: brfalse IL_00f9
+		IL_00b4: volatile.
+		IL_00b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00bb: brfalse IL_00d3
 
-		IL_00ea: ldstr "prototype"
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f4: br IL_010d
+		IL_00c0: ldloc.s 8
+		IL_00c2: ldstr "log"
+		IL_00c7: ldloc.s 12
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ce: br IL_00eb
 
-		IL_00f9: ldstr "prototype"
-		IL_00fe: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:35"
-		IL_0103: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00d3: ldloc.s 8
+		IL_00d5: ldstr "log"
+		IL_00da: ldloc.s 12
+		IL_00dc: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:27"
+		IL_00e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_010d: stloc.s 10
-		IL_010f: volatile.
-		IL_0111: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0116: brfalse IL_012c
+		IL_00eb: pop
+		IL_00ec: ldstr "console"
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fb: stloc.s 8
+		IL_00fd: ldstr "Set"
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0107: volatile.
+		IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_010e: brfalse IL_0122
 
-		IL_011b: ldloc.s 10
-		IL_011d: ldstr "constructor"
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0127: br IL_0142
+		IL_0113: ldstr "prototype"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011d: br IL_0136
 
-		IL_012c: ldloc.s 10
-		IL_012e: ldstr "constructor"
-		IL_0133: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:37"
-		IL_0138: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0122: ldstr "prototype"
+		IL_0127: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:35"
+		IL_012c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0142: stloc.s 10
-		IL_0144: ldstr "Set"
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_014e: stloc.s 9
-		IL_0150: ldloc.s 10
-		IL_0152: ldloc.s 9
-		IL_0154: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0159: stloc.s 11
-		IL_015b: ldloc.s 11
-		IL_015d: box [System.Runtime]System.Boolean
-		IL_0162: stloc.s 12
-		IL_0164: ldloc.s 8
-		IL_0166: ldstr "log"
-		IL_016b: ldloc.s 12
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0172: pop
-		IL_0173: ldstr "console"
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0182: stloc.s 8
-		IL_0184: ldstr "Set"
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_018e: stloc.s 9
-		IL_0190: ldstr "Function"
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_019a: stloc.s 10
-		IL_019c: ldloc.s 9
-		IL_019e: ldloc.s 10
-		IL_01a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_01a5: stloc.s 11
-		IL_01a7: ldloc.s 11
-		IL_01a9: box [System.Runtime]System.Boolean
-		IL_01ae: stloc.s 12
-		IL_01b0: ldloc.s 8
-		IL_01b2: ldstr "log"
-		IL_01b7: ldloc.s 12
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01be: pop
-		IL_01bf: ldstr "console"
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ce: stloc.s 8
-		IL_01d0: ldstr "Set"
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_01df: stloc.s 10
-		IL_01e1: ldstr "Function"
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01eb: volatile.
-		IL_01ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_01f2: brfalse IL_0206
+		IL_0136: stloc.s 10
+		IL_0138: volatile.
+		IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_013f: brfalse IL_0155
 
-		IL_01f7: ldstr "prototype"
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0201: br IL_021a
+		IL_0144: ldloc.s 10
+		IL_0146: ldstr "constructor"
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0150: br IL_016b
 
-		IL_0206: ldstr "prototype"
-		IL_020b: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:64"
-		IL_0210: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0155: ldloc.s 10
+		IL_0157: ldstr "constructor"
+		IL_015c: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:37"
+		IL_0161: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_021a: stloc.s 9
-		IL_021c: ldloc.s 10
-		IL_021e: ldloc.s 9
-		IL_0220: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0225: stloc.s 11
-		IL_0227: ldloc.s 11
-		IL_0229: box [System.Runtime]System.Boolean
-		IL_022e: stloc.s 12
-		IL_0230: ldloc.s 8
-		IL_0232: ldstr "log"
-		IL_0237: ldloc.s 12
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023e: pop
-		IL_023f: ldstr "console"
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024e: stloc.s 8
-		IL_0250: ldstr "Set"
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_025a: volatile.
-		IL_025c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0261: brfalse IL_0275
+		IL_016b: stloc.s 10
+		IL_016d: ldstr "Set"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0177: stloc.s 9
+		IL_0179: ldloc.s 10
+		IL_017b: ldloc.s 9
+		IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0182: stloc.s 11
+		IL_0184: ldloc.s 11
+		IL_0186: box [System.Runtime]System.Boolean
+		IL_018b: stloc.s 12
+		IL_018d: volatile.
+		IL_018f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0194: brfalse IL_01ac
 
-		IL_0266: ldstr "prototype"
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0270: br IL_0289
+		IL_0199: ldloc.s 8
+		IL_019b: ldstr "log"
+		IL_01a0: ldloc.s 12
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a7: br IL_01c4
 
-		IL_0275: ldstr "prototype"
-		IL_027a: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:75"
-		IL_027f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01ac: ldloc.s 8
+		IL_01ae: ldstr "log"
+		IL_01b3: ldloc.s 12
+		IL_01b5: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:42"
+		IL_01ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0289: stloc.s 9
-		IL_028b: ldloc.s 9
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0292: stloc.s 9
-		IL_0294: ldstr "Object"
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_029e: volatile.
-		IL_02a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02a5: brfalse IL_02b9
+		IL_01c4: pop
+		IL_01c5: ldstr "console"
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d4: stloc.s 8
+		IL_01d6: ldstr "Set"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01e0: stloc.s 9
+		IL_01e2: ldstr "Function"
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ec: stloc.s 10
+		IL_01ee: ldloc.s 9
+		IL_01f0: ldloc.s 10
+		IL_01f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_01f7: stloc.s 11
+		IL_01f9: ldloc.s 11
+		IL_01fb: box [System.Runtime]System.Boolean
+		IL_0200: stloc.s 12
+		IL_0202: volatile.
+		IL_0204: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0209: brfalse IL_0221
 
-		IL_02aa: ldstr "prototype"
-		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b4: br IL_02cd
+		IL_020e: ldloc.s 8
+		IL_0210: ldstr "log"
+		IL_0215: ldloc.s 12
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021c: br IL_0239
 
-		IL_02b9: ldstr "prototype"
-		IL_02be: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:80"
-		IL_02c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0221: ldloc.s 8
+		IL_0223: ldstr "log"
+		IL_0228: ldloc.s 12
+		IL_022a: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:53"
+		IL_022f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02cd: stloc.s 10
-		IL_02cf: ldloc.s 9
-		IL_02d1: ldloc.s 10
-		IL_02d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02d8: stloc.s 11
-		IL_02da: ldloc.s 11
-		IL_02dc: box [System.Runtime]System.Boolean
-		IL_02e1: stloc.s 12
-		IL_02e3: ldloc.s 8
-		IL_02e5: ldstr "log"
-		IL_02ea: ldloc.s 12
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02f1: pop
-		IL_02f2: ldstr "Set"
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02fc: ldstr "prototype"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0306: stloc.1
-		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_030c: stloc.s 8
-		IL_030e: ldloc.s 8
-		IL_0310: ldstr "descriptor"
-		IL_0315: ldloc.1
-		IL_0316: ldc.i4.0
-		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_031c: pop
-		IL_031d: ldstr "console"
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_032c: stloc.s 8
-		IL_032e: volatile.
-		IL_0330: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0335: brfalse IL_034a
+		IL_0239: pop
+		IL_023a: ldstr "console"
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0249: stloc.s 8
+		IL_024b: ldstr "Set"
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_025a: stloc.s 10
+		IL_025c: ldstr "Function"
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0266: volatile.
+		IL_0268: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_026d: brfalse IL_0281
 
-		IL_033a: ldloc.1
-		IL_033b: ldstr "writable"
-		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0345: br IL_035f
+		IL_0272: ldstr "prototype"
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_027c: br IL_0295
 
-		IL_034a: ldloc.1
-		IL_034b: ldstr "writable"
-		IL_0350: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:99"
-		IL_0355: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0281: ldstr "prototype"
+		IL_0286: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:64"
+		IL_028b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_035f: stloc.s 10
-		IL_0361: ldloc.s 8
-		IL_0363: ldstr "log"
-		IL_0368: ldloc.s 10
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_036f: pop
-		IL_0370: ldstr "console"
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037f: stloc.s 10
-		IL_0381: volatile.
-		IL_0383: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0388: brfalse IL_039d
+		IL_0295: stloc.s 9
+		IL_0297: ldloc.s 10
+		IL_0299: ldloc.s 9
+		IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02a0: stloc.s 11
+		IL_02a2: ldloc.s 11
+		IL_02a4: box [System.Runtime]System.Boolean
+		IL_02a9: stloc.s 12
+		IL_02ab: volatile.
+		IL_02ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02b2: brfalse IL_02ca
 
-		IL_038d: ldloc.1
-		IL_038e: ldstr "enumerable"
-		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0398: br IL_03b2
+		IL_02b7: ldloc.s 8
+		IL_02b9: ldstr "log"
+		IL_02be: ldloc.s 12
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c5: br IL_02e2
 
-		IL_039d: ldloc.1
-		IL_039e: ldstr "enumerable"
-		IL_03a3: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:106"
-		IL_03a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02ca: ldloc.s 8
+		IL_02cc: ldstr "log"
+		IL_02d1: ldloc.s 12
+		IL_02d3: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:67"
+		IL_02d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03b2: stloc.s 8
-		IL_03b4: ldloc.s 10
-		IL_03b6: ldstr "log"
-		IL_03bb: ldloc.s 8
-		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03c2: pop
-		IL_03c3: ldstr "console"
-		IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d2: stloc.s 8
-		IL_03d4: volatile.
-		IL_03d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_03db: brfalse IL_03f0
+		IL_02e2: pop
+		IL_02e3: ldstr "console"
+		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f2: stloc.s 8
+		IL_02f4: ldstr "Set"
+		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02fe: volatile.
+		IL_0300: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0305: brfalse IL_0319
 
-		IL_03e0: ldloc.1
-		IL_03e1: ldstr "configurable"
-		IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03eb: br IL_0405
+		IL_030a: ldstr "prototype"
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0314: br IL_032d
 
-		IL_03f0: ldloc.1
-		IL_03f1: ldstr "configurable"
-		IL_03f6: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:113"
-		IL_03fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0319: ldstr "prototype"
+		IL_031e: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:75"
+		IL_0323: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0405: stloc.s 10
-		IL_0407: ldloc.s 8
-		IL_0409: ldstr "log"
-		IL_040e: ldloc.s 10
-		IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0415: pop
-		IL_0416: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
-		IL_041b: stloc.2
-		IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0421: stloc.s 10
-		IL_0423: ldloc.s 10
-		IL_0425: ldstr "set"
-		IL_042a: ldloc.2
-		IL_042b: ldc.i4.0
-		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_0431: pop
-		IL_0432: ldstr "console"
-		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0441: stloc.s 10
-		IL_0443: ldloc.2
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0449: stloc.s 8
-		IL_044b: ldstr "Set"
-		IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0455: volatile.
-		IL_0457: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_045c: brfalse IL_0470
+		IL_032d: stloc.s 9
+		IL_032f: ldloc.s 9
+		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0336: stloc.s 9
+		IL_0338: ldstr "Object"
+		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0342: volatile.
+		IL_0344: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0349: brfalse IL_035d
 
-		IL_0461: ldstr "prototype"
-		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_046b: br IL_0484
+		IL_034e: ldstr "prototype"
+		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0358: br IL_0371
 
-		IL_0470: ldstr "prototype"
-		IL_0475: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:130"
-		IL_047a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_035d: ldstr "prototype"
+		IL_0362: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:80"
+		IL_0367: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0484: stloc.s 9
-		IL_0486: ldloc.s 8
-		IL_0488: ldloc.s 9
-		IL_048a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_048f: stloc.s 11
-		IL_0491: ldloc.s 11
-		IL_0493: box [System.Runtime]System.Boolean
-		IL_0498: stloc.s 12
-		IL_049a: ldloc.s 10
-		IL_049c: ldstr "log"
-		IL_04a1: ldloc.s 12
-		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04a8: pop
-		IL_04a9: ldstr "console"
-		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04b8: stloc.s 10
-		IL_04ba: ldloc.2
-		IL_04bb: stloc.s 13
-		IL_04bd: ldstr "Set"
-		IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04c7: stloc.s 9
-		IL_04c9: ldloc.s 13
-		IL_04cb: ldloc.s 9
-		IL_04cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_04d2: stloc.s 11
-		IL_04d4: ldloc.s 11
-		IL_04d6: box [System.Runtime]System.Boolean
-		IL_04db: stloc.s 12
-		IL_04dd: ldloc.s 10
-		IL_04df: ldstr "log"
-		IL_04e4: ldloc.s 12
-		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04eb: pop
-		IL_04ec: ldstr "console"
-		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04fb: stloc.s 10
-		IL_04fd: volatile.
-		IL_04ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0504: brfalse IL_0519
+		IL_0371: stloc.s 10
+		IL_0373: ldloc.s 9
+		IL_0375: ldloc.s 10
+		IL_0377: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_037c: stloc.s 11
+		IL_037e: ldloc.s 11
+		IL_0380: box [System.Runtime]System.Boolean
+		IL_0385: stloc.s 12
+		IL_0387: volatile.
+		IL_0389: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_038e: brfalse IL_03a6
 
-		IL_0509: ldloc.2
-		IL_050a: ldstr "constructor"
-		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0514: br IL_052e
+		IL_0393: ldloc.s 8
+		IL_0395: ldstr "log"
+		IL_039a: ldloc.s 12
+		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a1: br IL_03be
 
-		IL_0519: ldloc.2
-		IL_051a: ldstr "constructor"
-		IL_051f: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:149"
-		IL_0524: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03a6: ldloc.s 8
+		IL_03a8: ldstr "log"
+		IL_03ad: ldloc.s 12
+		IL_03af: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:83"
+		IL_03b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_052e: stloc.s 9
-		IL_0530: ldstr "Set"
-		IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_053a: stloc.s 8
-		IL_053c: ldloc.s 9
-		IL_053e: ldloc.s 8
-		IL_0540: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0545: stloc.s 11
-		IL_0547: ldloc.s 11
-		IL_0549: box [System.Runtime]System.Boolean
-		IL_054e: stloc.s 12
-		IL_0550: ldloc.s 10
-		IL_0552: ldstr "log"
-		IL_0557: ldloc.s 12
-		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_055e: pop
-		IL_055f: ldstr "Set"
-		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0569: volatile.
-		IL_056b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0570: brfalse IL_0584
+		IL_03be: pop
+		IL_03bf: ldstr "Set"
+		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c9: ldstr "prototype"
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_03d3: stloc.1
+		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_03d9: stloc.s 8
+		IL_03db: ldloc.s 8
+		IL_03dd: ldstr "descriptor"
+		IL_03e2: ldloc.1
+		IL_03e3: ldc.i4.0
+		IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_03e9: pop
+		IL_03ea: ldstr "console"
+		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03f9: stloc.s 8
+		IL_03fb: volatile.
+		IL_03fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0402: brfalse IL_0417
 
-		IL_0575: ldstr "prototype"
-		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_057f: br IL_0598
+		IL_0407: ldloc.1
+		IL_0408: ldstr "writable"
+		IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0412: br IL_042c
 
-		IL_0584: ldstr "prototype"
-		IL_0589: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:159"
-		IL_058e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0417: ldloc.1
+		IL_0418: ldstr "writable"
+		IL_041d: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:99"
+		IL_0422: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0598: stloc.s 10
-		IL_059a: volatile.
-		IL_059c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_05a1: brfalse IL_05b7
+		IL_042c: stloc.s 10
+		IL_042e: volatile.
+		IL_0430: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0435: brfalse IL_044d
 
-		IL_05a6: ldloc.s 10
-		IL_05a8: ldstr "add"
-		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05b2: br IL_05cd
+		IL_043a: ldloc.s 8
+		IL_043c: ldstr "log"
+		IL_0441: ldloc.s 10
+		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0448: br IL_0465
 
-		IL_05b7: ldloc.s 10
-		IL_05b9: ldstr "add"
-		IL_05be: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:161"
-		IL_05c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_044d: ldloc.s 8
+		IL_044f: ldstr "log"
+		IL_0454: ldloc.s 10
+		IL_0456: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:100"
+		IL_045b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_05cd: stloc.s 10
-		IL_05cf: ldloc.s 10
-		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05d6: ldstr "call"
-		IL_05db: ldloc.2
-		IL_05dc: ldstr "value"
-		IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_05e6: pop
-		IL_05e7: ldstr "console"
-		IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05f6: stloc.s 10
-		IL_05f8: ldstr "Set"
-		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0602: volatile.
-		IL_0604: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0609: brfalse IL_061d
+		IL_0465: pop
+		IL_0466: ldstr "console"
+		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0475: stloc.s 10
+		IL_0477: volatile.
+		IL_0479: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_047e: brfalse IL_0493
 
-		IL_060e: ldstr "prototype"
-		IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0618: br IL_0631
+		IL_0483: ldloc.1
+		IL_0484: ldstr "enumerable"
+		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_048e: br IL_04a8
 
-		IL_061d: ldstr "prototype"
-		IL_0622: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:172"
-		IL_0627: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0493: ldloc.1
+		IL_0494: ldstr "enumerable"
+		IL_0499: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:106"
+		IL_049e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0631: stloc.s 8
-		IL_0633: volatile.
-		IL_0635: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_063a: brfalse IL_0650
+		IL_04a8: stloc.s 8
+		IL_04aa: volatile.
+		IL_04ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04b1: brfalse IL_04c9
 
-		IL_063f: ldloc.s 8
-		IL_0641: ldstr "has"
-		IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_064b: br IL_0666
+		IL_04b6: ldloc.s 10
+		IL_04b8: ldstr "log"
+		IL_04bd: ldloc.s 8
+		IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04c4: br IL_04e1
 
-		IL_0650: ldloc.s 8
-		IL_0652: ldstr "has"
-		IL_0657: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:174"
-		IL_065c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04c9: ldloc.s 10
+		IL_04cb: ldstr "log"
+		IL_04d0: ldloc.s 8
+		IL_04d2: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:107"
+		IL_04d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0666: stloc.s 8
-		IL_0668: ldloc.s 8
-		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_066f: ldstr "call"
-		IL_0674: ldloc.2
-		IL_0675: ldstr "value"
-		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_067f: stloc.s 8
-		IL_0681: ldloc.s 10
-		IL_0683: ldstr "log"
-		IL_0688: ldloc.s 8
-		IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_068f: pop
+		IL_04e1: pop
+		IL_04e2: ldstr "console"
+		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04f1: stloc.s 8
+		IL_04f3: volatile.
+		IL_04f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_04fa: brfalse IL_050f
+
+		IL_04ff: ldloc.1
+		IL_0500: ldstr "configurable"
+		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050a: br IL_0524
+
+		IL_050f: ldloc.1
+		IL_0510: ldstr "configurable"
+		IL_0515: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:113"
+		IL_051a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0524: stloc.s 10
+		IL_0526: volatile.
+		IL_0528: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_052d: brfalse IL_0545
+
+		IL_0532: ldloc.s 8
+		IL_0534: ldstr "log"
+		IL_0539: ldloc.s 10
+		IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0540: br IL_055d
+
+		IL_0545: ldloc.s 8
+		IL_0547: ldstr "log"
+		IL_054c: ldloc.s 10
+		IL_054e: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:114"
+		IL_0553: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_055d: pop
+		IL_055e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
+		IL_0563: stloc.2
+		IL_0564: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_0569: stloc.s 10
+		IL_056b: ldloc.s 10
+		IL_056d: ldstr "set"
+		IL_0572: ldloc.2
+		IL_0573: ldc.i4.0
+		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_0579: pop
+		IL_057a: ldstr "console"
+		IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0589: stloc.s 10
+		IL_058b: ldloc.2
+		IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0591: stloc.s 8
+		IL_0593: ldstr "Set"
+		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_059d: volatile.
+		IL_059f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05a4: brfalse IL_05b8
+
+		IL_05a9: ldstr "prototype"
+		IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05b3: br IL_05cc
+
+		IL_05b8: ldstr "prototype"
+		IL_05bd: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:130"
+		IL_05c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05cc: stloc.s 9
+		IL_05ce: ldloc.s 8
+		IL_05d0: ldloc.s 9
+		IL_05d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05d7: stloc.s 11
+		IL_05d9: ldloc.s 11
+		IL_05db: box [System.Runtime]System.Boolean
+		IL_05e0: stloc.s 12
+		IL_05e2: volatile.
+		IL_05e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_05e9: brfalse IL_0601
+
+		IL_05ee: ldloc.s 10
+		IL_05f0: ldstr "log"
+		IL_05f5: ldloc.s 12
+		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05fc: br IL_0619
+
+		IL_0601: ldloc.s 10
+		IL_0603: ldstr "log"
+		IL_0608: ldloc.s 12
+		IL_060a: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:133"
+		IL_060f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0614: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0619: pop
+		IL_061a: ldstr "console"
+		IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0624: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0629: stloc.s 10
+		IL_062b: ldloc.2
+		IL_062c: stloc.s 13
+		IL_062e: ldstr "Set"
+		IL_0633: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0638: stloc.s 9
+		IL_063a: ldloc.s 13
+		IL_063c: ldloc.s 9
+		IL_063e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0643: stloc.s 11
+		IL_0645: ldloc.s 11
+		IL_0647: box [System.Runtime]System.Boolean
+		IL_064c: stloc.s 12
+		IL_064e: volatile.
+		IL_0650: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0655: brfalse IL_066d
+
+		IL_065a: ldloc.s 10
+		IL_065c: ldstr "log"
+		IL_0661: ldloc.s 12
+		IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0668: br IL_0685
+
+		IL_066d: ldloc.s 10
+		IL_066f: ldstr "log"
+		IL_0674: ldloc.s 12
+		IL_0676: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:143"
+		IL_067b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0685: pop
+		IL_0686: ldstr "console"
+		IL_068b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0695: stloc.s 10
+		IL_0697: volatile.
+		IL_0699: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_069e: brfalse IL_06b3
+
+		IL_06a3: ldloc.2
+		IL_06a4: ldstr "constructor"
+		IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06ae: br IL_06c8
+
+		IL_06b3: ldloc.2
+		IL_06b4: ldstr "constructor"
+		IL_06b9: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:149"
+		IL_06be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06c8: stloc.s 9
+		IL_06ca: ldstr "Set"
+		IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06d4: stloc.s 8
+		IL_06d6: ldloc.s 9
+		IL_06d8: ldloc.s 8
+		IL_06da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06df: stloc.s 11
+		IL_06e1: ldloc.s 11
+		IL_06e3: box [System.Runtime]System.Boolean
+		IL_06e8: stloc.s 12
+		IL_06ea: volatile.
+		IL_06ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_06f1: brfalse IL_0709
+
+		IL_06f6: ldloc.s 10
+		IL_06f8: ldstr "log"
+		IL_06fd: ldloc.s 12
+		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0704: br IL_0721
+
+		IL_0709: ldloc.s 10
+		IL_070b: ldstr "log"
+		IL_0710: ldloc.s 12
+		IL_0712: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:154"
+		IL_0717: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_071c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0721: pop
+		IL_0722: ldstr "Set"
+		IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_072c: volatile.
+		IL_072e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0733: brfalse IL_0747
+
+		IL_0738: ldstr "prototype"
+		IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0742: br IL_075b
+
+		IL_0747: ldstr "prototype"
+		IL_074c: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:159"
+		IL_0751: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_075b: stloc.s 10
+		IL_075d: volatile.
+		IL_075f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0764: brfalse IL_077a
+
+		IL_0769: ldloc.s 10
+		IL_076b: ldstr "add"
+		IL_0770: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0775: br IL_0790
+
+		IL_077a: ldloc.s 10
+		IL_077c: ldstr "add"
+		IL_0781: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:161"
+		IL_0786: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_078b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0790: stloc.s 10
+		IL_0792: ldloc.s 10
+		IL_0794: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0799: ldstr "call"
+		IL_079e: ldloc.2
+		IL_079f: ldstr "value"
+		IL_07a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_07a9: pop
+		IL_07aa: ldstr "console"
+		IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07b9: stloc.s 10
+		IL_07bb: ldstr "Set"
+		IL_07c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07c5: volatile.
+		IL_07c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_07cc: brfalse IL_07e0
+
+		IL_07d1: ldstr "prototype"
+		IL_07d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07db: br IL_07f4
+
+		IL_07e0: ldstr "prototype"
+		IL_07e5: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:172"
+		IL_07ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_07ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_07f4: stloc.s 8
+		IL_07f6: volatile.
+		IL_07f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_07fd: brfalse IL_0813
+
+		IL_0802: ldloc.s 8
+		IL_0804: ldstr "has"
+		IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_080e: br IL_0829
+
+		IL_0813: ldloc.s 8
+		IL_0815: ldstr "has"
+		IL_081a: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:174"
+		IL_081f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0824: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0829: stloc.s 8
+		IL_082b: ldloc.s 8
+		IL_082d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0832: ldstr "call"
+		IL_0837: ldloc.2
+		IL_0838: ldstr "value"
+		IL_083d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0842: stloc.s 8
+		IL_0844: volatile.
+		IL_0846: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_084b: brfalse IL_0863
+
+		IL_0850: ldloc.s 10
+		IL_0852: ldstr "log"
+		IL_0857: ldloc.s 8
+		IL_0859: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_085e: br IL_087b
+
+		IL_0863: ldloc.s 10
+		IL_0865: ldstr "log"
+		IL_086a: ldloc.s 8
+		IL_086c: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:178"
+		IL_0871: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_087b: pop
 		.try
 		{
-			IL_0690: nop
-			IL_0691: ldstr "Set"
-			IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_069b: stloc.3
-			IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_06a1: stloc.s 8
-			IL_06a3: ldloc.s 8
-			IL_06a5: ldstr "setCtor"
-			IL_06aa: ldloc.3
-			IL_06ab: ldc.i4.0
-			IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-			IL_06b1: pop
-			IL_06b2: ldloc.3
-			IL_06b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_06bd: pop
-			IL_06be: ldstr "console"
-			IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06cd: ldstr "log"
-			IL_06d2: ldstr "no-throw"
-			IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06dc: pop
-			IL_06dd: leave IL_07bc
+			IL_087c: nop
+			IL_087d: ldstr "Set"
+			IL_0882: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0887: stloc.3
+			IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+			IL_088d: stloc.s 8
+			IL_088f: ldloc.s 8
+			IL_0891: ldstr "setCtor"
+			IL_0896: ldloc.3
+			IL_0897: ldc.i4.0
+			IL_0898: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+			IL_089d: pop
+			IL_089e: ldloc.3
+			IL_089f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_08a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_08a9: pop
+			IL_08aa: ldstr "console"
+			IL_08af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08b9: volatile.
+			IL_08bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_08c0: brfalse IL_08d9
+
+			IL_08c5: ldstr "log"
+			IL_08ca: ldstr "no-throw"
+			IL_08cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_08d4: br IL_08f2
+
+			IL_08d9: ldstr "log"
+			IL_08de: ldstr "no-throw"
+			IL_08e3: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:198"
+			IL_08e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_08ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_08f2: pop
+			IL_08f3: leave IL_09fb
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06e2: stloc.s 4
-			IL_06e4: ldloc.s 4
-			IL_06e6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_06eb: dup
-			IL_06ec: brtrue IL_0702
+			IL_08f8: stloc.s 4
+			IL_08fa: ldloc.s 4
+			IL_08fc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0901: dup
+			IL_0902: brtrue IL_0918
 
-			IL_06f1: pop
-			IL_06f2: ldloc.s 4
-			IL_06f4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_06f9: dup
-			IL_06fa: brtrue IL_070e
+			IL_0907: pop
+			IL_0908: ldloc.s 4
+			IL_090a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_090f: dup
+			IL_0910: brtrue IL_0924
 
-			IL_06ff: pop
-			IL_0700: rethrow
+			IL_0915: pop
+			IL_0916: rethrow
 
-			IL_0702: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0707: stloc.s 5
-			IL_0709: br IL_0710
+			IL_0918: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_091d: stloc.s 5
+			IL_091f: br IL_0926
 
-			IL_070e: stloc.s 5
+			IL_0924: stloc.s 5
 
-			IL_0710: ldloc.s 5
-			IL_0712: stloc.s 6
-			IL_0714: ldstr "console"
-			IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0723: stloc.s 8
-			IL_0725: volatile.
-			IL_0727: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_072c: brfalse IL_0742
+			IL_0926: ldloc.s 5
+			IL_0928: stloc.s 6
+			IL_092a: ldstr "console"
+			IL_092f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0934: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0939: stloc.s 8
+			IL_093b: volatile.
+			IL_093d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0942: brfalse IL_0958
 
-			IL_0731: ldloc.s 6
-			IL_0733: ldstr "name"
-			IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_073d: br IL_0758
+			IL_0947: ldloc.s 6
+			IL_0949: ldstr "name"
+			IL_094e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0953: br IL_096e
 
-			IL_0742: ldloc.s 6
-			IL_0744: ldstr "name"
-			IL_0749: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:211"
-			IL_074e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0958: ldloc.s 6
+			IL_095a: ldstr "name"
+			IL_095f: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:211"
+			IL_0964: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0969: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0758: stloc.s 10
-			IL_075a: ldloc.s 10
-			IL_075c: ldstr ": "
-			IL_0761: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0766: stloc.s 14
-			IL_0768: volatile.
-			IL_076a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_076f: brfalse IL_0785
+			IL_096e: stloc.s 10
+			IL_0970: ldloc.s 10
+			IL_0972: ldstr ": "
+			IL_0977: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_097c: stloc.s 14
+			IL_097e: volatile.
+			IL_0980: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0985: brfalse IL_099b
 
-			IL_0774: ldloc.s 6
-			IL_0776: ldstr "message"
-			IL_077b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0780: br IL_079b
+			IL_098a: ldloc.s 6
+			IL_098c: ldstr "message"
+			IL_0991: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0996: br IL_09b1
 
-			IL_0785: ldloc.s 6
-			IL_0787: ldstr "message"
-			IL_078c: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:215"
-			IL_0791: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0796: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_099b: ldloc.s 6
+			IL_099d: ldstr "message"
+			IL_09a2: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:215"
+			IL_09a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_09ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_079b: stloc.s 10
-			IL_079d: ldloc.s 14
-			IL_079f: ldloc.s 10
-			IL_07a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_07a6: stloc.s 14
-			IL_07a8: ldloc.s 8
-			IL_07aa: ldstr "log"
-			IL_07af: ldloc.s 14
-			IL_07b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07b6: pop
-			IL_07b7: leave IL_07bc
+			IL_09b1: stloc.s 10
+			IL_09b3: ldloc.s 14
+			IL_09b5: ldloc.s 10
+			IL_09b7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09bc: stloc.s 14
+			IL_09be: volatile.
+			IL_09c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_09c5: brfalse IL_09dd
+
+			IL_09ca: ldloc.s 8
+			IL_09cc: ldstr "log"
+			IL_09d1: ldloc.s 14
+			IL_09d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09d8: br IL_09f5
+
+			IL_09dd: ldloc.s 8
+			IL_09df: ldstr "log"
+			IL_09e4: ldloc.s 14
+			IL_09e6: ldstr "Set_Constructor_Prototype_Surface:Modules.Set_Constructor_Prototype_Surface:__js_module_init__:217"
+			IL_09eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_09f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_09f5: pop
+			IL_09f6: leave IL_09fb
 		} // end handler
 
-		IL_07bc: ldnull
-		IL_07bd: stloc.s 7
-		IL_07bf: ret
+		IL_09fb: ldnull
+		IL_09fc: stloc.s 7
+		IL_09fe: ret
 	} // end of method Set_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.Set_Constructor_Prototype_Surface
@@ -803,6 +984,20 @@
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Core_Methods.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Core_Methods.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 414 (0x19e)
+		// Code size: 674 (0x2a2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Set_Core_Methods/Scope,
@@ -117,131 +117,201 @@
 		IL_0006: nop
 		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Set::.ctor()
 		IL_000c: stloc.1
-		IL_000d: ldloc.1
-		IL_000e: ldstr "add"
-		IL_0013: ldc.r8 1
-		IL_001c: box [System.Runtime]System.Double
-		IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0026: pop
-		IL_0027: ldloc.1
-		IL_0028: ldstr "add"
-		IL_002d: ldc.r8 2
-		IL_0036: box [System.Runtime]System.Double
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0040: pop
-		IL_0041: ldloc.1
-		IL_0042: ldstr "add"
-		IL_0047: ldc.r8 2
-		IL_0050: box [System.Runtime]System.Double
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_000d: volatile.
+		IL_000f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0014: brfalse IL_0037
+
+		IL_0019: ldloc.1
+		IL_001a: ldstr "add"
+		IL_001f: ldc.r8 1
+		IL_0028: box [System.Runtime]System.Double
+		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0032: br IL_005a
+
+		IL_0037: ldloc.1
+		IL_0038: ldstr "add"
+		IL_003d: ldc.r8 1
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:9"
+		IL_0050: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
 		IL_005a: pop
-		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0060: stloc.2
-		IL_0061: volatile.
-		IL_0063: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0068: brfalse IL_007d
+		IL_005b: volatile.
+		IL_005d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0062: brfalse IL_0085
 
-		IL_006d: ldloc.1
-		IL_006e: ldstr "size"
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0078: br IL_0092
+		IL_0067: ldloc.1
+		IL_0068: ldstr "add"
+		IL_006d: ldc.r8 2
+		IL_0076: box [System.Runtime]System.Double
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0080: br IL_00a8
 
-		IL_007d: ldloc.1
-		IL_007e: ldstr "size"
-		IL_0083: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:21"
-		IL_0088: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0085: ldloc.1
+		IL_0086: ldstr "add"
+		IL_008b: ldc.r8 2
+		IL_0094: box [System.Runtime]System.Double
+		IL_0099: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:13"
+		IL_009e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0092: stloc.3
-		IL_0093: ldloc.2
-		IL_0094: ldloc.3
-		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009a: pop
-		IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a0: stloc.2
-		IL_00a1: ldloc.1
-		IL_00a2: ldstr "delete"
-		IL_00a7: ldc.r8 2
-		IL_00b0: box [System.Runtime]System.Double
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ba: stloc.3
-		IL_00bb: ldloc.2
-		IL_00bc: ldloc.3
-		IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c2: pop
-		IL_00c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c8: stloc.2
-		IL_00c9: ldloc.1
-		IL_00ca: ldstr "has"
-		IL_00cf: ldc.r8 2
-		IL_00d8: box [System.Runtime]System.Double
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e2: stloc.3
-		IL_00e3: ldloc.2
-		IL_00e4: ldloc.3
-		IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ea: pop
-		IL_00eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f0: stloc.2
-		IL_00f1: volatile.
-		IL_00f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00f8: brfalse IL_010d
+		IL_00a8: pop
+		IL_00a9: volatile.
+		IL_00ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b0: brfalse IL_00d3
 
-		IL_00fd: ldloc.1
-		IL_00fe: ldstr "size"
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0108: br IL_0122
+		IL_00b5: ldloc.1
+		IL_00b6: ldstr "add"
+		IL_00bb: ldc.r8 2
+		IL_00c4: box [System.Runtime]System.Double
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ce: br IL_00f6
 
-		IL_010d: ldloc.1
-		IL_010e: ldstr "size"
-		IL_0113: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:38"
-		IL_0118: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00d3: ldloc.1
+		IL_00d4: ldstr "add"
+		IL_00d9: ldc.r8 2
+		IL_00e2: box [System.Runtime]System.Double
+		IL_00e7: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:17"
+		IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0122: stloc.3
-		IL_0123: ldloc.2
-		IL_0124: ldloc.3
-		IL_0125: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012a: pop
-		IL_012b: volatile.
-		IL_012d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0132: brfalse IL_0147
+		IL_00f6: pop
+		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fc: stloc.2
+		IL_00fd: volatile.
+		IL_00ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0104: brfalse IL_0119
 
-		IL_0137: ldloc.1
-		IL_0138: ldstr "clear"
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0142: br IL_015c
+		IL_0109: ldloc.1
+		IL_010a: ldstr "size"
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0114: br IL_012e
 
-		IL_0147: ldloc.1
-		IL_0148: ldstr "clear"
-		IL_014d: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:41"
-		IL_0152: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0119: ldloc.1
+		IL_011a: ldstr "size"
+		IL_011f: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:21"
+		IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_015c: pop
-		IL_015d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0162: stloc.2
-		IL_0163: volatile.
-		IL_0165: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_016a: brfalse IL_017f
+		IL_012e: stloc.3
+		IL_012f: ldloc.2
+		IL_0130: ldloc.3
+		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0136: pop
+		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013c: stloc.2
+		IL_013d: volatile.
+		IL_013f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0144: brfalse IL_0167
 
-		IL_016f: ldloc.1
-		IL_0170: ldstr "size"
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017a: br IL_0194
+		IL_0149: ldloc.1
+		IL_014a: ldstr "delete"
+		IL_014f: ldc.r8 2
+		IL_0158: box [System.Runtime]System.Double
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0162: br IL_018a
 
-		IL_017f: ldloc.1
-		IL_0180: ldstr "size"
-		IL_0185: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:45"
-		IL_018a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0167: ldloc.1
+		IL_0168: ldstr "delete"
+		IL_016d: ldc.r8 2
+		IL_0176: box [System.Runtime]System.Double
+		IL_017b: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:27"
+		IL_0180: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0194: stloc.3
-		IL_0195: ldloc.2
-		IL_0196: ldloc.3
-		IL_0197: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019c: pop
-		IL_019d: ret
+		IL_018a: stloc.3
+		IL_018b: ldloc.2
+		IL_018c: ldloc.3
+		IL_018d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0192: pop
+		IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0198: stloc.2
+		IL_0199: volatile.
+		IL_019b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01a0: brfalse IL_01c3
+
+		IL_01a5: ldloc.1
+		IL_01a6: ldstr "has"
+		IL_01ab: ldc.r8 2
+		IL_01b4: box [System.Runtime]System.Double
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01be: br IL_01e6
+
+		IL_01c3: ldloc.1
+		IL_01c4: ldstr "has"
+		IL_01c9: ldc.r8 2
+		IL_01d2: box [System.Runtime]System.Double
+		IL_01d7: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:33"
+		IL_01dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01e6: stloc.3
+		IL_01e7: ldloc.2
+		IL_01e8: ldloc.3
+		IL_01e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ee: pop
+		IL_01ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f4: stloc.2
+		IL_01f5: volatile.
+		IL_01f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01fc: brfalse IL_0211
+
+		IL_0201: ldloc.1
+		IL_0202: ldstr "size"
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_020c: br IL_0226
+
+		IL_0211: ldloc.1
+		IL_0212: ldstr "size"
+		IL_0217: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:38"
+		IL_021c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0226: stloc.3
+		IL_0227: ldloc.2
+		IL_0228: ldloc.3
+		IL_0229: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_022e: pop
+		IL_022f: volatile.
+		IL_0231: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0236: brfalse IL_024b
+
+		IL_023b: ldloc.1
+		IL_023c: ldstr "clear"
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0246: br IL_0260
+
+		IL_024b: ldloc.1
+		IL_024c: ldstr "clear"
+		IL_0251: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:41"
+		IL_0256: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0260: pop
+		IL_0261: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0266: stloc.2
+		IL_0267: volatile.
+		IL_0269: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_026e: brfalse IL_0283
+
+		IL_0273: ldloc.1
+		IL_0274: ldstr "size"
+		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_027e: br IL_0298
+
+		IL_0283: ldloc.1
+		IL_0284: ldstr "size"
+		IL_0289: ldstr "Set_Core_Methods:Modules.Set_Core_Methods:__js_module_init__:45"
+		IL_028e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0298: stloc.3
+		IL_0299: ldloc.2
+		IL_029a: ldloc.3
+		IL_029b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a0: pop
+		IL_02a1: ret
 	} // end of method Set_Core_Methods::__js_module_init__
 
 } // end of class Modules.Set_Core_Methods
@@ -275,6 +345,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ExplicitReceiverAbi.verified.txt
@@ -275,7 +275,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2231 (0x8b7)
+		// Code size: 2315 (0x90b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_ExplicitReceiverAbi/Scope,
@@ -392,586 +392,612 @@
 		IL_014b: ldstr "mixed"
 		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
 		IL_0155: stloc.s 8
-		IL_0157: ldloc.s 7
-		IL_0159: ldstr "call"
-		IL_015e: ldloc.s 8
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0165: stloc.s 8
-		IL_0167: ldloc.s 6
-		IL_0169: ldloc.s 8
-		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0170: pop
-		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0176: stloc.s 6
-		IL_0178: ldstr "String"
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0182: volatile.
-		IL_0184: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0189: brfalse IL_019d
+		IL_0157: volatile.
+		IL_0159: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_015e: brfalse IL_0176
 
-		IL_018e: ldstr "prototype"
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0198: br IL_01b1
+		IL_0163: ldloc.s 7
+		IL_0165: ldstr "call"
+		IL_016a: ldloc.s 8
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0171: br IL_018e
 
-		IL_019d: ldstr "prototype"
-		IL_01a2: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:39"
-		IL_01a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0176: ldloc.s 7
+		IL_0178: ldstr "call"
+		IL_017d: ldloc.s 8
+		IL_017f: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:32"
+		IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01b1: stloc.s 8
-		IL_01b3: volatile.
-		IL_01b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01ba: brfalse IL_01d0
+		IL_018e: stloc.s 8
+		IL_0190: ldloc.s 6
+		IL_0192: ldloc.s 8
+		IL_0194: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0199: pop
+		IL_019a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019f: stloc.s 6
+		IL_01a1: ldstr "String"
+		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ab: volatile.
+		IL_01ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01b2: brfalse IL_01c6
 
-		IL_01bf: ldloc.s 8
-		IL_01c1: ldstr "startsWith"
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01cb: br IL_01e6
+		IL_01b7: ldstr "prototype"
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c1: br IL_01da
 
-		IL_01d0: ldloc.s 8
-		IL_01d2: ldstr "startsWith"
-		IL_01d7: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:41"
-		IL_01dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01c6: ldstr "prototype"
+		IL_01cb: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:39"
+		IL_01d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01e6: stloc.s 8
+		IL_01da: stloc.s 8
+		IL_01dc: volatile.
+		IL_01de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01e3: brfalse IL_01f9
+
 		IL_01e8: ldloc.s 8
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ef: ldstr "call"
-		IL_01f4: ldc.r8 12345
-		IL_01fd: box [System.Runtime]System.Double
-		IL_0202: ldstr "23"
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_020c: stloc.s 8
-		IL_020e: ldloc.s 6
-		IL_0210: ldloc.s 8
-		IL_0212: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0217: pop
-		IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021d: stloc.s 6
-		IL_021f: ldstr "String"
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0229: volatile.
-		IL_022b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0230: brfalse IL_0244
+		IL_01ea: ldstr "startsWith"
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f4: br IL_020f
 
-		IL_0235: ldstr "prototype"
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_023f: br IL_0258
+		IL_01f9: ldloc.s 8
+		IL_01fb: ldstr "startsWith"
+		IL_0200: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:41"
+		IL_0205: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0244: ldstr "prototype"
-		IL_0249: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:53"
-		IL_024e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_020f: stloc.s 8
+		IL_0211: ldloc.s 8
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0218: ldstr "call"
+		IL_021d: ldc.r8 12345
+		IL_0226: box [System.Runtime]System.Double
+		IL_022b: ldstr "23"
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0235: stloc.s 8
+		IL_0237: ldloc.s 6
+		IL_0239: ldloc.s 8
+		IL_023b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0240: pop
+		IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0246: stloc.s 6
+		IL_0248: ldstr "String"
+		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0252: volatile.
+		IL_0254: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0259: brfalse IL_026d
 
-		IL_0258: stloc.s 8
-		IL_025a: volatile.
-		IL_025c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0261: brfalse IL_0277
+		IL_025e: ldstr "prototype"
+		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0268: br IL_0281
 
-		IL_0266: ldloc.s 8
-		IL_0268: ldstr "endsWith"
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0272: br IL_028d
+		IL_026d: ldstr "prototype"
+		IL_0272: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:53"
+		IL_0277: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0277: ldloc.s 8
-		IL_0279: ldstr "endsWith"
-		IL_027e: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:55"
-		IL_0283: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0281: stloc.s 8
+		IL_0283: volatile.
+		IL_0285: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_028a: brfalse IL_02a0
 
-		IL_028d: stloc.s 8
 		IL_028f: ldloc.s 8
-		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0296: ldc.i4.2
-		IL_0297: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_029c: dup
-		IL_029d: ldstr "de"
-		IL_02a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_02a7: dup
-		IL_02a8: ldc.r8 5
-		IL_02b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02b6: stloc.s 9
-		IL_02b8: ldstr "apply"
-		IL_02bd: ldstr "abcdef"
-		IL_02c2: ldloc.s 9
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02c9: stloc.s 8
-		IL_02cb: ldloc.s 6
-		IL_02cd: ldloc.s 8
-		IL_02cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d4: pop
-		IL_02d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02da: stloc.s 6
-		IL_02dc: ldstr "String"
-		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02e6: volatile.
-		IL_02e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02ed: brfalse IL_0301
+		IL_0291: ldstr "endsWith"
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_029b: br IL_02b6
 
-		IL_02f2: ldstr "prototype"
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02fc: br IL_0315
+		IL_02a0: ldloc.s 8
+		IL_02a2: ldstr "endsWith"
+		IL_02a7: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:55"
+		IL_02ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0301: ldstr "prototype"
-		IL_0306: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:68"
-		IL_030b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02b6: stloc.s 8
+		IL_02b8: ldloc.s 8
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02bf: ldc.i4.2
+		IL_02c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02c5: dup
+		IL_02c6: ldstr "de"
+		IL_02cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_02d0: dup
+		IL_02d1: ldc.r8 5
+		IL_02da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02df: stloc.s 9
+		IL_02e1: ldstr "apply"
+		IL_02e6: ldstr "abcdef"
+		IL_02eb: ldloc.s 9
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02f2: stloc.s 8
+		IL_02f4: ldloc.s 6
+		IL_02f6: ldloc.s 8
+		IL_02f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02fd: pop
+		IL_02fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0303: stloc.s 6
+		IL_0305: ldstr "String"
+		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_030f: volatile.
+		IL_0311: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0316: brfalse IL_032a
 
-		IL_0315: stloc.s 8
-		IL_0317: volatile.
-		IL_0319: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_031e: brfalse IL_0334
+		IL_031b: ldstr "prototype"
+		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0325: br IL_033e
 
-		IL_0323: ldloc.s 8
-		IL_0325: ldstr "concat"
-		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_032f: br IL_034a
+		IL_032a: ldstr "prototype"
+		IL_032f: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:68"
+		IL_0334: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0334: ldloc.s 8
-		IL_0336: ldstr "concat"
-		IL_033b: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:70"
-		IL_0340: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_033e: stloc.s 8
+		IL_0340: volatile.
+		IL_0342: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0347: brfalse IL_035d
 
-		IL_034a: stloc.s 8
 		IL_034c: ldloc.s 8
-		IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0353: ldstr "call"
-		IL_0358: ldc.i4.7
-		IL_0359: newarr [System.Runtime]System.Object
-		IL_035e: dup
-		IL_035f: ldc.i4.0
-		IL_0360: ldstr "a"
-		IL_0365: stelem.ref
-		IL_0366: dup
-		IL_0367: ldc.i4.1
-		IL_0368: ldstr "b"
-		IL_036d: stelem.ref
-		IL_036e: dup
-		IL_036f: ldc.i4.2
-		IL_0370: ldstr "c"
-		IL_0375: stelem.ref
-		IL_0376: dup
-		IL_0377: ldc.i4.3
-		IL_0378: ldstr "d"
-		IL_037d: stelem.ref
-		IL_037e: dup
-		IL_037f: ldc.i4.4
-		IL_0380: ldstr "e"
-		IL_0385: stelem.ref
-		IL_0386: dup
-		IL_0387: ldc.i4.5
-		IL_0388: ldstr "f"
-		IL_038d: stelem.ref
-		IL_038e: dup
-		IL_038f: ldc.i4.6
-		IL_0390: ldstr "g"
-		IL_0395: stelem.ref
-		IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-		IL_039b: stloc.s 8
-		IL_039d: ldloc.s 6
-		IL_039f: ldloc.s 8
-		IL_03a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03a6: pop
-		IL_03a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03ac: stloc.s 6
-		IL_03ae: ldc.r8 3
-		IL_03b7: neg
-		IL_03b8: stloc.s 10
-		IL_03ba: ldloc.s 10
-		IL_03bc: box [System.Runtime]System.Double
-		IL_03c1: stloc.s 11
-		IL_03c3: ldc.i4.0
-		IL_03c4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_03c9: brfalse IL_03ef
+		IL_034e: ldstr "concat"
+		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0358: br IL_0373
 
-		IL_03ce: ldstr "abcdef"
-		IL_03d3: ldloc.s 11
-		IL_03d5: ldc.r8 2
-		IL_03de: box [System.Runtime]System.Double
-		IL_03e3: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
-		IL_03e8: stloc.s 8
-		IL_03ea: br IL_0410
+		IL_035d: ldloc.s 8
+		IL_035f: ldstr "concat"
+		IL_0364: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:70"
+		IL_0369: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03ef: ldstr "abcdef"
-		IL_03f4: ldstr "substr"
-		IL_03f9: ldloc.s 11
-		IL_03fb: ldc.r8 2
-		IL_0404: box [System.Runtime]System.Double
-		IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_040e: stloc.s 8
+		IL_0373: stloc.s 8
+		IL_0375: ldloc.s 8
+		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_037c: ldstr "call"
+		IL_0381: ldc.i4.7
+		IL_0382: newarr [System.Runtime]System.Object
+		IL_0387: dup
+		IL_0388: ldc.i4.0
+		IL_0389: ldstr "a"
+		IL_038e: stelem.ref
+		IL_038f: dup
+		IL_0390: ldc.i4.1
+		IL_0391: ldstr "b"
+		IL_0396: stelem.ref
+		IL_0397: dup
+		IL_0398: ldc.i4.2
+		IL_0399: ldstr "c"
+		IL_039e: stelem.ref
+		IL_039f: dup
+		IL_03a0: ldc.i4.3
+		IL_03a1: ldstr "d"
+		IL_03a6: stelem.ref
+		IL_03a7: dup
+		IL_03a8: ldc.i4.4
+		IL_03a9: ldstr "e"
+		IL_03ae: stelem.ref
+		IL_03af: dup
+		IL_03b0: ldc.i4.5
+		IL_03b1: ldstr "f"
+		IL_03b6: stelem.ref
+		IL_03b7: dup
+		IL_03b8: ldc.i4.6
+		IL_03b9: ldstr "g"
+		IL_03be: stelem.ref
+		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_03c4: stloc.s 8
+		IL_03c6: ldloc.s 6
+		IL_03c8: ldloc.s 8
+		IL_03ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03cf: pop
+		IL_03d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03d5: stloc.s 6
+		IL_03d7: ldc.r8 3
+		IL_03e0: neg
+		IL_03e1: stloc.s 10
+		IL_03e3: ldloc.s 10
+		IL_03e5: box [System.Runtime]System.Double
+		IL_03ea: stloc.s 11
+		IL_03ec: ldc.i4.0
+		IL_03ed: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_03f2: brfalse IL_0418
 
-		IL_0410: ldloc.s 6
-		IL_0412: ldloc.s 8
-		IL_0414: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0419: pop
-		IL_041a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_041f: stloc.s 6
-		IL_0421: ldstr "String"
-		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_042b: volatile.
-		IL_042d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0432: brfalse IL_0446
+		IL_03f7: ldstr "abcdef"
+		IL_03fc: ldloc.s 11
+		IL_03fe: ldc.r8 2
+		IL_0407: box [System.Runtime]System.Double
+		IL_040c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+		IL_0411: stloc.s 8
+		IL_0413: br IL_0439
 
-		IL_0437: ldstr "prototype"
-		IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0441: br IL_045a
+		IL_0418: ldstr "abcdef"
+		IL_041d: ldstr "substr"
+		IL_0422: ldloc.s 11
+		IL_0424: ldc.r8 2
+		IL_042d: box [System.Runtime]System.Double
+		IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0437: stloc.s 8
 
-		IL_0446: ldstr "prototype"
-		IL_044b: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:97"
-		IL_0450: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0439: ldloc.s 6
+		IL_043b: ldloc.s 8
+		IL_043d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0442: pop
+		IL_0443: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0448: stloc.s 6
+		IL_044a: ldstr "String"
+		IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0454: volatile.
+		IL_0456: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_045b: brfalse IL_046f
 
-		IL_045a: stloc.s 8
-		IL_045c: volatile.
-		IL_045e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0463: brfalse IL_0479
+		IL_0460: ldstr "prototype"
+		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_046a: br IL_0483
 
-		IL_0468: ldloc.s 8
-		IL_046a: ldstr "trimLeft"
-		IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0474: br IL_048f
+		IL_046f: ldstr "prototype"
+		IL_0474: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:97"
+		IL_0479: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0479: ldloc.s 8
-		IL_047b: ldstr "trimLeft"
-		IL_0480: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:99"
-		IL_0485: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0483: stloc.s 8
+		IL_0485: volatile.
+		IL_0487: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_048c: brfalse IL_04a2
 
-		IL_048f: stloc.s 8
-		IL_0491: ldstr "String"
-		IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_049b: volatile.
-		IL_049d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_04a2: brfalse IL_04b6
+		IL_0491: ldloc.s 8
+		IL_0493: ldstr "trimLeft"
+		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_049d: br IL_04b8
 
-		IL_04a7: ldstr "prototype"
-		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04b1: br IL_04ca
+		IL_04a2: ldloc.s 8
+		IL_04a4: ldstr "trimLeft"
+		IL_04a9: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:99"
+		IL_04ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04b6: ldstr "prototype"
-		IL_04bb: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:103"
-		IL_04c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_04c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04b8: stloc.s 8
+		IL_04ba: ldstr "String"
+		IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04c4: volatile.
+		IL_04c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_04cb: brfalse IL_04df
 
-		IL_04ca: stloc.s 7
-		IL_04cc: volatile.
-		IL_04ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_04d3: brfalse IL_04e9
+		IL_04d0: ldstr "prototype"
+		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04da: br IL_04f3
 
-		IL_04d8: ldloc.s 7
-		IL_04da: ldstr "trimStart"
-		IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04e4: br IL_04ff
+		IL_04df: ldstr "prototype"
+		IL_04e4: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:103"
+		IL_04e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_04ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04e9: ldloc.s 7
-		IL_04eb: ldstr "trimStart"
-		IL_04f0: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:105"
-		IL_04f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04f3: stloc.s 7
+		IL_04f5: volatile.
+		IL_04f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04fc: brfalse IL_0512
 
-		IL_04ff: stloc.s 7
-		IL_0501: ldloc.s 8
-		IL_0503: ldloc.s 7
-		IL_0505: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_050a: stloc.s 12
-		IL_050c: ldloc.s 12
-		IL_050e: box [System.Runtime]System.Boolean
-		IL_0513: stloc.s 13
-		IL_0515: ldloc.s 6
-		IL_0517: ldloc.s 13
-		IL_0519: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_051e: pop
-		IL_051f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0524: stloc.s 6
-		IL_0526: ldstr "String"
-		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0530: volatile.
-		IL_0532: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0537: brfalse IL_054b
+		IL_0501: ldloc.s 7
+		IL_0503: ldstr "trimStart"
+		IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050d: br IL_0528
 
-		IL_053c: ldstr "prototype"
-		IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0546: br IL_055f
+		IL_0512: ldloc.s 7
+		IL_0514: ldstr "trimStart"
+		IL_0519: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:105"
+		IL_051e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_054b: ldstr "prototype"
-		IL_0550: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:114"
-		IL_0555: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0528: stloc.s 7
+		IL_052a: ldloc.s 8
+		IL_052c: ldloc.s 7
+		IL_052e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0533: stloc.s 12
+		IL_0535: ldloc.s 12
+		IL_0537: box [System.Runtime]System.Boolean
+		IL_053c: stloc.s 13
+		IL_053e: ldloc.s 6
+		IL_0540: ldloc.s 13
+		IL_0542: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0547: pop
+		IL_0548: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_054d: stloc.s 6
+		IL_054f: ldstr "String"
+		IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0559: volatile.
+		IL_055b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0560: brfalse IL_0574
 
-		IL_055f: stloc.s 7
-		IL_0561: volatile.
-		IL_0563: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0568: brfalse IL_057e
+		IL_0565: ldstr "prototype"
+		IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_056f: br IL_0588
 
-		IL_056d: ldloc.s 7
-		IL_056f: ldstr "trimRight"
-		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0579: br IL_0594
+		IL_0574: ldstr "prototype"
+		IL_0579: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:114"
+		IL_057e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_057e: ldloc.s 7
-		IL_0580: ldstr "trimRight"
-		IL_0585: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:116"
-		IL_058a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0588: stloc.s 7
+		IL_058a: volatile.
+		IL_058c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0591: brfalse IL_05a7
 
-		IL_0594: stloc.s 7
-		IL_0596: ldstr "String"
-		IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05a0: volatile.
-		IL_05a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_05a7: brfalse IL_05bb
+		IL_0596: ldloc.s 7
+		IL_0598: ldstr "trimRight"
+		IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05a2: br IL_05bd
 
-		IL_05ac: ldstr "prototype"
-		IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05b6: br IL_05cf
+		IL_05a7: ldloc.s 7
+		IL_05a9: ldstr "trimRight"
+		IL_05ae: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:116"
+		IL_05b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05bb: ldstr "prototype"
-		IL_05c0: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:120"
-		IL_05c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05bd: stloc.s 7
+		IL_05bf: ldstr "String"
+		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05c9: volatile.
+		IL_05cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05d0: brfalse IL_05e4
 
-		IL_05cf: stloc.s 8
-		IL_05d1: volatile.
-		IL_05d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_05d8: brfalse IL_05ee
+		IL_05d5: ldstr "prototype"
+		IL_05da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05df: br IL_05f8
 
-		IL_05dd: ldloc.s 8
-		IL_05df: ldstr "trimEnd"
-		IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05e9: br IL_0604
+		IL_05e4: ldstr "prototype"
+		IL_05e9: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:120"
+		IL_05ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05ee: ldloc.s 8
-		IL_05f0: ldstr "trimEnd"
-		IL_05f5: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:122"
-		IL_05fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05f8: stloc.s 8
+		IL_05fa: volatile.
+		IL_05fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0601: brfalse IL_0617
 
-		IL_0604: stloc.s 8
-		IL_0606: ldloc.s 7
-		IL_0608: ldloc.s 8
-		IL_060a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_060f: stloc.s 12
-		IL_0611: ldloc.s 12
-		IL_0613: box [System.Runtime]System.Boolean
-		IL_0618: stloc.s 13
-		IL_061a: ldloc.s 6
-		IL_061c: ldloc.s 13
-		IL_061e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0623: pop
+		IL_0606: ldloc.s 8
+		IL_0608: ldstr "trimEnd"
+		IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0612: br IL_062d
+
+		IL_0617: ldloc.s 8
+		IL_0619: ldstr "trimEnd"
+		IL_061e: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:122"
+		IL_0623: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_062d: stloc.s 8
+		IL_062f: ldloc.s 7
+		IL_0631: ldloc.s 8
+		IL_0633: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0638: stloc.s 12
+		IL_063a: ldloc.s 12
+		IL_063c: box [System.Runtime]System.Boolean
+		IL_0641: stloc.s 13
+		IL_0643: ldloc.s 6
+		IL_0645: ldloc.s 13
+		IL_0647: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_064c: pop
 		.try
 		{
-			IL_0624: nop
-			IL_0625: ldstr "String"
-			IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_062f: volatile.
-			IL_0631: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_0636: brfalse IL_064a
+			IL_064d: nop
+			IL_064e: ldstr "String"
+			IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0658: volatile.
+			IL_065a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_065f: brfalse IL_0673
 
-			IL_063b: ldstr "prototype"
-			IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0645: br IL_065e
+			IL_0664: ldstr "prototype"
+			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_066e: br IL_0687
 
-			IL_064a: ldstr "prototype"
-			IL_064f: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:133"
-			IL_0654: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0673: ldstr "prototype"
+			IL_0678: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:133"
+			IL_067d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_065e: stloc.s 8
-			IL_0660: volatile.
-			IL_0662: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0667: brfalse IL_067d
+			IL_0687: stloc.s 8
+			IL_0689: volatile.
+			IL_068b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0690: brfalse IL_06a6
 
-			IL_066c: ldloc.s 8
-			IL_066e: ldstr "trim"
-			IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0678: br IL_0693
-
-			IL_067d: ldloc.s 8
-			IL_067f: ldstr "trim"
-			IL_0684: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:135"
-			IL_0689: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_068e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0693: stloc.s 8
 			IL_0695: ldloc.s 8
-			IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_069c: ldstr "call"
-			IL_06a1: ldc.i4.0
-			IL_06a2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_06a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06ac: pop
-			IL_06ad: leave IL_0716
+			IL_0697: ldstr "trim"
+			IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06a1: br IL_06bc
+
+			IL_06a6: ldloc.s 8
+			IL_06a8: ldstr "trim"
+			IL_06ad: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:135"
+			IL_06b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_06bc: stloc.s 8
+			IL_06be: ldloc.s 8
+			IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06c5: volatile.
+			IL_06c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_06cc: brfalse IL_06e6
+
+			IL_06d1: ldstr "call"
+			IL_06d6: ldc.i4.0
+			IL_06d7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06e1: br IL_0700
+
+			IL_06e6: ldstr "call"
+			IL_06eb: ldc.i4.0
+			IL_06ec: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_06f1: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:139"
+			IL_06f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0700: pop
+			IL_0701: leave IL_076a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06b2: stloc.1
-			IL_06b3: ldloc.1
-			IL_06b4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_06b9: dup
-			IL_06ba: brtrue IL_06cf
+			IL_0706: stloc.1
+			IL_0707: ldloc.1
+			IL_0708: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_070d: dup
+			IL_070e: brtrue IL_0723
 
-			IL_06bf: pop
-			IL_06c0: ldloc.1
-			IL_06c1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_06c6: dup
-			IL_06c7: brtrue IL_06da
+			IL_0713: pop
+			IL_0714: ldloc.1
+			IL_0715: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_071a: dup
+			IL_071b: brtrue IL_072e
 
-			IL_06cc: pop
-			IL_06cd: rethrow
+			IL_0720: pop
+			IL_0721: rethrow
 
-			IL_06cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_06d4: stloc.2
-			IL_06d5: br IL_06db
+			IL_0723: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0728: stloc.2
+			IL_0729: br IL_072f
 
-			IL_06da: stloc.2
+			IL_072e: stloc.2
 
-			IL_06db: ldloc.2
-			IL_06dc: stloc.3
-			IL_06dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06e2: stloc.s 6
-			IL_06e4: ldloc.3
-			IL_06e5: stloc.s 8
-			IL_06e7: ldstr "TypeError"
-			IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06f1: stloc.s 7
-			IL_06f3: ldloc.s 8
-			IL_06f5: ldloc.s 7
-			IL_06f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_06fc: stloc.s 12
-			IL_06fe: ldloc.s 12
-			IL_0700: box [System.Runtime]System.Boolean
-			IL_0705: stloc.s 13
-			IL_0707: ldloc.s 6
-			IL_0709: ldloc.s 13
-			IL_070b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0710: pop
-			IL_0711: leave IL_0716
+			IL_072f: ldloc.2
+			IL_0730: stloc.3
+			IL_0731: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0736: stloc.s 6
+			IL_0738: ldloc.3
+			IL_0739: stloc.s 8
+			IL_073b: ldstr "TypeError"
+			IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0745: stloc.s 7
+			IL_0747: ldloc.s 8
+			IL_0749: ldloc.s 7
+			IL_074b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0750: stloc.s 12
+			IL_0752: ldloc.s 12
+			IL_0754: box [System.Runtime]System.Boolean
+			IL_0759: stloc.s 13
+			IL_075b: ldloc.s 6
+			IL_075d: ldloc.s 13
+			IL_075f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0764: pop
+			IL_0765: leave IL_076a
 		} // end handler
 
-		IL_0716: ldstr "String"
-		IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0720: volatile.
-		IL_0722: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0727: brfalse IL_073b
+		IL_076a: ldstr "String"
+		IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0774: volatile.
+		IL_0776: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_077b: brfalse IL_078f
 
-		IL_072c: ldstr "prototype"
-		IL_0731: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0736: br IL_074f
+		IL_0780: ldstr "prototype"
+		IL_0785: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_078a: br IL_07a3
 
-		IL_073b: ldstr "prototype"
-		IL_0740: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:163"
-		IL_0745: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_074a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_078f: ldstr "prototype"
+		IL_0794: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:163"
+		IL_0799: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_074f: stloc.s 7
-		IL_0751: volatile.
-		IL_0753: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0758: brfalse IL_076e
+		IL_07a3: stloc.s 7
+		IL_07a5: volatile.
+		IL_07a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_07ac: brfalse IL_07c2
 
-		IL_075d: ldloc.s 7
-		IL_075f: ldstr "slice"
-		IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0769: br IL_0784
+		IL_07b1: ldloc.s 7
+		IL_07b3: ldstr "slice"
+		IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07bd: br IL_07d8
 
-		IL_076e: ldloc.s 7
-		IL_0770: ldstr "slice"
-		IL_0775: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:165"
-		IL_077a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_077f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07c2: ldloc.s 7
+		IL_07c4: ldstr "slice"
+		IL_07c9: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:165"
+		IL_07ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0784: stloc.s 4
-		IL_0786: ldstr "String"
-		IL_078b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0790: volatile.
-		IL_0792: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0797: brfalse IL_07ab
+		IL_07d8: stloc.s 4
+		IL_07da: ldstr "String"
+		IL_07df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07e4: volatile.
+		IL_07e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_07eb: brfalse IL_07ff
 
-		IL_079c: ldstr "prototype"
-		IL_07a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07a6: br IL_07bf
+		IL_07f0: ldstr "prototype"
+		IL_07f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07fa: br IL_0813
 
-		IL_07ab: ldstr "prototype"
-		IL_07b0: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:171"
-		IL_07b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07ff: ldstr "prototype"
+		IL_0804: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:171"
+		IL_0809: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_080e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07bf: stloc.s 7
-		IL_07c1: ldc.i4.1
-		IL_07c2: newarr [System.Runtime]System.Object
-		IL_07c7: dup
-		IL_07c8: ldc.i4.0
-		IL_07c9: ldloc.0
-		IL_07ca: stelem.ref
-		IL_07cb: stloc.s 14
-		IL_07cd: newobj instance void Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject::.ctor()
-		IL_07d2: ldc.i4.0
-		IL_07d3: conv.r8
-		IL_07d4: ldstr ""
-		IL_07d9: ldc.i4.0
-		IL_07da: ldc.i4.1
-		IL_07db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07e0: stloc.s 15
-		IL_07e2: ldloc.s 7
-		IL_07e4: ldstr "slice"
-		IL_07e9: ldloc.s 15
-		IL_07eb: ldc.i4.1
-		IL_07ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_07f1: pop
-		IL_07f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07f7: stloc.s 6
-		IL_07f9: ldc.i4.0
-		IL_07fa: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_07ff: brfalse IL_0831
+		IL_0813: stloc.s 7
+		IL_0815: ldc.i4.1
+		IL_0816: newarr [System.Runtime]System.Object
+		IL_081b: dup
+		IL_081c: ldc.i4.0
+		IL_081d: ldloc.0
+		IL_081e: stelem.ref
+		IL_081f: stloc.s 14
+		IL_0821: newobj instance void Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject::.ctor()
+		IL_0826: ldc.i4.0
+		IL_0827: conv.r8
+		IL_0828: ldstr ""
+		IL_082d: ldc.i4.0
+		IL_082e: ldc.i4.1
+		IL_082f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0834: stloc.s 15
+		IL_0836: ldloc.s 7
+		IL_0838: ldstr "slice"
+		IL_083d: ldloc.s 15
+		IL_083f: ldc.i4.1
+		IL_0840: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0845: pop
+		IL_0846: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_084b: stloc.s 6
+		IL_084d: ldc.i4.0
+		IL_084e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0853: brfalse IL_0885
 
-		IL_0804: ldstr "abcdef"
-		IL_0809: ldc.r8 1
-		IL_0812: box [System.Runtime]System.Double
-		IL_0817: ldc.r8 4
-		IL_0820: box [System.Runtime]System.Double
-		IL_0825: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-		IL_082a: stloc.s 7
-		IL_082c: br IL_085e
+		IL_0858: ldstr "abcdef"
+		IL_085d: ldc.r8 1
+		IL_0866: box [System.Runtime]System.Double
+		IL_086b: ldc.r8 4
+		IL_0874: box [System.Runtime]System.Double
+		IL_0879: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+		IL_087e: stloc.s 7
+		IL_0880: br IL_08b2
 
-		IL_0831: ldstr "abcdef"
-		IL_0836: ldstr "slice"
-		IL_083b: ldc.r8 1
-		IL_0844: box [System.Runtime]System.Double
-		IL_0849: ldc.r8 4
-		IL_0852: box [System.Runtime]System.Double
-		IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_085c: stloc.s 7
+		IL_0885: ldstr "abcdef"
+		IL_088a: ldstr "slice"
+		IL_088f: ldc.r8 1
+		IL_0898: box [System.Runtime]System.Double
+		IL_089d: ldc.r8 4
+		IL_08a6: box [System.Runtime]System.Double
+		IL_08ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_08b0: stloc.s 7
 
-		IL_085e: ldloc.s 6
-		IL_0860: ldloc.s 7
-		IL_0862: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0867: pop
-		IL_0868: ldstr "String"
-		IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0872: volatile.
-		IL_0874: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0879: brfalse IL_088d
+		IL_08b2: ldloc.s 6
+		IL_08b4: ldloc.s 7
+		IL_08b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08bb: pop
+		IL_08bc: ldstr "String"
+		IL_08c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08c6: volatile.
+		IL_08c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_08cd: brfalse IL_08e1
 
-		IL_087e: ldstr "prototype"
-		IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0888: br IL_08a1
+		IL_08d2: ldstr "prototype"
+		IL_08d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08dc: br IL_08f5
 
-		IL_088d: ldstr "prototype"
-		IL_0892: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:189"
-		IL_0897: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_089c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_08e1: ldstr "prototype"
+		IL_08e6: ldstr "String_ExplicitReceiverAbi:Modules.String_ExplicitReceiverAbi:__js_module_init__:189"
+		IL_08eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_08f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_08a1: stloc.s 7
-		IL_08a3: ldloc.s 7
-		IL_08a5: ldstr "slice"
-		IL_08aa: ldloc.s 4
-		IL_08ac: ldc.i4.1
-		IL_08ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_08b2: pop
-		IL_08b3: ldnull
-		IL_08b4: stloc.s 5
-		IL_08b6: ret
+		IL_08f5: stloc.s 7
+		IL_08f7: ldloc.s 7
+		IL_08f9: ldstr "slice"
+		IL_08fe: ldloc.s 4
+		IL_0900: ldc.i4.1
+		IL_0901: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0906: pop
+		IL_0907: ldnull
+		IL_0908: stloc.s 5
+		IL_090a: ret
 	} // end of method String_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.String_ExplicitReceiverAbi
@@ -1025,6 +1051,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_22
 	.field assembly static int32 __jroc_dynamicLookup_23
 	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MatchAll_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MatchAll_Basic.verified.txt
@@ -143,7 +143,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 896 (0x380)
+		// Code size: 1031 (0x407)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MatchAll_Basic/Scope,
@@ -166,265 +166,304 @@
 		IL_000c: ldstr "g"
 		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_0016: stloc.s 7
-		IL_0018: ldstr "test1 test22"
-		IL_001d: ldstr "matchAll"
-		IL_0022: ldloc.s 7
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0029: stloc.s 8
-		IL_002b: ldloc.s 8
-		IL_002d: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0032: stloc.1
-		IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0038: stloc.s 9
-		IL_003a: ldloc.1
-		IL_003b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_0040: box [System.Runtime]System.Double
-		IL_0045: stloc.s 10
-		IL_0047: ldloc.s 9
-		IL_0049: ldloc.s 10
-		IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0050: pop
-		IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0056: stloc.s 9
-		IL_0058: ldloc.1
-		IL_0059: ldc.r8 0.0
-		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0067: ldc.r8 0.0
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0075: stloc.s 8
-		IL_0077: ldloc.s 9
-		IL_0079: ldloc.s 8
-		IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0080: pop
-		IL_0081: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0086: stloc.s 9
-		IL_0088: ldloc.1
-		IL_0089: ldc.r8 0.0
-		IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0097: ldc.r8 1
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00a5: stloc.s 8
-		IL_00a7: ldloc.s 9
-		IL_00a9: ldloc.s 8
-		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b0: pop
-		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b6: stloc.s 9
-		IL_00b8: ldloc.1
-		IL_00b9: ldc.r8 0.0
-		IL_00c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00c7: ldc.r8 2
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00d5: stloc.s 8
-		IL_00d7: ldloc.s 9
-		IL_00d9: ldloc.s 8
-		IL_00db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e0: pop
-		IL_00e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e6: stloc.s 9
-		IL_00e8: ldloc.1
-		IL_00e9: ldc.r8 0.0
-		IL_00f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_00f7: volatile.
-		IL_00f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00fe: brfalse IL_0112
+		IL_0018: volatile.
+		IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_001f: brfalse IL_003a
 
-		IL_0103: ldstr "index"
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010d: br IL_0126
+		IL_0024: ldstr "test1 test22"
+		IL_0029: ldstr "matchAll"
+		IL_002e: ldloc.s 7
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0035: br IL_0055
 
-		IL_0112: ldstr "index"
-		IL_0117: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:42"
-		IL_011c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_003a: ldstr "test1 test22"
+		IL_003f: ldstr "matchAll"
+		IL_0044: ldloc.s 7
+		IL_0046: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:8"
+		IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0126: stloc.s 8
-		IL_0128: ldloc.s 9
-		IL_012a: ldloc.s 8
-		IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0131: pop
-		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0137: stloc.s 9
-		IL_0139: ldloc.1
-		IL_013a: ldc.r8 1
-		IL_0143: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0148: ldc.r8 0.0
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0156: stloc.s 8
-		IL_0158: ldloc.s 9
-		IL_015a: ldloc.s 8
-		IL_015c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0161: pop
-		IL_0162: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0167: stloc.s 9
-		IL_0169: ldloc.1
-		IL_016a: ldc.r8 1
-		IL_0173: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0178: ldc.r8 1
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0186: stloc.s 8
-		IL_0188: ldloc.s 9
-		IL_018a: ldloc.s 8
-		IL_018c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0191: pop
-		IL_0192: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0197: stloc.s 9
-		IL_0199: ldloc.1
-		IL_019a: ldc.r8 1
-		IL_01a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01a8: ldc.r8 2
-		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01b6: stloc.s 8
-		IL_01b8: ldloc.s 9
-		IL_01ba: ldloc.s 8
-		IL_01bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01c1: pop
-		IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c7: stloc.s 9
-		IL_01c9: ldloc.1
-		IL_01ca: ldc.r8 1
-		IL_01d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01d8: volatile.
-		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_01df: brfalse IL_01f3
+		IL_0055: stloc.s 8
+		IL_0057: ldloc.s 8
+		IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_005e: stloc.1
+		IL_005f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0064: stloc.s 9
+		IL_0066: ldloc.1
+		IL_0067: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_006c: box [System.Runtime]System.Double
+		IL_0071: stloc.s 10
+		IL_0073: ldloc.s 9
+		IL_0075: ldloc.s 10
+		IL_0077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007c: pop
+		IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0082: stloc.s 9
+		IL_0084: ldloc.1
+		IL_0085: ldc.r8 0.0
+		IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0093: ldc.r8 0.0
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00a1: stloc.s 8
+		IL_00a3: ldloc.s 9
+		IL_00a5: ldloc.s 8
+		IL_00a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ac: pop
+		IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b2: stloc.s 9
+		IL_00b4: ldloc.1
+		IL_00b5: ldc.r8 0.0
+		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00c3: ldc.r8 1
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00d1: stloc.s 8
+		IL_00d3: ldloc.s 9
+		IL_00d5: ldloc.s 8
+		IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00dc: pop
+		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e2: stloc.s 9
+		IL_00e4: ldloc.1
+		IL_00e5: ldc.r8 0.0
+		IL_00ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_00f3: ldc.r8 2
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0101: stloc.s 8
+		IL_0103: ldloc.s 9
+		IL_0105: ldloc.s 8
+		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010c: pop
+		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0112: stloc.s 9
+		IL_0114: ldloc.1
+		IL_0115: ldc.r8 0.0
+		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0123: volatile.
+		IL_0125: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_012a: brfalse IL_013e
 
-		IL_01e4: ldstr "index"
-		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ee: br IL_0207
+		IL_012f: ldstr "index"
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0139: br IL_0152
 
-		IL_01f3: ldstr "index"
-		IL_01f8: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:70"
-		IL_01fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_013e: ldstr "index"
+		IL_0143: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:42"
+		IL_0148: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0207: stloc.s 8
-		IL_0209: ldloc.s 9
-		IL_020b: ldloc.s 8
-		IL_020d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0212: pop
-		IL_0213: ldstr "aba"
-		IL_0218: ldstr "matchAll"
-		IL_021d: ldstr "a"
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0227: stloc.s 8
-		IL_0229: ldloc.s 8
-		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_0230: stloc.2
-		IL_0231: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0236: stloc.s 9
-		IL_0238: ldloc.2
-		IL_0239: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_023e: box [System.Runtime]System.Double
-		IL_0243: stloc.s 10
-		IL_0245: ldloc.s 9
-		IL_0247: ldloc.s 10
-		IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024e: pop
-		IL_024f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0254: stloc.s 9
-		IL_0256: ldloc.2
-		IL_0257: ldc.r8 0.0
-		IL_0260: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0265: ldc.r8 0.0
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0273: stloc.s 8
-		IL_0275: ldloc.s 9
-		IL_0277: ldloc.s 8
-		IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_027e: pop
-		IL_027f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0284: stloc.s 9
-		IL_0286: ldloc.2
-		IL_0287: ldc.r8 1
-		IL_0290: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0295: volatile.
-		IL_0297: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_029c: brfalse IL_02b0
+		IL_0152: stloc.s 8
+		IL_0154: ldloc.s 9
+		IL_0156: ldloc.s 8
+		IL_0158: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015d: pop
+		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0163: stloc.s 9
+		IL_0165: ldloc.1
+		IL_0166: ldc.r8 1
+		IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0174: ldc.r8 0.0
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0182: stloc.s 8
+		IL_0184: ldloc.s 9
+		IL_0186: ldloc.s 8
+		IL_0188: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_018d: pop
+		IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0193: stloc.s 9
+		IL_0195: ldloc.1
+		IL_0196: ldc.r8 1
+		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01a4: ldc.r8 1
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01b2: stloc.s 8
+		IL_01b4: ldloc.s 9
+		IL_01b6: ldloc.s 8
+		IL_01b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01bd: pop
+		IL_01be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c3: stloc.s 9
+		IL_01c5: ldloc.1
+		IL_01c6: ldc.r8 1
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01d4: ldc.r8 2
+		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01e2: stloc.s 8
+		IL_01e4: ldloc.s 9
+		IL_01e6: ldloc.s 8
+		IL_01e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ed: pop
+		IL_01ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f3: stloc.s 9
+		IL_01f5: ldloc.1
+		IL_01f6: ldc.r8 1
+		IL_01ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0204: volatile.
+		IL_0206: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_020b: brfalse IL_021f
 
-		IL_02a1: ldstr "index"
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ab: br IL_02c4
+		IL_0210: ldstr "index"
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021a: br IL_0233
 
-		IL_02b0: ldstr "index"
-		IL_02b5: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:95"
-		IL_02ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_021f: ldstr "index"
+		IL_0224: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:70"
+		IL_0229: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02c4: stloc.s 8
-		IL_02c6: ldloc.s 9
-		IL_02c8: ldloc.s 8
-		IL_02ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02cf: pop
+		IL_0233: stloc.s 8
+		IL_0235: ldloc.s 9
+		IL_0237: ldloc.s 8
+		IL_0239: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_023e: pop
+		IL_023f: volatile.
+		IL_0241: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0246: brfalse IL_0264
+
+		IL_024b: ldstr "aba"
+		IL_0250: ldstr "matchAll"
+		IL_0255: ldstr "a"
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025f: br IL_0282
+
+		IL_0264: ldstr "aba"
+		IL_0269: ldstr "matchAll"
+		IL_026e: ldstr "a"
+		IL_0273: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:75"
+		IL_0278: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0282: stloc.s 8
+		IL_0284: ldloc.s 8
+		IL_0286: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_028b: stloc.2
+		IL_028c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0291: stloc.s 9
+		IL_0293: ldloc.2
+		IL_0294: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0299: box [System.Runtime]System.Double
+		IL_029e: stloc.s 10
+		IL_02a0: ldloc.s 9
+		IL_02a2: ldloc.s 10
+		IL_02a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a9: pop
+		IL_02aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02af: stloc.s 9
+		IL_02b1: ldloc.2
+		IL_02b2: ldc.r8 0.0
+		IL_02bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_02c0: ldc.r8 0.0
+		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02ce: stloc.s 8
+		IL_02d0: ldloc.s 9
+		IL_02d2: ldloc.s 8
+		IL_02d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d9: pop
+		IL_02da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02df: stloc.s 9
+		IL_02e1: ldloc.2
+		IL_02e2: ldc.r8 1
+		IL_02eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_02f0: volatile.
+		IL_02f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_02f7: brfalse IL_030b
+
+		IL_02fc: ldstr "index"
+		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0306: br IL_031f
+
+		IL_030b: ldstr "index"
+		IL_0310: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:95"
+		IL_0315: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_031f: stloc.s 8
+		IL_0321: ldloc.s 9
+		IL_0323: ldloc.s 8
+		IL_0325: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_032a: pop
 		.try
 		{
-			IL_02d0: nop
-			IL_02d1: ldstr "a"
-			IL_02d6: ldstr ""
-			IL_02db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02e0: stloc.s 7
-			IL_02e2: ldstr "aba"
-			IL_02e7: ldstr "matchAll"
-			IL_02ec: ldloc.s 7
-			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02f3: stloc.s 8
-			IL_02f5: ldloc.s 8
-			IL_02f7: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-			IL_02fc: pop
-			IL_02fd: leave IL_037c
+			IL_032b: nop
+			IL_032c: ldstr "a"
+			IL_0331: ldstr ""
+			IL_0336: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_033b: stloc.s 7
+			IL_033d: volatile.
+			IL_033f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0344: brfalse IL_035f
+
+			IL_0349: ldstr "aba"
+			IL_034e: ldstr "matchAll"
+			IL_0353: ldloc.s 7
+			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_035a: br IL_037a
+
+			IL_035f: ldstr "aba"
+			IL_0364: ldstr "matchAll"
+			IL_0369: ldloc.s 7
+			IL_036b: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:105"
+			IL_0370: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_037a: stloc.s 8
+			IL_037c: ldloc.s 8
+			IL_037e: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+			IL_0383: pop
+			IL_0384: leave IL_0403
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0302: stloc.3
-			IL_0303: ldloc.3
-			IL_0304: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0309: dup
-			IL_030a: brtrue IL_031f
+			IL_0389: stloc.3
+			IL_038a: ldloc.3
+			IL_038b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0390: dup
+			IL_0391: brtrue IL_03a6
 
-			IL_030f: pop
-			IL_0310: ldloc.3
-			IL_0311: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0316: dup
-			IL_0317: brtrue IL_032b
+			IL_0396: pop
+			IL_0397: ldloc.3
+			IL_0398: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_039d: dup
+			IL_039e: brtrue IL_03b2
 
-			IL_031c: pop
-			IL_031d: rethrow
+			IL_03a3: pop
+			IL_03a4: rethrow
 
-			IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0324: stloc.s 4
-			IL_0326: br IL_032d
+			IL_03a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03ab: stloc.s 4
+			IL_03ad: br IL_03b4
 
-			IL_032b: stloc.s 4
+			IL_03b2: stloc.s 4
 
-			IL_032d: ldloc.s 4
-			IL_032f: stloc.s 5
-			IL_0331: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0336: stloc.s 9
-			IL_0338: volatile.
-			IL_033a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-			IL_033f: brfalse IL_0355
+			IL_03b4: ldloc.s 4
+			IL_03b6: stloc.s 5
+			IL_03b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03bd: stloc.s 9
+			IL_03bf: volatile.
+			IL_03c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_03c6: brfalse IL_03dc
 
-			IL_0344: ldloc.s 5
-			IL_0346: ldstr "name"
-			IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0350: br IL_036b
+			IL_03cb: ldloc.s 5
+			IL_03cd: ldstr "name"
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d7: br IL_03f2
 
-			IL_0355: ldloc.s 5
-			IL_0357: ldstr "name"
-			IL_035c: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:117"
-			IL_0361: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03dc: ldloc.s 5
+			IL_03de: ldstr "name"
+			IL_03e3: ldstr "String_MatchAll_Basic:Modules.String_MatchAll_Basic:__js_module_init__:117"
+			IL_03e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_036b: stloc.s 8
-			IL_036d: ldloc.s 9
-			IL_036f: ldloc.s 8
-			IL_0371: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0376: pop
-			IL_0377: leave IL_037c
+			IL_03f2: stloc.s 8
+			IL_03f4: ldloc.s 9
+			IL_03f6: ldloc.s 8
+			IL_03f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03fd: pop
+			IL_03fe: leave IL_0403
 		} // end handler
 
-		IL_037c: ldnull
-		IL_037d: stloc.s 6
-		IL_037f: ret
+		IL_0403: ldnull
+		IL_0404: stloc.s 6
+		IL_0406: ret
 	} // end of method String_MatchAll_Basic::__js_module_init__
 
 } // end of class Modules.String_MatchAll_Basic
@@ -458,6 +497,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_Global.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 252 (0xfc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Match_Global/Scope,
@@ -123,64 +123,77 @@
 		IL_0012: ldstr "g"
 		IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_001c: stloc.3
-		IL_001d: ldloc.1
-		IL_001e: ldstr "match"
-		IL_0023: ldloc.3
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0029: stloc.2
-		IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_002f: stloc.s 4
-		IL_0031: volatile.
-		IL_0033: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0038: brfalse IL_004d
+		IL_001d: volatile.
+		IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0024: brfalse IL_003a
 
-		IL_003d: ldloc.2
-		IL_003e: ldstr "length"
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0048: br IL_0062
+		IL_0029: ldloc.1
+		IL_002a: ldstr "match"
+		IL_002f: ldloc.3
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0035: br IL_0050
 
-		IL_004d: ldloc.2
-		IL_004e: ldstr "length"
-		IL_0053: ldstr "String_Match_Global:Modules.String_Match_Global:__js_module_init__:15"
-		IL_0058: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_003a: ldloc.1
+		IL_003b: ldstr "match"
+		IL_0040: ldloc.3
+		IL_0041: ldstr "String_Match_Global:Modules.String_Match_Global:__js_module_init__:10"
+		IL_0046: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0062: stloc.s 5
-		IL_0064: ldloc.s 4
-		IL_0066: ldloc.s 5
-		IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006d: pop
-		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.2
-		IL_0076: ldc.r8 0.0
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0084: stloc.s 5
-		IL_0086: ldloc.s 4
-		IL_0088: ldloc.s 5
-		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008f: pop
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.2
-		IL_0098: ldc.r8 1
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00a6: stloc.s 5
-		IL_00a8: ldloc.s 4
-		IL_00aa: ldloc.s 5
-		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b1: pop
-		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b7: stloc.s 4
-		IL_00b9: ldloc.2
-		IL_00ba: ldc.r8 2
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00c8: stloc.s 5
-		IL_00ca: ldloc.s 4
-		IL_00cc: ldloc.s 5
-		IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d3: pop
-		IL_00d4: ret
+		IL_0050: stloc.2
+		IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0056: stloc.s 4
+		IL_0058: volatile.
+		IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_005f: brfalse IL_0074
+
+		IL_0064: ldloc.2
+		IL_0065: ldstr "length"
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006f: br IL_0089
+
+		IL_0074: ldloc.2
+		IL_0075: ldstr "length"
+		IL_007a: ldstr "String_Match_Global:Modules.String_Match_Global:__js_module_init__:15"
+		IL_007f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0089: stloc.s 5
+		IL_008b: ldloc.s 4
+		IL_008d: ldloc.s 5
+		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0094: pop
+		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009a: stloc.s 4
+		IL_009c: ldloc.2
+		IL_009d: ldc.r8 0.0
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00ab: stloc.s 5
+		IL_00ad: ldloc.s 4
+		IL_00af: ldloc.s 5
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b6: pop
+		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bc: stloc.s 4
+		IL_00be: ldloc.2
+		IL_00bf: ldc.r8 1
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00cd: stloc.s 5
+		IL_00cf: ldloc.s 4
+		IL_00d1: ldloc.s 5
+		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d8: pop
+		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00de: stloc.s 4
+		IL_00e0: ldloc.2
+		IL_00e1: ldc.r8 2
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00ef: stloc.s 5
+		IL_00f1: ldloc.s 4
+		IL_00f3: ldloc.s 5
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fa: pop
+		IL_00fb: ret
 	} // end of method String_Match_Global::__js_module_init__
 
 } // end of class Modules.String_Match_Global
@@ -211,6 +224,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_NonGlobal.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Match_NonGlobal.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 281 (0x119)
+		// Code size: 320 (0x140)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Match_NonGlobal/Scope,
@@ -123,86 +123,99 @@
 		IL_0012: ldstr ""
 		IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_001c: stloc.3
-		IL_001d: ldloc.1
-		IL_001e: ldstr "match"
-		IL_0023: ldloc.3
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0029: stloc.2
-		IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_002f: stloc.s 4
-		IL_0031: ldloc.2
-		IL_0032: ldc.r8 0.0
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0040: stloc.s 5
-		IL_0042: ldloc.s 4
-		IL_0044: ldloc.s 5
-		IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_004b: pop
-		IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0051: stloc.s 4
-		IL_0053: ldloc.2
-		IL_0054: ldc.r8 1
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0062: stloc.s 5
-		IL_0064: ldloc.s 4
-		IL_0066: ldloc.s 5
-		IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006d: pop
-		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.2
-		IL_0076: ldc.r8 2
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0084: stloc.s 5
-		IL_0086: ldloc.s 4
-		IL_0088: ldloc.s 5
-		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008f: pop
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0095: stloc.s 4
-		IL_0097: volatile.
-		IL_0099: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_009e: brfalse IL_00b3
+		IL_001d: volatile.
+		IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0024: brfalse IL_003a
 
-		IL_00a3: ldloc.2
-		IL_00a4: ldstr "index"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ae: br IL_00c8
+		IL_0029: ldloc.1
+		IL_002a: ldstr "match"
+		IL_002f: ldloc.3
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0035: br IL_0050
 
-		IL_00b3: ldloc.2
-		IL_00b4: ldstr "index"
-		IL_00b9: ldstr "String_Match_NonGlobal:Modules.String_Match_NonGlobal:__js_module_init__:30"
-		IL_00be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_003a: ldloc.1
+		IL_003b: ldstr "match"
+		IL_0040: ldloc.3
+		IL_0041: ldstr "String_Match_NonGlobal:Modules.String_Match_NonGlobal:__js_module_init__:10"
+		IL_0046: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00c8: stloc.s 5
-		IL_00ca: ldloc.s 4
-		IL_00cc: ldloc.s 5
-		IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d3: pop
-		IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d9: stloc.s 4
-		IL_00db: volatile.
-		IL_00dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00e2: brfalse IL_00f7
+		IL_0050: stloc.2
+		IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0056: stloc.s 4
+		IL_0058: ldloc.2
+		IL_0059: ldc.r8 0.0
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0067: stloc.s 5
+		IL_0069: ldloc.s 4
+		IL_006b: ldloc.s 5
+		IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0072: pop
+		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0078: stloc.s 4
+		IL_007a: ldloc.2
+		IL_007b: ldc.r8 1
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0089: stloc.s 5
+		IL_008b: ldloc.s 4
+		IL_008d: ldloc.s 5
+		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0094: pop
+		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009a: stloc.s 4
+		IL_009c: ldloc.2
+		IL_009d: ldc.r8 2
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00ab: stloc.s 5
+		IL_00ad: ldloc.s 4
+		IL_00af: ldloc.s 5
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b6: pop
+		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bc: stloc.s 4
+		IL_00be: volatile.
+		IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c5: brfalse IL_00da
 
-		IL_00e7: ldloc.2
-		IL_00e8: ldstr "input"
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f2: br IL_010c
+		IL_00ca: ldloc.2
+		IL_00cb: ldstr "index"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d5: br IL_00ef
 
-		IL_00f7: ldloc.2
-		IL_00f8: ldstr "input"
-		IL_00fd: ldstr "String_Match_NonGlobal:Modules.String_Match_NonGlobal:__js_module_init__:35"
-		IL_0102: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00da: ldloc.2
+		IL_00db: ldstr "index"
+		IL_00e0: ldstr "String_Match_NonGlobal:Modules.String_Match_NonGlobal:__js_module_init__:30"
+		IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_010c: stloc.s 5
-		IL_010e: ldloc.s 4
-		IL_0110: ldloc.s 5
-		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0117: pop
-		IL_0118: ret
+		IL_00ef: stloc.s 5
+		IL_00f1: ldloc.s 4
+		IL_00f3: ldloc.s 5
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fa: pop
+		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0100: stloc.s 4
+		IL_0102: volatile.
+		IL_0104: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0109: brfalse IL_011e
+
+		IL_010e: ldloc.2
+		IL_010f: ldstr "input"
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0119: br IL_0133
+
+		IL_011e: ldloc.2
+		IL_011f: ldstr "input"
+		IL_0124: ldstr "String_Match_NonGlobal:Modules.String_Match_NonGlobal:__js_module_init__:35"
+		IL_0129: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0133: stloc.s 5
+		IL_0135: ldloc.s 4
+		IL_0137: ldloc.s 5
+		IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_013e: pop
+		IL_013f: ret
 	} // end of method String_Match_NonGlobal::__js_module_init__
 
 } // end of class Modules.String_Match_NonGlobal
@@ -234,6 +247,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1084 (0x43c)
+		// Code size: 1352 (0x548)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_NewApis_Basic/Scope,
@@ -203,227 +203,296 @@
 		IL_0135: pop
 		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_013b: stloc.1
-		IL_013c: ldstr "abc"
-		IL_0141: ldstr "at"
-		IL_0146: ldc.r8 0.0
-		IL_014f: box [System.Runtime]System.Double
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0159: stloc.s 4
-		IL_015b: ldloc.1
-		IL_015c: ldloc.s 4
-		IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0163: pop
-		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0169: stloc.1
-		IL_016a: ldc.r8 1
-		IL_0173: neg
-		IL_0174: stloc.s 5
-		IL_0176: ldloc.s 5
-		IL_0178: box [System.Runtime]System.Double
-		IL_017d: stloc.s 6
-		IL_017f: ldstr "abc"
-		IL_0184: ldstr "at"
-		IL_0189: ldloc.s 6
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0190: stloc.s 4
-		IL_0192: ldloc.1
-		IL_0193: ldloc.s 4
-		IL_0195: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019a: pop
-		IL_019b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a0: stloc.1
-		IL_01a1: ldstr "abc"
-		IL_01a6: ldstr "at"
-		IL_01ab: ldc.r8 99
-		IL_01b4: box [System.Runtime]System.Double
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01be: stloc.s 4
-		IL_01c0: ldloc.s 4
-		IL_01c2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_01c7: stloc.2
-		IL_01c8: ldloc.1
-		IL_01c9: ldloc.2
-		IL_01ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01cf: pop
-		IL_01d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d5: stloc.1
-		IL_01d6: ldstr "A\ud83d\ude00B"
-		IL_01db: ldstr "codePointAt"
-		IL_01e0: ldc.r8 1
-		IL_01e9: box [System.Runtime]System.Double
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01f3: stloc.s 4
-		IL_01f5: ldloc.1
-		IL_01f6: ldloc.s 4
-		IL_01f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01fd: pop
-		IL_01fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0203: stloc.1
-		IL_0204: ldstr "A\ud83d\ude00B"
-		IL_0209: ldstr "codePointAt"
-		IL_020e: ldc.r8 20
-		IL_0217: box [System.Runtime]System.Double
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0221: stloc.s 4
-		IL_0223: ldloc.s 4
-		IL_0225: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_022a: stloc.2
-		IL_022b: ldloc.1
-		IL_022c: ldloc.2
-		IL_022d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0232: pop
-		IL_0233: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0238: stloc.1
-		IL_0239: ldstr "5"
-		IL_023e: ldstr "padStart"
-		IL_0243: ldc.r8 3
-		IL_024c: box [System.Runtime]System.Double
-		IL_0251: ldstr "0"
-		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_025b: stloc.s 4
-		IL_025d: ldloc.1
-		IL_025e: ldloc.s 4
-		IL_0260: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0265: pop
-		IL_0266: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_026b: stloc.1
-		IL_026c: ldstr "5"
-		IL_0271: ldstr "padEnd"
-		IL_0276: ldc.r8 4
-		IL_027f: box [System.Runtime]System.Double
-		IL_0284: ldstr "xy"
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_028e: stloc.s 4
-		IL_0290: ldloc.1
-		IL_0291: ldloc.s 4
-		IL_0293: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0298: pop
-		IL_0299: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_029e: stloc.1
-		IL_029f: ldstr "foofoo"
-		IL_02a4: ldstr "replaceAll"
-		IL_02a9: ldstr "oo"
-		IL_02ae: ldstr "ar"
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02b8: stloc.s 4
-		IL_02ba: ldloc.1
-		IL_02bb: ldloc.s 4
-		IL_02bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c2: pop
-		IL_02c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c8: stloc.1
-		IL_02c9: ldstr "aba"
-		IL_02ce: ldstr "replaceAll"
-		IL_02d3: ldstr ""
-		IL_02d8: ldstr "-"
-		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02e2: stloc.s 4
-		IL_02e4: ldloc.1
-		IL_02e5: ldloc.s 4
-		IL_02e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ec: pop
-		IL_02ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f2: stloc.1
-		IL_02f3: volatile.
-		IL_02f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_02fa: brfalse IL_0313
+		IL_013c: volatile.
+		IL_013e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0143: brfalse IL_016a
 
-		IL_02ff: ldstr "\ud83d\ude00"
-		IL_0304: ldstr "isWellFormed"
-		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_030e: br IL_032c
+		IL_0148: ldstr "abc"
+		IL_014d: ldstr "at"
+		IL_0152: ldc.r8 0.0
+		IL_015b: box [System.Runtime]System.Double
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0165: br IL_0191
 
-		IL_0313: ldstr "\ud83d\ude00"
-		IL_0318: ldstr "isWellFormed"
-		IL_031d: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:113"
-		IL_0322: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_016a: ldstr "abc"
+		IL_016f: ldstr "at"
+		IL_0174: ldc.r8 0.0
+		IL_017d: box [System.Runtime]System.Double
+		IL_0182: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:47"
+		IL_0187: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_032c: stloc.s 4
-		IL_032e: ldloc.1
+		IL_0191: stloc.s 4
+		IL_0193: ldloc.1
+		IL_0194: ldloc.s 4
+		IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019b: pop
+		IL_019c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a1: stloc.1
+		IL_01a2: ldc.r8 1
+		IL_01ab: neg
+		IL_01ac: stloc.s 5
+		IL_01ae: ldloc.s 5
+		IL_01b0: box [System.Runtime]System.Double
+		IL_01b5: stloc.s 6
+		IL_01b7: volatile.
+		IL_01b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_01be: brfalse IL_01d9
+
+		IL_01c3: ldstr "abc"
+		IL_01c8: ldstr "at"
+		IL_01cd: ldloc.s 6
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d4: br IL_01f4
+
+		IL_01d9: ldstr "abc"
+		IL_01de: ldstr "at"
+		IL_01e3: ldloc.s 6
+		IL_01e5: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:55"
+		IL_01ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01f4: stloc.s 4
+		IL_01f6: ldloc.1
+		IL_01f7: ldloc.s 4
+		IL_01f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01fe: pop
+		IL_01ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0204: stloc.1
+		IL_0205: volatile.
+		IL_0207: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_020c: brfalse IL_0233
+
+		IL_0211: ldstr "abc"
+		IL_0216: ldstr "at"
+		IL_021b: ldc.r8 99
+		IL_0224: box [System.Runtime]System.Double
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_022e: br IL_025a
+
+		IL_0233: ldstr "abc"
+		IL_0238: ldstr "at"
+		IL_023d: ldc.r8 99
+		IL_0246: box [System.Runtime]System.Double
+		IL_024b: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:62"
+		IL_0250: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_025a: stloc.s 4
+		IL_025c: ldloc.s 4
+		IL_025e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0263: stloc.2
+		IL_0264: ldloc.1
+		IL_0265: ldloc.2
+		IL_0266: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_026b: pop
+		IL_026c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0271: stloc.1
+		IL_0272: volatile.
+		IL_0274: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0279: brfalse IL_02a0
+
+		IL_027e: ldstr "A\ud83d\ude00B"
+		IL_0283: ldstr "codePointAt"
+		IL_0288: ldc.r8 1
+		IL_0291: box [System.Runtime]System.Double
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029b: br IL_02c7
+
+		IL_02a0: ldstr "A\ud83d\ude00B"
+		IL_02a5: ldstr "codePointAt"
+		IL_02aa: ldc.r8 1
+		IL_02b3: box [System.Runtime]System.Double
+		IL_02b8: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:70"
+		IL_02bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02c7: stloc.s 4
+		IL_02c9: ldloc.1
+		IL_02ca: ldloc.s 4
+		IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d1: pop
+		IL_02d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d7: stloc.1
+		IL_02d8: volatile.
+		IL_02da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_02df: brfalse IL_0306
+
+		IL_02e4: ldstr "A\ud83d\ude00B"
+		IL_02e9: ldstr "codePointAt"
+		IL_02ee: ldc.r8 20
+		IL_02f7: box [System.Runtime]System.Double
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0301: br IL_032d
+
+		IL_0306: ldstr "A\ud83d\ude00B"
+		IL_030b: ldstr "codePointAt"
+		IL_0310: ldc.r8 20
+		IL_0319: box [System.Runtime]System.Double
+		IL_031e: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:77"
+		IL_0323: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_032d: stloc.s 4
 		IL_032f: ldloc.s 4
-		IL_0331: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0336: pop
-		IL_0337: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_033c: stloc.1
-		IL_033d: volatile.
-		IL_033f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0344: brfalse IL_035d
+		IL_0331: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+		IL_0336: stloc.2
+		IL_0337: ldloc.1
+		IL_0338: ldloc.2
+		IL_0339: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_033e: pop
+		IL_033f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0344: stloc.1
+		IL_0345: ldstr "5"
+		IL_034a: ldstr "padStart"
+		IL_034f: ldc.r8 3
+		IL_0358: box [System.Runtime]System.Double
+		IL_035d: ldstr "0"
+		IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0367: stloc.s 4
+		IL_0369: ldloc.1
+		IL_036a: ldloc.s 4
+		IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0371: pop
+		IL_0372: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0377: stloc.1
+		IL_0378: ldstr "5"
+		IL_037d: ldstr "padEnd"
+		IL_0382: ldc.r8 4
+		IL_038b: box [System.Runtime]System.Double
+		IL_0390: ldstr "xy"
+		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_039a: stloc.s 4
+		IL_039c: ldloc.1
+		IL_039d: ldloc.s 4
+		IL_039f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03a4: pop
+		IL_03a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03aa: stloc.1
+		IL_03ab: ldstr "foofoo"
+		IL_03b0: ldstr "replaceAll"
+		IL_03b5: ldstr "oo"
+		IL_03ba: ldstr "ar"
+		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03c4: stloc.s 4
+		IL_03c6: ldloc.1
+		IL_03c7: ldloc.s 4
+		IL_03c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03ce: pop
+		IL_03cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03d4: stloc.1
+		IL_03d5: ldstr "aba"
+		IL_03da: ldstr "replaceAll"
+		IL_03df: ldstr ""
+		IL_03e4: ldstr "-"
+		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03ee: stloc.s 4
+		IL_03f0: ldloc.1
+		IL_03f1: ldloc.s 4
+		IL_03f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03f8: pop
+		IL_03f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03fe: stloc.1
+		IL_03ff: volatile.
+		IL_0401: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0406: brfalse IL_041f
 
-		IL_0349: ldstr "\ud83d"
-		IL_034e: ldstr "isWellFormed"
-		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0358: br IL_0376
+		IL_040b: ldstr "\ud83d\ude00"
+		IL_0410: ldstr "isWellFormed"
+		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_041a: br IL_0438
 
-		IL_035d: ldstr "\ud83d"
-		IL_0362: ldstr "isWellFormed"
-		IL_0367: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:118"
-		IL_036c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_041f: ldstr "\ud83d\ude00"
+		IL_0424: ldstr "isWellFormed"
+		IL_0429: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:113"
+		IL_042e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0376: stloc.s 4
-		IL_0378: ldloc.1
-		IL_0379: ldloc.s 4
-		IL_037b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0380: pop
-		IL_0381: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0386: stloc.1
-		IL_0387: volatile.
-		IL_0389: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_038e: brfalse IL_03a7
+		IL_0438: stloc.s 4
+		IL_043a: ldloc.1
+		IL_043b: ldloc.s 4
+		IL_043d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0442: pop
+		IL_0443: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0448: stloc.1
+		IL_0449: volatile.
+		IL_044b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0450: brfalse IL_0469
 
-		IL_0393: ldstr "A\ud83d"
-		IL_0398: ldstr "toWellFormed"
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_03a2: br IL_03c0
+		IL_0455: ldstr "\ud83d"
+		IL_045a: ldstr "isWellFormed"
+		IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0464: br IL_0482
 
-		IL_03a7: ldstr "A\ud83d"
-		IL_03ac: ldstr "toWellFormed"
-		IL_03b1: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:123"
-		IL_03b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0469: ldstr "\ud83d"
+		IL_046e: ldstr "isWellFormed"
+		IL_0473: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:118"
+		IL_0478: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_03c0: stloc.s 4
-		IL_03c2: ldloc.s 4
-		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03c9: stloc.s 4
-		IL_03cb: ldc.i4.0
-		IL_03cc: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_03d1: brfalse IL_0416
+		IL_0482: stloc.s 4
+		IL_0484: ldloc.1
+		IL_0485: ldloc.s 4
+		IL_0487: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_048c: pop
+		IL_048d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0492: stloc.1
+		IL_0493: volatile.
+		IL_0495: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_049a: brfalse IL_04b3
 
-		IL_03d6: ldloc.s 4
-		IL_03d8: isinst [System.Runtime]System.String
-		IL_03dd: dup
-		IL_03de: brtrue IL_03f6
+		IL_049f: ldstr "A\ud83d"
+		IL_04a4: ldstr "toWellFormed"
+		IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_04ae: br IL_04cc
 
-		IL_03e3: pop
-		IL_03e4: ldloc.s 4
-		IL_03e6: ldstr "charCodeAt"
-		IL_03eb: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_03f0: dup
-		IL_03f1: brfalse IL_0415
+		IL_04b3: ldstr "A\ud83d"
+		IL_04b8: ldstr "toWellFormed"
+		IL_04bd: ldstr "String_NewApis_Basic:Modules.String_NewApis_Basic:__js_module_init__:123"
+		IL_04c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_03f6: ldc.r8 1
-		IL_03ff: box [System.Runtime]System.Double
-		IL_0404: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_0409: box [System.Runtime]System.Double
-		IL_040e: stloc.s 4
-		IL_0410: br IL_0432
+		IL_04cc: stloc.s 4
+		IL_04ce: ldloc.s 4
+		IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04d5: stloc.s 4
+		IL_04d7: ldc.i4.0
+		IL_04d8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_04dd: brfalse IL_0522
 
-		IL_0415: pop
+		IL_04e2: ldloc.s 4
+		IL_04e4: isinst [System.Runtime]System.String
+		IL_04e9: dup
+		IL_04ea: brtrue IL_0502
 
-		IL_0416: ldloc.s 4
-		IL_0418: ldstr "charCodeAt"
-		IL_041d: ldc.r8 1
-		IL_0426: box [System.Runtime]System.Double
-		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0430: stloc.s 4
+		IL_04ef: pop
+		IL_04f0: ldloc.s 4
+		IL_04f2: ldstr "charCodeAt"
+		IL_04f7: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_04fc: dup
+		IL_04fd: brfalse IL_0521
 
-		IL_0432: ldloc.1
-		IL_0433: ldloc.s 4
-		IL_0435: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_043a: pop
-		IL_043b: ret
+		IL_0502: ldc.r8 1
+		IL_050b: box [System.Runtime]System.Double
+		IL_0510: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0515: box [System.Runtime]System.Double
+		IL_051a: stloc.s 4
+		IL_051c: br IL_053e
+
+		IL_0521: pop
+
+		IL_0522: ldloc.s 4
+		IL_0524: ldstr "charCodeAt"
+		IL_0529: ldc.r8 1
+		IL_0532: box [System.Runtime]System.Double
+		IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_053c: stloc.s 4
+
+		IL_053e: ldloc.1
+		IL_053f: ldloc.s 4
+		IL_0541: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0546: pop
+		IL_0547: ret
 	} // end of method String_NewApis_Basic::__js_module_init__
 
 } // end of class Modules.String_NewApis_Basic
@@ -456,6 +525,11 @@
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Prototype_Iterator_Surface.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Prototype_Iterator_Surface.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1822 (0x71e)
+		// Code size: 1948 (0x79c)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.String_Prototype_Iterator_Surface/Scope,
@@ -303,373 +303,409 @@
 		IL_0258: stloc.s 8
 		IL_025a: ldloc.s 8
 		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0261: ldstr "call"
-		IL_0266: ldstr "abc"
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0270: stloc.s 8
-		IL_0272: ldloc.s 5
-		IL_0274: ldloc.s 8
-		IL_0276: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_027b: pop
-		IL_027c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0281: stloc.s 5
-		IL_0283: ldstr "String"
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_028d: volatile.
-		IL_028f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0294: brfalse IL_02a8
+		IL_0261: volatile.
+		IL_0263: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0268: brfalse IL_0281
 
-		IL_0299: ldstr "prototype"
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a3: br IL_02bc
+		IL_026d: ldstr "call"
+		IL_0272: ldstr "abc"
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027c: br IL_029a
 
-		IL_02a8: ldstr "prototype"
-		IL_02ad: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:62"
-		IL_02b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0281: ldstr "call"
+		IL_0286: ldstr "abc"
+		IL_028b: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:55"
+		IL_0290: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02bc: stloc.s 8
-		IL_02be: volatile.
-		IL_02c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02c5: brfalse IL_02db
+		IL_029a: stloc.s 8
+		IL_029c: ldloc.s 5
+		IL_029e: ldloc.s 8
+		IL_02a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a5: pop
+		IL_02a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ab: stloc.s 5
+		IL_02ad: ldstr "String"
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02b7: volatile.
+		IL_02b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02be: brfalse IL_02d2
 
-		IL_02ca: ldloc.s 8
-		IL_02cc: ldstr "valueOf"
-		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d6: br IL_02f1
+		IL_02c3: ldstr "prototype"
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02cd: br IL_02e6
 
-		IL_02db: ldloc.s 8
-		IL_02dd: ldstr "valueOf"
-		IL_02e2: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:64"
-		IL_02e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02d2: ldstr "prototype"
+		IL_02d7: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:62"
+		IL_02dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02f1: stloc.s 8
-		IL_02f3: ldloc.s 8
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02fa: ldstr "call"
-		IL_02ff: ldstr "abc"
-		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0309: stloc.s 8
-		IL_030b: ldloc.s 5
-		IL_030d: ldloc.s 8
-		IL_030f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0314: pop
-		IL_0315: volatile.
-		IL_0317: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_031c: brfalse IL_0335
+		IL_02e6: stloc.s 8
+		IL_02e8: volatile.
+		IL_02ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02ef: brfalse IL_0305
 
-		IL_0321: ldstr "abc"
-		IL_0326: ldstr "at"
-		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0330: br IL_034e
+		IL_02f4: ldloc.s 8
+		IL_02f6: ldstr "valueOf"
+		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0300: br IL_031b
 
+		IL_0305: ldloc.s 8
+		IL_0307: ldstr "valueOf"
+		IL_030c: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:64"
+		IL_0311: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_031b: stloc.s 8
+		IL_031d: ldloc.s 8
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0324: volatile.
+		IL_0326: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_032b: brfalse IL_0344
+
+		IL_0330: ldstr "call"
 		IL_0335: ldstr "abc"
-		IL_033a: ldstr "at"
-		IL_033f: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:72"
-		IL_0344: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_033f: br IL_035d
 
-		IL_034e: stloc.2
-		IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0354: stloc.s 5
-		IL_0356: ldloc.2
-		IL_0357: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_035c: stloc.s 7
-		IL_035e: ldloc.s 5
-		IL_0360: ldloc.s 7
-		IL_0362: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0367: pop
-		IL_0368: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_036d: stloc.s 5
-		IL_036f: ldloc.2
-		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0375: ldstr "call"
-		IL_037a: ldstr "xyz"
-		IL_037f: ldc.r8 1
-		IL_0388: box [System.Runtime]System.Double
-		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0392: stloc.s 8
-		IL_0394: ldloc.s 5
-		IL_0396: ldloc.s 8
-		IL_0398: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_039d: pop
-		IL_039e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03a3: stloc.s 5
-		IL_03a5: ldstr "iterator"
-		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_03af: stloc.s 8
-		IL_03b1: ldstr "abc"
-		IL_03b6: ldloc.s 8
-		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_03bd: stloc.s 8
-		IL_03bf: ldloc.s 8
-		IL_03c1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_03c6: stloc.s 7
-		IL_03c8: ldloc.s 5
-		IL_03ca: ldloc.s 7
-		IL_03cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03d1: pop
-		IL_03d2: ldstr "String"
-		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03dc: volatile.
-		IL_03de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_03e3: brfalse IL_03f7
+		IL_0344: ldstr "call"
+		IL_0349: ldstr "abc"
+		IL_034e: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:67"
+		IL_0353: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03e8: ldstr "prototype"
-		IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03f2: br IL_040b
+		IL_035d: stloc.s 8
+		IL_035f: ldloc.s 5
+		IL_0361: ldloc.s 8
+		IL_0363: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0368: pop
+		IL_0369: volatile.
+		IL_036b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0370: brfalse IL_0389
 
-		IL_03f7: ldstr "prototype"
-		IL_03fc: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:98"
-		IL_0401: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0375: ldstr "abc"
+		IL_037a: ldstr "at"
+		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0384: br IL_03a2
 
-		IL_040b: stloc.s 8
-		IL_040d: ldstr "iterator"
-		IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0417: stloc.s 6
-		IL_0419: ldloc.s 8
-		IL_041b: ldloc.s 6
-		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0422: stloc.s 6
-		IL_0424: ldloc.s 6
-		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_042b: ldstr "call"
-		IL_0430: ldstr "A\ud83d\ude00B"
-		IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_043a: stloc.3
-		IL_043b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0440: stloc.s 5
-		IL_0442: ldloc.3
-		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0448: volatile.
-		IL_044a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_044f: brfalse IL_0463
+		IL_0389: ldstr "abc"
+		IL_038e: ldstr "at"
+		IL_0393: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:72"
+		IL_0398: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0454: ldstr "next"
-		IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_045e: br IL_0477
+		IL_03a2: stloc.2
+		IL_03a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a8: stloc.s 5
+		IL_03aa: ldloc.2
+		IL_03ab: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_03b0: stloc.s 7
+		IL_03b2: ldloc.s 5
+		IL_03b4: ldloc.s 7
+		IL_03b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03bb: pop
+		IL_03bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03c1: stloc.s 5
+		IL_03c3: ldloc.2
+		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c9: ldstr "call"
+		IL_03ce: ldstr "xyz"
+		IL_03d3: ldc.r8 1
+		IL_03dc: box [System.Runtime]System.Double
+		IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03e6: stloc.s 8
+		IL_03e8: ldloc.s 5
+		IL_03ea: ldloc.s 8
+		IL_03ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03f1: pop
+		IL_03f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03f7: stloc.s 5
+		IL_03f9: ldstr "iterator"
+		IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0403: stloc.s 8
+		IL_0405: ldstr "abc"
+		IL_040a: ldloc.s 8
+		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0411: stloc.s 8
+		IL_0413: ldloc.s 8
+		IL_0415: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_041a: stloc.s 7
+		IL_041c: ldloc.s 5
+		IL_041e: ldloc.s 7
+		IL_0420: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0425: pop
+		IL_0426: ldstr "String"
+		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0430: volatile.
+		IL_0432: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0437: brfalse IL_044b
 
-		IL_0463: ldstr "next"
-		IL_0468: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:109"
-		IL_046d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_043c: ldstr "prototype"
+		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0446: br IL_045f
 
-		IL_0477: stloc.s 6
-		IL_0479: volatile.
-		IL_047b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0480: brfalse IL_0496
+		IL_044b: ldstr "prototype"
+		IL_0450: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:98"
+		IL_0455: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0485: ldloc.s 6
-		IL_0487: ldstr "value"
-		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0491: br IL_04ac
+		IL_045f: stloc.s 8
+		IL_0461: ldstr "iterator"
+		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_046b: stloc.s 6
+		IL_046d: ldloc.s 8
+		IL_046f: ldloc.s 6
+		IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0476: stloc.s 6
+		IL_0478: ldloc.s 6
+		IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_047f: volatile.
+		IL_0481: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0486: brfalse IL_049f
 
-		IL_0496: ldloc.s 6
-		IL_0498: ldstr "value"
-		IL_049d: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:111"
-		IL_04a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_048b: ldstr "call"
+		IL_0490: ldstr "A\ud83d\ude00B"
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_049a: br IL_04b8
 
-		IL_04ac: stloc.s 6
-		IL_04ae: ldloc.s 5
-		IL_04b0: ldloc.s 6
-		IL_04b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04b7: pop
-		IL_04b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04bd: stloc.s 5
-		IL_04bf: ldloc.3
-		IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c5: volatile.
-		IL_04c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_04cc: brfalse IL_04e0
+		IL_049f: ldstr "call"
+		IL_04a4: ldstr "A\ud83d\ude00B"
+		IL_04a9: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:104"
+		IL_04ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_04d1: ldstr "next"
-		IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_04db: br IL_04f4
+		IL_04b8: stloc.3
+		IL_04b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04be: stloc.s 5
+		IL_04c0: ldloc.3
+		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04c6: volatile.
+		IL_04c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_04cd: brfalse IL_04e1
 
-		IL_04e0: ldstr "next"
-		IL_04e5: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:116"
-		IL_04ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_04d2: ldstr "next"
+		IL_04d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_04dc: br IL_04f5
 
-		IL_04f4: stloc.s 6
-		IL_04f6: volatile.
-		IL_04f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_04fd: brfalse IL_0513
+		IL_04e1: ldstr "next"
+		IL_04e6: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:109"
+		IL_04eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0502: ldloc.s 6
-		IL_0504: ldstr "value"
-		IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_050e: br IL_0529
+		IL_04f5: stloc.s 6
+		IL_04f7: volatile.
+		IL_04f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_04fe: brfalse IL_0514
 
-		IL_0513: ldloc.s 6
-		IL_0515: ldstr "value"
-		IL_051a: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:118"
-		IL_051f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0503: ldloc.s 6
+		IL_0505: ldstr "value"
+		IL_050a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050f: br IL_052a
 
-		IL_0529: stloc.s 6
-		IL_052b: ldloc.s 5
-		IL_052d: ldloc.s 6
-		IL_052f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0534: pop
-		IL_0535: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_053a: stloc.s 5
-		IL_053c: ldloc.3
-		IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0542: volatile.
-		IL_0544: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0549: brfalse IL_055d
+		IL_0514: ldloc.s 6
+		IL_0516: ldstr "value"
+		IL_051b: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:111"
+		IL_0520: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_054e: ldstr "next"
-		IL_0553: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0558: br IL_0571
+		IL_052a: stloc.s 6
+		IL_052c: ldloc.s 5
+		IL_052e: ldloc.s 6
+		IL_0530: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0535: pop
+		IL_0536: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_053b: stloc.s 5
+		IL_053d: ldloc.3
+		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0543: volatile.
+		IL_0545: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_054a: brfalse IL_055e
 
-		IL_055d: ldstr "next"
-		IL_0562: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:123"
-		IL_0567: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_054f: ldstr "next"
+		IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0559: br IL_0572
 
-		IL_0571: stloc.s 6
-		IL_0573: volatile.
-		IL_0575: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_057a: brfalse IL_0590
+		IL_055e: ldstr "next"
+		IL_0563: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:116"
+		IL_0568: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_057f: ldloc.s 6
-		IL_0581: ldstr "value"
-		IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_058b: br IL_05a6
+		IL_0572: stloc.s 6
+		IL_0574: volatile.
+		IL_0576: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_057b: brfalse IL_0591
 
-		IL_0590: ldloc.s 6
-		IL_0592: ldstr "value"
-		IL_0597: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:125"
-		IL_059c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0580: ldloc.s 6
+		IL_0582: ldstr "value"
+		IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_058c: br IL_05a7
 
-		IL_05a6: stloc.s 6
-		IL_05a8: ldloc.s 5
-		IL_05aa: ldloc.s 6
-		IL_05ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05b1: pop
-		IL_05b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05b7: stloc.s 5
-		IL_05b9: ldloc.3
-		IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05bf: volatile.
-		IL_05c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_05c6: brfalse IL_05da
+		IL_0591: ldloc.s 6
+		IL_0593: ldstr "value"
+		IL_0598: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:118"
+		IL_059d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05cb: ldstr "next"
-		IL_05d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_05d5: br IL_05ee
+		IL_05a7: stloc.s 6
+		IL_05a9: ldloc.s 5
+		IL_05ab: ldloc.s 6
+		IL_05ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05b2: pop
+		IL_05b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05b8: stloc.s 5
+		IL_05ba: ldloc.3
+		IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05c0: volatile.
+		IL_05c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_05c7: brfalse IL_05db
 
-		IL_05da: ldstr "next"
-		IL_05df: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:130"
-		IL_05e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_05cc: ldstr "next"
+		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05d6: br IL_05ef
 
-		IL_05ee: stloc.s 6
-		IL_05f0: volatile.
-		IL_05f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_05f7: brfalse IL_060d
+		IL_05db: ldstr "next"
+		IL_05e0: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:123"
+		IL_05e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_05fc: ldloc.s 6
-		IL_05fe: ldstr "done"
-		IL_0603: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0608: br IL_0623
+		IL_05ef: stloc.s 6
+		IL_05f1: volatile.
+		IL_05f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_05f8: brfalse IL_060e
 
-		IL_060d: ldloc.s 6
-		IL_060f: ldstr "done"
-		IL_0614: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:132"
-		IL_0619: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05fd: ldloc.s 6
+		IL_05ff: ldstr "value"
+		IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0609: br IL_0624
 
-		IL_0623: stloc.s 6
-		IL_0625: ldloc.s 5
-		IL_0627: ldloc.s 6
-		IL_0629: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_062e: pop
-		IL_062f: ldloc.3
-		IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0635: stloc.s 4
-		IL_0637: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_063c: stloc.s 5
-		IL_063e: volatile.
-		IL_0640: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0645: brfalse IL_065b
+		IL_060e: ldloc.s 6
+		IL_0610: ldstr "value"
+		IL_0615: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:125"
+		IL_061a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_064a: ldloc.s 4
-		IL_064c: ldstr "next"
-		IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0656: br IL_0671
+		IL_0624: stloc.s 6
+		IL_0626: ldloc.s 5
+		IL_0628: ldloc.s 6
+		IL_062a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_062f: pop
+		IL_0630: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0635: stloc.s 5
+		IL_0637: ldloc.3
+		IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_063d: volatile.
+		IL_063f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0644: brfalse IL_0658
 
-		IL_065b: ldloc.s 4
-		IL_065d: ldstr "next"
-		IL_0662: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:140"
-		IL_0667: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0649: ldstr "next"
+		IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0653: br IL_066c
 
-		IL_0671: stloc.s 6
-		IL_0673: ldloc.s 6
-		IL_0675: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_067a: stloc.s 7
-		IL_067c: ldloc.s 5
-		IL_067e: ldloc.s 7
-		IL_0680: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0685: pop
-		IL_0686: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_068b: stloc.s 5
-		IL_068d: ldstr "toStringTag"
-		IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0697: stloc.s 6
-		IL_0699: ldloc.s 4
-		IL_069b: ldloc.s 6
-		IL_069d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_06a2: stloc.s 6
-		IL_06a4: ldloc.s 5
-		IL_06a6: ldloc.s 6
-		IL_06a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06ad: pop
-		IL_06ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06b3: stloc.s 5
-		IL_06b5: ldloc.3
-		IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06bb: ldstr "iterator"
-		IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_06c5: stloc.s 6
-		IL_06c7: ldloc.s 6
-		IL_06c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
-		IL_06ce: stloc.s 6
-		IL_06d0: ldloc.s 6
-		IL_06d2: ldloc.3
-		IL_06d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_06d8: stloc.s 9
-		IL_06da: ldloc.s 9
-		IL_06dc: box [System.Runtime]System.Boolean
-		IL_06e1: stloc.s 10
-		IL_06e3: ldloc.s 5
-		IL_06e5: ldloc.s 10
-		IL_06e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06ec: pop
-		IL_06ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06f2: stloc.s 5
-		IL_06f4: ldstr "A\ud83d\ude00B"
-		IL_06f9: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_06fe: ldc.i4.1
-		IL_06ff: newarr [System.Runtime]System.Object
-		IL_0704: dup
-		IL_0705: ldc.i4.0
-		IL_0706: ldstr "|"
-		IL_070b: stelem.ref
-		IL_070c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_0711: stloc.s 7
-		IL_0713: ldloc.s 5
-		IL_0715: ldloc.s 7
-		IL_0717: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_071c: pop
-		IL_071d: ret
+		IL_0658: ldstr "next"
+		IL_065d: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:130"
+		IL_0662: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0667: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_066c: stloc.s 6
+		IL_066e: volatile.
+		IL_0670: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0675: brfalse IL_068b
+
+		IL_067a: ldloc.s 6
+		IL_067c: ldstr "done"
+		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0686: br IL_06a1
+
+		IL_068b: ldloc.s 6
+		IL_068d: ldstr "done"
+		IL_0692: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:132"
+		IL_0697: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06a1: stloc.s 6
+		IL_06a3: ldloc.s 5
+		IL_06a5: ldloc.s 6
+		IL_06a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06ac: pop
+		IL_06ad: ldloc.3
+		IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_06b3: stloc.s 4
+		IL_06b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06ba: stloc.s 5
+		IL_06bc: volatile.
+		IL_06be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_06c3: brfalse IL_06d9
+
+		IL_06c8: ldloc.s 4
+		IL_06ca: ldstr "next"
+		IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06d4: br IL_06ef
+
+		IL_06d9: ldloc.s 4
+		IL_06db: ldstr "next"
+		IL_06e0: ldstr "String_Prototype_Iterator_Surface:Modules.String_Prototype_Iterator_Surface:__js_module_init__:140"
+		IL_06e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06ef: stloc.s 6
+		IL_06f1: ldloc.s 6
+		IL_06f3: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_06f8: stloc.s 7
+		IL_06fa: ldloc.s 5
+		IL_06fc: ldloc.s 7
+		IL_06fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0703: pop
+		IL_0704: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0709: stloc.s 5
+		IL_070b: ldstr "toStringTag"
+		IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0715: stloc.s 6
+		IL_0717: ldloc.s 4
+		IL_0719: ldloc.s 6
+		IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0720: stloc.s 6
+		IL_0722: ldloc.s 5
+		IL_0724: ldloc.s 6
+		IL_0726: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_072b: pop
+		IL_072c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0731: stloc.s 5
+		IL_0733: ldloc.3
+		IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0739: ldstr "iterator"
+		IL_073e: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0743: stloc.s 6
+		IL_0745: ldloc.s 6
+		IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallComputedMember0(object, object)
+		IL_074c: stloc.s 6
+		IL_074e: ldloc.s 6
+		IL_0750: ldloc.3
+		IL_0751: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0756: stloc.s 9
+		IL_0758: ldloc.s 9
+		IL_075a: box [System.Runtime]System.Boolean
+		IL_075f: stloc.s 10
+		IL_0761: ldloc.s 5
+		IL_0763: ldloc.s 10
+		IL_0765: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_076a: pop
+		IL_076b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0770: stloc.s 5
+		IL_0772: ldstr "A\ud83d\ude00B"
+		IL_0777: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_077c: ldc.i4.1
+		IL_077d: newarr [System.Runtime]System.Object
+		IL_0782: dup
+		IL_0783: ldc.i4.0
+		IL_0784: ldstr "|"
+		IL_0789: stelem.ref
+		IL_078a: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_078f: stloc.s 7
+		IL_0791: ldloc.s 5
+		IL_0793: ldloc.s 7
+		IL_0795: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_079a: pop
+		IL_079b: ret
 	} // end of method String_Prototype_Iterator_Surface::__js_module_init__
 
 } // end of class Modules.String_Prototype_Iterator_Surface
@@ -720,6 +756,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_19
 	.field assembly static int32 __jroc_dynamicLookup_20
 	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_EmptyMatch_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_EmptyMatch_Global.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 563 (0x233)
+		// Code size: 680 (0x2a8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global/Scope,
@@ -149,156 +149,195 @@
 		IL_0059: ldloc.s 7
 		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0060: pop
-		IL_0061: ldloc.1
-		IL_0062: ldstr "exec"
-		IL_0067: ldloc.2
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006d: stloc.3
-		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0073: stloc.s 6
-		IL_0075: ldloc.3
-		IL_0076: ldc.r8 0.0
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0084: stloc.s 7
-		IL_0086: volatile.
-		IL_0088: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_008d: brfalse IL_00a3
+		IL_0061: volatile.
+		IL_0063: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0068: brfalse IL_007e
 
-		IL_0092: ldloc.s 7
-		IL_0094: ldstr "length"
-		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009e: br IL_00b9
+		IL_006d: ldloc.1
+		IL_006e: ldstr "exec"
+		IL_0073: ldloc.2
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0079: br IL_0094
 
-		IL_00a3: ldloc.s 7
-		IL_00a5: ldstr "length"
-		IL_00aa: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:24"
-		IL_00af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_007e: ldloc.1
+		IL_007f: ldstr "exec"
+		IL_0084: ldloc.2
+		IL_0085: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:17"
+		IL_008a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00b9: stloc.s 7
-		IL_00bb: ldloc.s 6
-		IL_00bd: ldloc.s 7
-		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c4: pop
-		IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ca: stloc.s 6
-		IL_00cc: volatile.
-		IL_00ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00d3: brfalse IL_00e8
+		IL_0094: stloc.3
+		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009a: stloc.s 6
+		IL_009c: ldloc.3
+		IL_009d: ldc.r8 0.0
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00ab: stloc.s 7
+		IL_00ad: volatile.
+		IL_00af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b4: brfalse IL_00ca
 
-		IL_00d8: ldloc.1
-		IL_00d9: ldstr "lastIndex"
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e3: br IL_00fd
+		IL_00b9: ldloc.s 7
+		IL_00bb: ldstr "length"
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c5: br IL_00e0
 
-		IL_00e8: ldloc.1
-		IL_00e9: ldstr "lastIndex"
-		IL_00ee: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:29"
-		IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00ca: ldloc.s 7
+		IL_00cc: ldstr "length"
+		IL_00d1: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:24"
+		IL_00d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00fd: stloc.s 7
-		IL_00ff: ldloc.s 6
-		IL_0101: ldloc.s 7
-		IL_0103: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0108: pop
-		IL_0109: ldloc.1
-		IL_010a: ldstr "exec"
-		IL_010f: ldloc.2
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0115: stloc.s 4
-		IL_0117: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011c: stloc.s 6
-		IL_011e: ldloc.s 4
-		IL_0120: ldc.r8 0.0
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_012e: stloc.s 7
+		IL_00e0: stloc.s 7
+		IL_00e2: ldloc.s 6
+		IL_00e4: ldloc.s 7
+		IL_00e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00eb: pop
+		IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f1: stloc.s 6
+		IL_00f3: volatile.
+		IL_00f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00fa: brfalse IL_010f
+
+		IL_00ff: ldloc.1
+		IL_0100: ldstr "lastIndex"
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010a: br IL_0124
+
+		IL_010f: ldloc.1
+		IL_0110: ldstr "lastIndex"
+		IL_0115: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:29"
+		IL_011a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0124: stloc.s 7
+		IL_0126: ldloc.s 6
+		IL_0128: ldloc.s 7
+		IL_012a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_012f: pop
 		IL_0130: volatile.
-		IL_0132: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0132: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 		IL_0137: brfalse IL_014d
 
-		IL_013c: ldloc.s 7
-		IL_013e: ldstr "length"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013c: ldloc.1
+		IL_013d: ldstr "exec"
+		IL_0142: ldloc.2
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 		IL_0148: br IL_0163
 
-		IL_014d: ldloc.s 7
-		IL_014f: ldstr "length"
-		IL_0154: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:39"
-		IL_0159: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_014d: ldloc.1
+		IL_014e: ldstr "exec"
+		IL_0153: ldloc.2
+		IL_0154: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:32"
+		IL_0159: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0163: stloc.s 7
-		IL_0165: ldloc.s 6
-		IL_0167: ldloc.s 7
-		IL_0169: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_016e: pop
-		IL_016f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0174: stloc.s 6
-		IL_0176: volatile.
-		IL_0178: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_017d: brfalse IL_0192
+		IL_0163: stloc.s 4
+		IL_0165: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016a: stloc.s 6
+		IL_016c: ldloc.s 4
+		IL_016e: ldc.r8 0.0
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_017c: stloc.s 7
+		IL_017e: volatile.
+		IL_0180: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0185: brfalse IL_019b
 
-		IL_0182: ldloc.1
-		IL_0183: ldstr "lastIndex"
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018d: br IL_01a7
+		IL_018a: ldloc.s 7
+		IL_018c: ldstr "length"
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0196: br IL_01b1
 
-		IL_0192: ldloc.1
-		IL_0193: ldstr "lastIndex"
-		IL_0198: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:44"
-		IL_019d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_019b: ldloc.s 7
+		IL_019d: ldstr "length"
+		IL_01a2: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:39"
+		IL_01a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01a7: stloc.s 7
-		IL_01a9: ldloc.s 6
-		IL_01ab: ldloc.s 7
-		IL_01ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b2: pop
-		IL_01b3: ldloc.1
-		IL_01b4: ldstr "exec"
-		IL_01b9: ldloc.2
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01bf: stloc.s 5
-		IL_01c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c6: stloc.s 6
-		IL_01c8: ldloc.s 5
-		IL_01ca: stloc.s 7
-		IL_01cc: ldloc.s 7
-		IL_01ce: ldc.i4.0
-		IL_01cf: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_01d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_01d9: stloc.s 8
-		IL_01db: ldloc.s 8
-		IL_01dd: box [System.Runtime]System.Boolean
-		IL_01e2: stloc.s 9
-		IL_01e4: ldloc.s 6
-		IL_01e6: ldloc.s 9
-		IL_01e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ed: pop
-		IL_01ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f3: stloc.s 6
-		IL_01f5: volatile.
-		IL_01f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01fc: brfalse IL_0211
+		IL_01b1: stloc.s 7
+		IL_01b3: ldloc.s 6
+		IL_01b5: ldloc.s 7
+		IL_01b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01bc: pop
+		IL_01bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c2: stloc.s 6
+		IL_01c4: volatile.
+		IL_01c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01cb: brfalse IL_01e0
 
-		IL_0201: ldloc.1
-		IL_0202: ldstr "lastIndex"
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020c: br IL_0226
+		IL_01d0: ldloc.1
+		IL_01d1: ldstr "lastIndex"
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01db: br IL_01f5
 
-		IL_0211: ldloc.1
-		IL_0212: ldstr "lastIndex"
-		IL_0217: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:60"
-		IL_021c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01e0: ldloc.1
+		IL_01e1: ldstr "lastIndex"
+		IL_01e6: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:44"
+		IL_01eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0226: stloc.s 7
-		IL_0228: ldloc.s 6
-		IL_022a: ldloc.s 7
-		IL_022c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0231: pop
-		IL_0232: ret
+		IL_01f5: stloc.s 7
+		IL_01f7: ldloc.s 6
+		IL_01f9: ldloc.s 7
+		IL_01fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0200: pop
+		IL_0201: volatile.
+		IL_0203: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0208: brfalse IL_021e
+
+		IL_020d: ldloc.1
+		IL_020e: ldstr "exec"
+		IL_0213: ldloc.2
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0219: br IL_0234
+
+		IL_021e: ldloc.1
+		IL_021f: ldstr "exec"
+		IL_0224: ldloc.2
+		IL_0225: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:47"
+		IL_022a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0234: stloc.s 5
+		IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023b: stloc.s 6
+		IL_023d: ldloc.s 5
+		IL_023f: stloc.s 7
+		IL_0241: ldloc.s 7
+		IL_0243: ldc.i4.0
+		IL_0244: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0249: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_024e: stloc.s 8
+		IL_0250: ldloc.s 8
+		IL_0252: box [System.Runtime]System.Boolean
+		IL_0257: stloc.s 9
+		IL_0259: ldloc.s 6
+		IL_025b: ldloc.s 9
+		IL_025d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0262: pop
+		IL_0263: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0268: stloc.s 6
+		IL_026a: volatile.
+		IL_026c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0271: brfalse IL_0286
+
+		IL_0276: ldloc.1
+		IL_0277: ldstr "lastIndex"
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0281: br IL_029b
+
+		IL_0286: ldloc.1
+		IL_0287: ldstr "lastIndex"
+		IL_028c: ldstr "String_RegExp_Exec_LastIndex_EmptyMatch_Global:Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global:__js_module_init__:60"
+		IL_0291: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_029b: stloc.s 7
+		IL_029d: ldloc.s 6
+		IL_029f: ldloc.s 7
+		IL_02a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a6: pop
+		IL_02a7: ret
 	} // end of method String_RegExp_Exec_LastIndex_EmptyMatch_Global::__js_module_init__
 
 } // end of class Modules.String_RegExp_Exec_LastIndex_EmptyMatch_Global
@@ -334,6 +373,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Global.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Global.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 536 (0x218)
+		// Code size: 614 (0x266)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_Exec_LastIndex_Global/Scope,
@@ -146,147 +146,173 @@
 		IL_0059: ldloc.s 6
 		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0060: pop
-		IL_0061: ldloc.1
-		IL_0062: ldstr "exec"
-		IL_0067: ldloc.2
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006d: stloc.3
-		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0073: stloc.s 5
-		IL_0075: ldloc.3
-		IL_0076: ldc.r8 0.0
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0084: stloc.s 6
-		IL_0086: ldloc.s 5
-		IL_0088: ldloc.s 6
-		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008f: pop
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0095: stloc.s 5
-		IL_0097: volatile.
-		IL_0099: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_009e: brfalse IL_00b3
+		IL_0061: volatile.
+		IL_0063: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0068: brfalse IL_007e
 
-		IL_00a3: ldloc.3
-		IL_00a4: ldstr "index"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ae: br IL_00c8
+		IL_006d: ldloc.1
+		IL_006e: ldstr "exec"
+		IL_0073: ldloc.2
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0079: br IL_0094
 
-		IL_00b3: ldloc.3
-		IL_00b4: ldstr "index"
-		IL_00b9: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:27"
-		IL_00be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_007e: ldloc.1
+		IL_007f: ldstr "exec"
+		IL_0084: ldloc.2
+		IL_0085: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:17"
+		IL_008a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00c8: stloc.s 6
-		IL_00ca: ldloc.s 5
-		IL_00cc: ldloc.s 6
-		IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d3: pop
-		IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d9: stloc.s 5
-		IL_00db: volatile.
-		IL_00dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00e2: brfalse IL_00f7
+		IL_0094: stloc.3
+		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009a: stloc.s 5
+		IL_009c: ldloc.3
+		IL_009d: ldc.r8 0.0
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00ab: stloc.s 6
+		IL_00ad: ldloc.s 5
+		IL_00af: ldloc.s 6
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b6: pop
+		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bc: stloc.s 5
+		IL_00be: volatile.
+		IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00c5: brfalse IL_00da
 
-		IL_00e7: ldloc.3
-		IL_00e8: ldstr "input"
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f2: br IL_010c
+		IL_00ca: ldloc.3
+		IL_00cb: ldstr "index"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d5: br IL_00ef
 
-		IL_00f7: ldloc.3
-		IL_00f8: ldstr "input"
-		IL_00fd: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:32"
-		IL_0102: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00da: ldloc.3
+		IL_00db: ldstr "index"
+		IL_00e0: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:27"
+		IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_010c: stloc.s 6
-		IL_010e: ldloc.s 5
-		IL_0110: ldloc.s 6
-		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0117: pop
-		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011d: stloc.s 5
-		IL_011f: volatile.
-		IL_0121: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0126: brfalse IL_013b
+		IL_00ef: stloc.s 6
+		IL_00f1: ldloc.s 5
+		IL_00f3: ldloc.s 6
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fa: pop
+		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0100: stloc.s 5
+		IL_0102: volatile.
+		IL_0104: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0109: brfalse IL_011e
 
-		IL_012b: ldloc.1
-		IL_012c: ldstr "lastIndex"
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0136: br IL_0150
+		IL_010e: ldloc.3
+		IL_010f: ldstr "input"
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0119: br IL_0133
 
-		IL_013b: ldloc.1
-		IL_013c: ldstr "lastIndex"
-		IL_0141: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:37"
-		IL_0146: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_011e: ldloc.3
+		IL_011f: ldstr "input"
+		IL_0124: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:32"
+		IL_0129: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0150: stloc.s 6
-		IL_0152: ldloc.s 5
-		IL_0154: ldloc.s 6
-		IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015b: pop
-		IL_015c: ldloc.1
-		IL_015d: ldstr "exec"
-		IL_0162: ldloc.2
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0168: stloc.s 4
-		IL_016a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016f: stloc.s 5
-		IL_0171: ldloc.s 4
-		IL_0173: ldc.r8 0.0
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0181: stloc.s 6
-		IL_0183: ldloc.s 5
-		IL_0185: ldloc.s 6
-		IL_0187: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018c: pop
-		IL_018d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0192: stloc.s 5
-		IL_0194: volatile.
-		IL_0196: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_019b: brfalse IL_01b1
+		IL_0133: stloc.s 6
+		IL_0135: ldloc.s 5
+		IL_0137: ldloc.s 6
+		IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_013e: pop
+		IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0144: stloc.s 5
+		IL_0146: volatile.
+		IL_0148: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_014d: brfalse IL_0162
 
-		IL_01a0: ldloc.s 4
-		IL_01a2: ldstr "index"
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ac: br IL_01c7
+		IL_0152: ldloc.1
+		IL_0153: ldstr "lastIndex"
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015d: br IL_0177
 
-		IL_01b1: ldloc.s 4
-		IL_01b3: ldstr "index"
-		IL_01b8: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:50"
-		IL_01bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0162: ldloc.1
+		IL_0163: ldstr "lastIndex"
+		IL_0168: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:37"
+		IL_016d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01c7: stloc.s 6
-		IL_01c9: ldloc.s 5
-		IL_01cb: ldloc.s 6
-		IL_01cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d2: pop
-		IL_01d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d8: stloc.s 5
-		IL_01da: volatile.
-		IL_01dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01e1: brfalse IL_01f6
+		IL_0177: stloc.s 6
+		IL_0179: ldloc.s 5
+		IL_017b: ldloc.s 6
+		IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0182: pop
+		IL_0183: volatile.
+		IL_0185: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_018a: brfalse IL_01a0
 
-		IL_01e6: ldloc.1
-		IL_01e7: ldstr "lastIndex"
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f1: br IL_020b
+		IL_018f: ldloc.1
+		IL_0190: ldstr "exec"
+		IL_0195: ldloc.2
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019b: br IL_01b6
 
-		IL_01f6: ldloc.1
-		IL_01f7: ldstr "lastIndex"
-		IL_01fc: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:55"
-		IL_0201: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01a0: ldloc.1
+		IL_01a1: ldstr "exec"
+		IL_01a6: ldloc.2
+		IL_01a7: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:40"
+		IL_01ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_020b: stloc.s 6
-		IL_020d: ldloc.s 5
-		IL_020f: ldloc.s 6
-		IL_0211: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0216: pop
-		IL_0217: ret
+		IL_01b6: stloc.s 4
+		IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01bd: stloc.s 5
+		IL_01bf: ldloc.s 4
+		IL_01c1: ldc.r8 0.0
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01cf: stloc.s 6
+		IL_01d1: ldloc.s 5
+		IL_01d3: ldloc.s 6
+		IL_01d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01da: pop
+		IL_01db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e0: stloc.s 5
+		IL_01e2: volatile.
+		IL_01e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01e9: brfalse IL_01ff
+
+		IL_01ee: ldloc.s 4
+		IL_01f0: ldstr "index"
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01fa: br IL_0215
+
+		IL_01ff: ldloc.s 4
+		IL_0201: ldstr "index"
+		IL_0206: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:50"
+		IL_020b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0215: stloc.s 6
+		IL_0217: ldloc.s 5
+		IL_0219: ldloc.s 6
+		IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0220: pop
+		IL_0221: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0226: stloc.s 5
+		IL_0228: volatile.
+		IL_022a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_022f: brfalse IL_0244
+
+		IL_0234: ldloc.1
+		IL_0235: ldstr "lastIndex"
+		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023f: br IL_0259
+
+		IL_0244: ldloc.1
+		IL_0245: ldstr "lastIndex"
+		IL_024a: ldstr "String_RegExp_Exec_LastIndex_Global:Modules.String_RegExp_Exec_LastIndex_Global:__js_module_init__:55"
+		IL_024f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0259: stloc.s 6
+		IL_025b: ldloc.s 5
+		IL_025d: ldloc.s 6
+		IL_025f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0264: pop
+		IL_0265: ret
 	} // end of method String_RegExp_Exec_LastIndex_Global::__js_module_init__
 
 } // end of class Modules.String_RegExp_Exec_LastIndex_Global
@@ -322,6 +348,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Sticky.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_Exec_LastIndex_Sticky.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 894 (0x37e)
+		// Code size: 1050 (0x41a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_Exec_LastIndex_Sticky/Scope,
@@ -172,239 +172,291 @@
 		IL_00a4: pop
 		IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00aa: stloc.s 5
-		IL_00ac: ldloc.1
-		IL_00ad: ldstr "exec"
-		IL_00b2: ldloc.2
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b8: stloc.s 6
-		IL_00ba: ldloc.s 6
-		IL_00bc: ldc.i4.0
-		IL_00bd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00c7: stloc.s 7
-		IL_00c9: ldloc.s 7
-		IL_00cb: box [System.Runtime]System.Boolean
-		IL_00d0: stloc.s 8
-		IL_00d2: ldloc.s 5
-		IL_00d4: ldloc.s 8
-		IL_00d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00db: pop
-		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e1: stloc.s 5
-		IL_00e3: volatile.
-		IL_00e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00ea: brfalse IL_00ff
+		IL_00ac: volatile.
+		IL_00ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00b3: brfalse IL_00c9
 
-		IL_00ef: ldloc.1
-		IL_00f0: ldstr "lastIndex"
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fa: br IL_0114
+		IL_00b8: ldloc.1
+		IL_00b9: ldstr "exec"
+		IL_00be: ldloc.2
+		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c4: br IL_00df
 
-		IL_00ff: ldloc.1
-		IL_0100: ldstr "lastIndex"
-		IL_0105: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:32"
-		IL_010a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00c9: ldloc.1
+		IL_00ca: ldstr "exec"
+		IL_00cf: ldloc.2
+		IL_00d0: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:23"
+		IL_00d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0114: stloc.s 6
-		IL_0116: ldloc.s 5
-		IL_0118: ldloc.s 6
-		IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_011f: pop
-		IL_0120: ldloc.1
-		IL_0121: ldstr "lastIndex"
-		IL_0126: ldc.r8 1
-		IL_012f: ldc.i4.1
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0135: pop
-		IL_0136: ldloc.1
-		IL_0137: ldstr "exec"
-		IL_013c: ldloc.2
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0142: stloc.3
-		IL_0143: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0148: stloc.s 5
-		IL_014a: ldloc.3
-		IL_014b: ldc.r8 0.0
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0159: stloc.s 6
-		IL_015b: ldloc.s 5
-		IL_015d: ldloc.s 6
-		IL_015f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0164: pop
-		IL_0165: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016a: stloc.s 5
-		IL_016c: volatile.
-		IL_016e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0173: brfalse IL_0188
+		IL_00df: stloc.s 6
+		IL_00e1: ldloc.s 6
+		IL_00e3: ldc.i4.0
+		IL_00e4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00ee: stloc.s 7
+		IL_00f0: ldloc.s 7
+		IL_00f2: box [System.Runtime]System.Boolean
+		IL_00f7: stloc.s 8
+		IL_00f9: ldloc.s 5
+		IL_00fb: ldloc.s 8
+		IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0102: pop
+		IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0108: stloc.s 5
+		IL_010a: volatile.
+		IL_010c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0111: brfalse IL_0126
 
-		IL_0178: ldloc.3
-		IL_0179: ldstr "index"
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0183: br IL_019d
+		IL_0116: ldloc.1
+		IL_0117: ldstr "lastIndex"
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0121: br IL_013b
 
-		IL_0188: ldloc.3
-		IL_0189: ldstr "index"
-		IL_018e: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:49"
-		IL_0193: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0126: ldloc.1
+		IL_0127: ldstr "lastIndex"
+		IL_012c: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:32"
+		IL_0131: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_019d: stloc.s 6
-		IL_019f: ldloc.s 5
-		IL_01a1: ldloc.s 6
-		IL_01a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a8: pop
-		IL_01a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ae: stloc.s 5
-		IL_01b0: volatile.
-		IL_01b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01b7: brfalse IL_01cc
+		IL_013b: stloc.s 6
+		IL_013d: ldloc.s 5
+		IL_013f: ldloc.s 6
+		IL_0141: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0146: pop
+		IL_0147: ldloc.1
+		IL_0148: ldstr "lastIndex"
+		IL_014d: ldc.r8 1
+		IL_0156: ldc.i4.1
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_015c: pop
+		IL_015d: volatile.
+		IL_015f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0164: brfalse IL_017a
 
-		IL_01bc: ldloc.3
-		IL_01bd: ldstr "input"
-		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c7: br IL_01e1
+		IL_0169: ldloc.1
+		IL_016a: ldstr "exec"
+		IL_016f: ldloc.2
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0175: br IL_0190
 
-		IL_01cc: ldloc.3
-		IL_01cd: ldstr "input"
-		IL_01d2: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:54"
-		IL_01d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_017a: ldloc.1
+		IL_017b: ldstr "exec"
+		IL_0180: ldloc.2
+		IL_0181: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:39"
+		IL_0186: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01e1: stloc.s 6
-		IL_01e3: ldloc.s 5
-		IL_01e5: ldloc.s 6
-		IL_01e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ec: pop
-		IL_01ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f2: stloc.s 5
-		IL_01f4: volatile.
-		IL_01f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01fb: brfalse IL_0210
+		IL_0190: stloc.3
+		IL_0191: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0196: stloc.s 5
+		IL_0198: ldloc.3
+		IL_0199: ldc.r8 0.0
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01a7: stloc.s 6
+		IL_01a9: ldloc.s 5
+		IL_01ab: ldloc.s 6
+		IL_01ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b2: pop
+		IL_01b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b8: stloc.s 5
+		IL_01ba: volatile.
+		IL_01bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01c1: brfalse IL_01d6
 
-		IL_0200: ldloc.1
-		IL_0201: ldstr "lastIndex"
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020b: br IL_0225
+		IL_01c6: ldloc.3
+		IL_01c7: ldstr "index"
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d1: br IL_01eb
 
-		IL_0210: ldloc.1
-		IL_0211: ldstr "lastIndex"
-		IL_0216: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:59"
-		IL_021b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01d6: ldloc.3
+		IL_01d7: ldstr "index"
+		IL_01dc: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:49"
+		IL_01e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0225: stloc.s 6
-		IL_0227: ldloc.s 5
-		IL_0229: ldloc.s 6
-		IL_022b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0230: pop
-		IL_0231: ldloc.1
-		IL_0232: ldstr "exec"
-		IL_0237: ldloc.2
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023d: stloc.s 4
-		IL_023f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0244: stloc.s 5
-		IL_0246: ldloc.s 4
-		IL_0248: ldc.r8 0.0
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0256: stloc.s 6
-		IL_0258: ldloc.s 5
-		IL_025a: ldloc.s 6
-		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0261: pop
-		IL_0262: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0267: stloc.s 5
-		IL_0269: volatile.
-		IL_026b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0270: brfalse IL_0286
+		IL_01eb: stloc.s 6
+		IL_01ed: ldloc.s 5
+		IL_01ef: ldloc.s 6
+		IL_01f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f6: pop
+		IL_01f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01fc: stloc.s 5
+		IL_01fe: volatile.
+		IL_0200: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0205: brfalse IL_021a
 
-		IL_0275: ldloc.s 4
-		IL_0277: ldstr "index"
-		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0281: br IL_029c
+		IL_020a: ldloc.3
+		IL_020b: ldstr "input"
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0215: br IL_022f
 
-		IL_0286: ldloc.s 4
-		IL_0288: ldstr "index"
-		IL_028d: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:72"
-		IL_0292: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_021a: ldloc.3
+		IL_021b: ldstr "input"
+		IL_0220: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:54"
+		IL_0225: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_029c: stloc.s 6
-		IL_029e: ldloc.s 5
-		IL_02a0: ldloc.s 6
-		IL_02a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02a7: pop
-		IL_02a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ad: stloc.s 5
-		IL_02af: volatile.
-		IL_02b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_02b6: brfalse IL_02cb
+		IL_022f: stloc.s 6
+		IL_0231: ldloc.s 5
+		IL_0233: ldloc.s 6
+		IL_0235: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_023a: pop
+		IL_023b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0240: stloc.s 5
+		IL_0242: volatile.
+		IL_0244: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0249: brfalse IL_025e
 
-		IL_02bb: ldloc.1
-		IL_02bc: ldstr "lastIndex"
-		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02c6: br IL_02e0
+		IL_024e: ldloc.1
+		IL_024f: ldstr "lastIndex"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0259: br IL_0273
 
-		IL_02cb: ldloc.1
-		IL_02cc: ldstr "lastIndex"
-		IL_02d1: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:77"
-		IL_02d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_025e: ldloc.1
+		IL_025f: ldstr "lastIndex"
+		IL_0264: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:59"
+		IL_0269: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02e0: stloc.s 6
-		IL_02e2: ldloc.s 5
-		IL_02e4: ldloc.s 6
-		IL_02e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02eb: pop
-		IL_02ec: ldloc.1
-		IL_02ed: ldstr "lastIndex"
-		IL_02f2: ldc.r8 10
-		IL_02fb: ldc.i4.1
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0301: pop
-		IL_0302: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0307: stloc.s 5
-		IL_0309: ldloc.1
-		IL_030a: ldstr "exec"
-		IL_030f: ldloc.2
-		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0315: stloc.s 6
-		IL_0317: ldloc.s 6
-		IL_0319: ldc.i4.0
-		IL_031a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_031f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0324: stloc.s 7
-		IL_0326: ldloc.s 7
-		IL_0328: box [System.Runtime]System.Boolean
-		IL_032d: stloc.s 8
-		IL_032f: ldloc.s 5
-		IL_0331: ldloc.s 8
-		IL_0333: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0338: pop
-		IL_0339: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_033e: stloc.s 5
-		IL_0340: volatile.
-		IL_0342: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0347: brfalse IL_035c
+		IL_0273: stloc.s 6
+		IL_0275: ldloc.s 5
+		IL_0277: ldloc.s 6
+		IL_0279: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_027e: pop
+		IL_027f: volatile.
+		IL_0281: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0286: brfalse IL_029c
 
-		IL_034c: ldloc.1
-		IL_034d: ldstr "lastIndex"
-		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0357: br IL_0371
+		IL_028b: ldloc.1
+		IL_028c: ldstr "exec"
+		IL_0291: ldloc.2
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0297: br IL_02b2
 
-		IL_035c: ldloc.1
-		IL_035d: ldstr "lastIndex"
-		IL_0362: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:94"
-		IL_0367: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_029c: ldloc.1
+		IL_029d: ldstr "exec"
+		IL_02a2: ldloc.2
+		IL_02a3: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:62"
+		IL_02a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0371: stloc.s 6
-		IL_0373: ldloc.s 5
-		IL_0375: ldloc.s 6
-		IL_0377: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_037c: pop
-		IL_037d: ret
+		IL_02b2: stloc.s 4
+		IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02b9: stloc.s 5
+		IL_02bb: ldloc.s 4
+		IL_02bd: ldc.r8 0.0
+		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02cb: stloc.s 6
+		IL_02cd: ldloc.s 5
+		IL_02cf: ldloc.s 6
+		IL_02d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d6: pop
+		IL_02d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02dc: stloc.s 5
+		IL_02de: volatile.
+		IL_02e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02e5: brfalse IL_02fb
+
+		IL_02ea: ldloc.s 4
+		IL_02ec: ldstr "index"
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02f6: br IL_0311
+
+		IL_02fb: ldloc.s 4
+		IL_02fd: ldstr "index"
+		IL_0302: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:72"
+		IL_0307: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0311: stloc.s 6
+		IL_0313: ldloc.s 5
+		IL_0315: ldloc.s 6
+		IL_0317: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_031c: pop
+		IL_031d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0322: stloc.s 5
+		IL_0324: volatile.
+		IL_0326: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_032b: brfalse IL_0340
+
+		IL_0330: ldloc.1
+		IL_0331: ldstr "lastIndex"
+		IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_033b: br IL_0355
+
+		IL_0340: ldloc.1
+		IL_0341: ldstr "lastIndex"
+		IL_0346: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:77"
+		IL_034b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0355: stloc.s 6
+		IL_0357: ldloc.s 5
+		IL_0359: ldloc.s 6
+		IL_035b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0360: pop
+		IL_0361: ldloc.1
+		IL_0362: ldstr "lastIndex"
+		IL_0367: ldc.r8 10
+		IL_0370: ldc.i4.1
+		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0376: pop
+		IL_0377: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_037c: stloc.s 5
+		IL_037e: volatile.
+		IL_0380: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0385: brfalse IL_039b
+
+		IL_038a: ldloc.1
+		IL_038b: ldstr "exec"
+		IL_0390: ldloc.2
+		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0396: br IL_03b1
+
+		IL_039b: ldloc.1
+		IL_039c: ldstr "exec"
+		IL_03a1: ldloc.2
+		IL_03a2: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:85"
+		IL_03a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03b1: stloc.s 6
+		IL_03b3: ldloc.s 6
+		IL_03b5: ldc.i4.0
+		IL_03b6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_03bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_03c0: stloc.s 7
+		IL_03c2: ldloc.s 7
+		IL_03c4: box [System.Runtime]System.Boolean
+		IL_03c9: stloc.s 8
+		IL_03cb: ldloc.s 5
+		IL_03cd: ldloc.s 8
+		IL_03cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03d4: pop
+		IL_03d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03da: stloc.s 5
+		IL_03dc: volatile.
+		IL_03de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_03e3: brfalse IL_03f8
+
+		IL_03e8: ldloc.1
+		IL_03e9: ldstr "lastIndex"
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03f3: br IL_040d
+
+		IL_03f8: ldloc.1
+		IL_03f9: ldstr "lastIndex"
+		IL_03fe: ldstr "String_RegExp_Exec_LastIndex_Sticky:Modules.String_RegExp_Exec_LastIndex_Sticky:__js_module_init__:94"
+		IL_0403: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_040d: stloc.s 6
+		IL_040f: ldloc.s 5
+		IL_0411: ldloc.s 6
+		IL_0413: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0418: pop
+		IL_0419: ret
 	} // end of method String_RegExp_Exec_LastIndex_Sticky::__js_module_init__
 
 } // end of class Modules.String_RegExp_Exec_LastIndex_Sticky
@@ -443,6 +495,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_NamedGroups_Indices.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_NamedGroups_Indices.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3168 (0xc60)
+		// Code size: 3344 (0xd10)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.String_RegExp_NamedGroups_Indices/Scope,
@@ -128,986 +128,1038 @@
 		IL_0011: ldstr "d"
 		IL_0016: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_001b: stloc.s 5
-		IL_001d: ldloc.s 5
-		IL_001f: ldstr "exec"
-		IL_0024: ldstr "a"
-		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_002e: stloc.1
-		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0034: stloc.s 6
-		IL_0036: volatile.
-		IL_0038: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_003d: brfalse IL_0052
+		IL_001d: volatile.
+		IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0024: brfalse IL_003f
 
-		IL_0042: ldloc.1
-		IL_0043: ldstr "groups"
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_004d: br IL_0067
+		IL_0029: ldloc.s 5
+		IL_002b: ldstr "exec"
+		IL_0030: ldstr "a"
+		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003a: br IL_005a
 
-		IL_0052: ldloc.1
-		IL_0053: ldstr "groups"
-		IL_0058: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:13"
-		IL_005d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_003f: ldloc.s 5
+		IL_0041: ldstr "exec"
+		IL_0046: ldstr "a"
+		IL_004b: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:8"
+		IL_0050: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0067: stloc.s 7
-		IL_0069: ldloc.s 7
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0070: stloc.s 7
-		IL_0072: ldloc.s 7
-		IL_0074: ldc.i4.0
-		IL_0075: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_007a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_007f: stloc.s 8
-		IL_0081: ldloc.s 8
-		IL_0083: box [System.Runtime]System.Boolean
-		IL_0088: stloc.s 9
-		IL_008a: ldloc.s 6
-		IL_008c: ldloc.s 9
-		IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0093: pop
-		IL_0094: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0099: stloc.s 6
-		IL_009b: ldloc.1
-		IL_009c: ldstr "groups"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_00ab: stloc.s 7
-		IL_00ad: ldloc.s 6
-		IL_00af: ldloc.s 7
-		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b6: pop
-		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bc: stloc.s 6
-		IL_00be: volatile.
-		IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00c5: brfalse IL_00da
+		IL_005a: stloc.1
+		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0060: stloc.s 6
+		IL_0062: volatile.
+		IL_0064: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0069: brfalse IL_007e
 
-		IL_00ca: ldloc.1
-		IL_00cb: ldstr "groups"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d5: br IL_00ef
+		IL_006e: ldloc.1
+		IL_006f: ldstr "groups"
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0079: br IL_0093
 
-		IL_00da: ldloc.1
-		IL_00db: ldstr "groups"
-		IL_00e0: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:29"
-		IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_007e: ldloc.1
+		IL_007f: ldstr "groups"
+		IL_0084: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:13"
+		IL_0089: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00ef: stloc.s 7
-		IL_00f1: ldloc.s 7
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_00f8: stloc.s 7
-		IL_00fa: ldloc.s 7
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0101: stloc.s 7
-		IL_0103: ldloc.s 6
-		IL_0105: ldloc.s 7
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010c: pop
-		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0112: stloc.s 6
-		IL_0114: volatile.
-		IL_0116: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_011b: brfalse IL_0130
+		IL_0093: stloc.s 7
+		IL_0095: ldloc.s 7
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_009c: stloc.s 7
+		IL_009e: ldloc.s 7
+		IL_00a0: ldc.i4.0
+		IL_00a1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00ab: stloc.s 8
+		IL_00ad: ldloc.s 8
+		IL_00af: box [System.Runtime]System.Boolean
+		IL_00b4: stloc.s 9
+		IL_00b6: ldloc.s 6
+		IL_00b8: ldloc.s 9
+		IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00bf: pop
+		IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c5: stloc.s 6
+		IL_00c7: ldloc.1
+		IL_00c8: ldstr "groups"
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_00d7: stloc.s 7
+		IL_00d9: ldloc.s 6
+		IL_00db: ldloc.s 7
+		IL_00dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e2: pop
+		IL_00e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e8: stloc.s 6
+		IL_00ea: volatile.
+		IL_00ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00f1: brfalse IL_0106
 
-		IL_0120: ldloc.1
-		IL_0121: ldstr "groups"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012b: br IL_0145
+		IL_00f6: ldloc.1
+		IL_00f7: ldstr "groups"
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0101: br IL_011b
 
-		IL_0130: ldloc.1
-		IL_0131: ldstr "groups"
-		IL_0136: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:36"
-		IL_013b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0106: ldloc.1
+		IL_0107: ldstr "groups"
+		IL_010c: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:29"
+		IL_0111: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0145: stloc.s 7
-		IL_0147: volatile.
-		IL_0149: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_014e: brfalse IL_0164
+		IL_011b: stloc.s 7
+		IL_011d: ldloc.s 7
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0124: stloc.s 7
+		IL_0126: ldloc.s 7
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_012d: stloc.s 7
+		IL_012f: ldloc.s 6
+		IL_0131: ldloc.s 7
+		IL_0133: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0138: pop
+		IL_0139: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013e: stloc.s 6
+		IL_0140: volatile.
+		IL_0142: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0147: brfalse IL_015c
 
-		IL_0153: ldloc.s 7
-		IL_0155: ldstr "word"
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015f: br IL_017a
+		IL_014c: ldloc.1
+		IL_014d: ldstr "groups"
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0157: br IL_0171
 
-		IL_0164: ldloc.s 7
-		IL_0166: ldstr "word"
-		IL_016b: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:38"
-		IL_0170: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_015c: ldloc.1
+		IL_015d: ldstr "groups"
+		IL_0162: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:36"
+		IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_017a: stloc.s 7
-		IL_017c: ldloc.s 6
-		IL_017e: ldloc.s 7
-		IL_0180: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0185: pop
-		IL_0186: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018b: stloc.s 6
-		IL_018d: volatile.
-		IL_018f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0194: brfalse IL_01a9
+		IL_0171: stloc.s 7
+		IL_0173: volatile.
+		IL_0175: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_017a: brfalse IL_0190
 
-		IL_0199: ldloc.1
-		IL_019a: ldstr "groups"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a4: br IL_01be
+		IL_017f: ldloc.s 7
+		IL_0181: ldstr "word"
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018b: br IL_01a6
 
-		IL_01a9: ldloc.1
-		IL_01aa: ldstr "groups"
-		IL_01af: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:43"
-		IL_01b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0190: ldloc.s 7
+		IL_0192: ldstr "word"
+		IL_0197: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:38"
+		IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01be: stloc.s 7
-		IL_01c0: ldloc.s 7
-		IL_01c2: ldstr "optional"
-		IL_01c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_01cc: box [System.Runtime]System.Boolean
-		IL_01d1: stloc.s 9
-		IL_01d3: ldloc.s 6
-		IL_01d5: ldloc.s 9
-		IL_01d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01dc: pop
-		IL_01dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e2: stloc.s 6
-		IL_01e4: volatile.
-		IL_01e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01eb: brfalse IL_0200
+		IL_01a6: stloc.s 7
+		IL_01a8: ldloc.s 6
+		IL_01aa: ldloc.s 7
+		IL_01ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b1: pop
+		IL_01b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b7: stloc.s 6
+		IL_01b9: volatile.
+		IL_01bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01c0: brfalse IL_01d5
 
-		IL_01f0: ldloc.1
-		IL_01f1: ldstr "groups"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01fb: br IL_0215
+		IL_01c5: ldloc.1
+		IL_01c6: ldstr "groups"
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d0: br IL_01ea
 
-		IL_0200: ldloc.1
-		IL_0201: ldstr "groups"
-		IL_0206: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:51"
-		IL_020b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01d5: ldloc.1
+		IL_01d6: ldstr "groups"
+		IL_01db: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:43"
+		IL_01e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0215: stloc.s 7
-		IL_0217: volatile.
-		IL_0219: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_021e: brfalse IL_0234
+		IL_01ea: stloc.s 7
+		IL_01ec: ldloc.s 7
+		IL_01ee: ldstr "optional"
+		IL_01f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_01f8: box [System.Runtime]System.Boolean
+		IL_01fd: stloc.s 9
+		IL_01ff: ldloc.s 6
+		IL_0201: ldloc.s 9
+		IL_0203: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0208: pop
+		IL_0209: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_020e: stloc.s 6
+		IL_0210: volatile.
+		IL_0212: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0217: brfalse IL_022c
 
-		IL_0223: ldloc.s 7
-		IL_0225: ldstr "optional"
-		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_022f: br IL_024a
+		IL_021c: ldloc.1
+		IL_021d: ldstr "groups"
+		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0227: br IL_0241
 
-		IL_0234: ldloc.s 7
-		IL_0236: ldstr "optional"
-		IL_023b: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:53"
-		IL_0240: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_022c: ldloc.1
+		IL_022d: ldstr "groups"
+		IL_0232: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:51"
+		IL_0237: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_024a: stloc.s 7
-		IL_024c: ldloc.s 7
-		IL_024e: ldnull
-		IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0254: stloc.s 8
-		IL_0256: ldloc.s 8
-		IL_0258: box [System.Runtime]System.Boolean
-		IL_025d: stloc.s 9
-		IL_025f: ldloc.s 6
-		IL_0261: ldloc.s 9
-		IL_0263: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0268: pop
-		IL_0269: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_026e: stloc.s 6
-		IL_0270: volatile.
-		IL_0272: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0277: brfalse IL_028c
+		IL_0241: stloc.s 7
+		IL_0243: volatile.
+		IL_0245: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_024a: brfalse IL_0260
 
-		IL_027c: ldloc.1
-		IL_027d: ldstr "groups"
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0287: br IL_02a1
+		IL_024f: ldloc.s 7
+		IL_0251: ldstr "optional"
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_025b: br IL_0276
 
-		IL_028c: ldloc.1
-		IL_028d: ldstr "groups"
-		IL_0292: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:61"
-		IL_0297: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0260: ldloc.s 7
+		IL_0262: ldstr "optional"
+		IL_0267: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:53"
+		IL_026c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02a1: stloc.s 7
-		IL_02a3: ldloc.s 7
-		IL_02a5: ldstr "word"
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_02af: stloc.s 7
-		IL_02b1: ldloc.s 7
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_02b8: stloc.s 7
-		IL_02ba: ldloc.s 6
-		IL_02bc: ldloc.s 7
-		IL_02be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c3: pop
-		IL_02c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c9: stloc.s 6
-		IL_02cb: volatile.
-		IL_02cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02d2: brfalse IL_02e7
+		IL_0276: stloc.s 7
+		IL_0278: ldloc.s 7
+		IL_027a: ldnull
+		IL_027b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0280: stloc.s 8
+		IL_0282: ldloc.s 8
+		IL_0284: box [System.Runtime]System.Boolean
+		IL_0289: stloc.s 9
+		IL_028b: ldloc.s 6
+		IL_028d: ldloc.s 9
+		IL_028f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0294: pop
+		IL_0295: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_029a: stloc.s 6
+		IL_029c: volatile.
+		IL_029e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02a3: brfalse IL_02b8
 
-		IL_02d7: ldloc.1
-		IL_02d8: ldstr "groups"
-		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e2: br IL_02fc
+		IL_02a8: ldloc.1
+		IL_02a9: ldstr "groups"
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b3: br IL_02cd
 
-		IL_02e7: ldloc.1
-		IL_02e8: ldstr "groups"
-		IL_02ed: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:69"
-		IL_02f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02b8: ldloc.1
+		IL_02b9: ldstr "groups"
+		IL_02be: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:61"
+		IL_02c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02fc: stloc.s 7
-		IL_02fe: ldloc.s 7
-		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0305: stloc.s 7
-		IL_0307: ldloc.s 6
-		IL_0309: ldloc.s 7
-		IL_030b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0310: pop
-		IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0316: stloc.s 6
-		IL_0318: volatile.
-		IL_031a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_031f: brfalse IL_0334
+		IL_02cd: stloc.s 7
+		IL_02cf: ldloc.s 7
+		IL_02d1: ldstr "word"
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_02db: stloc.s 7
+		IL_02dd: ldloc.s 7
+		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_02e4: stloc.s 7
+		IL_02e6: ldloc.s 6
+		IL_02e8: ldloc.s 7
+		IL_02ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ef: pop
+		IL_02f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02f5: stloc.s 6
+		IL_02f7: volatile.
+		IL_02f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02fe: brfalse IL_0313
 
-		IL_0324: ldloc.1
-		IL_0325: ldstr "indices"
-		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_032f: br IL_0349
+		IL_0303: ldloc.1
+		IL_0304: ldstr "groups"
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_030e: br IL_0328
 
-		IL_0334: ldloc.1
-		IL_0335: ldstr "indices"
-		IL_033a: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:75"
-		IL_033f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0313: ldloc.1
+		IL_0314: ldstr "groups"
+		IL_0319: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:69"
+		IL_031e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0349: stloc.s 7
-		IL_034b: ldloc.s 7
-		IL_034d: ldc.r8 0.0
-		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_035b: stloc.s 7
-		IL_035d: ldloc.s 7
-		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0364: stloc.s 7
-		IL_0366: ldloc.s 6
-		IL_0368: ldloc.s 7
-		IL_036a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_036f: pop
-		IL_0370: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0375: stloc.s 6
-		IL_0377: volatile.
-		IL_0379: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_037e: brfalse IL_0393
+		IL_0328: stloc.s 7
+		IL_032a: ldloc.s 7
+		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0331: stloc.s 7
+		IL_0333: ldloc.s 6
+		IL_0335: ldloc.s 7
+		IL_0337: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_033c: pop
+		IL_033d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0342: stloc.s 6
+		IL_0344: volatile.
+		IL_0346: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_034b: brfalse IL_0360
 
-		IL_0383: ldloc.1
-		IL_0384: ldstr "indices"
-		IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_038e: br IL_03a8
+		IL_0350: ldloc.1
+		IL_0351: ldstr "indices"
+		IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_035b: br IL_0375
 
-		IL_0393: ldloc.1
-		IL_0394: ldstr "indices"
-		IL_0399: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:83"
-		IL_039e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0360: ldloc.1
+		IL_0361: ldstr "indices"
+		IL_0366: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:75"
+		IL_036b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03a8: stloc.s 7
-		IL_03aa: ldloc.s 7
-		IL_03ac: ldc.r8 1
-		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03ba: stloc.s 7
-		IL_03bc: ldloc.s 7
-		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_03c3: stloc.s 7
-		IL_03c5: ldloc.s 6
-		IL_03c7: ldloc.s 7
-		IL_03c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03ce: pop
-		IL_03cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03d4: stloc.s 6
-		IL_03d6: volatile.
-		IL_03d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_03dd: brfalse IL_03f2
+		IL_0375: stloc.s 7
+		IL_0377: ldloc.s 7
+		IL_0379: ldc.r8 0.0
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0387: stloc.s 7
+		IL_0389: ldloc.s 7
+		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0390: stloc.s 7
+		IL_0392: ldloc.s 6
+		IL_0394: ldloc.s 7
+		IL_0396: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_039b: pop
+		IL_039c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a1: stloc.s 6
+		IL_03a3: volatile.
+		IL_03a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_03aa: brfalse IL_03bf
 
-		IL_03e2: ldloc.1
-		IL_03e3: ldstr "indices"
-		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03ed: br IL_0407
+		IL_03af: ldloc.1
+		IL_03b0: ldstr "indices"
+		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ba: br IL_03d4
 
-		IL_03f2: ldloc.1
-		IL_03f3: ldstr "indices"
-		IL_03f8: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:91"
-		IL_03fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03bf: ldloc.1
+		IL_03c0: ldstr "indices"
+		IL_03c5: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:83"
+		IL_03ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0407: stloc.s 7
-		IL_0409: ldloc.s 7
-		IL_040b: ldc.r8 2
-		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0419: stloc.s 7
-		IL_041b: ldloc.s 7
-		IL_041d: ldnull
-		IL_041e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0423: stloc.s 8
-		IL_0425: ldloc.s 8
-		IL_0427: box [System.Runtime]System.Boolean
-		IL_042c: stloc.s 9
-		IL_042e: ldloc.s 6
-		IL_0430: ldloc.s 9
-		IL_0432: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0437: pop
-		IL_0438: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_043d: stloc.s 6
-		IL_043f: volatile.
-		IL_0441: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0446: brfalse IL_045b
+		IL_03d4: stloc.s 7
+		IL_03d6: ldloc.s 7
+		IL_03d8: ldc.r8 1
+		IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03e6: stloc.s 7
+		IL_03e8: ldloc.s 7
+		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_03ef: stloc.s 7
+		IL_03f1: ldloc.s 6
+		IL_03f3: ldloc.s 7
+		IL_03f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03fa: pop
+		IL_03fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0400: stloc.s 6
+		IL_0402: volatile.
+		IL_0404: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0409: brfalse IL_041e
 
-		IL_044b: ldloc.1
-		IL_044c: ldstr "indices"
-		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0456: br IL_0470
+		IL_040e: ldloc.1
+		IL_040f: ldstr "indices"
+		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0419: br IL_0433
 
-		IL_045b: ldloc.1
-		IL_045c: ldstr "indices"
-		IL_0461: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:101"
-		IL_0466: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_041e: ldloc.1
+		IL_041f: ldstr "indices"
+		IL_0424: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:91"
+		IL_0429: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0470: stloc.s 7
-		IL_0472: volatile.
-		IL_0474: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0479: brfalse IL_048f
+		IL_0433: stloc.s 7
+		IL_0435: ldloc.s 7
+		IL_0437: ldc.r8 2
+		IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0445: stloc.s 7
+		IL_0447: ldloc.s 7
+		IL_0449: ldnull
+		IL_044a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_044f: stloc.s 8
+		IL_0451: ldloc.s 8
+		IL_0453: box [System.Runtime]System.Boolean
+		IL_0458: stloc.s 9
+		IL_045a: ldloc.s 6
+		IL_045c: ldloc.s 9
+		IL_045e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0463: pop
+		IL_0464: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0469: stloc.s 6
+		IL_046b: volatile.
+		IL_046d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0472: brfalse IL_0487
 
-		IL_047e: ldloc.s 7
-		IL_0480: ldstr "groups"
-		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_048a: br IL_04a5
+		IL_0477: ldloc.1
+		IL_0478: ldstr "indices"
+		IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0482: br IL_049c
 
-		IL_048f: ldloc.s 7
-		IL_0491: ldstr "groups"
-		IL_0496: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:103"
-		IL_049b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0487: ldloc.1
+		IL_0488: ldstr "indices"
+		IL_048d: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:101"
+		IL_0492: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04a5: stloc.s 7
-		IL_04a7: ldloc.s 7
-		IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_04ae: stloc.s 7
-		IL_04b0: ldloc.s 7
-		IL_04b2: ldc.i4.0
-		IL_04b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_04b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04bd: stloc.s 8
-		IL_04bf: ldloc.s 8
-		IL_04c1: box [System.Runtime]System.Boolean
-		IL_04c6: stloc.s 9
-		IL_04c8: ldloc.s 6
-		IL_04ca: ldloc.s 9
-		IL_04cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04d1: pop
-		IL_04d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04d7: stloc.s 6
-		IL_04d9: volatile.
-		IL_04db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_04e0: brfalse IL_04f5
+		IL_049c: stloc.s 7
+		IL_049e: volatile.
+		IL_04a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04a5: brfalse IL_04bb
 
-		IL_04e5: ldloc.1
-		IL_04e6: ldstr "indices"
-		IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04f0: br IL_050a
+		IL_04aa: ldloc.s 7
+		IL_04ac: ldstr "groups"
+		IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04b6: br IL_04d1
 
-		IL_04f5: ldloc.1
-		IL_04f6: ldstr "indices"
-		IL_04fb: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:113"
-		IL_0500: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04bb: ldloc.s 7
+		IL_04bd: ldstr "groups"
+		IL_04c2: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:103"
+		IL_04c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_050a: stloc.s 7
-		IL_050c: ldloc.s 7
-		IL_050e: ldstr "groups"
-		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0518: stloc.s 7
-		IL_051a: ldloc.s 7
-		IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0521: stloc.s 7
-		IL_0523: ldloc.s 6
-		IL_0525: ldloc.s 7
-		IL_0527: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_052c: pop
-		IL_052d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0532: stloc.s 6
-		IL_0534: volatile.
-		IL_0536: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_053b: brfalse IL_0550
+		IL_04d1: stloc.s 7
+		IL_04d3: ldloc.s 7
+		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_04da: stloc.s 7
+		IL_04dc: ldloc.s 7
+		IL_04de: ldc.i4.0
+		IL_04df: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_04e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04e9: stloc.s 8
+		IL_04eb: ldloc.s 8
+		IL_04ed: box [System.Runtime]System.Boolean
+		IL_04f2: stloc.s 9
+		IL_04f4: ldloc.s 6
+		IL_04f6: ldloc.s 9
+		IL_04f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04fd: pop
+		IL_04fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0503: stloc.s 6
+		IL_0505: volatile.
+		IL_0507: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_050c: brfalse IL_0521
 
-		IL_0540: ldloc.1
-		IL_0541: ldstr "indices"
-		IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_054b: br IL_0565
+		IL_0511: ldloc.1
+		IL_0512: ldstr "indices"
+		IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_051c: br IL_0536
 
-		IL_0550: ldloc.1
-		IL_0551: ldstr "indices"
-		IL_0556: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:121"
-		IL_055b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0560: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0521: ldloc.1
+		IL_0522: ldstr "indices"
+		IL_0527: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:113"
+		IL_052c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0531: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0565: stloc.s 7
-		IL_0567: volatile.
-		IL_0569: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_056e: brfalse IL_0584
+		IL_0536: stloc.s 7
+		IL_0538: ldloc.s 7
+		IL_053a: ldstr "groups"
+		IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0544: stloc.s 7
+		IL_0546: ldloc.s 7
+		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_054d: stloc.s 7
+		IL_054f: ldloc.s 6
+		IL_0551: ldloc.s 7
+		IL_0553: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0558: pop
+		IL_0559: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_055e: stloc.s 6
+		IL_0560: volatile.
+		IL_0562: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0567: brfalse IL_057c
 
-		IL_0573: ldloc.s 7
-		IL_0575: ldstr "groups"
-		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_057f: br IL_059a
+		IL_056c: ldloc.1
+		IL_056d: ldstr "indices"
+		IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0577: br IL_0591
 
-		IL_0584: ldloc.s 7
-		IL_0586: ldstr "groups"
-		IL_058b: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:123"
-		IL_0590: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_057c: ldloc.1
+		IL_057d: ldstr "indices"
+		IL_0582: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:121"
+		IL_0587: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_059a: stloc.s 7
-		IL_059c: ldloc.s 7
-		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_05a3: stloc.s 7
-		IL_05a5: ldloc.s 7
-		IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_05ac: stloc.s 7
-		IL_05ae: ldloc.s 6
+		IL_0591: stloc.s 7
+		IL_0593: volatile.
+		IL_0595: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_059a: brfalse IL_05b0
+
+		IL_059f: ldloc.s 7
+		IL_05a1: ldstr "groups"
+		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ab: br IL_05c6
+
 		IL_05b0: ldloc.s 7
-		IL_05b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05b7: pop
-		IL_05b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05bd: stloc.s 6
-		IL_05bf: volatile.
-		IL_05c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_05c6: brfalse IL_05db
-
-		IL_05cb: ldloc.1
-		IL_05cc: ldstr "indices"
-		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05d6: br IL_05f0
-
-		IL_05db: ldloc.1
-		IL_05dc: ldstr "indices"
-		IL_05e1: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:130"
-		IL_05e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_05f0: stloc.s 7
-		IL_05f2: volatile.
-		IL_05f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_05f9: brfalse IL_060f
-
-		IL_05fe: ldloc.s 7
-		IL_0600: ldstr "groups"
-		IL_0605: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_060a: br IL_0625
-
-		IL_060f: ldloc.s 7
-		IL_0611: ldstr "groups"
-		IL_0616: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:132"
-		IL_061b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0625: stloc.s 7
-		IL_0627: volatile.
-		IL_0629: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_062e: brfalse IL_0644
-
-		IL_0633: ldloc.s 7
-		IL_0635: ldstr "word"
-		IL_063a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_063f: br IL_065a
-
-		IL_0644: ldloc.s 7
-		IL_0646: ldstr "word"
-		IL_064b: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:134"
-		IL_0650: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_065a: stloc.s 7
-		IL_065c: ldloc.s 7
-		IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0663: stloc.s 7
-		IL_0665: ldloc.s 6
-		IL_0667: ldloc.s 7
-		IL_0669: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_066e: pop
-		IL_066f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0674: stloc.s 6
-		IL_0676: volatile.
-		IL_0678: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_067d: brfalse IL_0692
-
-		IL_0682: ldloc.1
-		IL_0683: ldstr "indices"
-		IL_0688: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_068d: br IL_06a7
-
-		IL_0692: ldloc.1
-		IL_0693: ldstr "indices"
-		IL_0698: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:140"
-		IL_069d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_06a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_06a7: stloc.s 7
-		IL_06a9: volatile.
-		IL_06ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_06b0: brfalse IL_06c6
-
-		IL_06b5: ldloc.s 7
-		IL_06b7: ldstr "groups"
-		IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06c1: br IL_06dc
-
-		IL_06c6: ldloc.s 7
-		IL_06c8: ldstr "groups"
-		IL_06cd: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:142"
-		IL_06d2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_06dc: stloc.s 7
-		IL_06de: ldloc.s 7
-		IL_06e0: ldstr "optional"
-		IL_06e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_06ea: box [System.Runtime]System.Boolean
-		IL_06ef: stloc.s 9
-		IL_06f1: ldloc.s 6
-		IL_06f3: ldloc.s 9
-		IL_06f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06fa: pop
-		IL_06fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0700: stloc.s 6
-		IL_0702: volatile.
-		IL_0704: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0709: brfalse IL_071e
-
-		IL_070e: ldloc.1
-		IL_070f: ldstr "indices"
-		IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0719: br IL_0733
-
-		IL_071e: ldloc.1
-		IL_071f: ldstr "indices"
-		IL_0724: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:150"
-		IL_0729: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0733: stloc.s 7
-		IL_0735: volatile.
-		IL_0737: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_073c: brfalse IL_0752
-
-		IL_0741: ldloc.s 7
-		IL_0743: ldstr "groups"
-		IL_0748: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_074d: br IL_0768
-
-		IL_0752: ldloc.s 7
-		IL_0754: ldstr "groups"
-		IL_0759: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:152"
-		IL_075e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0768: stloc.s 7
-		IL_076a: volatile.
-		IL_076c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0771: brfalse IL_0787
-
-		IL_0776: ldloc.s 7
-		IL_0778: ldstr "optional"
-		IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0782: br IL_079d
-
-		IL_0787: ldloc.s 7
-		IL_0789: ldstr "optional"
-		IL_078e: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:154"
-		IL_0793: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_079d: stloc.s 7
-		IL_079f: ldloc.s 7
-		IL_07a1: ldnull
-		IL_07a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_07a7: stloc.s 8
-		IL_07a9: ldloc.s 8
-		IL_07ab: box [System.Runtime]System.Boolean
-		IL_07b0: stloc.s 9
-		IL_07b2: ldloc.s 6
-		IL_07b4: ldloc.s 9
-		IL_07b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07bb: pop
-		IL_07bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07c1: stloc.s 6
-		IL_07c3: volatile.
-		IL_07c5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_07ca: brfalse IL_07df
-
-		IL_07cf: ldloc.1
-		IL_07d0: ldstr "groups"
-		IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07da: br IL_07f4
-
-		IL_07df: ldloc.1
-		IL_07e0: ldstr "groups"
-		IL_07e5: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:162"
-		IL_07ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_07ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_07f4: stloc.s 7
-		IL_07f6: volatile.
-		IL_07f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_07fd: brfalse IL_0812
-
-		IL_0802: ldloc.1
-		IL_0803: ldstr "indices"
-		IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_080d: br IL_0827
-
-		IL_0812: ldloc.1
-		IL_0813: ldstr "indices"
-		IL_0818: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:164"
-		IL_081d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0822: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0827: stloc.s 10
-		IL_0829: volatile.
-		IL_082b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0830: brfalse IL_0846
-
-		IL_0835: ldloc.s 10
-		IL_0837: ldstr "groups"
-		IL_083c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0841: br IL_085c
-
-		IL_0846: ldloc.s 10
-		IL_0848: ldstr "groups"
-		IL_084d: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:166"
-		IL_0852: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0857: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_085c: stloc.s 10
-		IL_085e: ldloc.s 7
-		IL_0860: ldloc.s 10
-		IL_0862: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0867: stloc.s 8
-		IL_0869: ldloc.s 8
-		IL_086b: box [System.Runtime]System.Boolean
-		IL_0870: stloc.s 9
-		IL_0872: ldloc.s 6
-		IL_0874: ldloc.s 9
-		IL_0876: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_087b: pop
-		IL_087c: ldstr "(?<letter>a)"
-		IL_0881: ldstr ""
-		IL_0886: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_088b: stloc.s 5
-		IL_088d: ldstr "a"
-		IL_0892: ldstr "match"
-		IL_0897: ldloc.s 5
-		IL_0899: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_089e: stloc.2
-		IL_089f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08a4: stloc.s 6
-		IL_08a6: volatile.
-		IL_08a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_08ad: brfalse IL_08c2
-
-		IL_08b2: ldloc.2
-		IL_08b3: ldstr "groups"
-		IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08bd: br IL_08d7
-
-		IL_08c2: ldloc.2
-		IL_08c3: ldstr "groups"
-		IL_08c8: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:180"
-		IL_08cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_08d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_08d7: stloc.s 10
-		IL_08d9: ldloc.s 10
-		IL_08db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_08e0: stloc.s 10
-		IL_08e2: ldloc.s 10
-		IL_08e4: ldc.i4.0
-		IL_08e5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_08ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_08ef: stloc.s 8
-		IL_08f1: ldloc.s 8
-		IL_08f3: box [System.Runtime]System.Boolean
-		IL_08f8: stloc.s 9
-		IL_08fa: ldloc.s 6
-		IL_08fc: ldloc.s 9
-		IL_08fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0903: pop
-		IL_0904: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0909: stloc.s 6
-		IL_090b: volatile.
-		IL_090d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0912: brfalse IL_0927
-
-		IL_0917: ldloc.2
-		IL_0918: ldstr "groups"
-		IL_091d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0922: br IL_093c
-
-		IL_0927: ldloc.2
-		IL_0928: ldstr "groups"
-		IL_092d: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:190"
-		IL_0932: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0937: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_093c: stloc.s 10
-		IL_093e: volatile.
-		IL_0940: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0945: brfalse IL_095b
-
-		IL_094a: ldloc.s 10
-		IL_094c: ldstr "letter"
-		IL_0951: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0956: br IL_0971
-
-		IL_095b: ldloc.s 10
-		IL_095d: ldstr "letter"
-		IL_0962: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:192"
-		IL_0967: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_096c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0971: stloc.s 10
-		IL_0973: ldloc.s 6
-		IL_0975: ldloc.s 10
-		IL_0977: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_097c: pop
-		IL_097d: ldstr "(?<letter>a)"
-		IL_0982: ldstr "g"
-		IL_0987: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_098c: stloc.s 5
-		IL_098e: ldstr "a a"
-		IL_0993: ldstr "matchAll"
-		IL_0998: ldloc.s 5
-		IL_099a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_099f: stloc.s 10
-		IL_09a1: ldloc.s 10
-		IL_09a3: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
-		IL_09a8: stloc.3
-		IL_09a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09ae: stloc.s 6
-		IL_09b0: ldloc.3
-		IL_09b1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-		IL_09b6: box [System.Runtime]System.Double
-		IL_09bb: stloc.s 11
-		IL_09bd: ldloc.s 6
-		IL_09bf: ldloc.s 11
-		IL_09c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_09c6: pop
-		IL_09c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09cc: stloc.s 6
-		IL_09ce: ldloc.3
-		IL_09cf: ldc.r8 0.0
-		IL_09d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_09dd: volatile.
-		IL_09df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_09e4: brfalse IL_09f8
-
-		IL_09e9: ldstr "groups"
-		IL_09ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09f3: br IL_0a0c
-
-		IL_09f8: ldstr "groups"
-		IL_09fd: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:212"
-		IL_0a02: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0a0c: stloc.s 10
-		IL_0a0e: volatile.
-		IL_0a10: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0a15: brfalse IL_0a2b
-
-		IL_0a1a: ldloc.s 10
-		IL_0a1c: ldstr "letter"
-		IL_0a21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a26: br IL_0a41
-
-		IL_0a2b: ldloc.s 10
-		IL_0a2d: ldstr "letter"
-		IL_0a32: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:214"
-		IL_0a37: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0a3c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0a41: stloc.s 10
-		IL_0a43: ldloc.s 6
-		IL_0a45: ldloc.s 10
-		IL_0a47: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0a4c: pop
-		IL_0a4d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0a52: stloc.s 6
-		IL_0a54: ldloc.3
-		IL_0a55: ldc.r8 1
-		IL_0a5e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0a63: volatile.
-		IL_0a65: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0a6a: brfalse IL_0a7e
-
-		IL_0a6f: ldstr "groups"
-		IL_0a74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a79: br IL_0a92
-
-		IL_0a7e: ldstr "groups"
-		IL_0a83: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:221"
-		IL_0a88: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0a8d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0a92: stloc.s 10
-		IL_0a94: volatile.
-		IL_0a96: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0a9b: brfalse IL_0ab1
-
-		IL_0aa0: ldloc.s 10
-		IL_0aa2: ldstr "letter"
-		IL_0aa7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0aac: br IL_0ac7
-
-		IL_0ab1: ldloc.s 10
-		IL_0ab3: ldstr "letter"
-		IL_0ab8: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:223"
-		IL_0abd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0ac2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0ac7: stloc.s 10
-		IL_0ac9: ldloc.s 6
-		IL_0acb: ldloc.s 10
-		IL_0acd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0ad2: pop
-		IL_0ad3: ldstr "a"
-		IL_0ad8: ldstr "d"
-		IL_0add: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0ae2: stloc.s 5
-		IL_0ae4: ldloc.s 5
-		IL_0ae6: ldstr "exec"
-		IL_0aeb: ldstr "a"
-		IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0af5: stloc.s 4
-		IL_0af7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0afc: stloc.s 6
-		IL_0afe: volatile.
-		IL_0b00: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_0b05: brfalse IL_0b1b
-
-		IL_0b0a: ldloc.s 4
-		IL_0b0c: ldstr "groups"
-		IL_0b11: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b16: br IL_0b31
-
-		IL_0b1b: ldloc.s 4
-		IL_0b1d: ldstr "groups"
-		IL_0b22: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:235"
-		IL_0b27: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_0b2c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0b31: stloc.s 10
-		IL_0b33: ldloc.s 10
-		IL_0b35: ldnull
-		IL_0b36: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0b3b: stloc.s 8
-		IL_0b3d: ldloc.s 8
-		IL_0b3f: box [System.Runtime]System.Boolean
-		IL_0b44: stloc.s 9
-		IL_0b46: ldloc.s 6
-		IL_0b48: ldloc.s 9
-		IL_0b4a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0b4f: pop
-		IL_0b50: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b55: stloc.s 6
-		IL_0b57: volatile.
-		IL_0b59: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_0b5e: brfalse IL_0b74
-
-		IL_0b63: ldloc.s 4
-		IL_0b65: ldstr "indices"
-		IL_0b6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b6f: br IL_0b8a
-
-		IL_0b74: ldloc.s 4
-		IL_0b76: ldstr "indices"
-		IL_0b7b: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:243"
-		IL_0b80: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_0b85: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0b8a: stloc.s 10
-		IL_0b8c: volatile.
-		IL_0b8e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_0b93: brfalse IL_0ba9
-
-		IL_0b98: ldloc.s 10
-		IL_0b9a: ldstr "groups"
-		IL_0b9f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ba4: br IL_0bbf
-
-		IL_0ba9: ldloc.s 10
-		IL_0bab: ldstr "groups"
-		IL_0bb0: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:245"
-		IL_0bb5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_0bba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0bbf: stloc.s 10
-		IL_0bc1: ldloc.s 10
-		IL_0bc3: ldnull
-		IL_0bc4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0bc9: stloc.s 8
-		IL_0bcb: ldloc.s 8
-		IL_0bcd: box [System.Runtime]System.Boolean
-		IL_0bd2: stloc.s 9
-		IL_0bd4: ldloc.s 6
-		IL_0bd6: ldloc.s 9
-		IL_0bd8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0bdd: pop
-		IL_0bde: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0be3: stloc.s 6
-		IL_0be5: ldloc.s 4
-		IL_0be7: ldstr "groups"
-		IL_0bec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0bf1: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0bf6: stloc.s 10
-		IL_0bf8: ldloc.s 6
-		IL_0bfa: ldloc.s 10
-		IL_0bfc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0c01: pop
-		IL_0c02: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0c07: stloc.s 6
-		IL_0c09: volatile.
-		IL_0c0b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_0c10: brfalse IL_0c26
-
-		IL_0c15: ldloc.s 4
-		IL_0c17: ldstr "indices"
-		IL_0c1c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c21: br IL_0c3c
-
-		IL_0c26: ldloc.s 4
-		IL_0c28: ldstr "indices"
-		IL_0c2d: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:259"
-		IL_0c32: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_0c37: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0c3c: stloc.s 10
-		IL_0c3e: ldloc.s 10
-		IL_0c40: ldstr "groups"
-		IL_0c45: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0c4a: stloc.s 10
-		IL_0c4c: ldloc.s 10
-		IL_0c4e: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0c53: stloc.s 10
-		IL_0c55: ldloc.s 6
-		IL_0c57: ldloc.s 10
-		IL_0c59: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0c5e: pop
-		IL_0c5f: ret
+		IL_05b2: ldstr "groups"
+		IL_05b7: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:123"
+		IL_05bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05c6: stloc.s 7
+		IL_05c8: ldloc.s 7
+		IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_05cf: stloc.s 7
+		IL_05d1: ldloc.s 7
+		IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_05d8: stloc.s 7
+		IL_05da: ldloc.s 6
+		IL_05dc: ldloc.s 7
+		IL_05de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05e3: pop
+		IL_05e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05e9: stloc.s 6
+		IL_05eb: volatile.
+		IL_05ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_05f2: brfalse IL_0607
+
+		IL_05f7: ldloc.1
+		IL_05f8: ldstr "indices"
+		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0602: br IL_061c
+
+		IL_0607: ldloc.1
+		IL_0608: ldstr "indices"
+		IL_060d: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:130"
+		IL_0612: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_061c: stloc.s 7
+		IL_061e: volatile.
+		IL_0620: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0625: brfalse IL_063b
+
+		IL_062a: ldloc.s 7
+		IL_062c: ldstr "groups"
+		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0636: br IL_0651
+
+		IL_063b: ldloc.s 7
+		IL_063d: ldstr "groups"
+		IL_0642: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:132"
+		IL_0647: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0651: stloc.s 7
+		IL_0653: volatile.
+		IL_0655: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_065a: brfalse IL_0670
+
+		IL_065f: ldloc.s 7
+		IL_0661: ldstr "word"
+		IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_066b: br IL_0686
+
+		IL_0670: ldloc.s 7
+		IL_0672: ldstr "word"
+		IL_0677: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:134"
+		IL_067c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0686: stloc.s 7
+		IL_0688: ldloc.s 7
+		IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_068f: stloc.s 7
+		IL_0691: ldloc.s 6
+		IL_0693: ldloc.s 7
+		IL_0695: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_069a: pop
+		IL_069b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06a0: stloc.s 6
+		IL_06a2: volatile.
+		IL_06a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_06a9: brfalse IL_06be
+
+		IL_06ae: ldloc.1
+		IL_06af: ldstr "indices"
+		IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06b9: br IL_06d3
+
+		IL_06be: ldloc.1
+		IL_06bf: ldstr "indices"
+		IL_06c4: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:140"
+		IL_06c9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_06ce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06d3: stloc.s 7
+		IL_06d5: volatile.
+		IL_06d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_06dc: brfalse IL_06f2
+
+		IL_06e1: ldloc.s 7
+		IL_06e3: ldstr "groups"
+		IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06ed: br IL_0708
+
+		IL_06f2: ldloc.s 7
+		IL_06f4: ldstr "groups"
+		IL_06f9: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:142"
+		IL_06fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0703: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0708: stloc.s 7
+		IL_070a: ldloc.s 7
+		IL_070c: ldstr "optional"
+		IL_0711: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0716: box [System.Runtime]System.Boolean
+		IL_071b: stloc.s 9
+		IL_071d: ldloc.s 6
+		IL_071f: ldloc.s 9
+		IL_0721: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0726: pop
+		IL_0727: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_072c: stloc.s 6
+		IL_072e: volatile.
+		IL_0730: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0735: brfalse IL_074a
+
+		IL_073a: ldloc.1
+		IL_073b: ldstr "indices"
+		IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0745: br IL_075f
+
+		IL_074a: ldloc.1
+		IL_074b: ldstr "indices"
+		IL_0750: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:150"
+		IL_0755: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_075a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_075f: stloc.s 7
+		IL_0761: volatile.
+		IL_0763: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0768: brfalse IL_077e
+
+		IL_076d: ldloc.s 7
+		IL_076f: ldstr "groups"
+		IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0779: br IL_0794
+
+		IL_077e: ldloc.s 7
+		IL_0780: ldstr "groups"
+		IL_0785: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:152"
+		IL_078a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_078f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0794: stloc.s 7
+		IL_0796: volatile.
+		IL_0798: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_079d: brfalse IL_07b3
+
+		IL_07a2: ldloc.s 7
+		IL_07a4: ldstr "optional"
+		IL_07a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07ae: br IL_07c9
+
+		IL_07b3: ldloc.s 7
+		IL_07b5: ldstr "optional"
+		IL_07ba: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:154"
+		IL_07bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_07c9: stloc.s 7
+		IL_07cb: ldloc.s 7
+		IL_07cd: ldnull
+		IL_07ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_07d3: stloc.s 8
+		IL_07d5: ldloc.s 8
+		IL_07d7: box [System.Runtime]System.Boolean
+		IL_07dc: stloc.s 9
+		IL_07de: ldloc.s 6
+		IL_07e0: ldloc.s 9
+		IL_07e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07e7: pop
+		IL_07e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07ed: stloc.s 6
+		IL_07ef: volatile.
+		IL_07f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_07f6: brfalse IL_080b
+
+		IL_07fb: ldloc.1
+		IL_07fc: ldstr "groups"
+		IL_0801: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0806: br IL_0820
+
+		IL_080b: ldloc.1
+		IL_080c: ldstr "groups"
+		IL_0811: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:162"
+		IL_0816: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_081b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0820: stloc.s 7
+		IL_0822: volatile.
+		IL_0824: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0829: brfalse IL_083e
+
+		IL_082e: ldloc.1
+		IL_082f: ldstr "indices"
+		IL_0834: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0839: br IL_0853
+
+		IL_083e: ldloc.1
+		IL_083f: ldstr "indices"
+		IL_0844: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:164"
+		IL_0849: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0853: stloc.s 10
+		IL_0855: volatile.
+		IL_0857: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_085c: brfalse IL_0872
+
+		IL_0861: ldloc.s 10
+		IL_0863: ldstr "groups"
+		IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_086d: br IL_0888
+
+		IL_0872: ldloc.s 10
+		IL_0874: ldstr "groups"
+		IL_0879: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:166"
+		IL_087e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0888: stloc.s 10
+		IL_088a: ldloc.s 7
+		IL_088c: ldloc.s 10
+		IL_088e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0893: stloc.s 8
+		IL_0895: ldloc.s 8
+		IL_0897: box [System.Runtime]System.Boolean
+		IL_089c: stloc.s 9
+		IL_089e: ldloc.s 6
+		IL_08a0: ldloc.s 9
+		IL_08a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08a7: pop
+		IL_08a8: ldstr "(?<letter>a)"
+		IL_08ad: ldstr ""
+		IL_08b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_08b7: stloc.s 5
+		IL_08b9: volatile.
+		IL_08bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_08c0: brfalse IL_08db
+
+		IL_08c5: ldstr "a"
+		IL_08ca: ldstr "match"
+		IL_08cf: ldloc.s 5
+		IL_08d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_08d6: br IL_08f6
+
+		IL_08db: ldstr "a"
+		IL_08e0: ldstr "match"
+		IL_08e5: ldloc.s 5
+		IL_08e7: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:175"
+		IL_08ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_08f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_08f6: stloc.2
+		IL_08f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08fc: stloc.s 6
+		IL_08fe: volatile.
+		IL_0900: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0905: brfalse IL_091a
+
+		IL_090a: ldloc.2
+		IL_090b: ldstr "groups"
+		IL_0910: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0915: br IL_092f
+
+		IL_091a: ldloc.2
+		IL_091b: ldstr "groups"
+		IL_0920: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:180"
+		IL_0925: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_092a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_092f: stloc.s 10
+		IL_0931: ldloc.s 10
+		IL_0933: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0938: stloc.s 10
+		IL_093a: ldloc.s 10
+		IL_093c: ldc.i4.0
+		IL_093d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0942: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0947: stloc.s 8
+		IL_0949: ldloc.s 8
+		IL_094b: box [System.Runtime]System.Boolean
+		IL_0950: stloc.s 9
+		IL_0952: ldloc.s 6
+		IL_0954: ldloc.s 9
+		IL_0956: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_095b: pop
+		IL_095c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0961: stloc.s 6
+		IL_0963: volatile.
+		IL_0965: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_096a: brfalse IL_097f
+
+		IL_096f: ldloc.2
+		IL_0970: ldstr "groups"
+		IL_0975: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_097a: br IL_0994
+
+		IL_097f: ldloc.2
+		IL_0980: ldstr "groups"
+		IL_0985: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:190"
+		IL_098a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_098f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0994: stloc.s 10
+		IL_0996: volatile.
+		IL_0998: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_099d: brfalse IL_09b3
+
+		IL_09a2: ldloc.s 10
+		IL_09a4: ldstr "letter"
+		IL_09a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09ae: br IL_09c9
+
+		IL_09b3: ldloc.s 10
+		IL_09b5: ldstr "letter"
+		IL_09ba: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:192"
+		IL_09bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_09c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_09c9: stloc.s 10
+		IL_09cb: ldloc.s 6
+		IL_09cd: ldloc.s 10
+		IL_09cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_09d4: pop
+		IL_09d5: ldstr "(?<letter>a)"
+		IL_09da: ldstr "g"
+		IL_09df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_09e4: stloc.s 5
+		IL_09e6: volatile.
+		IL_09e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_09ed: brfalse IL_0a08
+
+		IL_09f2: ldstr "a a"
+		IL_09f7: ldstr "matchAll"
+		IL_09fc: ldloc.s 5
+		IL_09fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a03: br IL_0a23
+
+		IL_0a08: ldstr "a a"
+		IL_0a0d: ldstr "matchAll"
+		IL_0a12: ldloc.s 5
+		IL_0a14: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:199"
+		IL_0a19: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0a1e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0a23: stloc.s 10
+		IL_0a25: ldloc.s 10
+		IL_0a27: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::from(object)
+		IL_0a2c: stloc.3
+		IL_0a2d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0a32: stloc.s 6
+		IL_0a34: ldloc.3
+		IL_0a35: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+		IL_0a3a: box [System.Runtime]System.Double
+		IL_0a3f: stloc.s 11
+		IL_0a41: ldloc.s 6
+		IL_0a43: ldloc.s 11
+		IL_0a45: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0a4a: pop
+		IL_0a4b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0a50: stloc.s 6
+		IL_0a52: ldloc.3
+		IL_0a53: ldc.r8 0.0
+		IL_0a5c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0a61: volatile.
+		IL_0a63: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0a68: brfalse IL_0a7c
+
+		IL_0a6d: ldstr "groups"
+		IL_0a72: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a77: br IL_0a90
+
+		IL_0a7c: ldstr "groups"
+		IL_0a81: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:212"
+		IL_0a86: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0a8b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0a90: stloc.s 10
+		IL_0a92: volatile.
+		IL_0a94: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0a99: brfalse IL_0aaf
+
+		IL_0a9e: ldloc.s 10
+		IL_0aa0: ldstr "letter"
+		IL_0aa5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0aaa: br IL_0ac5
+
+		IL_0aaf: ldloc.s 10
+		IL_0ab1: ldstr "letter"
+		IL_0ab6: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:214"
+		IL_0abb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0ac0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0ac5: stloc.s 10
+		IL_0ac7: ldloc.s 6
+		IL_0ac9: ldloc.s 10
+		IL_0acb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0ad0: pop
+		IL_0ad1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ad6: stloc.s 6
+		IL_0ad8: ldloc.3
+		IL_0ad9: ldc.r8 1
+		IL_0ae2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0ae7: volatile.
+		IL_0ae9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_0aee: brfalse IL_0b02
+
+		IL_0af3: ldstr "groups"
+		IL_0af8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0afd: br IL_0b16
+
+		IL_0b02: ldstr "groups"
+		IL_0b07: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:221"
+		IL_0b0c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_0b11: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0b16: stloc.s 10
+		IL_0b18: volatile.
+		IL_0b1a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_0b1f: brfalse IL_0b35
+
+		IL_0b24: ldloc.s 10
+		IL_0b26: ldstr "letter"
+		IL_0b2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b30: br IL_0b4b
+
+		IL_0b35: ldloc.s 10
+		IL_0b37: ldstr "letter"
+		IL_0b3c: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:223"
+		IL_0b41: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_0b46: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0b4b: stloc.s 10
+		IL_0b4d: ldloc.s 6
+		IL_0b4f: ldloc.s 10
+		IL_0b51: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b56: pop
+		IL_0b57: ldstr "a"
+		IL_0b5c: ldstr "d"
+		IL_0b61: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0b66: stloc.s 5
+		IL_0b68: volatile.
+		IL_0b6a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_0b6f: brfalse IL_0b8a
+
+		IL_0b74: ldloc.s 5
+		IL_0b76: ldstr "exec"
+		IL_0b7b: ldstr "a"
+		IL_0b80: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0b85: br IL_0ba5
+
+		IL_0b8a: ldloc.s 5
+		IL_0b8c: ldstr "exec"
+		IL_0b91: ldstr "a"
+		IL_0b96: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:230"
+		IL_0b9b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_0ba0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0ba5: stloc.s 4
+		IL_0ba7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0bac: stloc.s 6
+		IL_0bae: volatile.
+		IL_0bb0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0bb5: brfalse IL_0bcb
+
+		IL_0bba: ldloc.s 4
+		IL_0bbc: ldstr "groups"
+		IL_0bc1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0bc6: br IL_0be1
+
+		IL_0bcb: ldloc.s 4
+		IL_0bcd: ldstr "groups"
+		IL_0bd2: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:235"
+		IL_0bd7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0bdc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0be1: stloc.s 10
+		IL_0be3: ldloc.s 10
+		IL_0be5: ldnull
+		IL_0be6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0beb: stloc.s 8
+		IL_0bed: ldloc.s 8
+		IL_0bef: box [System.Runtime]System.Boolean
+		IL_0bf4: stloc.s 9
+		IL_0bf6: ldloc.s 6
+		IL_0bf8: ldloc.s 9
+		IL_0bfa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0bff: pop
+		IL_0c00: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0c05: stloc.s 6
+		IL_0c07: volatile.
+		IL_0c09: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_0c0e: brfalse IL_0c24
+
+		IL_0c13: ldloc.s 4
+		IL_0c15: ldstr "indices"
+		IL_0c1a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c1f: br IL_0c3a
+
+		IL_0c24: ldloc.s 4
+		IL_0c26: ldstr "indices"
+		IL_0c2b: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:243"
+		IL_0c30: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+		IL_0c35: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0c3a: stloc.s 10
+		IL_0c3c: volatile.
+		IL_0c3e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_0c43: brfalse IL_0c59
+
+		IL_0c48: ldloc.s 10
+		IL_0c4a: ldstr "groups"
+		IL_0c4f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c54: br IL_0c6f
+
+		IL_0c59: ldloc.s 10
+		IL_0c5b: ldstr "groups"
+		IL_0c60: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:245"
+		IL_0c65: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+		IL_0c6a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0c6f: stloc.s 10
+		IL_0c71: ldloc.s 10
+		IL_0c73: ldnull
+		IL_0c74: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0c79: stloc.s 8
+		IL_0c7b: ldloc.s 8
+		IL_0c7d: box [System.Runtime]System.Boolean
+		IL_0c82: stloc.s 9
+		IL_0c84: ldloc.s 6
+		IL_0c86: ldloc.s 9
+		IL_0c88: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0c8d: pop
+		IL_0c8e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0c93: stloc.s 6
+		IL_0c95: ldloc.s 4
+		IL_0c97: ldstr "groups"
+		IL_0c9c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0ca1: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0ca6: stloc.s 10
+		IL_0ca8: ldloc.s 6
+		IL_0caa: ldloc.s 10
+		IL_0cac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0cb1: pop
+		IL_0cb2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0cb7: stloc.s 6
+		IL_0cb9: volatile.
+		IL_0cbb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_0cc0: brfalse IL_0cd6
+
+		IL_0cc5: ldloc.s 4
+		IL_0cc7: ldstr "indices"
+		IL_0ccc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0cd1: br IL_0cec
+
+		IL_0cd6: ldloc.s 4
+		IL_0cd8: ldstr "indices"
+		IL_0cdd: ldstr "String_RegExp_NamedGroups_Indices:Modules.String_RegExp_NamedGroups_Indices:__js_module_init__:259"
+		IL_0ce2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+		IL_0ce7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0cec: stloc.s 10
+		IL_0cee: ldloc.s 10
+		IL_0cf0: ldstr "groups"
+		IL_0cf5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0cfa: stloc.s 10
+		IL_0cfc: ldloc.s 10
+		IL_0cfe: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0d03: stloc.s 10
+		IL_0d05: ldloc.s 6
+		IL_0d07: ldloc.s 10
+		IL_0d09: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0d0e: pop
+		IL_0d0f: ret
 	} // end of method String_RegExp_NamedGroups_Indices::__js_module_init__
 
 } // end of class Modules.String_RegExp_NamedGroups_Indices
@@ -1176,6 +1228,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_37
 	.field assembly static int32 __jroc_dynamicLookup_38
 	.field assembly static int32 __jroc_dynamicLookup_39
+	.field assembly static int32 __jroc_dynamicLookup_40
+	.field assembly static int32 __jroc_dynamicLookup_41
+	.field assembly static int32 __jroc_dynamicLookup_42
+	.field assembly static int32 __jroc_dynamicLookup_43
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
@@ -997,7 +997,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 925 (0x39d)
+		// Code size: 1057 (0x421)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_Custom/Scope,
@@ -1157,206 +1157,245 @@
 		IL_0142: ldloc.0
 		IL_0143: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
 		IL_0148: stloc.s 11
-		IL_014a: ldstr "abc"
-		IL_014f: ldstr "match"
-		IL_0154: ldloc.s 11
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_015b: stloc.1
-		IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0161: stloc.s 18
-		IL_0163: ldloc.1
-		IL_0164: ldc.r8 0.0
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0172: stloc.s 11
-		IL_0174: ldloc.s 18
+		IL_014a: volatile.
+		IL_014c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0151: brfalse IL_016c
+
+		IL_0156: ldstr "abc"
+		IL_015b: ldstr "match"
+		IL_0160: ldloc.s 11
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0167: br IL_0187
+
+		IL_016c: ldstr "abc"
+		IL_0171: ldstr "match"
 		IL_0176: ldloc.s 11
-		IL_0178: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017d: pop
-		IL_017e: ldloc.0
-		IL_017f: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_0184: stloc.s 11
-		IL_0186: ldstr "abc"
-		IL_018b: ldstr "replace"
-		IL_0190: ldloc.s 11
-		IL_0192: ldstr "x"
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_019c: stloc.2
-		IL_019d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a2: stloc.s 18
-		IL_01a4: ldloc.2
-		IL_01a5: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_01aa: stloc.s 19
-		IL_01ac: ldloc.s 18
-		IL_01ae: ldloc.s 19
-		IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b5: pop
-		IL_01b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01bb: stloc.s 18
-		IL_01bd: ldloc.s 18
-		IL_01bf: ldloc.2
-		IL_01c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01c5: pop
-		IL_01c6: ldloc.0
-		IL_01c7: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_01cc: stloc.s 11
-		IL_01ce: ldstr "abc"
-		IL_01d3: ldstr "search"
-		IL_01d8: ldloc.s 11
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01df: stloc.3
-		IL_01e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e5: stloc.s 18
-		IL_01e7: ldloc.3
-		IL_01e8: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_01ed: stloc.s 19
-		IL_01ef: ldloc.s 18
-		IL_01f1: ldloc.s 19
-		IL_01f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01f8: pop
-		IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fe: stloc.s 18
-		IL_0200: ldloc.s 18
-		IL_0202: ldloc.3
-		IL_0203: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0208: pop
-		IL_0209: ldloc.0
-		IL_020a: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
-		IL_020f: stloc.s 11
-		IL_0211: ldstr "abc"
-		IL_0216: ldstr "split"
-		IL_021b: ldloc.s 11
-		IL_021d: ldc.r8 5
-		IL_0226: box [System.Runtime]System.Double
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0230: stloc.s 4
-		IL_0232: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0237: stloc.s 18
-		IL_0239: ldloc.s 4
-		IL_023b: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0240: stloc.s 19
-		IL_0242: ldloc.s 18
-		IL_0244: ldloc.s 19
-		IL_0246: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024b: pop
-		IL_024c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0251: stloc.s 18
-		IL_0253: volatile.
-		IL_0255: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_025a: brfalse IL_0270
+		IL_0178: ldstr "String_RegExp_SymbolDispatch_Custom:Modules.String_RegExp_SymbolDispatch_Custom:__js_module_init__:37"
+		IL_017d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_025f: ldloc.s 4
-		IL_0261: ldstr "marker"
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026b: br IL_0286
+		IL_0187: stloc.1
+		IL_0188: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_018d: stloc.s 18
+		IL_018f: ldloc.1
+		IL_0190: ldc.r8 0.0
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_019e: stloc.s 11
+		IL_01a0: ldloc.s 18
+		IL_01a2: ldloc.s 11
+		IL_01a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a9: pop
+		IL_01aa: ldloc.0
+		IL_01ab: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_01b0: stloc.s 11
+		IL_01b2: ldstr "abc"
+		IL_01b7: ldstr "replace"
+		IL_01bc: ldloc.s 11
+		IL_01be: ldstr "x"
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01c8: stloc.2
+		IL_01c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ce: stloc.s 18
+		IL_01d0: ldloc.2
+		IL_01d1: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_01d6: stloc.s 19
+		IL_01d8: ldloc.s 18
+		IL_01da: ldloc.s 19
+		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01e1: pop
+		IL_01e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e7: stloc.s 18
+		IL_01e9: ldloc.s 18
+		IL_01eb: ldloc.2
+		IL_01ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f1: pop
+		IL_01f2: ldloc.0
+		IL_01f3: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_01f8: stloc.s 11
+		IL_01fa: volatile.
+		IL_01fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0201: brfalse IL_021c
 
-		IL_0270: ldloc.s 4
-		IL_0272: ldstr "marker"
-		IL_0277: ldstr "String_RegExp_SymbolDispatch_Custom:Modules.String_RegExp_SymbolDispatch_Custom:__js_module_init__:83"
-		IL_027c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0206: ldstr "abc"
+		IL_020b: ldstr "search"
+		IL_0210: ldloc.s 11
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0217: br IL_0237
 
-		IL_0286: stloc.s 11
-		IL_0288: ldloc.s 18
-		IL_028a: ldloc.s 11
-		IL_028c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0291: pop
-		IL_0292: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0297: stloc.s 5
-		IL_0299: ldstr "match"
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_02a3: stloc.s 11
-		IL_02a5: ldloc.s 5
-		IL_02a7: ldloc.s 11
-		IL_02a9: ldc.r8 1
-		IL_02b2: box [System.Runtime]System.Double
-		IL_02b7: ldc.i4.1
-		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_02bd: pop
+		IL_021c: ldstr "abc"
+		IL_0221: ldstr "search"
+		IL_0226: ldloc.s 11
+		IL_0228: ldstr "String_RegExp_SymbolDispatch_Custom:Modules.String_RegExp_SymbolDispatch_Custom:__js_module_init__:60"
+		IL_022d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0237: stloc.3
+		IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023d: stloc.s 18
+		IL_023f: ldloc.3
+		IL_0240: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0245: stloc.s 19
+		IL_0247: ldloc.s 18
+		IL_0249: ldloc.s 19
+		IL_024b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0250: pop
+		IL_0251: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0256: stloc.s 18
+		IL_0258: ldloc.s 18
+		IL_025a: ldloc.3
+		IL_025b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0260: pop
+		IL_0261: ldloc.0
+		IL_0262: ldfld object Modules.String_RegExp_SymbolDispatch_Custom/Scope::'custom'
+		IL_0267: stloc.s 11
+		IL_0269: ldstr "abc"
+		IL_026e: ldstr "split"
+		IL_0273: ldloc.s 11
+		IL_0275: ldc.r8 5
+		IL_027e: box [System.Runtime]System.Double
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0288: stloc.s 4
+		IL_028a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_028f: stloc.s 18
+		IL_0291: ldloc.s 4
+		IL_0293: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0298: stloc.s 19
+		IL_029a: ldloc.s 18
+		IL_029c: ldloc.s 19
+		IL_029e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a3: pop
+		IL_02a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a9: stloc.s 18
+		IL_02ab: volatile.
+		IL_02ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02b2: brfalse IL_02c8
+
+		IL_02b7: ldloc.s 4
+		IL_02b9: ldstr "marker"
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02c3: br IL_02de
+
+		IL_02c8: ldloc.s 4
+		IL_02ca: ldstr "marker"
+		IL_02cf: ldstr "String_RegExp_SymbolDispatch_Custom:Modules.String_RegExp_SymbolDispatch_Custom:__js_module_init__:83"
+		IL_02d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02de: stloc.s 11
+		IL_02e0: ldloc.s 18
+		IL_02e2: ldloc.s 11
+		IL_02e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e9: pop
+		IL_02ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02ef: stloc.s 5
+		IL_02f1: ldstr "match"
+		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_02fb: stloc.s 11
+		IL_02fd: ldloc.s 5
+		IL_02ff: ldloc.s 11
+		IL_0301: ldc.r8 1
+		IL_030a: box [System.Runtime]System.Double
+		IL_030f: ldc.i4.1
+		IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_0315: pop
 		.try
 		{
-			IL_02be: nop
-			IL_02bf: ldstr "abc"
-			IL_02c4: ldstr "match"
-			IL_02c9: ldloc.s 5
-			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02d0: pop
-			IL_02d1: leave IL_0399
+			IL_0316: nop
+			IL_0317: volatile.
+			IL_0319: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_031e: brfalse IL_0339
+
+			IL_0323: ldstr "abc"
+			IL_0328: ldstr "match"
+			IL_032d: ldloc.s 5
+			IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0334: br IL_0354
+
+			IL_0339: ldstr "abc"
+			IL_033e: ldstr "match"
+			IL_0343: ldloc.s 5
+			IL_0345: ldstr "String_RegExp_SymbolDispatch_Custom:Modules.String_RegExp_SymbolDispatch_Custom:__js_module_init__:99"
+			IL_034a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0354: pop
+			IL_0355: leave IL_041d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02d6: stloc.s 6
-			IL_02d8: ldloc.s 6
-			IL_02da: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02df: dup
-			IL_02e0: brtrue IL_02f6
+			IL_035a: stloc.s 6
+			IL_035c: ldloc.s 6
+			IL_035e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0363: dup
+			IL_0364: brtrue IL_037a
 
-			IL_02e5: pop
-			IL_02e6: ldloc.s 6
-			IL_02e8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02ed: dup
-			IL_02ee: brtrue IL_0302
+			IL_0369: pop
+			IL_036a: ldloc.s 6
+			IL_036c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0371: dup
+			IL_0372: brtrue IL_0386
 
-			IL_02f3: pop
-			IL_02f4: rethrow
+			IL_0377: pop
+			IL_0378: rethrow
 
-			IL_02f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02fb: stloc.s 7
-			IL_02fd: br IL_0304
+			IL_037a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_037f: stloc.s 7
+			IL_0381: br IL_0388
 
-			IL_0302: stloc.s 7
+			IL_0386: stloc.s 7
 
-			IL_0304: ldloc.s 7
-			IL_0306: stloc.s 8
-			IL_0308: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_030d: stloc.s 18
-			IL_030f: volatile.
-			IL_0311: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-			IL_0316: brfalse IL_032c
+			IL_0388: ldloc.s 7
+			IL_038a: stloc.s 8
+			IL_038c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0391: stloc.s 18
+			IL_0393: volatile.
+			IL_0395: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_039a: brfalse IL_03b0
 
-			IL_031b: ldloc.s 8
-			IL_031d: ldstr "name"
-			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0327: br IL_0342
+			IL_039f: ldloc.s 8
+			IL_03a1: ldstr "name"
+			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ab: br IL_03c6
 
-			IL_032c: ldloc.s 8
-			IL_032e: ldstr "name"
-			IL_0333: ldstr "String_RegExp_SymbolDispatch_Custom:Modules.String_RegExp_SymbolDispatch_Custom:__js_module_init__:110"
-			IL_0338: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03b0: ldloc.s 8
+			IL_03b2: ldstr "name"
+			IL_03b7: ldstr "String_RegExp_SymbolDispatch_Custom:Modules.String_RegExp_SymbolDispatch_Custom:__js_module_init__:110"
+			IL_03bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0342: stloc.s 11
-			IL_0344: ldloc.s 18
-			IL_0346: ldloc.s 11
-			IL_0348: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_034d: pop
-			IL_034e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0353: stloc.s 18
-			IL_0355: volatile.
-			IL_0357: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_035c: brfalse IL_0372
+			IL_03c6: stloc.s 11
+			IL_03c8: ldloc.s 18
+			IL_03ca: ldloc.s 11
+			IL_03cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03d1: pop
+			IL_03d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03d7: stloc.s 18
+			IL_03d9: volatile.
+			IL_03db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_03e0: brfalse IL_03f6
 
-			IL_0361: ldloc.s 8
-			IL_0363: ldstr "message"
-			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_036d: br IL_0388
+			IL_03e5: ldloc.s 8
+			IL_03e7: ldstr "message"
+			IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03f1: br IL_040c
 
-			IL_0372: ldloc.s 8
-			IL_0374: ldstr "message"
-			IL_0379: ldstr "String_RegExp_SymbolDispatch_Custom:Modules.String_RegExp_SymbolDispatch_Custom:__js_module_init__:115"
-			IL_037e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03f6: ldloc.s 8
+			IL_03f8: ldstr "message"
+			IL_03fd: ldstr "String_RegExp_SymbolDispatch_Custom:Modules.String_RegExp_SymbolDispatch_Custom:__js_module_init__:115"
+			IL_0402: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0388: stloc.s 11
-			IL_038a: ldloc.s 18
-			IL_038c: ldloc.s 11
-			IL_038e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0393: pop
-			IL_0394: leave IL_0399
+			IL_040c: stloc.s 11
+			IL_040e: ldloc.s 18
+			IL_0410: ldloc.s 11
+			IL_0412: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0417: pop
+			IL_0418: leave IL_041d
 		} // end handler
 
-		IL_0399: ldnull
-		IL_039a: stloc.s 9
-		IL_039c: ret
+		IL_041d: ldnull
+		IL_041e: stloc.s 9
+		IL_0420: ret
 	} // end of method String_RegExp_SymbolDispatch_Custom::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_Custom
@@ -1389,6 +1428,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
@@ -984,7 +984,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 566 (0x236)
+		// Code size: 652 (0x28c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope,
@@ -1139,79 +1139,105 @@
 		IL_0149: ldloc.0
 		IL_014a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
 		IL_014f: stloc.3
-		IL_0150: ldstr "aba"
-		IL_0155: ldstr "match"
-		IL_015a: ldloc.3
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0160: stloc.3
-		IL_0161: ldloc.3
-		IL_0162: ldc.r8 0.0
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0170: stloc.3
-		IL_0171: ldloc.s 10
-		IL_0173: ldloc.3
-		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0179: pop
-		IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017f: stloc.s 10
-		IL_0181: ldloc.0
-		IL_0182: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_0187: stloc.3
-		IL_0188: ldstr "aba"
-		IL_018d: ldstr "replace"
-		IL_0192: ldloc.3
-		IL_0193: ldstr "x"
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_019d: stloc.3
-		IL_019e: ldloc.s 10
-		IL_01a0: ldloc.3
-		IL_01a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a6: pop
-		IL_01a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ac: stloc.s 10
-		IL_01ae: ldloc.0
-		IL_01af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_01b4: stloc.3
-		IL_01b5: ldstr "aba"
-		IL_01ba: ldstr "search"
-		IL_01bf: ldloc.3
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c5: stloc.3
-		IL_01c6: ldloc.s 10
-		IL_01c8: ldloc.3
-		IL_01c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ce: pop
-		IL_01cf: ldloc.0
-		IL_01d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
-		IL_01d5: stloc.3
-		IL_01d6: ldstr "aba"
-		IL_01db: ldstr "split"
-		IL_01e0: ldloc.3
-		IL_01e1: ldc.r8 3
-		IL_01ea: box [System.Runtime]System.Double
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01f4: stloc.1
-		IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fa: stloc.s 10
-		IL_01fc: ldloc.1
-		IL_01fd: ldc.r8 0.0
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_020b: stloc.3
-		IL_020c: ldloc.s 10
-		IL_020e: ldloc.3
-		IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0214: pop
-		IL_0215: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021a: stloc.s 10
-		IL_021c: ldloc.1
-		IL_021d: ldc.r8 1
-		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0150: volatile.
+		IL_0152: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0157: brfalse IL_0171
+
+		IL_015c: ldstr "aba"
+		IL_0161: ldstr "match"
+		IL_0166: ldloc.3
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016c: br IL_018b
+
+		IL_0171: ldstr "aba"
+		IL_0176: ldstr "match"
+		IL_017b: ldloc.3
+		IL_017c: ldstr "String_RegExp_SymbolDispatch_RegExpOverride:Modules.String_RegExp_SymbolDispatch_RegExpOverride:__js_module_init__:40"
+		IL_0181: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_018b: stloc.3
+		IL_018c: ldloc.3
+		IL_018d: ldc.r8 0.0
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_019b: stloc.3
+		IL_019c: ldloc.s 10
+		IL_019e: ldloc.3
+		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a4: pop
+		IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01aa: stloc.s 10
+		IL_01ac: ldloc.0
+		IL_01ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+		IL_01b2: stloc.3
+		IL_01b3: ldstr "aba"
+		IL_01b8: ldstr "replace"
+		IL_01bd: ldloc.3
+		IL_01be: ldstr "x"
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01c8: stloc.3
+		IL_01c9: ldloc.s 10
+		IL_01cb: ldloc.3
+		IL_01cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d1: pop
+		IL_01d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01d7: stloc.s 10
+		IL_01d9: ldloc.0
+		IL_01da: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
+		IL_01df: stloc.3
+		IL_01e0: volatile.
+		IL_01e2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01e7: brfalse IL_0201
+
+		IL_01ec: ldstr "aba"
+		IL_01f1: ldstr "search"
+		IL_01f6: ldloc.3
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01fc: br IL_021b
+
+		IL_0201: ldstr "aba"
+		IL_0206: ldstr "search"
+		IL_020b: ldloc.3
+		IL_020c: ldstr "String_RegExp_SymbolDispatch_RegExpOverride:Modules.String_RegExp_SymbolDispatch_RegExpOverride:__js_module_init__:55"
+		IL_0211: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_021b: stloc.3
+		IL_021c: ldloc.s 10
+		IL_021e: ldloc.3
+		IL_021f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0224: pop
+		IL_0225: ldloc.0
+		IL_0226: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::re
 		IL_022b: stloc.3
-		IL_022c: ldloc.s 10
-		IL_022e: ldloc.3
-		IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0234: pop
-		IL_0235: ret
+		IL_022c: ldstr "aba"
+		IL_0231: ldstr "split"
+		IL_0236: ldloc.3
+		IL_0237: ldc.r8 3
+		IL_0240: box [System.Runtime]System.Double
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_024a: stloc.1
+		IL_024b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0250: stloc.s 10
+		IL_0252: ldloc.1
+		IL_0253: ldc.r8 0.0
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0261: stloc.3
+		IL_0262: ldloc.s 10
+		IL_0264: ldloc.3
+		IL_0265: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_026a: pop
+		IL_026b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0270: stloc.s 10
+		IL_0272: ldloc.1
+		IL_0273: ldc.r8 1
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0281: stloc.3
+		IL_0282: ldloc.s 10
+		IL_0284: ldloc.3
+		IL_0285: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_028a: pop
+		IL_028b: ret
 	} // end of method String_RegExp_SymbolDispatch_RegExpOverride::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_RegExpOverride
@@ -1236,4 +1262,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
@@ -984,7 +984,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 764 (0x2fc)
+		// Code size: 852 (0x354)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope,
@@ -1166,115 +1166,141 @@
 		IL_019a: ldloc.0
 		IL_019b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
 		IL_01a0: stloc.s 8
-		IL_01a2: ldstr "aba"
-		IL_01a7: ldstr "match"
-		IL_01ac: ldloc.s 8
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b3: stloc.s 8
-		IL_01b5: ldloc.s 8
-		IL_01b7: ldc.r8 0.0
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_01c5: stloc.s 8
-		IL_01c7: ldloc.s 14
-		IL_01c9: ldloc.s 8
-		IL_01cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d0: pop
-		IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d6: stloc.s 14
-		IL_01d8: ldloc.0
-		IL_01d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_01de: stloc.s 8
-		IL_01e0: ldstr "aba"
-		IL_01e5: ldstr "replace"
-		IL_01ea: ldloc.s 8
-		IL_01ec: ldstr "x"
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_01f6: stloc.s 8
-		IL_01f8: ldloc.s 14
-		IL_01fa: ldloc.s 8
-		IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0201: pop
-		IL_0202: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0207: stloc.s 14
-		IL_0209: ldloc.0
-		IL_020a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_020f: stloc.s 8
-		IL_0211: ldstr "aba"
-		IL_0216: ldstr "search"
-		IL_021b: ldloc.s 8
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a2: volatile.
+		IL_01a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01a9: brfalse IL_01c4
+
+		IL_01ae: ldstr "aba"
+		IL_01b3: ldstr "match"
+		IL_01b8: ldloc.s 8
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01bf: br IL_01df
+
+		IL_01c4: ldstr "aba"
+		IL_01c9: ldstr "match"
+		IL_01ce: ldloc.s 8
+		IL_01d0: ldstr "String_RegExp_SymbolDispatch_RegExpPrototypeOverride:Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride:__js_module_init__:60"
+		IL_01d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01df: stloc.s 8
+		IL_01e1: ldloc.s 8
+		IL_01e3: ldc.r8 0.0
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01f1: stloc.s 8
+		IL_01f3: ldloc.s 14
+		IL_01f5: ldloc.s 8
+		IL_01f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01fc: pop
+		IL_01fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0202: stloc.s 14
+		IL_0204: ldloc.0
+		IL_0205: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+		IL_020a: stloc.s 8
+		IL_020c: ldstr "aba"
+		IL_0211: ldstr "replace"
+		IL_0216: ldloc.s 8
+		IL_0218: ldstr "x"
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
 		IL_0222: stloc.s 8
 		IL_0224: ldloc.s 14
 		IL_0226: ldloc.s 8
 		IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_022d: pop
-		IL_022e: ldloc.0
-		IL_022f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
-		IL_0234: stloc.s 8
-		IL_0236: ldstr "aba"
-		IL_023b: ldstr "split"
-		IL_0240: ldloc.s 8
-		IL_0242: ldc.r8 3
-		IL_024b: box [System.Runtime]System.Double
-		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0255: stloc.s 6
-		IL_0257: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_025c: stloc.s 14
-		IL_025e: ldloc.s 6
-		IL_0260: ldc.r8 0.0
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_026e: stloc.s 8
-		IL_0270: ldloc.s 14
-		IL_0272: ldloc.s 8
-		IL_0274: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0279: pop
-		IL_027a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_027f: stloc.s 14
-		IL_0281: ldloc.s 6
-		IL_0283: ldc.r8 1
-		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0291: stloc.s 8
-		IL_0293: ldloc.s 14
-		IL_0295: ldloc.s 8
-		IL_0297: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_029c: pop
-		IL_029d: ldstr "match"
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_02a7: stloc.s 8
-		IL_02a9: ldloc.1
-		IL_02aa: ldloc.s 8
-		IL_02ac: ldloc.2
-		IL_02ad: ldc.i4.1
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_02b3: pop
-		IL_02b4: ldstr "replace"
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_02be: stloc.s 8
-		IL_02c0: ldloc.1
-		IL_02c1: ldloc.s 8
-		IL_02c3: ldloc.3
-		IL_02c4: ldc.i4.1
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_02ca: pop
-		IL_02cb: ldstr "search"
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_02d5: stloc.s 8
-		IL_02d7: ldloc.1
-		IL_02d8: ldloc.s 8
-		IL_02da: ldloc.s 4
-		IL_02dc: ldc.i4.1
-		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_02e2: pop
-		IL_02e3: ldstr "split"
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_02ed: stloc.s 8
-		IL_02ef: ldloc.1
-		IL_02f0: ldloc.s 8
-		IL_02f2: ldloc.s 5
-		IL_02f4: ldc.i4.1
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-		IL_02fa: pop
-		IL_02fb: ret
+		IL_022e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0233: stloc.s 14
+		IL_0235: ldloc.0
+		IL_0236: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+		IL_023b: stloc.s 8
+		IL_023d: volatile.
+		IL_023f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0244: brfalse IL_025f
+
+		IL_0249: ldstr "aba"
+		IL_024e: ldstr "search"
+		IL_0253: ldloc.s 8
+		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_025a: br IL_027a
+
+		IL_025f: ldstr "aba"
+		IL_0264: ldstr "search"
+		IL_0269: ldloc.s 8
+		IL_026b: ldstr "String_RegExp_SymbolDispatch_RegExpPrototypeOverride:Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride:__js_module_init__:75"
+		IL_0270: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_027a: stloc.s 8
+		IL_027c: ldloc.s 14
+		IL_027e: ldloc.s 8
+		IL_0280: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0285: pop
+		IL_0286: ldloc.0
+		IL_0287: ldfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope::re
+		IL_028c: stloc.s 8
+		IL_028e: ldstr "aba"
+		IL_0293: ldstr "split"
+		IL_0298: ldloc.s 8
+		IL_029a: ldc.r8 3
+		IL_02a3: box [System.Runtime]System.Double
+		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02ad: stloc.s 6
+		IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02b4: stloc.s 14
+		IL_02b6: ldloc.s 6
+		IL_02b8: ldc.r8 0.0
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02c6: stloc.s 8
+		IL_02c8: ldloc.s 14
+		IL_02ca: ldloc.s 8
+		IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d1: pop
+		IL_02d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d7: stloc.s 14
+		IL_02d9: ldloc.s 6
+		IL_02db: ldc.r8 1
+		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02e9: stloc.s 8
+		IL_02eb: ldloc.s 14
+		IL_02ed: ldloc.s 8
+		IL_02ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02f4: pop
+		IL_02f5: ldstr "match"
+		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_02ff: stloc.s 8
+		IL_0301: ldloc.1
+		IL_0302: ldloc.s 8
+		IL_0304: ldloc.2
+		IL_0305: ldc.i4.1
+		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_030b: pop
+		IL_030c: ldstr "replace"
+		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0316: stloc.s 8
+		IL_0318: ldloc.1
+		IL_0319: ldloc.s 8
+		IL_031b: ldloc.3
+		IL_031c: ldc.i4.1
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_0322: pop
+		IL_0323: ldstr "search"
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_032d: stloc.s 8
+		IL_032f: ldloc.1
+		IL_0330: ldloc.s 8
+		IL_0332: ldloc.s 4
+		IL_0334: ldc.i4.1
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_033a: pop
+		IL_033b: ldstr "split"
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0345: stloc.s 8
+		IL_0347: ldloc.1
+		IL_0348: ldloc.s 8
+		IL_034a: ldloc.s 5
+		IL_034c: ldc.i4.1
+		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+		IL_0352: pop
+		IL_0353: ret
 	} // end of method String_RegExp_SymbolDispatch_RegExpPrototypeOverride::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride
@@ -1299,4 +1325,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
@@ -266,7 +266,7 @@
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
 			// Header size: 12
-			// Code size: 309 (0x135)
+			// Code size: 349 (0x15d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -289,126 +289,139 @@
 				IL_0001: ldarg.2
 				IL_0002: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 				IL_0007: stloc.s 6
-				IL_0009: ldloc.s 6
-				IL_000b: ldstr "repeat"
-				IL_0010: ldarg.3
-				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0016: stloc.0
-				IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_001c: stloc.s 7
-				IL_001e: ldstr "["
-				IL_0023: ldloc.0
-				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0029: stloc.s 8
-				IL_002b: ldloc.s 8
-				IL_002d: ldstr "]"
-				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0037: stloc.s 8
-				IL_0039: ldloc.s 7
-				IL_003b: ldloc.s 8
-				IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0042: pop
-				IL_0043: leave IL_012f
+				IL_0009: volatile.
+				IL_000b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+				IL_0010: brfalse IL_0027
+
+				IL_0015: ldloc.s 6
+				IL_0017: ldstr "repeat"
+				IL_001c: ldarg.3
+				IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0022: br IL_003e
+
+				IL_0027: ldloc.s 6
+				IL_0029: ldstr "repeat"
+				IL_002e: ldarg.3
+				IL_002f: ldstr "String_Repeat_Basic:<TwoPhaseDummy_M4>:__js_call__:7"
+				IL_0034: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+				IL_003e: stloc.0
+				IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0044: stloc.s 7
+				IL_0046: ldstr "["
+				IL_004b: ldloc.0
+				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0051: stloc.s 8
+				IL_0053: ldloc.s 8
+				IL_0055: ldstr "]"
+				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_005f: stloc.s 8
+				IL_0061: ldloc.s 7
+				IL_0063: ldloc.s 8
+				IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_006a: pop
+				IL_006b: leave IL_0157
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0048: stloc.1
-				IL_0049: ldloc.1
-				IL_004a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_004f: dup
-				IL_0050: brtrue IL_0065
+				IL_0070: stloc.1
+				IL_0071: ldloc.1
+				IL_0072: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0077: dup
+				IL_0078: brtrue IL_008d
 
-				IL_0055: pop
-				IL_0056: ldloc.1
-				IL_0057: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_005c: dup
-				IL_005d: brtrue IL_0070
+				IL_007d: pop
+				IL_007e: ldloc.1
+				IL_007f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0084: dup
+				IL_0085: brtrue IL_0098
 
-				IL_0062: pop
-				IL_0063: rethrow
+				IL_008a: pop
+				IL_008b: rethrow
 
-				IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_006a: stloc.2
-				IL_006b: br IL_0071
+				IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0092: stloc.2
+				IL_0093: br IL_0099
 
-				IL_0070: stloc.2
+				IL_0098: stloc.2
 
-				IL_0071: ldloc.2
-				IL_0072: stloc.3
-				IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0078: stloc.s 7
-				IL_007a: ldloc.3
-				IL_007b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0080: stloc.s 9
-				IL_0082: ldloc.s 9
-				IL_0084: brfalse IL_00c5
+				IL_0099: ldloc.2
+				IL_009a: stloc.3
+				IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_00a0: stloc.s 7
+				IL_00a2: ldloc.3
+				IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00a8: stloc.s 9
+				IL_00aa: ldloc.s 9
+				IL_00ac: brfalse IL_00ed
 
-				IL_0089: volatile.
-				IL_008b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-				IL_0090: brfalse IL_00a5
+				IL_00b1: volatile.
+				IL_00b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+				IL_00b8: brfalse IL_00cd
 
-				IL_0095: ldloc.3
-				IL_0096: ldstr "name"
-				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00a0: br IL_00ba
+				IL_00bd: ldloc.3
+				IL_00be: ldstr "name"
+				IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00c8: br IL_00e2
 
-				IL_00a5: ldloc.3
-				IL_00a6: ldstr "name"
-				IL_00ab: ldstr "String_Repeat_Basic:<TwoPhaseDummy_M4>:__js_call__:28"
-				IL_00b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_00cd: ldloc.3
+				IL_00ce: ldstr "name"
+				IL_00d3: ldstr "String_Repeat_Basic:<TwoPhaseDummy_M4>:__js_call__:28"
+				IL_00d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+				IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_00ba: stloc.s 10
-				IL_00bc: ldloc.s 10
-				IL_00be: stloc.s 11
-				IL_00c0: br IL_00c8
+				IL_00e2: stloc.s 10
+				IL_00e4: ldloc.s 10
+				IL_00e6: stloc.s 11
+				IL_00e8: br IL_00f0
 
-				IL_00c5: ldloc.3
-				IL_00c6: stloc.s 11
+				IL_00ed: ldloc.3
+				IL_00ee: stloc.s 11
 
-				IL_00c8: ldloc.s 11
-				IL_00ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00cf: stloc.s 9
-				IL_00d1: ldloc.s 9
-				IL_00d3: brfalse IL_0114
+				IL_00f0: ldloc.s 11
+				IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00f7: stloc.s 9
+				IL_00f9: ldloc.s 9
+				IL_00fb: brfalse IL_013c
 
-				IL_00d8: volatile.
-				IL_00da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-				IL_00df: brfalse IL_00f4
+				IL_0100: volatile.
+				IL_0102: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+				IL_0107: brfalse IL_011c
 
-				IL_00e4: ldloc.3
-				IL_00e5: ldstr "name"
-				IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00ef: br IL_0109
+				IL_010c: ldloc.3
+				IL_010d: ldstr "name"
+				IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0117: br IL_0131
 
-				IL_00f4: ldloc.3
-				IL_00f5: ldstr "name"
-				IL_00fa: ldstr "String_Repeat_Basic:<TwoPhaseDummy_M4>:__js_call__:37"
-				IL_00ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-				IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_011c: ldloc.3
+				IL_011d: ldstr "name"
+				IL_0122: ldstr "String_Repeat_Basic:<TwoPhaseDummy_M4>:__js_call__:37"
+				IL_0127: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+				IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0109: stloc.s 10
-				IL_010b: ldloc.s 10
-				IL_010d: stloc.s 4
-				IL_010f: br IL_0120
+				IL_0131: stloc.s 10
+				IL_0133: ldloc.s 10
+				IL_0135: stloc.s 4
+				IL_0137: br IL_0148
 
-				IL_0114: ldloc.3
-				IL_0115: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_011a: stloc.s 6
-				IL_011c: ldloc.s 6
-				IL_011e: stloc.s 4
+				IL_013c: ldloc.3
+				IL_013d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0142: stloc.s 6
+				IL_0144: ldloc.s 6
+				IL_0146: stloc.s 4
 
-				IL_0120: ldloc.s 7
-				IL_0122: ldloc.s 4
-				IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0129: pop
-				IL_012a: leave IL_012f
+				IL_0148: ldloc.s 7
+				IL_014a: ldloc.s 4
+				IL_014c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0151: pop
+				IL_0152: leave IL_0157
 			} // end handler
 
-			IL_012f: ldnull
-			IL_0130: stloc.s 5
-			IL_0132: ldloc.s 5
-			IL_0134: ret
+			IL_0157: ldnull
+			IL_0158: stloc.s 5
+			IL_015a: ldloc.s 5
+			IL_015c: ret
 		} // end of method logRepeat::__js_call__
 
 	} // end of class logRepeat
@@ -575,6 +588,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Search_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Search_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 352 (0x160)
+		// Code size: 518 (0x206)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Search_Basic/Scope,
@@ -125,107 +125,159 @@
 		IL_0018: ldstr ""
 		IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_0022: stloc.s 4
-		IL_0024: ldloc.1
-		IL_0025: ldstr "search"
-		IL_002a: ldloc.s 4
-		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0031: stloc.s 5
-		IL_0033: ldloc.3
-		IL_0034: ldloc.s 5
-		IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_003b: pop
-		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0041: stloc.3
+		IL_0024: volatile.
+		IL_0026: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_002b: brfalse IL_0042
+
+		IL_0030: ldloc.1
+		IL_0031: ldstr "search"
+		IL_0036: ldloc.s 4
+		IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_003d: br IL_0059
+
 		IL_0042: ldloc.1
 		IL_0043: ldstr "search"
-		IL_0048: ldstr "123"
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0052: stloc.s 5
-		IL_0054: ldloc.3
-		IL_0055: ldloc.s 5
-		IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005c: pop
-		IL_005d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0062: stloc.3
-		IL_0063: ldstr "xyz"
-		IL_0068: ldstr ""
-		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0072: stloc.s 4
-		IL_0074: ldloc.1
-		IL_0075: ldstr "search"
-		IL_007a: ldloc.s 4
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0081: stloc.s 5
-		IL_0083: ldloc.3
-		IL_0084: ldloc.s 5
-		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008b: pop
-		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0091: stloc.3
-		IL_0092: volatile.
-		IL_0094: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0099: brfalse IL_00b2
+		IL_0048: ldloc.s 4
+		IL_004a: ldstr "String_Search_Basic:Modules.String_Search_Basic:__js_module_init__:11"
+		IL_004f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_009e: ldstr "undefined-value"
-		IL_00a3: ldstr "search"
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00ad: br IL_00cb
+		IL_0059: stloc.s 5
+		IL_005b: ldloc.3
+		IL_005c: ldloc.s 5
+		IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0063: pop
+		IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0069: stloc.3
+		IL_006a: volatile.
+		IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0071: brfalse IL_008b
 
-		IL_00b2: ldstr "undefined-value"
-		IL_00b7: ldstr "search"
-		IL_00bc: ldstr "String_Search_Basic:Modules.String_Search_Basic:__js_module_init__:28"
-		IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0076: ldloc.1
+		IL_0077: ldstr "search"
+		IL_007c: ldstr "123"
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0086: br IL_00a5
 
-		IL_00cb: stloc.s 5
-		IL_00cd: ldloc.3
-		IL_00ce: ldloc.s 5
-		IL_00d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d5: pop
-		IL_00d6: ldstr "a"
-		IL_00db: ldstr "g"
-		IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00e5: stloc.2
-		IL_00e6: ldloc.2
-		IL_00e7: ldstr "lastIndex"
-		IL_00ec: ldc.r8 2
-		IL_00f5: ldc.i4.1
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_00fb: pop
-		IL_00fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0101: stloc.3
-		IL_0102: ldstr "baaa"
-		IL_0107: ldstr "search"
-		IL_010c: ldloc.2
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0112: stloc.s 5
-		IL_0114: ldloc.3
-		IL_0115: ldloc.s 5
-		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_011c: pop
-		IL_011d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0122: stloc.3
-		IL_0123: volatile.
-		IL_0125: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_012a: brfalse IL_013f
+		IL_008b: ldloc.1
+		IL_008c: ldstr "search"
+		IL_0091: ldstr "123"
+		IL_0096: ldstr "String_Search_Basic:Modules.String_Search_Basic:__js_module_init__:16"
+		IL_009b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_012f: ldloc.2
-		IL_0130: ldstr "lastIndex"
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013a: br IL_0154
+		IL_00a5: stloc.s 5
+		IL_00a7: ldloc.3
+		IL_00a8: ldloc.s 5
+		IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00af: pop
+		IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b5: stloc.3
+		IL_00b6: ldstr "xyz"
+		IL_00bb: ldstr ""
+		IL_00c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_00c5: stloc.s 4
+		IL_00c7: volatile.
+		IL_00c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ce: brfalse IL_00e5
 
-		IL_013f: ldloc.2
-		IL_0140: ldstr "lastIndex"
-		IL_0145: ldstr "String_Search_Basic:Modules.String_Search_Basic:__js_module_init__:47"
-		IL_014a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00d3: ldloc.1
+		IL_00d4: ldstr "search"
+		IL_00d9: ldloc.s 4
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e0: br IL_00fc
 
-		IL_0154: stloc.s 5
-		IL_0156: ldloc.3
-		IL_0157: ldloc.s 5
-		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015e: pop
-		IL_015f: ret
+		IL_00e5: ldloc.1
+		IL_00e6: ldstr "search"
+		IL_00eb: ldloc.s 4
+		IL_00ed: ldstr "String_Search_Basic:Modules.String_Search_Basic:__js_module_init__:23"
+		IL_00f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00fc: stloc.s 5
+		IL_00fe: ldloc.3
+		IL_00ff: ldloc.s 5
+		IL_0101: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0106: pop
+		IL_0107: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010c: stloc.3
+		IL_010d: volatile.
+		IL_010f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0114: brfalse IL_012d
+
+		IL_0119: ldstr "undefined-value"
+		IL_011e: ldstr "search"
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0128: br IL_0146
+
+		IL_012d: ldstr "undefined-value"
+		IL_0132: ldstr "search"
+		IL_0137: ldstr "String_Search_Basic:Modules.String_Search_Basic:__js_module_init__:28"
+		IL_013c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0146: stloc.s 5
+		IL_0148: ldloc.3
+		IL_0149: ldloc.s 5
+		IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0150: pop
+		IL_0151: ldstr "a"
+		IL_0156: ldstr "g"
+		IL_015b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_0160: stloc.2
+		IL_0161: ldloc.2
+		IL_0162: ldstr "lastIndex"
+		IL_0167: ldc.r8 2
+		IL_0170: ldc.i4.1
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0176: pop
+		IL_0177: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017c: stloc.3
+		IL_017d: volatile.
+		IL_017f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0184: brfalse IL_019e
+
+		IL_0189: ldstr "baaa"
+		IL_018e: ldstr "search"
+		IL_0193: ldloc.2
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0199: br IL_01b8
+
+		IL_019e: ldstr "baaa"
+		IL_01a3: ldstr "search"
+		IL_01a8: ldloc.2
+		IL_01a9: ldstr "String_Search_Basic:Modules.String_Search_Basic:__js_module_init__:42"
+		IL_01ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01b8: stloc.s 5
+		IL_01ba: ldloc.3
+		IL_01bb: ldloc.s 5
+		IL_01bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c2: pop
+		IL_01c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c8: stloc.3
+		IL_01c9: volatile.
+		IL_01cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01d0: brfalse IL_01e5
+
+		IL_01d5: ldloc.2
+		IL_01d6: ldstr "lastIndex"
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e0: br IL_01fa
+
+		IL_01e5: ldloc.2
+		IL_01e6: ldstr "lastIndex"
+		IL_01eb: ldstr "String_Search_Basic:Modules.String_Search_Basic:__js_module_init__:47"
+		IL_01f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_01fa: stloc.s 5
+		IL_01fc: ldloc.3
+		IL_01fd: ldloc.s 5
+		IL_01ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0204: pop
+		IL_0205: ret
 	} // end of method String_Search_Basic::__js_module_init__
 
 } // end of class Modules.String_Search_Basic
@@ -257,6 +309,10 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 193 (0xc1)
+		// Code size: 236 (0xec)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Basic/Scope,
@@ -118,64 +118,77 @@
 		IL_0006: nop
 		IL_0007: ldstr "a,b,c"
 		IL_000c: stloc.1
-		IL_000d: ldloc.1
-		IL_000e: ldstr "split"
-		IL_0013: ldstr ","
-		IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_001d: stloc.2
-		IL_001e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0023: stloc.3
-		IL_0024: volatile.
-		IL_0026: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_002b: brfalse IL_0040
+		IL_000d: volatile.
+		IL_000f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0014: brfalse IL_002e
 
-		IL_0030: ldloc.2
-		IL_0031: ldstr "length"
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003b: br IL_0055
+		IL_0019: ldloc.1
+		IL_001a: ldstr "split"
+		IL_001f: ldstr ","
+		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0029: br IL_0048
 
-		IL_0040: ldloc.2
-		IL_0041: ldstr "length"
-		IL_0046: ldstr "String_Split_Basic:Modules.String_Split_Basic:__js_module_init__:13"
-		IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_002e: ldloc.1
+		IL_002f: ldstr "split"
+		IL_0034: ldstr ","
+		IL_0039: ldstr "String_Split_Basic:Modules.String_Split_Basic:__js_module_init__:8"
+		IL_003e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0055: stloc.s 4
-		IL_0057: ldloc.3
-		IL_0058: ldloc.s 4
-		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005f: pop
-		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0065: stloc.3
-		IL_0066: ldloc.2
-		IL_0067: ldc.r8 0.0
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0075: stloc.s 4
-		IL_0077: ldloc.3
-		IL_0078: ldloc.s 4
-		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007f: pop
-		IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0085: stloc.3
-		IL_0086: ldloc.2
-		IL_0087: ldc.r8 1
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0095: stloc.s 4
-		IL_0097: ldloc.3
-		IL_0098: ldloc.s 4
-		IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009f: pop
-		IL_00a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a5: stloc.3
-		IL_00a6: ldloc.2
-		IL_00a7: ldc.r8 2
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00b5: stloc.s 4
-		IL_00b7: ldloc.3
-		IL_00b8: ldloc.s 4
-		IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bf: pop
-		IL_00c0: ret
+		IL_0048: stloc.2
+		IL_0049: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004e: stloc.3
+		IL_004f: volatile.
+		IL_0051: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0056: brfalse IL_006b
+
+		IL_005b: ldloc.2
+		IL_005c: ldstr "length"
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0066: br IL_0080
+
+		IL_006b: ldloc.2
+		IL_006c: ldstr "length"
+		IL_0071: ldstr "String_Split_Basic:Modules.String_Split_Basic:__js_module_init__:13"
+		IL_0076: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0080: stloc.s 4
+		IL_0082: ldloc.3
+		IL_0083: ldloc.s 4
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008a: pop
+		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0090: stloc.3
+		IL_0091: ldloc.2
+		IL_0092: ldc.r8 0.0
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00a0: stloc.s 4
+		IL_00a2: ldloc.3
+		IL_00a3: ldloc.s 4
+		IL_00a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00aa: pop
+		IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b0: stloc.3
+		IL_00b1: ldloc.2
+		IL_00b2: ldc.r8 1
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00c0: stloc.s 4
+		IL_00c2: ldloc.3
+		IL_00c3: ldloc.s 4
+		IL_00c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ca: pop
+		IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d0: stloc.3
+		IL_00d1: ldloc.2
+		IL_00d2: ldc.r8 2
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00e0: stloc.s 4
+		IL_00e2: ldloc.3
+		IL_00e3: ldloc.s 4
+		IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ea: pop
+		IL_00eb: ret
 	} // end of method String_Split_Basic::__js_module_init__
 
 } // end of class Modules.String_Split_Basic
@@ -206,6 +219,7 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 394 (0x18a)
+		// Code size: 437 (0x1b5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Regex_Basic/Scope,
@@ -121,117 +121,130 @@
 		IL_000c: ldstr ""
 		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_0016: stloc.3
-		IL_0017: ldstr "a,b,c"
-		IL_001c: ldstr "split"
-		IL_0021: ldloc.3
-		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0027: stloc.1
-		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_002d: stloc.s 4
-		IL_002f: volatile.
-		IL_0031: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0036: brfalse IL_004b
+		IL_0017: volatile.
+		IL_0019: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_001e: brfalse IL_0038
 
-		IL_003b: ldloc.1
-		IL_003c: ldstr "length"
-		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0046: br IL_0060
+		IL_0023: ldstr "a,b,c"
+		IL_0028: ldstr "split"
+		IL_002d: ldloc.3
+		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0033: br IL_0052
 
-		IL_004b: ldloc.1
-		IL_004c: ldstr "length"
-		IL_0051: ldstr "String_Split_Regex_Basic:Modules.String_Split_Regex_Basic:__js_module_init__:13"
-		IL_0056: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0038: ldstr "a,b,c"
+		IL_003d: ldstr "split"
+		IL_0042: ldloc.3
+		IL_0043: ldstr "String_Split_Regex_Basic:Modules.String_Split_Regex_Basic:__js_module_init__:8"
+		IL_0048: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0060: stloc.s 5
-		IL_0062: ldloc.s 4
-		IL_0064: ldloc.s 5
-		IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006b: pop
-		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0071: stloc.s 4
-		IL_0073: ldloc.1
-		IL_0074: ldc.r8 0.0
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0082: stloc.s 5
-		IL_0084: ldloc.s 4
-		IL_0086: ldloc.s 5
-		IL_0088: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008d: pop
-		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0093: stloc.s 4
-		IL_0095: ldloc.1
-		IL_0096: ldc.r8 1
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00a4: stloc.s 5
-		IL_00a6: ldloc.s 4
-		IL_00a8: ldloc.s 5
-		IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00af: pop
-		IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b5: stloc.s 4
-		IL_00b7: ldloc.1
-		IL_00b8: ldc.r8 2
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00c6: stloc.s 5
-		IL_00c8: ldloc.s 4
-		IL_00ca: ldloc.s 5
-		IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d1: pop
-		IL_00d2: ldstr ","
-		IL_00d7: ldstr ""
-		IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00e1: stloc.3
-		IL_00e2: ldstr "a,b,c"
-		IL_00e7: ldstr "split"
-		IL_00ec: ldloc.3
-		IL_00ed: ldc.r8 2
-		IL_00f6: box [System.Runtime]System.Double
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0100: stloc.2
-		IL_0101: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0106: stloc.s 4
-		IL_0108: volatile.
-		IL_010a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_010f: brfalse IL_0124
+		IL_0052: stloc.1
+		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0058: stloc.s 4
+		IL_005a: volatile.
+		IL_005c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0061: brfalse IL_0076
 
-		IL_0114: ldloc.2
-		IL_0115: ldstr "length"
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_011f: br IL_0139
+		IL_0066: ldloc.1
+		IL_0067: ldstr "length"
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0071: br IL_008b
 
-		IL_0124: ldloc.2
-		IL_0125: ldstr "length"
-		IL_012a: ldstr "String_Split_Regex_Basic:Modules.String_Split_Regex_Basic:__js_module_init__:42"
-		IL_012f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0076: ldloc.1
+		IL_0077: ldstr "length"
+		IL_007c: ldstr "String_Split_Regex_Basic:Modules.String_Split_Regex_Basic:__js_module_init__:13"
+		IL_0081: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0139: stloc.s 5
-		IL_013b: ldloc.s 4
-		IL_013d: ldloc.s 5
-		IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0144: pop
-		IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014a: stloc.s 4
-		IL_014c: ldloc.2
-		IL_014d: ldc.r8 0.0
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_015b: stloc.s 5
-		IL_015d: ldloc.s 4
-		IL_015f: ldloc.s 5
-		IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0166: pop
-		IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016c: stloc.s 4
-		IL_016e: ldloc.2
-		IL_016f: ldc.r8 1
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_017d: stloc.s 5
-		IL_017f: ldloc.s 4
-		IL_0181: ldloc.s 5
-		IL_0183: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0188: pop
-		IL_0189: ret
+		IL_008b: stloc.s 5
+		IL_008d: ldloc.s 4
+		IL_008f: ldloc.s 5
+		IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0096: pop
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: stloc.s 4
+		IL_009e: ldloc.1
+		IL_009f: ldc.r8 0.0
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00ad: stloc.s 5
+		IL_00af: ldloc.s 4
+		IL_00b1: ldloc.s 5
+		IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b8: pop
+		IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00be: stloc.s 4
+		IL_00c0: ldloc.1
+		IL_00c1: ldc.r8 1
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00cf: stloc.s 5
+		IL_00d1: ldloc.s 4
+		IL_00d3: ldloc.s 5
+		IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00da: pop
+		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e0: stloc.s 4
+		IL_00e2: ldloc.1
+		IL_00e3: ldc.r8 2
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00f1: stloc.s 5
+		IL_00f3: ldloc.s 4
+		IL_00f5: ldloc.s 5
+		IL_00f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fc: pop
+		IL_00fd: ldstr ","
+		IL_0102: ldstr ""
+		IL_0107: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_010c: stloc.3
+		IL_010d: ldstr "a,b,c"
+		IL_0112: ldstr "split"
+		IL_0117: ldloc.3
+		IL_0118: ldc.r8 2
+		IL_0121: box [System.Runtime]System.Double
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_012b: stloc.2
+		IL_012c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0131: stloc.s 4
+		IL_0133: volatile.
+		IL_0135: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_013a: brfalse IL_014f
+
+		IL_013f: ldloc.2
+		IL_0140: ldstr "length"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_014a: br IL_0164
+
+		IL_014f: ldloc.2
+		IL_0150: ldstr "length"
+		IL_0155: ldstr "String_Split_Regex_Basic:Modules.String_Split_Regex_Basic:__js_module_init__:42"
+		IL_015a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0164: stloc.s 5
+		IL_0166: ldloc.s 4
+		IL_0168: ldloc.s 5
+		IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_016f: pop
+		IL_0170: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0175: stloc.s 4
+		IL_0177: ldloc.2
+		IL_0178: ldc.r8 0.0
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0186: stloc.s 5
+		IL_0188: ldloc.s 4
+		IL_018a: ldloc.s 5
+		IL_018c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0191: pop
+		IL_0192: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0197: stloc.s 4
+		IL_0199: ldloc.2
+		IL_019a: ldc.r8 1
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01a8: stloc.s 5
+		IL_01aa: ldloc.s 4
+		IL_01ac: ldloc.s 5
+		IL_01ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b3: pop
+		IL_01b4: ret
 	} // end of method String_Split_Regex_Basic::__js_module_init__
 
 } // end of class Modules.String_Split_Regex_Basic
@@ -263,6 +276,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1112 (0x458)
+		// Code size: 1288 (0x508)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Regex_Empty/Scope,
@@ -124,330 +124,382 @@
 		IL_000c: ldstr ""
 		IL_0011: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
 		IL_0016: stloc.s 6
-		IL_0018: ldstr "abc"
-		IL_001d: ldstr "split"
-		IL_0022: ldloc.s 6
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0029: stloc.1
-		IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_002f: stloc.s 7
-		IL_0031: volatile.
-		IL_0033: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_0038: brfalse IL_004d
+		IL_0018: volatile.
+		IL_001a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_001f: brfalse IL_003a
 
-		IL_003d: ldloc.1
-		IL_003e: ldstr "length"
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0048: br IL_0062
+		IL_0024: ldstr "abc"
+		IL_0029: ldstr "split"
+		IL_002e: ldloc.s 6
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0035: br IL_0055
 
-		IL_004d: ldloc.1
-		IL_004e: ldstr "length"
-		IL_0053: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:13"
-		IL_0058: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_003a: ldstr "abc"
+		IL_003f: ldstr "split"
+		IL_0044: ldloc.s 6
+		IL_0046: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:8"
+		IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0062: stloc.s 8
-		IL_0064: ldloc.s 7
-		IL_0066: ldloc.s 8
-		IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006d: pop
-		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0073: stloc.s 7
-		IL_0075: ldloc.1
-		IL_0076: ldc.r8 0.0
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0084: stloc.s 8
-		IL_0086: ldloc.s 7
-		IL_0088: ldloc.s 8
-		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008f: pop
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0095: stloc.s 7
-		IL_0097: ldloc.1
-		IL_0098: ldc.r8 1
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00a6: stloc.s 8
-		IL_00a8: ldloc.s 7
-		IL_00aa: ldloc.s 8
-		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b1: pop
-		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b7: stloc.s 7
-		IL_00b9: ldloc.1
-		IL_00ba: ldc.r8 2
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_00c8: stloc.s 8
-		IL_00ca: ldloc.s 7
-		IL_00cc: ldloc.s 8
-		IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d3: pop
-		IL_00d4: ldstr "(?:)"
-		IL_00d9: ldstr ""
-		IL_00de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_00e3: stloc.s 6
-		IL_00e5: ldstr "abc"
-		IL_00ea: ldstr "split"
-		IL_00ef: ldloc.s 6
-		IL_00f1: ldc.r8 2
-		IL_00fa: box [System.Runtime]System.Double
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0104: stloc.2
-		IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010a: stloc.s 7
-		IL_010c: volatile.
-		IL_010e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0113: brfalse IL_0128
+		IL_0055: stloc.1
+		IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_005b: stloc.s 7
+		IL_005d: volatile.
+		IL_005f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0064: brfalse IL_0079
 
-		IL_0118: ldloc.2
-		IL_0119: ldstr "length"
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0123: br IL_013d
+		IL_0069: ldloc.1
+		IL_006a: ldstr "length"
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0074: br IL_008e
 
-		IL_0128: ldloc.2
-		IL_0129: ldstr "length"
-		IL_012e: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:42"
-		IL_0133: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0079: ldloc.1
+		IL_007a: ldstr "length"
+		IL_007f: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:13"
+		IL_0084: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_013d: stloc.s 8
-		IL_013f: ldloc.s 7
-		IL_0141: ldloc.s 8
-		IL_0143: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0148: pop
-		IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014e: stloc.s 7
-		IL_0150: ldloc.2
-		IL_0151: ldc.r8 0.0
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_015f: stloc.s 8
-		IL_0161: ldloc.s 7
-		IL_0163: ldloc.s 8
-		IL_0165: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_016a: pop
-		IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0170: stloc.s 7
-		IL_0172: ldloc.2
-		IL_0173: ldc.r8 1
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0181: stloc.s 8
-		IL_0183: ldloc.s 7
-		IL_0185: ldloc.s 8
-		IL_0187: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018c: pop
-		IL_018d: ldstr "(?:)"
-		IL_0192: ldstr ""
-		IL_0197: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_019c: stloc.s 6
-		IL_019e: ldstr ""
-		IL_01a3: ldstr "split"
-		IL_01a8: ldloc.s 6
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01af: stloc.3
-		IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b5: stloc.s 7
-		IL_01b7: volatile.
-		IL_01b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_01be: brfalse IL_01d3
+		IL_008e: stloc.s 8
+		IL_0090: ldloc.s 7
+		IL_0092: ldloc.s 8
+		IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0099: pop
+		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009f: stloc.s 7
+		IL_00a1: ldloc.1
+		IL_00a2: ldc.r8 0.0
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00b0: stloc.s 8
+		IL_00b2: ldloc.s 7
+		IL_00b4: ldloc.s 8
+		IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00bb: pop
+		IL_00bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c1: stloc.s 7
+		IL_00c3: ldloc.1
+		IL_00c4: ldc.r8 1
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00d2: stloc.s 8
+		IL_00d4: ldloc.s 7
+		IL_00d6: ldloc.s 8
+		IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00dd: pop
+		IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e3: stloc.s 7
+		IL_00e5: ldloc.1
+		IL_00e6: ldc.r8 2
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_00f4: stloc.s 8
+		IL_00f6: ldloc.s 7
+		IL_00f8: ldloc.s 8
+		IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ff: pop
+		IL_0100: ldstr "(?:)"
+		IL_0105: ldstr ""
+		IL_010a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_010f: stloc.s 6
+		IL_0111: ldstr "abc"
+		IL_0116: ldstr "split"
+		IL_011b: ldloc.s 6
+		IL_011d: ldc.r8 2
+		IL_0126: box [System.Runtime]System.Double
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0130: stloc.2
+		IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0136: stloc.s 7
+		IL_0138: volatile.
+		IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_013f: brfalse IL_0154
 
-		IL_01c3: ldloc.3
-		IL_01c4: ldstr "length"
-		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ce: br IL_01e8
+		IL_0144: ldloc.2
+		IL_0145: ldstr "length"
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_014f: br IL_0169
 
-		IL_01d3: ldloc.3
-		IL_01d4: ldstr "length"
-		IL_01d9: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:64"
-		IL_01de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0154: ldloc.2
+		IL_0155: ldstr "length"
+		IL_015a: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:42"
+		IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01e8: stloc.s 8
-		IL_01ea: ldloc.s 7
-		IL_01ec: ldloc.s 8
-		IL_01ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01f3: pop
-		IL_01f4: ldstr "(?:)"
-		IL_01f9: ldstr ""
-		IL_01fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_0203: stloc.s 6
-		IL_0205: ldstr "\ud83d\ude00a"
-		IL_020a: ldstr "split"
-		IL_020f: ldloc.s 6
-		IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0216: stloc.s 4
-		IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021d: stloc.s 7
-		IL_021f: volatile.
-		IL_0221: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0226: brfalse IL_023c
+		IL_0169: stloc.s 8
+		IL_016b: ldloc.s 7
+		IL_016d: ldloc.s 8
+		IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0174: pop
+		IL_0175: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017a: stloc.s 7
+		IL_017c: ldloc.2
+		IL_017d: ldc.r8 0.0
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_018b: stloc.s 8
+		IL_018d: ldloc.s 7
+		IL_018f: ldloc.s 8
+		IL_0191: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0196: pop
+		IL_0197: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019c: stloc.s 7
+		IL_019e: ldloc.2
+		IL_019f: ldc.r8 1
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_01ad: stloc.s 8
+		IL_01af: ldloc.s 7
+		IL_01b1: ldloc.s 8
+		IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b8: pop
+		IL_01b9: ldstr "(?:)"
+		IL_01be: ldstr ""
+		IL_01c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_01c8: stloc.s 6
+		IL_01ca: volatile.
+		IL_01cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01d1: brfalse IL_01ec
 
-		IL_022b: ldloc.s 4
-		IL_022d: ldstr "length"
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0237: br IL_0252
+		IL_01d6: ldstr ""
+		IL_01db: ldstr "split"
+		IL_01e0: ldloc.s 6
+		IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e7: br IL_0207
 
-		IL_023c: ldloc.s 4
-		IL_023e: ldstr "length"
-		IL_0243: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:76"
-		IL_0248: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01ec: ldstr ""
+		IL_01f1: ldstr "split"
+		IL_01f6: ldloc.s 6
+		IL_01f8: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:59"
+		IL_01fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0252: stloc.s 8
-		IL_0254: ldloc.s 7
-		IL_0256: ldloc.s 8
-		IL_0258: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_025d: pop
-		IL_025e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0263: stloc.s 7
-		IL_0265: ldloc.s 4
-		IL_0267: ldc.r8 0.0
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0275: stloc.s 8
-		IL_0277: ldloc.s 8
-		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027e: stloc.s 8
-		IL_0280: ldc.i4.0
-		IL_0281: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0286: brfalse IL_02cb
+		IL_0207: stloc.3
+		IL_0208: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_020d: stloc.s 7
+		IL_020f: volatile.
+		IL_0211: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0216: brfalse IL_022b
 
-		IL_028b: ldloc.s 8
-		IL_028d: isinst [System.Runtime]System.String
-		IL_0292: dup
-		IL_0293: brtrue IL_02ab
+		IL_021b: ldloc.3
+		IL_021c: ldstr "length"
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0226: br IL_0240
 
-		IL_0298: pop
-		IL_0299: ldloc.s 8
-		IL_029b: ldstr "charCodeAt"
-		IL_02a0: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_02a5: dup
-		IL_02a6: brfalse IL_02ca
+		IL_022b: ldloc.3
+		IL_022c: ldstr "length"
+		IL_0231: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:64"
+		IL_0236: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02ab: ldc.r8 0.0
-		IL_02b4: box [System.Runtime]System.Double
-		IL_02b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_02be: box [System.Runtime]System.Double
-		IL_02c3: stloc.s 8
-		IL_02c5: br IL_02e7
+		IL_0240: stloc.s 8
+		IL_0242: ldloc.s 7
+		IL_0244: ldloc.s 8
+		IL_0246: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_024b: pop
+		IL_024c: ldstr "(?:)"
+		IL_0251: ldstr ""
+		IL_0256: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_025b: stloc.s 6
+		IL_025d: volatile.
+		IL_025f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0264: brfalse IL_027f
 
-		IL_02ca: pop
+		IL_0269: ldstr "\ud83d\ude00a"
+		IL_026e: ldstr "split"
+		IL_0273: ldloc.s 6
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_027a: br IL_029a
 
-		IL_02cb: ldloc.s 8
-		IL_02cd: ldstr "charCodeAt"
-		IL_02d2: ldc.r8 0.0
-		IL_02db: box [System.Runtime]System.Double
-		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e5: stloc.s 8
+		IL_027f: ldstr "\ud83d\ude00a"
+		IL_0284: ldstr "split"
+		IL_0289: ldloc.s 6
+		IL_028b: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:71"
+		IL_0290: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02e7: ldloc.s 7
-		IL_02e9: ldloc.s 8
-		IL_02eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02f0: pop
-		IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f6: stloc.s 7
-		IL_02f8: ldloc.s 4
-		IL_02fa: ldc.r8 1
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0308: stloc.s 8
-		IL_030a: ldloc.s 8
-		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0311: stloc.s 8
-		IL_0313: ldc.i4.0
-		IL_0314: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0319: brfalse IL_035e
+		IL_029a: stloc.s 4
+		IL_029c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a1: stloc.s 7
+		IL_02a3: volatile.
+		IL_02a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02aa: brfalse IL_02c0
 
-		IL_031e: ldloc.s 8
-		IL_0320: isinst [System.Runtime]System.String
-		IL_0325: dup
-		IL_0326: brtrue IL_033e
+		IL_02af: ldloc.s 4
+		IL_02b1: ldstr "length"
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02bb: br IL_02d6
 
-		IL_032b: pop
-		IL_032c: ldloc.s 8
-		IL_032e: ldstr "charCodeAt"
-		IL_0333: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-		IL_0338: dup
-		IL_0339: brfalse IL_035d
+		IL_02c0: ldloc.s 4
+		IL_02c2: ldstr "length"
+		IL_02c7: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:76"
+		IL_02cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_033e: ldc.r8 0.0
-		IL_0347: box [System.Runtime]System.Double
-		IL_034c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_0351: box [System.Runtime]System.Double
-		IL_0356: stloc.s 8
-		IL_0358: br IL_037a
+		IL_02d6: stloc.s 8
+		IL_02d8: ldloc.s 7
+		IL_02da: ldloc.s 8
+		IL_02dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e1: pop
+		IL_02e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02e7: stloc.s 7
+		IL_02e9: ldloc.s 4
+		IL_02eb: ldc.r8 0.0
+		IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02f9: stloc.s 8
+		IL_02fb: ldloc.s 8
+		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0302: stloc.s 8
+		IL_0304: ldc.i4.0
+		IL_0305: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_030a: brfalse IL_034f
 
-		IL_035d: pop
+		IL_030f: ldloc.s 8
+		IL_0311: isinst [System.Runtime]System.String
+		IL_0316: dup
+		IL_0317: brtrue IL_032f
 
-		IL_035e: ldloc.s 8
-		IL_0360: ldstr "charCodeAt"
-		IL_0365: ldc.r8 0.0
-		IL_036e: box [System.Runtime]System.Double
-		IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0378: stloc.s 8
+		IL_031c: pop
+		IL_031d: ldloc.s 8
+		IL_031f: ldstr "charCodeAt"
+		IL_0324: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0329: dup
+		IL_032a: brfalse IL_034e
 
-		IL_037a: ldloc.s 7
-		IL_037c: ldloc.s 8
-		IL_037e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0383: pop
-		IL_0384: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0389: stloc.s 7
-		IL_038b: ldloc.s 4
-		IL_038d: ldc.r8 2
-		IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_039b: stloc.s 8
-		IL_039d: ldloc.s 7
-		IL_039f: ldloc.s 8
-		IL_03a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03a6: pop
-		IL_03a7: ldstr "(?:)"
-		IL_03ac: ldstr "u"
-		IL_03b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_03b6: stloc.s 6
-		IL_03b8: ldstr "\ud83d\ude00a"
-		IL_03bd: ldstr "split"
-		IL_03c2: ldloc.s 6
-		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03c9: stloc.s 5
-		IL_03cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03d0: stloc.s 7
-		IL_03d2: volatile.
-		IL_03d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_03d9: brfalse IL_03ef
+		IL_032f: ldc.r8 0.0
+		IL_0338: box [System.Runtime]System.Double
+		IL_033d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0342: box [System.Runtime]System.Double
+		IL_0347: stloc.s 8
+		IL_0349: br IL_036b
 
-		IL_03de: ldloc.s 5
-		IL_03e0: ldstr "length"
-		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03ea: br IL_0405
+		IL_034e: pop
 
-		IL_03ef: ldloc.s 5
-		IL_03f1: ldstr "length"
-		IL_03f6: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:111"
-		IL_03fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_034f: ldloc.s 8
+		IL_0351: ldstr "charCodeAt"
+		IL_0356: ldc.r8 0.0
+		IL_035f: box [System.Runtime]System.Double
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0369: stloc.s 8
 
-		IL_0405: stloc.s 8
-		IL_0407: ldloc.s 7
-		IL_0409: ldloc.s 8
-		IL_040b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0410: pop
-		IL_0411: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0416: stloc.s 7
-		IL_0418: ldloc.s 5
-		IL_041a: ldc.r8 0.0
-		IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0428: stloc.s 8
-		IL_042a: ldloc.s 7
-		IL_042c: ldloc.s 8
-		IL_042e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0433: pop
-		IL_0434: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0439: stloc.s 7
-		IL_043b: ldloc.s 5
-		IL_043d: ldc.r8 1
-		IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_044b: stloc.s 8
-		IL_044d: ldloc.s 7
-		IL_044f: ldloc.s 8
-		IL_0451: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0456: pop
-		IL_0457: ret
+		IL_036b: ldloc.s 7
+		IL_036d: ldloc.s 8
+		IL_036f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0374: pop
+		IL_0375: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_037a: stloc.s 7
+		IL_037c: ldloc.s 4
+		IL_037e: ldc.r8 1
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_038c: stloc.s 8
+		IL_038e: ldloc.s 8
+		IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0395: stloc.s 8
+		IL_0397: ldc.i4.0
+		IL_0398: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_039d: brfalse IL_03e2
+
+		IL_03a2: ldloc.s 8
+		IL_03a4: isinst [System.Runtime]System.String
+		IL_03a9: dup
+		IL_03aa: brtrue IL_03c2
+
+		IL_03af: pop
+		IL_03b0: ldloc.s 8
+		IL_03b2: ldstr "charCodeAt"
+		IL_03b7: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_03bc: dup
+		IL_03bd: brfalse IL_03e1
+
+		IL_03c2: ldc.r8 0.0
+		IL_03cb: box [System.Runtime]System.Double
+		IL_03d0: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_03d5: box [System.Runtime]System.Double
+		IL_03da: stloc.s 8
+		IL_03dc: br IL_03fe
+
+		IL_03e1: pop
+
+		IL_03e2: ldloc.s 8
+		IL_03e4: ldstr "charCodeAt"
+		IL_03e9: ldc.r8 0.0
+		IL_03f2: box [System.Runtime]System.Double
+		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03fc: stloc.s 8
+
+		IL_03fe: ldloc.s 7
+		IL_0400: ldloc.s 8
+		IL_0402: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0407: pop
+		IL_0408: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_040d: stloc.s 7
+		IL_040f: ldloc.s 4
+		IL_0411: ldc.r8 2
+		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_041f: stloc.s 8
+		IL_0421: ldloc.s 7
+		IL_0423: ldloc.s 8
+		IL_0425: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_042a: pop
+		IL_042b: ldstr "(?:)"
+		IL_0430: ldstr "u"
+		IL_0435: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_043a: stloc.s 6
+		IL_043c: volatile.
+		IL_043e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0443: brfalse IL_045e
+
+		IL_0448: ldstr "\ud83d\ude00a"
+		IL_044d: ldstr "split"
+		IL_0452: ldloc.s 6
+		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0459: br IL_0479
+
+		IL_045e: ldstr "\ud83d\ude00a"
+		IL_0463: ldstr "split"
+		IL_0468: ldloc.s 6
+		IL_046a: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:106"
+		IL_046f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0479: stloc.s 5
+		IL_047b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0480: stloc.s 7
+		IL_0482: volatile.
+		IL_0484: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0489: brfalse IL_049f
+
+		IL_048e: ldloc.s 5
+		IL_0490: ldstr "length"
+		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_049a: br IL_04b5
+
+		IL_049f: ldloc.s 5
+		IL_04a1: ldstr "length"
+		IL_04a6: ldstr "String_Split_Regex_Empty:Modules.String_Split_Regex_Empty:__js_module_init__:111"
+		IL_04ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04b5: stloc.s 8
+		IL_04b7: ldloc.s 7
+		IL_04b9: ldloc.s 8
+		IL_04bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04c0: pop
+		IL_04c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04c6: stloc.s 7
+		IL_04c8: ldloc.s 5
+		IL_04ca: ldc.r8 0.0
+		IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_04d8: stloc.s 8
+		IL_04da: ldloc.s 7
+		IL_04dc: ldloc.s 8
+		IL_04de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04e3: pop
+		IL_04e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04e9: stloc.s 7
+		IL_04eb: ldloc.s 5
+		IL_04ed: ldc.r8 1
+		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_04fb: stloc.s 8
+		IL_04fd: ldloc.s 7
+		IL_04ff: ldloc.s 8
+		IL_0501: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0506: pop
+		IL_0507: ret
 	} // end of method String_Split_Regex_Empty::__js_module_init__
 
 } // end of class Modules.String_Split_Regex_Empty
@@ -482,6 +534,10 @@
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_BoundsChecks_RangeError.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_BoundsChecks_RangeError.verified.txt
@@ -181,7 +181,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 372 (0x174)
+		// Code size: 424 (0x1a8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_BoundsChecks_RangeError/Scope,
@@ -215,126 +215,140 @@
 		.try
 		{
 			IL_003e: nop
-			IL_003f: ldloc.2
-			IL_0040: ldstr "getUint32"
-			IL_0045: ldc.r8 0.0
-			IL_004e: box [System.Runtime]System.Double
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0058: pop
-			IL_0059: leave IL_00d8
+			IL_003f: volatile.
+			IL_0041: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_0046: brfalse IL_0069
+
+			IL_004b: ldloc.2
+			IL_004c: ldstr "getUint32"
+			IL_0051: ldc.r8 0.0
+			IL_005a: box [System.Runtime]System.Double
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0064: br IL_008c
+
+			IL_0069: ldloc.2
+			IL_006a: ldstr "getUint32"
+			IL_006f: ldc.r8 0.0
+			IL_0078: box [System.Runtime]System.Double
+			IL_007d: ldstr "DataView_BoundsChecks_RangeError:Modules.DataView_BoundsChecks_RangeError:__js_module_init__:21"
+			IL_0082: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_008c: pop
+			IL_008d: leave IL_010c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_005e: stloc.3
-			IL_005f: ldloc.3
-			IL_0060: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0065: dup
-			IL_0066: brtrue IL_007b
+			IL_0092: stloc.3
+			IL_0093: ldloc.3
+			IL_0094: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0099: dup
+			IL_009a: brtrue IL_00af
 
-			IL_006b: pop
-			IL_006c: ldloc.3
-			IL_006d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0072: dup
-			IL_0073: brtrue IL_0087
+			IL_009f: pop
+			IL_00a0: ldloc.3
+			IL_00a1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00a6: dup
+			IL_00a7: brtrue IL_00bb
 
-			IL_0078: pop
-			IL_0079: rethrow
+			IL_00ac: pop
+			IL_00ad: rethrow
 
-			IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0080: stloc.s 4
-			IL_0082: br IL_0089
+			IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00b4: stloc.s 4
+			IL_00b6: br IL_00bd
 
-			IL_0087: stloc.s 4
+			IL_00bb: stloc.s 4
 
-			IL_0089: ldloc.s 4
-			IL_008b: stloc.s 5
-			IL_008d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0092: stloc.s 10
-			IL_0094: volatile.
-			IL_0096: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-			IL_009b: brfalse IL_00b1
+			IL_00bd: ldloc.s 4
+			IL_00bf: stloc.s 5
+			IL_00c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00c6: stloc.s 10
+			IL_00c8: volatile.
+			IL_00ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_00cf: brfalse IL_00e5
 
-			IL_00a0: ldloc.s 5
-			IL_00a2: ldstr "name"
-			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ac: br IL_00c7
+			IL_00d4: ldloc.s 5
+			IL_00d6: ldstr "name"
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e0: br IL_00fb
 
-			IL_00b1: ldloc.s 5
-			IL_00b3: ldstr "name"
-			IL_00b8: ldstr "DataView_BoundsChecks_RangeError:Modules.DataView_BoundsChecks_RangeError:__js_module_init__:32"
-			IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00e5: ldloc.s 5
+			IL_00e7: ldstr "name"
+			IL_00ec: ldstr "DataView_BoundsChecks_RangeError:Modules.DataView_BoundsChecks_RangeError:__js_module_init__:32"
+			IL_00f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00c7: stloc.s 11
-			IL_00c9: ldloc.s 10
-			IL_00cb: ldloc.s 11
-			IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00d2: pop
-			IL_00d3: leave IL_00d8
+			IL_00fb: stloc.s 11
+			IL_00fd: ldloc.s 10
+			IL_00ff: ldloc.s 11
+			IL_0101: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0106: pop
+			IL_0107: leave IL_010c
 		} // end handler
 		.try
 		{
-			IL_00d8: nop
-			IL_00d9: ldloc.1
-			IL_00da: ldc.r8 5
-			IL_00e3: box [System.Runtime]System.Double
-			IL_00e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
-			IL_00ed: pop
-			IL_00ee: leave IL_0170
+			IL_010c: nop
+			IL_010d: ldloc.1
+			IL_010e: ldc.r8 5
+			IL_0117: box [System.Runtime]System.Double
+			IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.DataView::.ctor(object, object)
+			IL_0121: pop
+			IL_0122: leave IL_01a4
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00f3: stloc.s 6
-			IL_00f5: ldloc.s 6
-			IL_00f7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00fc: dup
-			IL_00fd: brtrue IL_0113
+			IL_0127: stloc.s 6
+			IL_0129: ldloc.s 6
+			IL_012b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0130: dup
+			IL_0131: brtrue IL_0147
 
-			IL_0102: pop
-			IL_0103: ldloc.s 6
-			IL_0105: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_010a: dup
-			IL_010b: brtrue IL_011f
+			IL_0136: pop
+			IL_0137: ldloc.s 6
+			IL_0139: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_013e: dup
+			IL_013f: brtrue IL_0153
 
-			IL_0110: pop
-			IL_0111: rethrow
+			IL_0144: pop
+			IL_0145: rethrow
 
-			IL_0113: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0118: stloc.s 7
-			IL_011a: br IL_0121
+			IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_014c: stloc.s 7
+			IL_014e: br IL_0155
 
-			IL_011f: stloc.s 7
+			IL_0153: stloc.s 7
 
-			IL_0121: ldloc.s 7
-			IL_0123: stloc.s 8
-			IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_012a: stloc.s 10
-			IL_012c: volatile.
-			IL_012e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-			IL_0133: brfalse IL_0149
+			IL_0155: ldloc.s 7
+			IL_0157: stloc.s 8
+			IL_0159: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_015e: stloc.s 10
+			IL_0160: volatile.
+			IL_0162: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0167: brfalse IL_017d
 
-			IL_0138: ldloc.s 8
-			IL_013a: ldstr "name"
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0144: br IL_015f
+			IL_016c: ldloc.s 8
+			IL_016e: ldstr "name"
+			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0178: br IL_0193
 
-			IL_0149: ldloc.s 8
-			IL_014b: ldstr "name"
-			IL_0150: ldstr "DataView_BoundsChecks_RangeError:Modules.DataView_BoundsChecks_RangeError:__js_module_init__:55"
-			IL_0155: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_017d: ldloc.s 8
+			IL_017f: ldstr "name"
+			IL_0184: ldstr "DataView_BoundsChecks_RangeError:Modules.DataView_BoundsChecks_RangeError:__js_module_init__:55"
+			IL_0189: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_015f: stloc.s 11
-			IL_0161: ldloc.s 10
-			IL_0163: ldloc.s 11
-			IL_0165: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_016a: pop
-			IL_016b: leave IL_0170
+			IL_0193: stloc.s 11
+			IL_0195: ldloc.s 10
+			IL_0197: ldloc.s 11
+			IL_0199: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_019e: pop
+			IL_019f: leave IL_01a4
 		} // end handler
 
-		IL_0170: ldnull
-		IL_0171: stloc.s 9
-		IL_0173: ret
+		IL_01a4: ldnull
+		IL_01a5: stloc.s 9
+		IL_01a7: ret
 	} // end of method DataView_BoundsChecks_RangeError::__js_module_init__
 
 } // end of class Modules.DataView_BoundsChecks_RangeError
@@ -366,6 +380,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_ByteOffset_ByteLength.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_ByteOffset_ByteLength.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 495 (0x1ef)
+		// Code size: 599 (0x257)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_ByteOffset_ByteLength/Scope,
@@ -231,29 +231,57 @@
 		IL_0195: pop
 		IL_0196: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_019b: stloc.s 4
-		IL_019d: ldloc.3
-		IL_019e: ldstr "getUint8"
-		IL_01a3: ldc.r8 2
-		IL_01ac: box [System.Runtime]System.Double
-		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b6: stloc.s 5
-		IL_01b8: ldloc.s 4
-		IL_01ba: ldloc.s 5
-		IL_01bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01c1: pop
-		IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c7: stloc.s 4
-		IL_01c9: ldloc.3
-		IL_01ca: ldstr "getUint8"
-		IL_01cf: ldc.r8 5
-		IL_01d8: box [System.Runtime]System.Double
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e2: stloc.s 5
-		IL_01e4: ldloc.s 4
-		IL_01e6: ldloc.s 5
-		IL_01e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ed: pop
-		IL_01ee: ret
+		IL_019d: volatile.
+		IL_019f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01a4: brfalse IL_01c7
+
+		IL_01a9: ldloc.3
+		IL_01aa: ldstr "getUint8"
+		IL_01af: ldc.r8 2
+		IL_01b8: box [System.Runtime]System.Double
+		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c2: br IL_01ea
+
+		IL_01c7: ldloc.3
+		IL_01c8: ldstr "getUint8"
+		IL_01cd: ldc.r8 2
+		IL_01d6: box [System.Runtime]System.Double
+		IL_01db: ldstr "DataView_ByteOffset_ByteLength:Modules.DataView_ByteOffset_ByteLength:__js_module_init__:51"
+		IL_01e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01ea: stloc.s 5
+		IL_01ec: ldloc.s 4
+		IL_01ee: ldloc.s 5
+		IL_01f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f5: pop
+		IL_01f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01fb: stloc.s 4
+		IL_01fd: volatile.
+		IL_01ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0204: brfalse IL_0227
+
+		IL_0209: ldloc.3
+		IL_020a: ldstr "getUint8"
+		IL_020f: ldc.r8 5
+		IL_0218: box [System.Runtime]System.Double
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0222: br IL_024a
+
+		IL_0227: ldloc.3
+		IL_0228: ldstr "getUint8"
+		IL_022d: ldc.r8 5
+		IL_0236: box [System.Runtime]System.Double
+		IL_023b: ldstr "DataView_ByteOffset_ByteLength:Modules.DataView_ByteOffset_ByteLength:__js_module_init__:57"
+		IL_0240: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_024a: stloc.s 5
+		IL_024c: ldloc.s 4
+		IL_024e: ldloc.s 5
+		IL_0250: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0255: pop
+		IL_0256: ret
 	} // end of method DataView_ByteOffset_ByteLength::__js_module_init__
 
 } // end of class Modules.DataView_ByteOffset_ByteLength
@@ -287,6 +315,8 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_Float32_Float64_RoundTrip.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_Float32_Float64_RoundTrip.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 211 (0xd3)
+		// Code size: 263 (0x107)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_Float32_Float64_RoundTrip/Scope,
@@ -143,31 +143,45 @@
 		IL_0077: pop
 		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_007d: stloc.3
-		IL_007e: ldloc.2
-		IL_007f: ldstr "getFloat32"
-		IL_0084: ldc.r8 0.0
-		IL_008d: box [System.Runtime]System.Double
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0097: stloc.s 4
-		IL_0099: ldloc.3
-		IL_009a: ldloc.s 4
-		IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a1: pop
-		IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a7: stloc.3
+		IL_007e: volatile.
+		IL_0080: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0085: brfalse IL_00a8
+
+		IL_008a: ldloc.2
+		IL_008b: ldstr "getFloat32"
+		IL_0090: ldc.r8 0.0
+		IL_0099: box [System.Runtime]System.Double
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a3: br IL_00cb
+
 		IL_00a8: ldloc.2
-		IL_00a9: ldstr "getFloat64"
-		IL_00ae: ldc.r8 8
+		IL_00a9: ldstr "getFloat32"
+		IL_00ae: ldc.r8 0.0
 		IL_00b7: box [System.Runtime]System.Double
-		IL_00bc: ldc.i4.1
-		IL_00bd: box [System.Runtime]System.Boolean
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00c7: stloc.s 4
-		IL_00c9: ldloc.3
-		IL_00ca: ldloc.s 4
-		IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d1: pop
-		IL_00d2: ret
+		IL_00bc: ldstr "DataView_Float32_Float64_RoundTrip:Modules.DataView_Float32_Float64_RoundTrip:__js_module_init__:29"
+		IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00cb: stloc.s 4
+		IL_00cd: ldloc.3
+		IL_00ce: ldloc.s 4
+		IL_00d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d5: pop
+		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00db: stloc.3
+		IL_00dc: ldloc.2
+		IL_00dd: ldstr "getFloat64"
+		IL_00e2: ldc.r8 8
+		IL_00eb: box [System.Runtime]System.Double
+		IL_00f0: ldc.i4.1
+		IL_00f1: box [System.Runtime]System.Boolean
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00fb: stloc.s 4
+		IL_00fd: ldloc.3
+		IL_00fe: ldloc.s 4
+		IL_0100: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0105: pop
+		IL_0106: ret
 	} // end of method DataView_Float32_Float64_RoundTrip::__js_module_init__
 
 } // end of class Modules.DataView_Float32_Float64_RoundTrip
@@ -192,4 +206,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_SetGet_UintAndEndian.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.DataView_SetGet_UintAndEndian.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 478 (0x1de)
+		// Code size: 738 (0x2e2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.DataView_SetGet_UintAndEndian/Scope,
@@ -166,79 +166,149 @@
 		IL_00ce: pop
 		IL_00cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00d4: stloc.s 5
-		IL_00d6: ldloc.2
-		IL_00d7: ldstr "getUint8"
-		IL_00dc: ldc.r8 0.0
-		IL_00e5: box [System.Runtime]System.Double
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ef: stloc.s 6
-		IL_00f1: ldloc.s 5
-		IL_00f3: ldloc.s 6
-		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fa: pop
-		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0100: stloc.s 5
-		IL_0102: ldloc.2
-		IL_0103: ldstr "getUint16"
-		IL_0108: ldc.r8 1
-		IL_0111: box [System.Runtime]System.Double
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011b: stloc.s 6
-		IL_011d: ldloc.s 5
-		IL_011f: ldloc.s 6
-		IL_0121: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0126: pop
-		IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012c: stloc.s 5
-		IL_012e: ldloc.2
-		IL_012f: ldstr "getUint16"
-		IL_0134: ldc.r8 3
-		IL_013d: box [System.Runtime]System.Double
-		IL_0142: ldc.i4.1
-		IL_0143: box [System.Runtime]System.Boolean
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_014d: stloc.s 6
-		IL_014f: ldloc.s 5
-		IL_0151: ldloc.s 6
-		IL_0153: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0158: pop
-		IL_0159: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015e: stloc.s 5
+		IL_00d6: volatile.
+		IL_00d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00dd: brfalse IL_0100
+
+		IL_00e2: ldloc.2
+		IL_00e3: ldstr "getUint8"
+		IL_00e8: ldc.r8 0.0
+		IL_00f1: box [System.Runtime]System.Double
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00fb: br IL_0123
+
+		IL_0100: ldloc.2
+		IL_0101: ldstr "getUint8"
+		IL_0106: ldc.r8 0.0
+		IL_010f: box [System.Runtime]System.Double
+		IL_0114: ldstr "DataView_SetGet_UintAndEndian:Modules.DataView_SetGet_UintAndEndian:__js_module_init__:42"
+		IL_0119: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0123: stloc.s 6
+		IL_0125: ldloc.s 5
+		IL_0127: ldloc.s 6
+		IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_012e: pop
+		IL_012f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0134: stloc.s 5
+		IL_0136: volatile.
+		IL_0138: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_013d: brfalse IL_0160
+
+		IL_0142: ldloc.2
+		IL_0143: ldstr "getUint16"
+		IL_0148: ldc.r8 1
+		IL_0151: box [System.Runtime]System.Double
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_015b: br IL_0183
+
 		IL_0160: ldloc.2
 		IL_0161: ldstr "getUint16"
-		IL_0166: ldc.r8 3
+		IL_0166: ldc.r8 1
 		IL_016f: box [System.Runtime]System.Double
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0179: stloc.s 6
-		IL_017b: ldloc.s 5
-		IL_017d: ldloc.s 6
-		IL_017f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0184: pop
-		IL_0185: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018a: stloc.s 5
-		IL_018c: ldloc.2
-		IL_018d: ldstr "getInt32"
-		IL_0192: ldc.r8 4
-		IL_019b: box [System.Runtime]System.Double
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a5: stloc.s 6
-		IL_01a7: ldloc.s 5
-		IL_01a9: ldloc.s 6
-		IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b0: pop
-		IL_01b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b6: stloc.s 5
-		IL_01b8: ldloc.2
-		IL_01b9: ldstr "getUint32"
-		IL_01be: ldc.r8 4
-		IL_01c7: box [System.Runtime]System.Double
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d1: stloc.s 6
-		IL_01d3: ldloc.s 5
-		IL_01d5: ldloc.s 6
-		IL_01d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01dc: pop
-		IL_01dd: ret
+		IL_0174: ldstr "DataView_SetGet_UintAndEndian:Modules.DataView_SetGet_UintAndEndian:__js_module_init__:48"
+		IL_0179: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0183: stloc.s 6
+		IL_0185: ldloc.s 5
+		IL_0187: ldloc.s 6
+		IL_0189: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_018e: pop
+		IL_018f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0194: stloc.s 5
+		IL_0196: ldloc.2
+		IL_0197: ldstr "getUint16"
+		IL_019c: ldc.r8 3
+		IL_01a5: box [System.Runtime]System.Double
+		IL_01aa: ldc.i4.1
+		IL_01ab: box [System.Runtime]System.Boolean
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01b5: stloc.s 6
+		IL_01b7: ldloc.s 5
+		IL_01b9: ldloc.s 6
+		IL_01bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c0: pop
+		IL_01c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c6: stloc.s 5
+		IL_01c8: volatile.
+		IL_01ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_01cf: brfalse IL_01f2
+
+		IL_01d4: ldloc.2
+		IL_01d5: ldstr "getUint16"
+		IL_01da: ldc.r8 3
+		IL_01e3: box [System.Runtime]System.Double
+		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ed: br IL_0215
+
+		IL_01f2: ldloc.2
+		IL_01f3: ldstr "getUint16"
+		IL_01f8: ldc.r8 3
+		IL_0201: box [System.Runtime]System.Double
+		IL_0206: ldstr "DataView_SetGet_UintAndEndian:Modules.DataView_SetGet_UintAndEndian:__js_module_init__:62"
+		IL_020b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0215: stloc.s 6
+		IL_0217: ldloc.s 5
+		IL_0219: ldloc.s 6
+		IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0220: pop
+		IL_0221: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0226: stloc.s 5
+		IL_0228: volatile.
+		IL_022a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_022f: brfalse IL_0252
+
+		IL_0234: ldloc.2
+		IL_0235: ldstr "getInt32"
+		IL_023a: ldc.r8 4
+		IL_0243: box [System.Runtime]System.Double
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024d: br IL_0275
+
+		IL_0252: ldloc.2
+		IL_0253: ldstr "getInt32"
+		IL_0258: ldc.r8 4
+		IL_0261: box [System.Runtime]System.Double
+		IL_0266: ldstr "DataView_SetGet_UintAndEndian:Modules.DataView_SetGet_UintAndEndian:__js_module_init__:68"
+		IL_026b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0275: stloc.s 6
+		IL_0277: ldloc.s 5
+		IL_0279: ldloc.s 6
+		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0280: pop
+		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0286: stloc.s 5
+		IL_0288: volatile.
+		IL_028a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_028f: brfalse IL_02b2
+
+		IL_0294: ldloc.2
+		IL_0295: ldstr "getUint32"
+		IL_029a: ldc.r8 4
+		IL_02a3: box [System.Runtime]System.Double
+		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ad: br IL_02d5
+
+		IL_02b2: ldloc.2
+		IL_02b3: ldstr "getUint32"
+		IL_02b8: ldc.r8 4
+		IL_02c1: box [System.Runtime]System.Double
+		IL_02c6: ldstr "DataView_SetGet_UintAndEndian:Modules.DataView_SetGet_UintAndEndian:__js_module_init__:74"
+		IL_02cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02d5: stloc.s 6
+		IL_02d7: ldloc.s 5
+		IL_02d9: ldloc.s 6
+		IL_02db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e0: pop
+		IL_02e1: ret
 	} // end of method DataView_SetGet_UintAndEndian::__js_module_init__
 
 } // end of class Modules.DataView_SetGet_UintAndEndian
@@ -263,4 +333,16 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
@@ -1299,7 +1299,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 669 (0x29d)
+		// Code size: 1033 (0x409)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Float64Array_Callback_Methods/Scope,
@@ -1353,223 +1353,338 @@
 		IL_0061: ldc.i4.1
 		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 5
-		IL_0069: ldloc.1
-		IL_006a: ldstr "map"
-		IL_006f: ldloc.s 5
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0076: stloc.s 6
-		IL_0078: ldloc.s 6
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007f: ldstr "join"
-		IL_0084: ldstr "|"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008e: stloc.s 6
-		IL_0090: ldloc.3
-		IL_0091: ldloc.s 6
-		IL_0093: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0098: pop
-		IL_0099: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009e: stloc.3
-		IL_009f: ldc.i4.1
-		IL_00a0: newarr [System.Runtime]System.Object
-		IL_00a5: dup
-		IL_00a6: ldc.i4.0
-		IL_00a7: ldloc.0
-		IL_00a8: stelem.ref
-		IL_00a9: stloc.s 4
-		IL_00ab: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject::.ctor()
-		IL_00b0: ldc.i4.1
-		IL_00b1: conv.r8
-		IL_00b2: ldstr ""
-		IL_00b7: ldc.i4.0
-		IL_00b8: ldc.i4.1
-		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00be: stloc.s 7
-		IL_00c0: ldloc.1
-		IL_00c1: ldstr "filter"
-		IL_00c6: ldloc.s 7
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cd: stloc.s 6
-		IL_00cf: ldloc.s 6
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d6: ldstr "join"
-		IL_00db: ldstr "|"
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e5: stloc.s 6
-		IL_00e7: ldloc.3
-		IL_00e8: ldloc.s 6
-		IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ef: pop
-		IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f5: stloc.3
-		IL_00f6: ldc.i4.1
-		IL_00f7: newarr [System.Runtime]System.Object
-		IL_00fc: dup
-		IL_00fd: ldc.i4.0
-		IL_00fe: ldloc.0
-		IL_00ff: stelem.ref
-		IL_0100: stloc.s 4
-		IL_0102: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject::.ctor()
-		IL_0107: ldc.i4.1
-		IL_0108: conv.r8
-		IL_0109: ldstr ""
-		IL_010e: ldc.i4.0
-		IL_010f: ldc.i4.1
-		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0115: stloc.s 8
-		IL_0117: ldloc.1
-		IL_0118: ldstr "every"
-		IL_011d: ldloc.s 8
-		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0124: stloc.s 6
-		IL_0126: ldloc.3
-		IL_0127: ldloc.s 6
-		IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012e: pop
-		IL_012f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0134: stloc.3
-		IL_0135: ldc.i4.1
-		IL_0136: newarr [System.Runtime]System.Object
-		IL_013b: dup
-		IL_013c: ldc.i4.0
-		IL_013d: ldloc.0
-		IL_013e: stelem.ref
-		IL_013f: stloc.s 4
-		IL_0141: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject::.ctor()
-		IL_0146: ldc.i4.1
-		IL_0147: conv.r8
-		IL_0148: ldstr ""
-		IL_014d: ldc.i4.0
-		IL_014e: ldc.i4.1
-		IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0154: stloc.s 9
-		IL_0156: ldloc.1
-		IL_0157: ldstr "some"
-		IL_015c: ldloc.s 9
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0163: stloc.s 6
-		IL_0165: ldloc.3
-		IL_0166: ldloc.s 6
-		IL_0168: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_016d: pop
-		IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0173: stloc.3
-		IL_0174: ldc.i4.1
-		IL_0175: newarr [System.Runtime]System.Object
-		IL_017a: dup
-		IL_017b: ldc.i4.0
-		IL_017c: ldloc.0
-		IL_017d: stelem.ref
-		IL_017e: stloc.s 4
-		IL_0180: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject::.ctor()
-		IL_0185: ldc.i4.1
-		IL_0186: conv.r8
-		IL_0187: ldstr ""
-		IL_018c: ldc.i4.0
-		IL_018d: ldc.i4.1
-		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0193: stloc.s 10
-		IL_0195: ldloc.1
-		IL_0196: ldstr "find"
-		IL_019b: ldloc.s 10
-		IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a2: stloc.s 6
-		IL_01a4: ldloc.3
-		IL_01a5: ldloc.s 6
-		IL_01a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ac: pop
-		IL_01ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b2: stloc.3
+		IL_0069: volatile.
+		IL_006b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0070: brfalse IL_0087
+
+		IL_0075: ldloc.1
+		IL_0076: ldstr "map"
+		IL_007b: ldloc.s 5
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0082: br IL_009e
+
+		IL_0087: ldloc.1
+		IL_0088: ldstr "map"
+		IL_008d: ldloc.s 5
+		IL_008f: ldstr "Float64Array_Callback_Methods:Modules.Float64Array_Callback_Methods:__js_module_init__:14"
+		IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_009e: stloc.s 6
+		IL_00a0: ldloc.s 6
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a7: volatile.
+		IL_00a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00ae: brfalse IL_00c7
+
+		IL_00b3: ldstr "join"
+		IL_00b8: ldstr "|"
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c2: br IL_00e0
+
+		IL_00c7: ldstr "join"
+		IL_00cc: ldstr "|"
+		IL_00d1: ldstr "Float64Array_Callback_Methods:Modules.Float64Array_Callback_Methods:__js_module_init__:17"
+		IL_00d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00e0: stloc.s 6
+		IL_00e2: ldloc.3
+		IL_00e3: ldloc.s 6
+		IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ea: pop
+		IL_00eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f0: stloc.3
+		IL_00f1: ldc.i4.1
+		IL_00f2: newarr [System.Runtime]System.Object
+		IL_00f7: dup
+		IL_00f8: ldc.i4.0
+		IL_00f9: ldloc.0
+		IL_00fa: stelem.ref
+		IL_00fb: stloc.s 4
+		IL_00fd: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject::.ctor()
+		IL_0102: ldc.i4.1
+		IL_0103: conv.r8
+		IL_0104: ldstr ""
+		IL_0109: ldc.i4.0
+		IL_010a: ldc.i4.1
+		IL_010b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0110: stloc.s 7
+		IL_0112: volatile.
+		IL_0114: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0119: brfalse IL_0130
+
+		IL_011e: ldloc.1
+		IL_011f: ldstr "filter"
+		IL_0124: ldloc.s 7
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012b: br IL_0147
+
+		IL_0130: ldloc.1
+		IL_0131: ldstr "filter"
+		IL_0136: ldloc.s 7
+		IL_0138: ldstr "Float64Array_Callback_Methods:Modules.Float64Array_Callback_Methods:__js_module_init__:23"
+		IL_013d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0147: stloc.s 6
+		IL_0149: ldloc.s 6
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0150: volatile.
+		IL_0152: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0157: brfalse IL_0170
+
+		IL_015c: ldstr "join"
+		IL_0161: ldstr "|"
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_016b: br IL_0189
+
+		IL_0170: ldstr "join"
+		IL_0175: ldstr "|"
+		IL_017a: ldstr "Float64Array_Callback_Methods:Modules.Float64Array_Callback_Methods:__js_module_init__:26"
+		IL_017f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0189: stloc.s 6
+		IL_018b: ldloc.3
+		IL_018c: ldloc.s 6
+		IL_018e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0193: pop
+		IL_0194: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0199: stloc.3
+		IL_019a: ldc.i4.1
+		IL_019b: newarr [System.Runtime]System.Object
+		IL_01a0: dup
+		IL_01a1: ldc.i4.0
+		IL_01a2: ldloc.0
+		IL_01a3: stelem.ref
+		IL_01a4: stloc.s 4
+		IL_01a6: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject::.ctor()
+		IL_01ab: ldc.i4.1
+		IL_01ac: conv.r8
+		IL_01ad: ldstr ""
+		IL_01b2: ldc.i4.0
 		IL_01b3: ldc.i4.1
-		IL_01b4: newarr [System.Runtime]System.Object
-		IL_01b9: dup
-		IL_01ba: ldc.i4.0
-		IL_01bb: ldloc.0
-		IL_01bc: stelem.ref
-		IL_01bd: stloc.s 4
-		IL_01bf: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject::.ctor()
-		IL_01c4: ldc.i4.1
-		IL_01c5: conv.r8
-		IL_01c6: ldstr ""
-		IL_01cb: ldc.i4.0
-		IL_01cc: ldc.i4.1
-		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01d2: stloc.s 11
-		IL_01d4: ldloc.1
-		IL_01d5: ldstr "findIndex"
-		IL_01da: ldloc.s 11
-		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e1: stloc.s 6
-		IL_01e3: ldloc.3
-		IL_01e4: ldloc.s 6
-		IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01eb: pop
-		IL_01ec: ldloc.0
-		IL_01ed: ldc.r8 0.0
-		IL_01f6: box [System.Runtime]System.Double
-		IL_01fb: stfld object Modules.Float64Array_Callback_Methods/Scope::total
-		IL_0200: ldc.i4.1
-		IL_0201: newarr [System.Runtime]System.Object
-		IL_0206: dup
-		IL_0207: ldc.i4.0
-		IL_0208: ldloc.0
-		IL_0209: stelem.ref
-		IL_020a: stloc.s 4
-		IL_020c: ldloc.s 4
-		IL_020e: ldc.i4.0
-		IL_020f: ldelem.ref
-		IL_0210: castclass Modules.Float64Array_Callback_Methods/Scope
-		IL_0215: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject::.ctor(class Modules.Float64Array_Callback_Methods/Scope)
+		IL_01b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01b9: stloc.s 8
+		IL_01bb: volatile.
+		IL_01bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01c2: brfalse IL_01d9
+
+		IL_01c7: ldloc.1
+		IL_01c8: ldstr "every"
+		IL_01cd: ldloc.s 8
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d4: br IL_01f0
+
+		IL_01d9: ldloc.1
+		IL_01da: ldstr "every"
+		IL_01df: ldloc.s 8
+		IL_01e1: ldstr "Float64Array_Callback_Methods:Modules.Float64Array_Callback_Methods:__js_module_init__:32"
+		IL_01e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01f0: stloc.s 6
+		IL_01f2: ldloc.3
+		IL_01f3: ldloc.s 6
+		IL_01f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01fa: pop
+		IL_01fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0200: stloc.3
+		IL_0201: ldc.i4.1
+		IL_0202: newarr [System.Runtime]System.Object
+		IL_0207: dup
+		IL_0208: ldc.i4.0
+		IL_0209: ldloc.0
+		IL_020a: stelem.ref
+		IL_020b: stloc.s 4
+		IL_020d: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject::.ctor()
+		IL_0212: ldc.i4.1
+		IL_0213: conv.r8
+		IL_0214: ldstr ""
+		IL_0219: ldc.i4.0
 		IL_021a: ldc.i4.1
-		IL_021b: conv.r8
-		IL_021c: ldstr ""
-		IL_0221: ldc.i4.0
-		IL_0222: ldc.i4.1
-		IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0228: stloc.s 12
-		IL_022a: ldloc.1
-		IL_022b: ldstr "forEach"
-		IL_0230: ldloc.s 12
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0237: pop
-		IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_023d: stloc.3
-		IL_023e: ldloc.0
-		IL_023f: ldfld object Modules.Float64Array_Callback_Methods/Scope::total
-		IL_0244: stloc.s 6
-		IL_0246: ldloc.3
-		IL_0247: ldloc.s 6
-		IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024e: pop
-		IL_024f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0254: stloc.3
-		IL_0255: ldc.i4.1
-		IL_0256: newarr [System.Runtime]System.Object
-		IL_025b: dup
-		IL_025c: ldc.i4.0
-		IL_025d: ldloc.0
-		IL_025e: stelem.ref
-		IL_025f: stloc.s 4
-		IL_0261: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject::.ctor()
-		IL_0266: ldc.i4.2
-		IL_0267: conv.r8
-		IL_0268: ldstr ""
-		IL_026d: ldc.i4.0
-		IL_026e: ldc.i4.1
-		IL_026f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0274: stloc.s 13
-		IL_0276: ldloc.1
-		IL_0277: ldstr "reduce"
-		IL_027c: ldloc.s 13
-		IL_027e: ldc.r8 1
-		IL_0287: box [System.Runtime]System.Double
-		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0291: stloc.s 6
-		IL_0293: ldloc.3
-		IL_0294: ldloc.s 6
-		IL_0296: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_029b: pop
-		IL_029c: ret
+		IL_021b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0220: stloc.s 9
+		IL_0222: volatile.
+		IL_0224: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0229: brfalse IL_0240
+
+		IL_022e: ldloc.1
+		IL_022f: ldstr "some"
+		IL_0234: ldloc.s 9
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023b: br IL_0257
+
+		IL_0240: ldloc.1
+		IL_0241: ldstr "some"
+		IL_0246: ldloc.s 9
+		IL_0248: ldstr "Float64Array_Callback_Methods:Modules.Float64Array_Callback_Methods:__js_module_init__:38"
+		IL_024d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0257: stloc.s 6
+		IL_0259: ldloc.3
+		IL_025a: ldloc.s 6
+		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0261: pop
+		IL_0262: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0267: stloc.3
+		IL_0268: ldc.i4.1
+		IL_0269: newarr [System.Runtime]System.Object
+		IL_026e: dup
+		IL_026f: ldc.i4.0
+		IL_0270: ldloc.0
+		IL_0271: stelem.ref
+		IL_0272: stloc.s 4
+		IL_0274: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject::.ctor()
+		IL_0279: ldc.i4.1
+		IL_027a: conv.r8
+		IL_027b: ldstr ""
+		IL_0280: ldc.i4.0
+		IL_0281: ldc.i4.1
+		IL_0282: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0287: stloc.s 10
+		IL_0289: volatile.
+		IL_028b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0290: brfalse IL_02a7
+
+		IL_0295: ldloc.1
+		IL_0296: ldstr "find"
+		IL_029b: ldloc.s 10
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a2: br IL_02be
+
+		IL_02a7: ldloc.1
+		IL_02a8: ldstr "find"
+		IL_02ad: ldloc.s 10
+		IL_02af: ldstr "Float64Array_Callback_Methods:Modules.Float64Array_Callback_Methods:__js_module_init__:44"
+		IL_02b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02be: stloc.s 6
+		IL_02c0: ldloc.3
+		IL_02c1: ldloc.s 6
+		IL_02c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c8: pop
+		IL_02c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ce: stloc.3
+		IL_02cf: ldc.i4.1
+		IL_02d0: newarr [System.Runtime]System.Object
+		IL_02d5: dup
+		IL_02d6: ldc.i4.0
+		IL_02d7: ldloc.0
+		IL_02d8: stelem.ref
+		IL_02d9: stloc.s 4
+		IL_02db: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject::.ctor()
+		IL_02e0: ldc.i4.1
+		IL_02e1: conv.r8
+		IL_02e2: ldstr ""
+		IL_02e7: ldc.i4.0
+		IL_02e8: ldc.i4.1
+		IL_02e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02ee: stloc.s 11
+		IL_02f0: volatile.
+		IL_02f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02f7: brfalse IL_030e
+
+		IL_02fc: ldloc.1
+		IL_02fd: ldstr "findIndex"
+		IL_0302: ldloc.s 11
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0309: br IL_0325
+
+		IL_030e: ldloc.1
+		IL_030f: ldstr "findIndex"
+		IL_0314: ldloc.s 11
+		IL_0316: ldstr "Float64Array_Callback_Methods:Modules.Float64Array_Callback_Methods:__js_module_init__:50"
+		IL_031b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0325: stloc.s 6
+		IL_0327: ldloc.3
+		IL_0328: ldloc.s 6
+		IL_032a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_032f: pop
+		IL_0330: ldloc.0
+		IL_0331: ldc.r8 0.0
+		IL_033a: box [System.Runtime]System.Double
+		IL_033f: stfld object Modules.Float64Array_Callback_Methods/Scope::total
+		IL_0344: ldc.i4.1
+		IL_0345: newarr [System.Runtime]System.Object
+		IL_034a: dup
+		IL_034b: ldc.i4.0
+		IL_034c: ldloc.0
+		IL_034d: stelem.ref
+		IL_034e: stloc.s 4
+		IL_0350: ldloc.s 4
+		IL_0352: ldc.i4.0
+		IL_0353: ldelem.ref
+		IL_0354: castclass Modules.Float64Array_Callback_Methods/Scope
+		IL_0359: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject::.ctor(class Modules.Float64Array_Callback_Methods/Scope)
+		IL_035e: ldc.i4.1
+		IL_035f: conv.r8
+		IL_0360: ldstr ""
+		IL_0365: ldc.i4.0
+		IL_0366: ldc.i4.1
+		IL_0367: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_036c: stloc.s 12
+		IL_036e: volatile.
+		IL_0370: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0375: brfalse IL_038c
+
+		IL_037a: ldloc.1
+		IL_037b: ldstr "forEach"
+		IL_0380: ldloc.s 12
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0387: br IL_03a3
+
+		IL_038c: ldloc.1
+		IL_038d: ldstr "forEach"
+		IL_0392: ldloc.s 12
+		IL_0394: ldstr "Float64Array_Callback_Methods:Modules.Float64Array_Callback_Methods:__js_module_init__:59"
+		IL_0399: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_03a3: pop
+		IL_03a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a9: stloc.3
+		IL_03aa: ldloc.0
+		IL_03ab: ldfld object Modules.Float64Array_Callback_Methods/Scope::total
+		IL_03b0: stloc.s 6
+		IL_03b2: ldloc.3
+		IL_03b3: ldloc.s 6
+		IL_03b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03ba: pop
+		IL_03bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03c0: stloc.3
+		IL_03c1: ldc.i4.1
+		IL_03c2: newarr [System.Runtime]System.Object
+		IL_03c7: dup
+		IL_03c8: ldc.i4.0
+		IL_03c9: ldloc.0
+		IL_03ca: stelem.ref
+		IL_03cb: stloc.s 4
+		IL_03cd: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject::.ctor()
+		IL_03d2: ldc.i4.2
+		IL_03d3: conv.r8
+		IL_03d4: ldstr ""
+		IL_03d9: ldc.i4.0
+		IL_03da: ldc.i4.1
+		IL_03db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03e0: stloc.s 13
+		IL_03e2: ldloc.1
+		IL_03e3: ldstr "reduce"
+		IL_03e8: ldloc.s 13
+		IL_03ea: ldc.r8 1
+		IL_03f3: box [System.Runtime]System.Double
+		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03fd: stloc.s 6
+		IL_03ff: ldloc.3
+		IL_0400: ldloc.s 6
+		IL_0402: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0407: pop
+		IL_0408: ret
 	} // end of method Float64Array_Callback_Methods::__js_module_init__
 
 } // end of class Modules.Float64Array_Callback_Methods
@@ -1594,4 +1709,20 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 820 (0x334)
+		// Code size: 964 (0x3c4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Float64Array_Construct_ArrayBuffer_Search/Scope,
@@ -263,103 +263,144 @@
 		IL_01dd: pop
 		IL_01de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_01e3: stloc.s 5
-		IL_01e5: ldloc.3
-		IL_01e6: ldstr "includes"
-		IL_01eb: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_01f4: box [System.Runtime]System.Double
-		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fe: stloc.s 8
-		IL_0200: ldloc.s 5
-		IL_0202: ldloc.s 8
-		IL_0204: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0209: pop
-		IL_020a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_020f: stloc.s 5
-		IL_0211: ldloc.3
-		IL_0212: ldstr "indexOf"
-		IL_0217: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_0220: box [System.Runtime]System.Double
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_022a: stloc.s 8
-		IL_022c: ldloc.s 5
-		IL_022e: ldloc.s 8
-		IL_0230: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0235: pop
-		IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_023b: stloc.s 5
-		IL_023d: ldc.r8 1
-		IL_0246: neg
-		IL_0247: stloc.s 6
-		IL_0249: ldloc.s 6
-		IL_024b: box [System.Runtime]System.Double
-		IL_0250: stloc.s 7
-		IL_0252: ldloc.2
-		IL_0253: ldstr "at"
-		IL_0258: ldloc.s 7
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025f: stloc.s 8
-		IL_0261: ldloc.s 5
-		IL_0263: ldloc.s 8
-		IL_0265: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026a: pop
-		IL_026b: ldloc.3
-		IL_026c: ldstr "slice"
-		IL_0271: ldc.r8 1
-		IL_027a: box [System.Runtime]System.Double
-		IL_027f: ldc.r8 3
-		IL_0288: box [System.Runtime]System.Double
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0292: stloc.s 4
-		IL_0294: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0299: stloc.s 5
-		IL_029b: volatile.
-		IL_029d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_02a2: brfalse IL_02b8
+		IL_01e5: volatile.
+		IL_01e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01ec: brfalse IL_020f
 
-		IL_02a7: ldloc.s 4
-		IL_02a9: ldstr "buffer"
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b3: br IL_02ce
+		IL_01f1: ldloc.3
+		IL_01f2: ldstr "includes"
+		IL_01f7: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_0200: box [System.Runtime]System.Double
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_020a: br IL_0232
 
-		IL_02b8: ldloc.s 4
-		IL_02ba: ldstr "buffer"
-		IL_02bf: ldstr "Float64Array_Construct_ArrayBuffer_Search:Modules.Float64Array_Construct_ArrayBuffer_Search:__js_module_init__:92"
-		IL_02c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_020f: ldloc.3
+		IL_0210: ldstr "includes"
+		IL_0215: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_021e: box [System.Runtime]System.Double
+		IL_0223: ldstr "Float64Array_Construct_ArrayBuffer_Search:Modules.Float64Array_Construct_ArrayBuffer_Search:__js_module_init__:67"
+		IL_0228: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02ce: stloc.s 8
-		IL_02d0: ldloc.s 8
-		IL_02d2: ldloc.1
-		IL_02d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02d8: stloc.s 9
-		IL_02da: ldloc.s 9
-		IL_02dc: box [System.Runtime]System.Boolean
-		IL_02e1: stloc.s 10
-		IL_02e3: ldloc.s 5
-		IL_02e5: ldloc.s 10
-		IL_02e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ec: pop
-		IL_02ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f2: stloc.s 5
-		IL_02f4: ldloc.s 4
-		IL_02f6: ldc.r8 0.0
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0304: stloc.s 8
-		IL_0306: ldloc.s 5
-		IL_0308: ldloc.s 8
-		IL_030a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_030f: pop
-		IL_0310: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0315: stloc.s 5
-		IL_0317: ldloc.s 4
-		IL_0319: ldc.r8 1
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0327: stloc.s 8
-		IL_0329: ldloc.s 5
-		IL_032b: ldloc.s 8
-		IL_032d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0332: pop
-		IL_0333: ret
+		IL_0232: stloc.s 8
+		IL_0234: ldloc.s 5
+		IL_0236: ldloc.s 8
+		IL_0238: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_023d: pop
+		IL_023e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0243: stloc.s 5
+		IL_0245: volatile.
+		IL_0247: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_024c: brfalse IL_026f
+
+		IL_0251: ldloc.3
+		IL_0252: ldstr "indexOf"
+		IL_0257: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_0260: box [System.Runtime]System.Double
+		IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026a: br IL_0292
+
+		IL_026f: ldloc.3
+		IL_0270: ldstr "indexOf"
+		IL_0275: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_027e: box [System.Runtime]System.Double
+		IL_0283: ldstr "Float64Array_Construct_ArrayBuffer_Search:Modules.Float64Array_Construct_ArrayBuffer_Search:__js_module_init__:73"
+		IL_0288: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0292: stloc.s 8
+		IL_0294: ldloc.s 5
+		IL_0296: ldloc.s 8
+		IL_0298: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029d: pop
+		IL_029e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a3: stloc.s 5
+		IL_02a5: ldc.r8 1
+		IL_02ae: neg
+		IL_02af: stloc.s 6
+		IL_02b1: ldloc.s 6
+		IL_02b3: box [System.Runtime]System.Double
+		IL_02b8: stloc.s 7
+		IL_02ba: volatile.
+		IL_02bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_02c1: brfalse IL_02d8
+
+		IL_02c6: ldloc.2
+		IL_02c7: ldstr "at"
+		IL_02cc: ldloc.s 7
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d3: br IL_02ef
+
+		IL_02d8: ldloc.2
+		IL_02d9: ldstr "at"
+		IL_02de: ldloc.s 7
+		IL_02e0: ldstr "Float64Array_Construct_ArrayBuffer_Search:Modules.Float64Array_Construct_ArrayBuffer_Search:__js_module_init__:80"
+		IL_02e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02ef: stloc.s 8
+		IL_02f1: ldloc.s 5
+		IL_02f3: ldloc.s 8
+		IL_02f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02fa: pop
+		IL_02fb: ldloc.3
+		IL_02fc: ldstr "slice"
+		IL_0301: ldc.r8 1
+		IL_030a: box [System.Runtime]System.Double
+		IL_030f: ldc.r8 3
+		IL_0318: box [System.Runtime]System.Double
+		IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0322: stloc.s 4
+		IL_0324: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0329: stloc.s 5
+		IL_032b: volatile.
+		IL_032d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0332: brfalse IL_0348
+
+		IL_0337: ldloc.s 4
+		IL_0339: ldstr "buffer"
+		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0343: br IL_035e
+
+		IL_0348: ldloc.s 4
+		IL_034a: ldstr "buffer"
+		IL_034f: ldstr "Float64Array_Construct_ArrayBuffer_Search:Modules.Float64Array_Construct_ArrayBuffer_Search:__js_module_init__:92"
+		IL_0354: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_035e: stloc.s 8
+		IL_0360: ldloc.s 8
+		IL_0362: ldloc.1
+		IL_0363: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0368: stloc.s 9
+		IL_036a: ldloc.s 9
+		IL_036c: box [System.Runtime]System.Boolean
+		IL_0371: stloc.s 10
+		IL_0373: ldloc.s 5
+		IL_0375: ldloc.s 10
+		IL_0377: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_037c: pop
+		IL_037d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0382: stloc.s 5
+		IL_0384: ldloc.s 4
+		IL_0386: ldc.r8 0.0
+		IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0394: stloc.s 8
+		IL_0396: ldloc.s 5
+		IL_0398: ldloc.s 8
+		IL_039a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_039f: pop
+		IL_03a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a5: stloc.s 5
+		IL_03a7: ldloc.s 4
+		IL_03a9: ldc.r8 1
+		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_03b7: stloc.s 8
+		IL_03b9: ldloc.s 5
+		IL_03bb: ldloc.s 8
+		IL_03bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03c2: pop
+		IL_03c3: ret
 	} // end of method Float64Array_Construct_ArrayBuffer_Search::__js_module_init__
 
 } // end of class Modules.Float64Array_Construct_ArrayBuffer_Search
@@ -393,6 +434,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 439 (0x1b7)
+		// Code size: 576 (0x240)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf/Scope,
@@ -136,110 +136,149 @@
 		IL_0050: stloc.1
 		IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0056: stloc.3
-		IL_0057: ldloc.1
-		IL_0058: ldstr "lastIndexOf"
-		IL_005d: ldc.r8 2
-		IL_0066: box [System.Runtime]System.Double
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0070: stloc.s 4
-		IL_0072: ldloc.3
-		IL_0073: ldloc.s 4
-		IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007a: pop
-		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0080: stloc.3
+		IL_0057: volatile.
+		IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005e: brfalse IL_0081
+
+		IL_0063: ldloc.1
+		IL_0064: ldstr "lastIndexOf"
+		IL_0069: ldc.r8 2
+		IL_0072: box [System.Runtime]System.Double
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007c: br IL_00a4
+
 		IL_0081: ldloc.1
-		IL_0082: ldstr "fill"
-		IL_0087: ldc.r8 9
+		IL_0082: ldstr "lastIndexOf"
+		IL_0087: ldc.r8 2
 		IL_0090: box [System.Runtime]System.Double
-		IL_0095: ldc.r8 1
-		IL_009e: box [System.Runtime]System.Double
-		IL_00a3: ldc.r8 3
-		IL_00ac: box [System.Runtime]System.Double
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b6: stloc.s 4
-		IL_00b8: ldloc.s 4
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bf: ldstr "join"
-		IL_00c4: ldstr "|"
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ce: stloc.s 4
-		IL_00d0: ldloc.3
-		IL_00d1: ldloc.s 4
-		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d8: pop
-		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00de: stloc.3
-		IL_00df: volatile.
-		IL_00e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_00e6: brfalse IL_00fb
+		IL_0095: ldstr "Int32Array_Fill_Reverse_Join_LastIndexOf:Modules.Int32Array_Fill_Reverse_Join_LastIndexOf:__js_module_init__:15"
+		IL_009a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00eb: ldloc.1
-		IL_00ec: ldstr "reverse"
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00f6: br IL_0110
+		IL_00a4: stloc.s 4
+		IL_00a6: ldloc.3
+		IL_00a7: ldloc.s 4
+		IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ae: pop
+		IL_00af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b4: stloc.3
+		IL_00b5: ldloc.1
+		IL_00b6: ldstr "fill"
+		IL_00bb: ldc.r8 9
+		IL_00c4: box [System.Runtime]System.Double
+		IL_00c9: ldc.r8 1
+		IL_00d2: box [System.Runtime]System.Double
+		IL_00d7: ldc.r8 3
+		IL_00e0: box [System.Runtime]System.Double
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00ea: stloc.s 4
+		IL_00ec: ldloc.s 4
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f3: volatile.
+		IL_00f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00fa: brfalse IL_0113
 
-		IL_00fb: ldloc.1
-		IL_00fc: ldstr "reverse"
-		IL_0101: ldstr "Int32Array_Fill_Reverse_Join_LastIndexOf:Modules.Int32Array_Fill_Reverse_Join_LastIndexOf:__js_module_init__:32"
-		IL_0106: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_00ff: ldstr "join"
+		IL_0104: ldstr "|"
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010e: br IL_012c
 
-		IL_0110: stloc.s 4
-		IL_0112: ldloc.s 4
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0119: volatile.
-		IL_011b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0120: brfalse IL_0134
+		IL_0113: ldstr "join"
+		IL_0118: ldstr "|"
+		IL_011d: ldstr "Int32Array_Fill_Reverse_Join_LastIndexOf:Modules.Int32Array_Fill_Reverse_Join_LastIndexOf:__js_module_init__:28"
+		IL_0122: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0125: ldstr "toString"
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_012f: br IL_0148
+		IL_012c: stloc.s 4
+		IL_012e: ldloc.3
+		IL_012f: ldloc.s 4
+		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0136: pop
+		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013c: stloc.3
+		IL_013d: volatile.
+		IL_013f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0144: brfalse IL_0159
 
-		IL_0134: ldstr "toString"
-		IL_0139: ldstr "Int32Array_Fill_Reverse_Join_LastIndexOf:Modules.Int32Array_Fill_Reverse_Join_LastIndexOf:__js_module_init__:34"
-		IL_013e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0149: ldloc.1
+		IL_014a: ldstr "reverse"
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0154: br IL_016e
 
-		IL_0148: stloc.s 4
-		IL_014a: ldloc.3
-		IL_014b: ldloc.s 4
-		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0152: pop
-		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0158: stloc.3
 		IL_0159: ldloc.1
-		IL_015a: ldstr "toString"
-		IL_015f: ldstr "|"
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0169: stloc.s 4
-		IL_016b: ldloc.3
-		IL_016c: ldloc.s 4
-		IL_016e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0173: pop
-		IL_0174: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0179: stloc.3
-		IL_017a: volatile.
-		IL_017c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0181: brfalse IL_0196
+		IL_015a: ldstr "reverse"
+		IL_015f: ldstr "Int32Array_Fill_Reverse_Join_LastIndexOf:Modules.Int32Array_Fill_Reverse_Join_LastIndexOf:__js_module_init__:32"
+		IL_0164: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0186: ldloc.1
-		IL_0187: ldstr "toLocaleString"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0191: br IL_01ab
+		IL_016e: stloc.s 4
+		IL_0170: ldloc.s 4
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0177: volatile.
+		IL_0179: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_017e: brfalse IL_0192
 
-		IL_0196: ldloc.1
-		IL_0197: ldstr "toLocaleString"
-		IL_019c: ldstr "Int32Array_Fill_Reverse_Join_LastIndexOf:Modules.Int32Array_Fill_Reverse_Join_LastIndexOf:__js_module_init__:43"
-		IL_01a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0183: ldstr "toString"
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_018d: br IL_01a6
 
-		IL_01ab: stloc.s 4
-		IL_01ad: ldloc.3
-		IL_01ae: ldloc.s 4
-		IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b5: pop
-		IL_01b6: ret
+		IL_0192: ldstr "toString"
+		IL_0197: ldstr "Int32Array_Fill_Reverse_Join_LastIndexOf:Modules.Int32Array_Fill_Reverse_Join_LastIndexOf:__js_module_init__:34"
+		IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_01a6: stloc.s 4
+		IL_01a8: ldloc.3
+		IL_01a9: ldloc.s 4
+		IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b0: pop
+		IL_01b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b6: stloc.3
+		IL_01b7: volatile.
+		IL_01b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01be: brfalse IL_01d8
+
+		IL_01c3: ldloc.1
+		IL_01c4: ldstr "toString"
+		IL_01c9: ldstr "|"
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d3: br IL_01f2
+
+		IL_01d8: ldloc.1
+		IL_01d9: ldstr "toString"
+		IL_01de: ldstr "|"
+		IL_01e3: ldstr "Int32Array_Fill_Reverse_Join_LastIndexOf:Modules.Int32Array_Fill_Reverse_Join_LastIndexOf:__js_module_init__:39"
+		IL_01e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01f2: stloc.s 4
+		IL_01f4: ldloc.3
+		IL_01f5: ldloc.s 4
+		IL_01f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01fc: pop
+		IL_01fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0202: stloc.3
+		IL_0203: volatile.
+		IL_0205: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_020a: brfalse IL_021f
+
+		IL_020f: ldloc.1
+		IL_0210: ldstr "toLocaleString"
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_021a: br IL_0234
+
+		IL_021f: ldloc.1
+		IL_0220: ldstr "toLocaleString"
+		IL_0225: ldstr "Int32Array_Fill_Reverse_Join_LastIndexOf:Modules.Int32Array_Fill_Reverse_Join_LastIndexOf:__js_module_init__:43"
+		IL_022a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0234: stloc.s 4
+		IL_0236: ldloc.3
+		IL_0237: ldloc.s 4
+		IL_0239: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_023e: pop
+		IL_023f: ret
 	} // end of method Int32Array_Fill_Reverse_Join_LastIndexOf::__js_module_init__
 
 } // end of class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf
@@ -272,6 +311,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_RelativeIndices.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Slice_RelativeIndices.verified.txt
@@ -183,7 +183,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 720 (0x2d0)
+		// Code size: 772 (0x304)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Slice_RelativeIndices/Scope,
@@ -394,33 +394,47 @@
 		IL_026d: pop
 		IL_026e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0273: stloc.s 10
-		IL_0275: ldloc.1
-		IL_0276: ldstr "slice"
-		IL_027b: ldc.r8 10
-		IL_0284: box [System.Runtime]System.Double
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_028e: stloc.s 11
-		IL_0290: volatile.
-		IL_0292: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0297: brfalse IL_02ad
+		IL_0275: volatile.
+		IL_0277: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_027c: brfalse IL_029f
 
-		IL_029c: ldloc.s 11
-		IL_029e: ldstr "length"
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a8: br IL_02c3
+		IL_0281: ldloc.1
+		IL_0282: ldstr "slice"
+		IL_0287: ldc.r8 10
+		IL_0290: box [System.Runtime]System.Double
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029a: br IL_02c2
 
-		IL_02ad: ldloc.s 11
-		IL_02af: ldstr "length"
-		IL_02b4: ldstr "Int32Array_Slice_RelativeIndices:Modules.Int32Array_Slice_RelativeIndices:__js_module_init__:93"
-		IL_02b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_029f: ldloc.1
+		IL_02a0: ldstr "slice"
+		IL_02a5: ldc.r8 10
+		IL_02ae: box [System.Runtime]System.Double
+		IL_02b3: ldstr "Int32Array_Slice_RelativeIndices:Modules.Int32Array_Slice_RelativeIndices:__js_module_init__:91"
+		IL_02b8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02c3: stloc.s 11
-		IL_02c5: ldloc.s 10
-		IL_02c7: ldloc.s 11
-		IL_02c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ce: pop
-		IL_02cf: ret
+		IL_02c2: stloc.s 11
+		IL_02c4: volatile.
+		IL_02c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_02cb: brfalse IL_02e1
+
+		IL_02d0: ldloc.s 11
+		IL_02d2: ldstr "length"
+		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02dc: br IL_02f7
+
+		IL_02e1: ldloc.s 11
+		IL_02e3: ldstr "length"
+		IL_02e8: ldstr "Int32Array_Slice_RelativeIndices:Modules.Int32Array_Slice_RelativeIndices:__js_module_init__:93"
+		IL_02ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02f7: stloc.s 11
+		IL_02f9: ldloc.s 10
+		IL_02fb: ldloc.s 11
+		IL_02fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0302: pop
+		IL_0303: ret
 	} // end of method Int32Array_Slice_RelativeIndices::__js_module_init__
 
 } // end of class Modules.Int32Array_Slice_RelativeIndices
@@ -454,6 +468,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
 	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ConstructorAndSet_Errors.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ConstructorAndSet_Errors.verified.txt
@@ -257,7 +257,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1040 (0x410)
+		// Code size: 1085 (0x43d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_ConstructorAndSet_Errors/Scope,
@@ -581,89 +581,103 @@
 		.try
 		{
 			IL_0330: nop
-			IL_0331: ldloc.s 7
-			IL_0333: ldstr "set"
-			IL_0338: ldc.i4.0
-			IL_0339: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0343: pop
-			IL_0344: leave IL_040c
+			IL_0331: volatile.
+			IL_0333: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0338: brfalse IL_0354
+
+			IL_033d: ldloc.s 7
+			IL_033f: ldstr "set"
+			IL_0344: ldc.i4.0
+			IL_0345: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_034f: br IL_0370
+
+			IL_0354: ldloc.s 7
+			IL_0356: ldstr "set"
+			IL_035b: ldc.i4.0
+			IL_035c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0361: ldstr "TypedArray_ConstructorAndSet_Errors:Modules.TypedArray_ConstructorAndSet_Errors:__js_module_init__:112"
+			IL_0366: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0370: pop
+			IL_0371: leave IL_0439
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0349: stloc.s 11
-			IL_034b: ldloc.s 11
-			IL_034d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0352: dup
-			IL_0353: brtrue IL_0369
+			IL_0376: stloc.s 11
+			IL_0378: ldloc.s 11
+			IL_037a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_037f: dup
+			IL_0380: brtrue IL_0396
 
-			IL_0358: pop
-			IL_0359: ldloc.s 11
-			IL_035b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0360: dup
-			IL_0361: brtrue IL_0375
+			IL_0385: pop
+			IL_0386: ldloc.s 11
+			IL_0388: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_038d: dup
+			IL_038e: brtrue IL_03a2
 
-			IL_0366: pop
-			IL_0367: rethrow
+			IL_0393: pop
+			IL_0394: rethrow
 
-			IL_0369: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_036e: stloc.s 12
-			IL_0370: br IL_0377
+			IL_0396: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_039b: stloc.s 12
+			IL_039d: br IL_03a4
 
-			IL_0375: stloc.s 12
+			IL_03a2: stloc.s 12
 
-			IL_0377: ldloc.s 12
-			IL_0379: stloc.s 13
-			IL_037b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0380: stloc.s 15
-			IL_0382: volatile.
-			IL_0384: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_0389: brfalse IL_039f
+			IL_03a4: ldloc.s 12
+			IL_03a6: stloc.s 13
+			IL_03a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ad: stloc.s 15
+			IL_03af: volatile.
+			IL_03b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_03b6: brfalse IL_03cc
 
-			IL_038e: ldloc.s 13
-			IL_0390: ldstr "name"
-			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_039a: br IL_03b5
+			IL_03bb: ldloc.s 13
+			IL_03bd: ldstr "name"
+			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c7: br IL_03e2
 
-			IL_039f: ldloc.s 13
-			IL_03a1: ldstr "name"
-			IL_03a6: ldstr "TypedArray_ConstructorAndSet_Errors:Modules.TypedArray_ConstructorAndSet_Errors:__js_module_init__:123"
-			IL_03ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03cc: ldloc.s 13
+			IL_03ce: ldstr "name"
+			IL_03d3: ldstr "TypedArray_ConstructorAndSet_Errors:Modules.TypedArray_ConstructorAndSet_Errors:__js_module_init__:123"
+			IL_03d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03b5: stloc.s 19
-			IL_03b7: ldloc.s 15
-			IL_03b9: ldloc.s 19
-			IL_03bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03c0: pop
-			IL_03c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03c6: stloc.s 15
-			IL_03c8: volatile.
-			IL_03ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_03cf: brfalse IL_03e5
+			IL_03e2: stloc.s 19
+			IL_03e4: ldloc.s 15
+			IL_03e6: ldloc.s 19
+			IL_03e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03ed: pop
+			IL_03ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03f3: stloc.s 15
+			IL_03f5: volatile.
+			IL_03f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_03fc: brfalse IL_0412
 
-			IL_03d4: ldloc.s 13
-			IL_03d6: ldstr "message"
-			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e0: br IL_03fb
+			IL_0401: ldloc.s 13
+			IL_0403: ldstr "message"
+			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040d: br IL_0428
 
-			IL_03e5: ldloc.s 13
-			IL_03e7: ldstr "message"
-			IL_03ec: ldstr "TypedArray_ConstructorAndSet_Errors:Modules.TypedArray_ConstructorAndSet_Errors:__js_module_init__:128"
-			IL_03f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-			IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0412: ldloc.s 13
+			IL_0414: ldstr "message"
+			IL_0419: ldstr "TypedArray_ConstructorAndSet_Errors:Modules.TypedArray_ConstructorAndSet_Errors:__js_module_init__:128"
+			IL_041e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03fb: stloc.s 19
-			IL_03fd: ldloc.s 15
-			IL_03ff: ldloc.s 19
-			IL_0401: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0406: pop
-			IL_0407: leave IL_040c
+			IL_0428: stloc.s 19
+			IL_042a: ldloc.s 15
+			IL_042c: ldloc.s 19
+			IL_042e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0433: pop
+			IL_0434: leave IL_0439
 		} // end handler
 
-		IL_040c: ldnull
-		IL_040d: stloc.s 14
-		IL_040f: ret
+		IL_0439: ldnull
+		IL_043a: stloc.s 14
+		IL_043c: ret
 	} // end of method TypedArray_ConstructorAndSet_Errors::__js_module_init__
 
 } // end of class Modules.TypedArray_ConstructorAndSet_Errors
@@ -702,6 +716,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -508,7 +508,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1130 (0x46a)
+		// Code size: 1182 (0x49e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/Scope,
@@ -557,352 +557,366 @@
 		IL_004e: stloc.1
 		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0054: stloc.s 10
-		IL_0056: ldloc.1
-		IL_0057: ldstr "includes"
-		IL_005c: ldc.r8 1
-		IL_0065: box [System.Runtime]System.Double
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006f: stloc.s 11
-		IL_0071: ldloc.s 11
-		IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_0078: stloc.s 12
-		IL_007a: ldloc.s 12
-		IL_007c: brfalse IL_008c
+		IL_0056: volatile.
+		IL_0058: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005d: brfalse IL_0080
 
-		IL_0081: ldstr "cold included"
-		IL_0086: stloc.2
-		IL_0087: br IL_0092
+		IL_0062: ldloc.1
+		IL_0063: ldstr "includes"
+		IL_0068: ldc.r8 1
+		IL_0071: box [System.Runtime]System.Double
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007b: br IL_00a3
 
-		IL_008c: ldstr "cold missing"
-		IL_0091: stloc.2
+		IL_0080: ldloc.1
+		IL_0081: ldstr "includes"
+		IL_0086: ldc.r8 1
+		IL_008f: box [System.Runtime]System.Double
+		IL_0094: ldstr "TypedArray_ReceiverCandidate_GuardedOverrides:Modules.TypedArray_ReceiverCandidate_GuardedOverrides:__js_module_init__:18"
+		IL_0099: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0092: ldloc.s 10
-		IL_0094: ldloc.2
-		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009a: pop
-		IL_009b: ldc.r8 0.0
-		IL_00a4: stloc.3
-		// loop start (head: IL_00a5)
-			IL_00a5: ldloc.3
-			IL_00a6: stloc.s 13
-			IL_00a8: ldloc.s 13
-			IL_00aa: ldc.r8 1
-			IL_00b3: clt
-			IL_00b5: brfalse IL_0469
+		IL_00a3: stloc.s 11
+		IL_00a5: ldloc.s 11
+		IL_00a7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_00ac: stloc.s 12
+		IL_00ae: ldloc.s 12
+		IL_00b0: brfalse IL_00c0
 
-			IL_00ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00bf: stloc.s 10
-			IL_00c1: ldc.i4.2
-			IL_00c2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00c7: brfalse IL_010d
+		IL_00b5: ldstr "cold included"
+		IL_00ba: stloc.2
+		IL_00bb: br IL_00c6
 
-			IL_00cc: ldloc.1
-			IL_00cd: ldstr "includes"
-			IL_00d2: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_00d7: brtrue IL_010d
+		IL_00c0: ldstr "cold missing"
+		IL_00c5: stloc.2
 
-			IL_00dc: ldloc.1
-			IL_00dd: ldc.i4.2
-			IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00e3: brfalse IL_010d
+		IL_00c6: ldloc.s 10
+		IL_00c8: ldloc.2
+		IL_00c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ce: pop
+		IL_00cf: ldc.r8 0.0
+		IL_00d8: stloc.3
+		// loop start (head: IL_00d9)
+			IL_00d9: ldloc.3
+			IL_00da: stloc.s 13
+			IL_00dc: ldloc.s 13
+			IL_00de: ldc.r8 1
+			IL_00e7: clt
+			IL_00e9: brfalse IL_049d
 
-			IL_00e8: ldloc.1
-			IL_00e9: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
-			IL_00ee: ldc.r8 2
-			IL_00f7: box [System.Runtime]System.Double
-			IL_00fc: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
-			IL_0101: box [System.Runtime]System.Boolean
-			IL_0106: stloc.s 11
-			IL_0108: br IL_0128
+			IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00f3: stloc.s 10
+			IL_00f5: ldc.i4.2
+			IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00fb: brfalse IL_0141
 
-			IL_010d: ldloc.1
-			IL_010e: ldstr "includes"
-			IL_0113: ldc.r8 2
-			IL_011c: box [System.Runtime]System.Double
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0126: stloc.s 11
+			IL_0100: ldloc.1
+			IL_0101: ldstr "includes"
+			IL_0106: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_010b: brtrue IL_0141
 
-			IL_0128: ldloc.s 11
-			IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012f: stloc.s 12
-			IL_0131: ldloc.s 12
-			IL_0133: brfalse IL_0144
+			IL_0110: ldloc.1
+			IL_0111: ldc.i4.2
+			IL_0112: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0117: brfalse IL_0141
 
-			IL_0138: ldstr "included"
-			IL_013d: stloc.s 4
-			IL_013f: br IL_014b
+			IL_011c: ldloc.1
+			IL_011d: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			IL_0122: ldc.r8 2
+			IL_012b: box [System.Runtime]System.Double
+			IL_0130: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+			IL_0135: box [System.Runtime]System.Boolean
+			IL_013a: stloc.s 11
+			IL_013c: br IL_015c
 
-			IL_0144: ldstr "missing"
-			IL_0149: stloc.s 4
+			IL_0141: ldloc.1
+			IL_0142: ldstr "includes"
+			IL_0147: ldc.r8 2
+			IL_0150: box [System.Runtime]System.Double
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_015a: stloc.s 11
 
-			IL_014b: ldloc.s 10
-			IL_014d: ldloc.s 4
-			IL_014f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0154: pop
-			IL_0155: ldc.i4.1
-			IL_0156: newarr [System.Runtime]System.Object
-			IL_015b: dup
-			IL_015c: ldc.i4.0
-			IL_015d: ldloc.0
-			IL_015e: stelem.ref
-			IL_015f: stloc.s 14
-			IL_0161: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L10C24/FunctionObject::.ctor()
-			IL_0166: ldc.i4.0
-			IL_0167: conv.r8
-			IL_0168: ldstr ""
-			IL_016d: ldc.i4.0
-			IL_016e: ldc.i4.1
-			IL_016f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L10C24/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0174: stloc.s 15
-			IL_0176: ldloc.1
-			IL_0177: ldstr "includes"
-			IL_017c: ldloc.s 15
-			IL_017e: ldc.i4.1
-			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0184: pop
-			IL_0185: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_018a: stloc.s 10
-			IL_018c: ldc.i4.2
-			IL_018d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0192: brfalse IL_01d8
+			IL_015c: ldloc.s 11
+			IL_015e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0163: stloc.s 12
+			IL_0165: ldloc.s 12
+			IL_0167: brfalse IL_0178
 
-			IL_0197: ldloc.1
-			IL_0198: ldstr "includes"
-			IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_01a2: brtrue IL_01d8
+			IL_016c: ldstr "included"
+			IL_0171: stloc.s 4
+			IL_0173: br IL_017f
 
-			IL_01a7: ldloc.1
-			IL_01a8: ldc.i4.2
-			IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_01ae: brfalse IL_01d8
+			IL_0178: ldstr "missing"
+			IL_017d: stloc.s 4
 
-			IL_01b3: ldloc.1
-			IL_01b4: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
-			IL_01b9: ldc.r8 2
-			IL_01c2: box [System.Runtime]System.Double
-			IL_01c7: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
-			IL_01cc: box [System.Runtime]System.Boolean
-			IL_01d1: stloc.s 11
-			IL_01d3: br IL_01f3
+			IL_017f: ldloc.s 10
+			IL_0181: ldloc.s 4
+			IL_0183: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0188: pop
+			IL_0189: ldc.i4.1
+			IL_018a: newarr [System.Runtime]System.Object
+			IL_018f: dup
+			IL_0190: ldc.i4.0
+			IL_0191: ldloc.0
+			IL_0192: stelem.ref
+			IL_0193: stloc.s 14
+			IL_0195: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L10C24/FunctionObject::.ctor()
+			IL_019a: ldc.i4.0
+			IL_019b: conv.r8
+			IL_019c: ldstr ""
+			IL_01a1: ldc.i4.0
+			IL_01a2: ldc.i4.1
+			IL_01a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L10C24/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01a8: stloc.s 15
+			IL_01aa: ldloc.1
+			IL_01ab: ldstr "includes"
+			IL_01b0: ldloc.s 15
+			IL_01b2: ldc.i4.1
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_01b8: pop
+			IL_01b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01be: stloc.s 10
+			IL_01c0: ldc.i4.2
+			IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01c6: brfalse IL_020c
 
-			IL_01d8: ldloc.1
-			IL_01d9: ldstr "includes"
-			IL_01de: ldc.r8 2
-			IL_01e7: box [System.Runtime]System.Double
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01f1: stloc.s 11
+			IL_01cb: ldloc.1
+			IL_01cc: ldstr "includes"
+			IL_01d1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_01d6: brtrue IL_020c
 
-			IL_01f3: ldloc.s 11
-			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01fa: stloc.s 12
-			IL_01fc: ldloc.s 12
-			IL_01fe: brfalse IL_020f
+			IL_01db: ldloc.1
+			IL_01dc: ldc.i4.2
+			IL_01dd: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01e2: brfalse IL_020c
 
-			IL_0203: ldstr "own"
-			IL_0208: stloc.s 5
-			IL_020a: br IL_0216
+			IL_01e7: ldloc.1
+			IL_01e8: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			IL_01ed: ldc.r8 2
+			IL_01f6: box [System.Runtime]System.Double
+			IL_01fb: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+			IL_0200: box [System.Runtime]System.Boolean
+			IL_0205: stloc.s 11
+			IL_0207: br IL_0227
 
-			IL_020f: ldstr "own override"
-			IL_0214: stloc.s 5
+			IL_020c: ldloc.1
+			IL_020d: ldstr "includes"
+			IL_0212: ldc.r8 2
+			IL_021b: box [System.Runtime]System.Double
+			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0225: stloc.s 11
 
-			IL_0216: ldloc.s 10
-			IL_0218: ldloc.s 5
-			IL_021a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_021f: pop
-			IL_0220: ldloc.1
-			IL_0221: ldstr "includes"
-			IL_0226: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-			IL_022b: stloc.s 12
-			IL_022d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0232: stloc.s 16
-			IL_0234: ldc.i4.1
-			IL_0235: newarr [System.Runtime]System.Object
-			IL_023a: dup
-			IL_023b: ldc.i4.0
-			IL_023c: ldloc.0
-			IL_023d: stelem.ref
-			IL_023e: stloc.s 14
-			IL_0240: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject::.ctor()
-			IL_0245: ldc.i4.0
-			IL_0246: conv.r8
-			IL_0247: ldstr ""
-			IL_024c: ldc.i4.0
-			IL_024d: ldc.i4.1
-			IL_024e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0253: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject>(!!0)
-			IL_0258: stloc.s 17
-			IL_025a: ldloc.s 16
-			IL_025c: ldstr "includes"
-			IL_0261: ldloc.s 17
-			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0268: pop
-			IL_0269: ldloc.1
-			IL_026a: ldloc.s 16
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-			IL_0271: pop
-			IL_0272: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0277: stloc.s 10
-			IL_0279: ldc.i4.2
-			IL_027a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_027f: brfalse IL_02c5
+			IL_0227: ldloc.s 11
+			IL_0229: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_022e: stloc.s 12
+			IL_0230: ldloc.s 12
+			IL_0232: brfalse IL_0243
 
-			IL_0284: ldloc.1
-			IL_0285: ldstr "includes"
-			IL_028a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_028f: brtrue IL_02c5
+			IL_0237: ldstr "own"
+			IL_023c: stloc.s 5
+			IL_023e: br IL_024a
 
-			IL_0294: ldloc.1
-			IL_0295: ldc.i4.2
-			IL_0296: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_029b: brfalse IL_02c5
+			IL_0243: ldstr "own override"
+			IL_0248: stloc.s 5
 
-			IL_02a0: ldloc.1
-			IL_02a1: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
-			IL_02a6: ldc.r8 2
-			IL_02af: box [System.Runtime]System.Double
-			IL_02b4: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
-			IL_02b9: box [System.Runtime]System.Boolean
-			IL_02be: stloc.s 11
-			IL_02c0: br IL_02e0
+			IL_024a: ldloc.s 10
+			IL_024c: ldloc.s 5
+			IL_024e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0253: pop
+			IL_0254: ldloc.1
+			IL_0255: ldstr "includes"
+			IL_025a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_025f: stloc.s 12
+			IL_0261: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0266: stloc.s 16
+			IL_0268: ldc.i4.1
+			IL_0269: newarr [System.Runtime]System.Object
+			IL_026e: dup
+			IL_026f: ldc.i4.0
+			IL_0270: ldloc.0
+			IL_0271: stelem.ref
+			IL_0272: stloc.s 14
+			IL_0274: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject::.ctor()
+			IL_0279: ldc.i4.0
+			IL_027a: conv.r8
+			IL_027b: ldstr ""
+			IL_0280: ldc.i4.0
+			IL_0281: ldc.i4.1
+			IL_0282: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0287: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject>(!!0)
+			IL_028c: stloc.s 17
+			IL_028e: ldloc.s 16
+			IL_0290: ldstr "includes"
+			IL_0295: ldloc.s 17
+			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_029c: pop
+			IL_029d: ldloc.1
+			IL_029e: ldloc.s 16
+			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_02a5: pop
+			IL_02a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02ab: stloc.s 10
+			IL_02ad: ldc.i4.2
+			IL_02ae: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_02b3: brfalse IL_02f9
 
-			IL_02c5: ldloc.1
-			IL_02c6: ldstr "includes"
-			IL_02cb: ldc.r8 2
-			IL_02d4: box [System.Runtime]System.Double
-			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02de: stloc.s 11
+			IL_02b8: ldloc.1
+			IL_02b9: ldstr "includes"
+			IL_02be: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_02c3: brtrue IL_02f9
 
-			IL_02e0: ldloc.s 11
-			IL_02e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02e7: stloc.s 12
-			IL_02e9: ldloc.s 12
-			IL_02eb: brfalse IL_02fc
+			IL_02c8: ldloc.1
+			IL_02c9: ldc.i4.2
+			IL_02ca: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_02cf: brfalse IL_02f9
 
-			IL_02f0: ldstr "custom"
-			IL_02f5: stloc.s 6
-			IL_02f7: br IL_0303
+			IL_02d4: ldloc.1
+			IL_02d5: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			IL_02da: ldc.r8 2
+			IL_02e3: box [System.Runtime]System.Double
+			IL_02e8: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+			IL_02ed: box [System.Runtime]System.Boolean
+			IL_02f2: stloc.s 11
+			IL_02f4: br IL_0314
 
-			IL_02fc: ldstr "custom override"
-			IL_0301: stloc.s 6
+			IL_02f9: ldloc.1
+			IL_02fa: ldstr "includes"
+			IL_02ff: ldc.r8 2
+			IL_0308: box [System.Runtime]System.Double
+			IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0312: stloc.s 11
 
-			IL_0303: ldloc.s 10
-			IL_0305: ldloc.s 6
-			IL_0307: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_030c: pop
-			IL_030d: ldstr "Int32Array"
-			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0317: volatile.
-			IL_0319: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-			IL_031e: brfalse IL_0332
+			IL_0314: ldloc.s 11
+			IL_0316: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_031b: stloc.s 12
+			IL_031d: ldloc.s 12
+			IL_031f: brfalse IL_0330
 
-			IL_0323: ldstr "prototype"
-			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_032d: br IL_0346
+			IL_0324: ldstr "custom"
+			IL_0329: stloc.s 6
+			IL_032b: br IL_0337
 
-			IL_0332: ldstr "prototype"
-			IL_0337: ldstr "TypedArray_ReceiverCandidate_GuardedOverrides:Modules.TypedArray_ReceiverCandidate_GuardedOverrides:__js_module_init__:102"
-			IL_033c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
-			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0330: ldstr "custom override"
+			IL_0335: stloc.s 6
 
-			IL_0346: stloc.s 11
-			IL_0348: ldloc.1
-			IL_0349: ldloc.s 11
-			IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-			IL_0350: pop
-			IL_0351: ldstr "Int32Array"
-			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_035b: volatile.
-			IL_035d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-			IL_0362: brfalse IL_0376
+			IL_0337: ldloc.s 10
+			IL_0339: ldloc.s 6
+			IL_033b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0340: pop
+			IL_0341: ldstr "Int32Array"
+			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_034b: volatile.
+			IL_034d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0352: brfalse IL_0366
 
-			IL_0367: ldstr "prototype"
-			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0371: br IL_038a
+			IL_0357: ldstr "prototype"
+			IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0361: br IL_037a
 
-			IL_0376: ldstr "prototype"
-			IL_037b: ldstr "TypedArray_ReceiverCandidate_GuardedOverrides:Modules.TypedArray_ReceiverCandidate_GuardedOverrides:__js_module_init__:108"
-			IL_0380: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-			IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0366: ldstr "prototype"
+			IL_036b: ldstr "TypedArray_ReceiverCandidate_GuardedOverrides:Modules.TypedArray_ReceiverCandidate_GuardedOverrides:__js_module_init__:102"
+			IL_0370: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+			IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_038a: stloc.s 11
-			IL_038c: ldc.i4.1
-			IL_038d: newarr [System.Runtime]System.Object
-			IL_0392: dup
-			IL_0393: ldc.i4.0
-			IL_0394: ldloc.0
-			IL_0395: stelem.ref
-			IL_0396: stloc.s 14
-			IL_0398: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L24C36/FunctionObject::.ctor()
-			IL_039d: ldc.i4.0
-			IL_039e: conv.r8
-			IL_039f: ldstr ""
-			IL_03a4: ldc.i4.0
-			IL_03a5: ldc.i4.1
-			IL_03a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L24C36/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_03ab: stloc.s 18
-			IL_03ad: ldloc.s 11
-			IL_03af: ldstr "includes"
-			IL_03b4: ldloc.s 18
-			IL_03b6: ldc.i4.1
-			IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_03bc: pop
-			IL_03bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03c2: stloc.s 10
-			IL_03c4: ldc.i4.2
-			IL_03c5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_03ca: brfalse IL_0410
+			IL_037a: stloc.s 11
+			IL_037c: ldloc.1
+			IL_037d: ldloc.s 11
+			IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_0384: pop
+			IL_0385: ldstr "Int32Array"
+			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_038f: volatile.
+			IL_0391: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_0396: brfalse IL_03aa
 
-			IL_03cf: ldloc.1
-			IL_03d0: ldstr "includes"
-			IL_03d5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_03da: brtrue IL_0410
+			IL_039b: ldstr "prototype"
+			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a5: br IL_03be
 
-			IL_03df: ldloc.1
-			IL_03e0: ldc.i4.2
-			IL_03e1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_03e6: brfalse IL_0410
+			IL_03aa: ldstr "prototype"
+			IL_03af: ldstr "TypedArray_ReceiverCandidate_GuardedOverrides:Modules.TypedArray_ReceiverCandidate_GuardedOverrides:__js_module_init__:108"
+			IL_03b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03eb: ldloc.1
-			IL_03ec: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
-			IL_03f1: ldc.r8 2
-			IL_03fa: box [System.Runtime]System.Double
-			IL_03ff: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
-			IL_0404: box [System.Runtime]System.Boolean
-			IL_0409: stloc.s 11
-			IL_040b: br IL_042b
+			IL_03be: stloc.s 11
+			IL_03c0: ldc.i4.1
+			IL_03c1: newarr [System.Runtime]System.Object
+			IL_03c6: dup
+			IL_03c7: ldc.i4.0
+			IL_03c8: ldloc.0
+			IL_03c9: stelem.ref
+			IL_03ca: stloc.s 14
+			IL_03cc: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L24C36/FunctionObject::.ctor()
+			IL_03d1: ldc.i4.0
+			IL_03d2: conv.r8
+			IL_03d3: ldstr ""
+			IL_03d8: ldc.i4.0
+			IL_03d9: ldc.i4.1
+			IL_03da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L24C36/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_03df: stloc.s 18
+			IL_03e1: ldloc.s 11
+			IL_03e3: ldstr "includes"
+			IL_03e8: ldloc.s 18
+			IL_03ea: ldc.i4.1
+			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_03f0: pop
+			IL_03f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03f6: stloc.s 10
+			IL_03f8: ldc.i4.2
+			IL_03f9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_03fe: brfalse IL_0444
 
-			IL_0410: ldloc.1
-			IL_0411: ldstr "includes"
-			IL_0416: ldc.r8 2
-			IL_041f: box [System.Runtime]System.Double
-			IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0429: stloc.s 11
+			IL_0403: ldloc.1
+			IL_0404: ldstr "includes"
+			IL_0409: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_040e: brtrue IL_0444
 
-			IL_042b: ldloc.s 11
-			IL_042d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0432: stloc.s 12
-			IL_0434: ldloc.s 12
-			IL_0436: brfalse IL_0447
+			IL_0413: ldloc.1
+			IL_0414: ldc.i4.2
+			IL_0415: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_041a: brfalse IL_0444
 
-			IL_043b: ldstr "prototype"
-			IL_0440: stloc.s 7
-			IL_0442: br IL_044e
+			IL_041f: ldloc.1
+			IL_0420: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			IL_0425: ldc.r8 2
+			IL_042e: box [System.Runtime]System.Double
+			IL_0433: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+			IL_0438: box [System.Runtime]System.Boolean
+			IL_043d: stloc.s 11
+			IL_043f: br IL_045f
 
-			IL_0447: ldstr "prototype override"
-			IL_044c: stloc.s 7
+			IL_0444: ldloc.1
+			IL_0445: ldstr "includes"
+			IL_044a: ldc.r8 2
+			IL_0453: box [System.Runtime]System.Double
+			IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_045d: stloc.s 11
 
-			IL_044e: ldloc.s 10
-			IL_0450: ldloc.s 7
-			IL_0452: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0457: pop
-			IL_0458: ldloc.3
-			IL_0459: ldc.r8 1
-			IL_0462: add
-			IL_0463: stloc.3
-			IL_0464: br IL_00a5
+			IL_045f: ldloc.s 11
+			IL_0461: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0466: stloc.s 12
+			IL_0468: ldloc.s 12
+			IL_046a: brfalse IL_047b
+
+			IL_046f: ldstr "prototype"
+			IL_0474: stloc.s 7
+			IL_0476: br IL_0482
+
+			IL_047b: ldstr "prototype override"
+			IL_0480: stloc.s 7
+
+			IL_0482: ldloc.s 10
+			IL_0484: ldloc.s 7
+			IL_0486: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_048b: pop
+			IL_048c: ldloc.3
+			IL_048d: ldc.r8 1
+			IL_0496: add
+			IL_0497: stloc.3
+			IL_0498: br IL_00d9
 		// end loop
 
-		IL_0469: ret
+		IL_049d: ret
 	} // end of method TypedArray_ReceiverCandidate_GuardedOverrides::__js_module_init__
 
 } // end of class Modules.TypedArray_ReceiverCandidate_GuardedOverrides
@@ -934,6 +948,7 @@
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
@@ -278,7 +278,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1059 (0x423)
+		// Code size: 1232 (0x4d0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope,
@@ -338,269 +338,321 @@
 		IL_0091: stloc.1
 		IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0097: stloc.s 12
-		IL_0099: ldloc.1
-		IL_009a: ldstr "join"
-		IL_009f: ldstr "|"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a9: stloc.s 13
-		IL_00ab: ldloc.s 12
-		IL_00ad: ldloc.s 13
-		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b4: pop
-		IL_00b5: ldc.i4.8
-		IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00bb: dup
-		IL_00bc: ldc.r8 32769
-		IL_00c5: neg
-		IL_00c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00cb: dup
-		IL_00cc: ldc.r8 32768
-		IL_00d5: neg
-		IL_00d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00db: dup
-		IL_00dc: ldc.r8 32767
-		IL_00e5: neg
-		IL_00e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00eb: dup
-		IL_00ec: ldc.r8 32767
-		IL_00f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00fa: dup
-		IL_00fb: ldc.r8 32768
-		IL_0104: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0109: dup
-		IL_010a: ldc.r8 32769
-		IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0118: dup
-		IL_0119: ldc.r8 65535
-		IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0127: dup
-		IL_0128: ldc.r8 65536
-		IL_0131: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0136: stloc.s 11
-		IL_0138: ldloc.s 11
-		IL_013a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
-		IL_013f: stloc.2
-		IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0145: stloc.s 12
-		IL_0147: ldloc.2
-		IL_0148: ldstr "join"
-		IL_014d: ldstr "|"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0157: stloc.s 13
-		IL_0159: ldloc.s 12
-		IL_015b: ldloc.s 13
-		IL_015d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0162: pop
-		IL_0163: ldc.i4.8
-		IL_0164: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0169: dup
-		IL_016a: ldc.r8 1
-		IL_0173: neg
-		IL_0174: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0179: dup
-		IL_017a: ldc.r8 0.0
-		IL_0183: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0188: dup
-		IL_0189: ldc.r8 1
-		IL_0192: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0197: dup
-		IL_0198: ldc.r8 255
-		IL_01a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01a6: dup
-		IL_01a7: ldc.r8 256
-		IL_01b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01b5: dup
-		IL_01b6: ldc.r8 257
-		IL_01bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01c4: dup
-		IL_01c5: ldc.r8 511
-		IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01d3: dup
-		IL_01d4: ldc.r8 1.9
-		IL_01dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01e2: stloc.s 11
-		IL_01e4: ldloc.s 11
-		IL_01e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_01eb: stloc.3
-		IL_01ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f1: stloc.s 12
-		IL_01f3: ldloc.3
-		IL_01f4: ldstr "join"
-		IL_01f9: ldstr "|"
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0203: stloc.s 13
-		IL_0205: ldloc.s 12
-		IL_0207: ldloc.s 13
-		IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_020e: pop
-		IL_020f: ldc.i4.s 10
-		IL_0211: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0216: dup
-		IL_0217: ldc.r8 20
-		IL_0220: neg
-		IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0226: dup
-		IL_0227: ldc.r8 0.5
-		IL_0230: neg
-		IL_0231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0236: dup
-		IL_0237: ldc.r8 0.49
-		IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0245: dup
-		IL_0246: ldc.r8 0.5
-		IL_024f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0254: dup
-		IL_0255: ldc.r8 1.5
-		IL_025e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0263: dup
-		IL_0264: ldc.r8 2.5
-		IL_026d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0272: dup
-		IL_0273: ldc.r8 254.6
-		IL_027c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0281: dup
-		IL_0282: ldc.r8 255.4
-		IL_028b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0290: dup
-		IL_0291: ldc.r8 300
-		IL_029a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_029f: dup
-		IL_02a0: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_02a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ae: stloc.s 11
-		IL_02b0: ldloc.s 11
-		IL_02b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
-		IL_02b7: stloc.s 4
-		IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02be: stloc.s 12
-		IL_02c0: ldloc.s 4
-		IL_02c2: ldstr "join"
-		IL_02c7: ldstr "|"
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d1: stloc.s 13
-		IL_02d3: ldloc.s 12
-		IL_02d5: ldloc.s 13
-		IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02dc: pop
-		IL_02dd: ldloc.0
-		IL_02de: ldc.r8 0.0
-		IL_02e7: box [System.Runtime]System.Double
-		IL_02ec: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02f6: stloc.s 14
-		IL_02f8: ldc.i4.1
-		IL_02f9: newarr [System.Runtime]System.Object
-		IL_02fe: dup
-		IL_02ff: ldc.i4.0
-		IL_0300: ldloc.0
-		IL_0301: stelem.ref
-		IL_0302: stloc.s 15
-		IL_0304: ldloc.s 15
-		IL_0306: ldc.i4.0
-		IL_0307: ldelem.ref
-		IL_0308: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
-		IL_030d: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject::.ctor(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope)
-		IL_0312: ldc.i4.0
-		IL_0313: conv.r8
-		IL_0314: ldstr ""
-		IL_0319: ldc.i4.0
-		IL_031a: ldc.i4.1
-		IL_031b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0320: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0)
-		IL_0325: stloc.s 16
-		IL_0327: ldloc.s 14
-		IL_0329: ldstr "valueOf"
-		IL_032e: ldloc.s 16
-		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0335: pop
-		IL_0336: ldloc.s 14
-		IL_0338: stloc.s 5
-		IL_033a: ldc.r8 0.0
-		IL_0343: box [System.Runtime]System.Double
-		IL_0348: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_034d: stloc.s 6
-		IL_034f: ldloc.s 6
-		IL_0351: ldc.r8 0.0
-		IL_035a: ldloc.s 5
-		IL_035c: ldc.i4.1
-		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_0362: pop
-		IL_0363: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0368: stloc.s 12
-		IL_036a: ldloc.0
-		IL_036b: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_0370: stloc.s 13
-		IL_0372: ldloc.s 12
-		IL_0374: ldloc.s 13
-		IL_0376: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_037b: pop
+		IL_0099: volatile.
+		IL_009b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00a0: brfalse IL_00ba
+
+		IL_00a5: ldloc.1
+		IL_00a6: ldstr "join"
+		IL_00ab: ldstr "|"
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b5: br IL_00d4
+
+		IL_00ba: ldloc.1
+		IL_00bb: ldstr "join"
+		IL_00c0: ldstr "|"
+		IL_00c5: ldstr "TypedArray_SignedAndClamped_ConversionSemantics:Modules.TypedArray_SignedAndClamped_ConversionSemantics:__js_module_init__:21"
+		IL_00ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d4: stloc.s 13
+		IL_00d6: ldloc.s 12
+		IL_00d8: ldloc.s 13
+		IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00df: pop
+		IL_00e0: ldc.i4.8
+		IL_00e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00e6: dup
+		IL_00e7: ldc.r8 32769
+		IL_00f0: neg
+		IL_00f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00f6: dup
+		IL_00f7: ldc.r8 32768
+		IL_0100: neg
+		IL_0101: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0106: dup
+		IL_0107: ldc.r8 32767
+		IL_0110: neg
+		IL_0111: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0116: dup
+		IL_0117: ldc.r8 32767
+		IL_0120: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0125: dup
+		IL_0126: ldc.r8 32768
+		IL_012f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0134: dup
+		IL_0135: ldc.r8 32769
+		IL_013e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0143: dup
+		IL_0144: ldc.r8 65535
+		IL_014d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0152: dup
+		IL_0153: ldc.r8 65536
+		IL_015c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0161: stloc.s 11
+		IL_0163: ldloc.s 11
+		IL_0165: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
+		IL_016a: stloc.2
+		IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0170: stloc.s 12
+		IL_0172: volatile.
+		IL_0174: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0179: brfalse IL_0193
+
+		IL_017e: ldloc.2
+		IL_017f: ldstr "join"
+		IL_0184: ldstr "|"
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018e: br IL_01ad
+
+		IL_0193: ldloc.2
+		IL_0194: ldstr "join"
+		IL_0199: ldstr "|"
+		IL_019e: ldstr "TypedArray_SignedAndClamped_ConversionSemantics:Modules.TypedArray_SignedAndClamped_ConversionSemantics:__js_module_init__:41"
+		IL_01a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_01ad: stloc.s 13
+		IL_01af: ldloc.s 12
+		IL_01b1: ldloc.s 13
+		IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b8: pop
+		IL_01b9: ldc.i4.8
+		IL_01ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01bf: dup
+		IL_01c0: ldc.r8 1
+		IL_01c9: neg
+		IL_01ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01cf: dup
+		IL_01d0: ldc.r8 0.0
+		IL_01d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01de: dup
+		IL_01df: ldc.r8 1
+		IL_01e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01ed: dup
+		IL_01ee: ldc.r8 255
+		IL_01f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01fc: dup
+		IL_01fd: ldc.r8 256
+		IL_0206: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_020b: dup
+		IL_020c: ldc.r8 257
+		IL_0215: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_021a: dup
+		IL_021b: ldc.r8 511
+		IL_0224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0229: dup
+		IL_022a: ldc.r8 1.9
+		IL_0233: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0238: stloc.s 11
+		IL_023a: ldloc.s 11
+		IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_0241: stloc.3
+		IL_0242: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0247: stloc.s 12
+		IL_0249: volatile.
+		IL_024b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0250: brfalse IL_026a
+
+		IL_0255: ldloc.3
+		IL_0256: ldstr "join"
+		IL_025b: ldstr "|"
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0265: br IL_0284
+
+		IL_026a: ldloc.3
+		IL_026b: ldstr "join"
+		IL_0270: ldstr "|"
+		IL_0275: ldstr "TypedArray_SignedAndClamped_ConversionSemantics:Modules.TypedArray_SignedAndClamped_ConversionSemantics:__js_module_init__:59"
+		IL_027a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0284: stloc.s 13
+		IL_0286: ldloc.s 12
+		IL_0288: ldloc.s 13
+		IL_028a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_028f: pop
+		IL_0290: ldc.i4.s 10
+		IL_0292: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0297: dup
+		IL_0298: ldc.r8 20
+		IL_02a1: neg
+		IL_02a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02a7: dup
+		IL_02a8: ldc.r8 0.5
+		IL_02b1: neg
+		IL_02b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02b7: dup
+		IL_02b8: ldc.r8 0.49
+		IL_02c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02c6: dup
+		IL_02c7: ldc.r8 0.5
+		IL_02d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02d5: dup
+		IL_02d6: ldc.r8 1.5
+		IL_02df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02e4: dup
+		IL_02e5: ldc.r8 2.5
+		IL_02ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02f3: dup
+		IL_02f4: ldc.r8 254.6
+		IL_02fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0302: dup
+		IL_0303: ldc.r8 255.4
+		IL_030c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0311: dup
+		IL_0312: ldc.r8 300
+		IL_031b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0320: dup
+		IL_0321: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_032a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_032f: stloc.s 11
+		IL_0331: ldloc.s 11
+		IL_0333: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
+		IL_0338: stloc.s 4
+		IL_033a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_033f: stloc.s 12
+		IL_0341: volatile.
+		IL_0343: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0348: brfalse IL_0363
+
+		IL_034d: ldloc.s 4
+		IL_034f: ldstr "join"
+		IL_0354: ldstr "|"
+		IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_035e: br IL_037e
+
+		IL_0363: ldloc.s 4
+		IL_0365: ldstr "join"
+		IL_036a: ldstr "|"
+		IL_036f: ldstr "TypedArray_SignedAndClamped_ConversionSemantics:Modules.TypedArray_SignedAndClamped_ConversionSemantics:__js_module_init__:80"
+		IL_0374: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_037e: stloc.s 13
+		IL_0380: ldloc.s 12
+		IL_0382: ldloc.s 13
+		IL_0384: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0389: pop
+		IL_038a: ldloc.0
+		IL_038b: ldc.r8 0.0
+		IL_0394: box [System.Runtime]System.Double
+		IL_0399: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_039e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03a3: stloc.s 14
+		IL_03a5: ldc.i4.1
+		IL_03a6: newarr [System.Runtime]System.Object
+		IL_03ab: dup
+		IL_03ac: ldc.i4.0
+		IL_03ad: ldloc.0
+		IL_03ae: stelem.ref
+		IL_03af: stloc.s 15
+		IL_03b1: ldloc.s 15
+		IL_03b3: ldc.i4.0
+		IL_03b4: ldelem.ref
+		IL_03b5: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
+		IL_03ba: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject::.ctor(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope)
+		IL_03bf: ldc.i4.0
+		IL_03c0: conv.r8
+		IL_03c1: ldstr ""
+		IL_03c6: ldc.i4.0
+		IL_03c7: ldc.i4.1
+		IL_03c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0)
+		IL_03d2: stloc.s 16
+		IL_03d4: ldloc.s 14
+		IL_03d6: ldstr "valueOf"
+		IL_03db: ldloc.s 16
+		IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_03e2: pop
+		IL_03e3: ldloc.s 14
+		IL_03e5: stloc.s 5
+		IL_03e7: ldc.r8 0.0
+		IL_03f0: box [System.Runtime]System.Double
+		IL_03f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_03fa: stloc.s 6
+		IL_03fc: ldloc.s 6
+		IL_03fe: ldc.r8 0.0
+		IL_0407: ldloc.s 5
+		IL_0409: ldc.i4.1
+		IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_040f: pop
+		IL_0410: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0415: stloc.s 12
+		IL_0417: ldloc.0
+		IL_0418: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_041d: stloc.s 13
+		IL_041f: ldloc.s 12
+		IL_0421: ldloc.s 13
+		IL_0423: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0428: pop
 		.try
 		{
-			IL_037c: nop
-			IL_037d: ldstr "value"
-			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
-			IL_0387: stloc.s 13
-			IL_0389: ldloc.s 6
-			IL_038b: ldc.r8 0.0
-			IL_0394: ldloc.s 13
-			IL_0396: ldc.i4.1
-			IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_039c: pop
-			IL_039d: leave IL_041f
+			IL_0429: nop
+			IL_042a: ldstr "value"
+			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
+			IL_0434: stloc.s 13
+			IL_0436: ldloc.s 6
+			IL_0438: ldc.r8 0.0
+			IL_0441: ldloc.s 13
+			IL_0443: ldc.i4.1
+			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0449: pop
+			IL_044a: leave IL_04cc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03a2: stloc.s 7
-			IL_03a4: ldloc.s 7
-			IL_03a6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03ab: dup
-			IL_03ac: brtrue IL_03c2
+			IL_044f: stloc.s 7
+			IL_0451: ldloc.s 7
+			IL_0453: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0458: dup
+			IL_0459: brtrue IL_046f
 
-			IL_03b1: pop
-			IL_03b2: ldloc.s 7
-			IL_03b4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03b9: dup
-			IL_03ba: brtrue IL_03ce
+			IL_045e: pop
+			IL_045f: ldloc.s 7
+			IL_0461: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0466: dup
+			IL_0467: brtrue IL_047b
 
-			IL_03bf: pop
-			IL_03c0: rethrow
+			IL_046c: pop
+			IL_046d: rethrow
 
-			IL_03c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03c7: stloc.s 8
-			IL_03c9: br IL_03d0
+			IL_046f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0474: stloc.s 8
+			IL_0476: br IL_047d
 
-			IL_03ce: stloc.s 8
+			IL_047b: stloc.s 8
 
-			IL_03d0: ldloc.s 8
-			IL_03d2: stloc.s 9
-			IL_03d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03d9: stloc.s 12
-			IL_03db: volatile.
-			IL_03dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-			IL_03e2: brfalse IL_03f8
+			IL_047d: ldloc.s 8
+			IL_047f: stloc.s 9
+			IL_0481: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0486: stloc.s 12
+			IL_0488: volatile.
+			IL_048a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_048f: brfalse IL_04a5
 
-			IL_03e7: ldloc.s 9
-			IL_03e9: ldstr "name"
-			IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03f3: br IL_040e
+			IL_0494: ldloc.s 9
+			IL_0496: ldstr "name"
+			IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a0: br IL_04bb
 
-			IL_03f8: ldloc.s 9
-			IL_03fa: ldstr "name"
-			IL_03ff: ldstr "TypedArray_SignedAndClamped_ConversionSemantics:Modules.TypedArray_SignedAndClamped_ConversionSemantics:__js_module_init__:123"
-			IL_0404: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-			IL_0409: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04a5: ldloc.s 9
+			IL_04a7: ldstr "name"
+			IL_04ac: ldstr "TypedArray_SignedAndClamped_ConversionSemantics:Modules.TypedArray_SignedAndClamped_ConversionSemantics:__js_module_init__:123"
+			IL_04b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_04b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_040e: stloc.s 13
-			IL_0410: ldloc.s 12
-			IL_0412: ldloc.s 13
-			IL_0414: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0419: pop
-			IL_041a: leave IL_041f
+			IL_04bb: stloc.s 13
+			IL_04bd: ldloc.s 12
+			IL_04bf: ldloc.s 13
+			IL_04c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04c6: pop
+			IL_04c7: leave IL_04cc
 		} // end handler
 
-		IL_041f: ldnull
-		IL_0420: stloc.s 10
-		IL_0422: ret
+		IL_04cc: ldnull
+		IL_04cd: stloc.s 10
+		IL_04cf: ret
 	} // end of method TypedArray_SignedAndClamped_ConversionSemantics::__js_module_init__
 
 } // end of class Modules.TypedArray_SignedAndClamped_ConversionSemantics
@@ -631,6 +683,10 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
@@ -240,7 +240,7 @@
 			IL_0002: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0007: stloc.0
 			IL_0008: volatile.
-			IL_000a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_000a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_000f: brfalse IL_002e
 
 			IL_0014: ldarg.1
@@ -255,7 +255,7 @@
 			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0039: ldstr "bump"
 			IL_003e: ldstr "TypedArray_Static_From_Of:<TwoPhaseDummy_M4>:__js_call__:6"
-			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004d: stloc.1
@@ -443,7 +443,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 537 (0x219)
+		// Code size: 713 (0x2c9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_Static_From_Of/Scope,
@@ -510,126 +510,178 @@
 		IL_008c: ldloc.1
 		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
 		IL_0092: stloc.s 10
-		IL_0094: ldloc.s 10
-		IL_0096: ldstr "join"
-		IL_009b: ldstr "|"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a5: stloc.s 11
-		IL_00a7: ldloc.s 9
-		IL_00a9: ldloc.s 11
-		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b0: pop
-		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00b6: dup
-		IL_00b7: ldstr "0"
-		IL_00bc: ldc.r8 7
-		IL_00c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00ca: dup
-		IL_00cb: ldstr "1"
-		IL_00d0: ldc.r8 8
-		IL_00d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00de: dup
-		IL_00df: ldstr "length"
-		IL_00e4: ldc.r8 2
-		IL_00ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Int32Array [JavaScriptRuntime]JavaScriptRuntime.Int32Array::from(object)
-		IL_00f7: stloc.2
-		IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fd: stloc.s 9
-		IL_00ff: ldloc.2
-		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0105: stloc.s 10
-		IL_0107: ldloc.s 10
-		IL_0109: ldstr "join"
-		IL_010e: ldstr "|"
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0118: stloc.s 11
-		IL_011a: ldloc.s 9
-		IL_011c: ldloc.s 11
-		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0123: pop
-		IL_0124: ldc.i4.3
-		IL_0125: newarr [System.Runtime]System.Object
-		IL_012a: dup
-		IL_012b: ldc.i4.0
-		IL_012c: ldc.r8 257
-		IL_0135: box [System.Runtime]System.Double
-		IL_013a: stelem.ref
-		IL_013b: dup
-		IL_013c: ldc.i4.1
-		IL_013d: ldc.r8 1
-		IL_0146: neg
-		IL_0147: box [System.Runtime]System.Double
-		IL_014c: stelem.ref
-		IL_014d: dup
-		IL_014e: ldc.i4.2
-		IL_014f: ldc.r8 3
-		IL_0158: box [System.Runtime]System.Double
-		IL_015d: stelem.ref
-		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
-		IL_0163: stloc.3
-		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0169: stloc.s 9
-		IL_016b: ldloc.3
-		IL_016c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_0171: stloc.s 12
-		IL_0173: ldloc.s 12
-		IL_0175: ldstr "join"
-		IL_017a: ldstr "|"
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0184: stloc.s 11
-		IL_0186: ldloc.s 9
-		IL_0188: ldloc.s 11
-		IL_018a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018f: pop
-		IL_0190: ldc.i4.2
-		IL_0191: newarr [System.Runtime]System.Object
-		IL_0196: dup
-		IL_0197: ldc.i4.0
-		IL_0198: ldc.r8 4
-		IL_01a1: box [System.Runtime]System.Double
-		IL_01a6: stelem.ref
-		IL_01a7: dup
-		IL_01a8: ldc.i4.1
-		IL_01a9: ldc.r8 5
-		IL_01b2: box [System.Runtime]System.Double
-		IL_01b7: stelem.ref
-		IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
-		IL_01bd: stloc.s 12
-		IL_01bf: ldc.i4.1
-		IL_01c0: newarr [System.Runtime]System.Object
-		IL_01c5: dup
-		IL_01c6: ldc.i4.0
-		IL_01c7: ldloc.0
-		IL_01c8: stelem.ref
-		IL_01c9: stloc.s 6
-		IL_01cb: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject::.ctor()
-		IL_01d0: ldc.i4.1
-		IL_01d1: conv.r8
-		IL_01d2: ldstr ""
-		IL_01d7: ldc.i4.0
-		IL_01d8: ldc.i4.1
-		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01de: stloc.s 13
-		IL_01e0: ldloc.s 12
-		IL_01e2: ldloc.s 13
-		IL_01e4: call class [JavaScriptRuntime]JavaScriptRuntime.Float64Array [JavaScriptRuntime]JavaScriptRuntime.Float64Array::from(object, object)
-		IL_01e9: stloc.s 4
-		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f0: stloc.s 9
-		IL_01f2: ldloc.s 4
-		IL_01f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_01f9: stloc.s 14
-		IL_01fb: ldloc.s 14
-		IL_01fd: ldstr "join"
-		IL_0202: ldstr "|"
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020c: stloc.s 11
-		IL_020e: ldloc.s 9
-		IL_0210: ldloc.s 11
-		IL_0212: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0217: pop
-		IL_0218: ret
+		IL_0094: volatile.
+		IL_0096: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_009b: brfalse IL_00b6
+
+		IL_00a0: ldloc.s 10
+		IL_00a2: ldstr "join"
+		IL_00a7: ldstr "|"
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b1: br IL_00d1
+
+		IL_00b6: ldloc.s 10
+		IL_00b8: ldstr "join"
+		IL_00bd: ldstr "|"
+		IL_00c2: ldstr "TypedArray_Static_From_Of:Modules.TypedArray_Static_From_Of:__js_module_init__:19"
+		IL_00c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00d1: stloc.s 11
+		IL_00d3: ldloc.s 9
+		IL_00d5: ldloc.s 11
+		IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00dc: pop
+		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00e2: dup
+		IL_00e3: ldstr "0"
+		IL_00e8: ldc.r8 7
+		IL_00f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00f6: dup
+		IL_00f7: ldstr "1"
+		IL_00fc: ldc.r8 8
+		IL_0105: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_010a: dup
+		IL_010b: ldstr "length"
+		IL_0110: ldc.r8 2
+		IL_0119: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_011e: call class [JavaScriptRuntime]JavaScriptRuntime.Int32Array [JavaScriptRuntime]JavaScriptRuntime.Int32Array::from(object)
+		IL_0123: stloc.2
+		IL_0124: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0129: stloc.s 9
+		IL_012b: ldloc.2
+		IL_012c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0131: stloc.s 10
+		IL_0133: volatile.
+		IL_0135: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_013a: brfalse IL_0155
+
+		IL_013f: ldloc.s 10
+		IL_0141: ldstr "join"
+		IL_0146: ldstr "|"
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0150: br IL_0170
+
+		IL_0155: ldloc.s 10
+		IL_0157: ldstr "join"
+		IL_015c: ldstr "|"
+		IL_0161: ldstr "TypedArray_Static_From_Of:Modules.TypedArray_Static_From_Of:__js_module_init__:32"
+		IL_0166: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0170: stloc.s 11
+		IL_0172: ldloc.s 9
+		IL_0174: ldloc.s 11
+		IL_0176: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_017b: pop
+		IL_017c: ldc.i4.3
+		IL_017d: newarr [System.Runtime]System.Object
+		IL_0182: dup
+		IL_0183: ldc.i4.0
+		IL_0184: ldc.r8 257
+		IL_018d: box [System.Runtime]System.Double
+		IL_0192: stelem.ref
+		IL_0193: dup
+		IL_0194: ldc.i4.1
+		IL_0195: ldc.r8 1
+		IL_019e: neg
+		IL_019f: box [System.Runtime]System.Double
+		IL_01a4: stelem.ref
+		IL_01a5: dup
+		IL_01a6: ldc.i4.2
+		IL_01a7: ldc.r8 3
+		IL_01b0: box [System.Runtime]System.Double
+		IL_01b5: stelem.ref
+		IL_01b6: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
+		IL_01bb: stloc.3
+		IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c1: stloc.s 9
+		IL_01c3: ldloc.3
+		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_01c9: stloc.s 12
+		IL_01cb: volatile.
+		IL_01cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_01d2: brfalse IL_01ed
+
+		IL_01d7: ldloc.s 12
+		IL_01d9: ldstr "join"
+		IL_01de: ldstr "|"
+		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e8: br IL_0208
+
+		IL_01ed: ldloc.s 12
+		IL_01ef: ldstr "join"
+		IL_01f4: ldstr "|"
+		IL_01f9: ldstr "TypedArray_Static_From_Of:Modules.TypedArray_Static_From_Of:__js_module_init__:48"
+		IL_01fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0208: stloc.s 11
+		IL_020a: ldloc.s 9
+		IL_020c: ldloc.s 11
+		IL_020e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0213: pop
+		IL_0214: ldc.i4.2
+		IL_0215: newarr [System.Runtime]System.Object
+		IL_021a: dup
+		IL_021b: ldc.i4.0
+		IL_021c: ldc.r8 4
+		IL_0225: box [System.Runtime]System.Double
+		IL_022a: stelem.ref
+		IL_022b: dup
+		IL_022c: ldc.i4.1
+		IL_022d: ldc.r8 5
+		IL_0236: box [System.Runtime]System.Double
+		IL_023b: stelem.ref
+		IL_023c: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
+		IL_0241: stloc.s 12
+		IL_0243: ldc.i4.1
+		IL_0244: newarr [System.Runtime]System.Object
+		IL_0249: dup
+		IL_024a: ldc.i4.0
+		IL_024b: ldloc.0
+		IL_024c: stelem.ref
+		IL_024d: stloc.s 6
+		IL_024f: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject::.ctor()
+		IL_0254: ldc.i4.1
+		IL_0255: conv.r8
+		IL_0256: ldstr ""
+		IL_025b: ldc.i4.0
+		IL_025c: ldc.i4.1
+		IL_025d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0262: stloc.s 13
+		IL_0264: ldloc.s 12
+		IL_0266: ldloc.s 13
+		IL_0268: call class [JavaScriptRuntime]JavaScriptRuntime.Float64Array [JavaScriptRuntime]JavaScriptRuntime.Float64Array::from(object, object)
+		IL_026d: stloc.s 4
+		IL_026f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0274: stloc.s 9
+		IL_0276: ldloc.s 4
+		IL_0278: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_027d: stloc.s 14
+		IL_027f: volatile.
+		IL_0281: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0286: brfalse IL_02a1
+
+		IL_028b: ldloc.s 14
+		IL_028d: ldstr "join"
+		IL_0292: ldstr "|"
+		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_029c: br IL_02bc
+
+		IL_02a1: ldloc.s 14
+		IL_02a3: ldstr "join"
+		IL_02a8: ldstr "|"
+		IL_02ad: ldstr "TypedArray_Static_From_Of:Modules.TypedArray_Static_From_Of:__js_module_init__:64"
+		IL_02b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02bc: stloc.s 11
+		IL_02be: ldloc.s 9
+		IL_02c0: ldloc.s 11
+		IL_02c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c7: pop
+		IL_02c8: ret
 	} // end of method TypedArray_Static_From_Of::__js_module_init__
 
 } // end of class Modules.TypedArray_Static_From_Of
@@ -660,6 +712,10 @@
 {
 	// Fields
 	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
@@ -143,7 +143,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 753 (0x2f1)
+		// Code size: 900 (0x384)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope,
@@ -345,46 +345,87 @@
 		IL_025f: pop
 		IL_0260: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0265: stloc.s 7
-		IL_0267: ldloc.s 4
-		IL_0269: ldstr "includes"
-		IL_026e: ldc.r8 43
-		IL_0277: box [System.Runtime]System.Double
-		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0281: stloc.s 11
-		IL_0283: ldloc.s 7
-		IL_0285: ldloc.s 11
-		IL_0287: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_028c: pop
-		IL_028d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0292: stloc.s 7
-		IL_0294: ldloc.s 4
-		IL_0296: ldstr "indexOf"
-		IL_029b: ldc.r8 42
-		IL_02a4: box [System.Runtime]System.Double
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ae: stloc.s 11
-		IL_02b0: ldloc.s 7
-		IL_02b2: ldloc.s 11
-		IL_02b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b9: pop
-		IL_02ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02bf: stloc.s 7
-		IL_02c1: ldc.r8 1
-		IL_02ca: neg
-		IL_02cb: stloc.s 10
-		IL_02cd: ldloc.s 10
-		IL_02cf: box [System.Runtime]System.Double
-		IL_02d4: stloc.s 9
-		IL_02d6: ldloc.s 4
-		IL_02d8: ldstr "at"
-		IL_02dd: ldloc.s 9
-		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e4: stloc.s 11
-		IL_02e6: ldloc.s 7
-		IL_02e8: ldloc.s 11
-		IL_02ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ef: pop
-		IL_02f0: ret
+		IL_0267: volatile.
+		IL_0269: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_026e: brfalse IL_0292
+
+		IL_0273: ldloc.s 4
+		IL_0275: ldstr "includes"
+		IL_027a: ldc.r8 43
+		IL_0283: box [System.Runtime]System.Double
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028d: br IL_02b6
+
+		IL_0292: ldloc.s 4
+		IL_0294: ldstr "includes"
+		IL_0299: ldc.r8 43
+		IL_02a2: box [System.Runtime]System.Double
+		IL_02a7: ldstr "Uint8Array_Construct_ArrayLike_Buffer_Search:Modules.Uint8Array_Construct_ArrayLike_Buffer_Search:__js_module_init__:89"
+		IL_02ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02b6: stloc.s 11
+		IL_02b8: ldloc.s 7
+		IL_02ba: ldloc.s 11
+		IL_02bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c1: pop
+		IL_02c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c7: stloc.s 7
+		IL_02c9: volatile.
+		IL_02cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_02d0: brfalse IL_02f4
+
+		IL_02d5: ldloc.s 4
+		IL_02d7: ldstr "indexOf"
+		IL_02dc: ldc.r8 42
+		IL_02e5: box [System.Runtime]System.Double
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ef: br IL_0318
+
+		IL_02f4: ldloc.s 4
+		IL_02f6: ldstr "indexOf"
+		IL_02fb: ldc.r8 42
+		IL_0304: box [System.Runtime]System.Double
+		IL_0309: ldstr "Uint8Array_Construct_ArrayLike_Buffer_Search:Modules.Uint8Array_Construct_ArrayLike_Buffer_Search:__js_module_init__:95"
+		IL_030e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0318: stloc.s 11
+		IL_031a: ldloc.s 7
+		IL_031c: ldloc.s 11
+		IL_031e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0323: pop
+		IL_0324: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0329: stloc.s 7
+		IL_032b: ldc.r8 1
+		IL_0334: neg
+		IL_0335: stloc.s 10
+		IL_0337: ldloc.s 10
+		IL_0339: box [System.Runtime]System.Double
+		IL_033e: stloc.s 9
+		IL_0340: volatile.
+		IL_0342: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0347: brfalse IL_035f
+
+		IL_034c: ldloc.s 4
+		IL_034e: ldstr "at"
+		IL_0353: ldloc.s 9
+		IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_035a: br IL_0377
+
+		IL_035f: ldloc.s 4
+		IL_0361: ldstr "at"
+		IL_0366: ldloc.s 9
+		IL_0368: ldstr "Uint8Array_Construct_ArrayLike_Buffer_Search:Modules.Uint8Array_Construct_ArrayLike_Buffer_Search:__js_module_init__:102"
+		IL_036d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0377: stloc.s 11
+		IL_0379: ldloc.s 7
+		IL_037b: ldloc.s 11
+		IL_037d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0382: pop
+		IL_0383: ret
 	} // end of method Uint8Array_Construct_ArrayLike_Buffer_Search::__js_module_init__
 
 } // end of class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search
@@ -417,6 +458,9 @@
 	.field assembly static int32 __jroc_dynamicLookup_1
 	.field assembly static int32 __jroc_dynamicLookup_2
 	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Iterator_Metadata.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Iterator_Metadata.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1071 (0x42f)
+		// Code size: 1109 (0x455)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Uint8Array_Iterator_Metadata/Scope,
@@ -409,37 +409,49 @@
 		IL_03ca: stloc.s 6
 		IL_03cc: ldloc.s 6
 		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d3: ldstr "call"
-		IL_03d8: ldloc.1
-		IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03de: stloc.s 6
-		IL_03e0: ldloc.s 5
-		IL_03e2: ldloc.s 6
-		IL_03e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03e9: pop
-		IL_03ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03ef: stloc.s 5
-		IL_03f1: volatile.
-		IL_03f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_03f8: brfalse IL_040d
+		IL_03d3: volatile.
+		IL_03d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_03da: brfalse IL_03ef
 
-		IL_03fd: ldloc.1
-		IL_03fe: ldstr "BYTES_PER_ELEMENT"
-		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0408: br IL_0422
+		IL_03df: ldstr "call"
+		IL_03e4: ldloc.1
+		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03ea: br IL_0404
 
-		IL_040d: ldloc.1
-		IL_040e: ldstr "BYTES_PER_ELEMENT"
-		IL_0413: ldstr "Uint8Array_Iterator_Metadata:Modules.Uint8Array_Iterator_Metadata:__js_module_init__:74"
-		IL_0418: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03ef: ldstr "call"
+		IL_03f4: ldloc.1
+		IL_03f5: ldstr "Uint8Array_Iterator_Metadata:Modules.Uint8Array_Iterator_Metadata:__js_module_init__:69"
+		IL_03fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0422: stloc.s 6
-		IL_0424: ldloc.s 5
-		IL_0426: ldloc.s 6
-		IL_0428: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_042d: pop
-		IL_042e: ret
+		IL_0404: stloc.s 6
+		IL_0406: ldloc.s 5
+		IL_0408: ldloc.s 6
+		IL_040a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_040f: pop
+		IL_0410: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0415: stloc.s 5
+		IL_0417: volatile.
+		IL_0419: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_041e: brfalse IL_0433
+
+		IL_0423: ldloc.1
+		IL_0424: ldstr "BYTES_PER_ELEMENT"
+		IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_042e: br IL_0448
+
+		IL_0433: ldloc.1
+		IL_0434: ldstr "BYTES_PER_ELEMENT"
+		IL_0439: ldstr "Uint8Array_Iterator_Metadata:Modules.Uint8Array_Iterator_Metadata:__js_module_init__:74"
+		IL_043e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0448: stloc.s 6
+		IL_044a: ldloc.s 5
+		IL_044c: ldloc.s 6
+		IL_044e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0453: pop
+		IL_0454: ret
 	} // end of method Uint8Array_Iterator_Metadata::__js_module_init__
 
 } // end of class Modules.Uint8Array_Iterator_Metadata
@@ -484,6 +496,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Constructor_Prototype_Surface.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Constructor_Prototype_Surface.verified.txt
@@ -143,7 +143,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2031 (0x7ef)
+		// Code size: 2606 (0xa2e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Constructor_Prototype_Surface/Scope,
@@ -212,566 +212,747 @@
 		IL_00b5: ldloc.s 12
 		IL_00b7: box [System.Runtime]System.Boolean
 		IL_00bc: stloc.s 13
-		IL_00be: ldloc.s 9
-		IL_00c0: ldstr "log"
-		IL_00c5: ldloc.s 13
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cc: pop
-		IL_00cd: ldstr "console"
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00dc: stloc.s 9
-		IL_00de: ldstr "WeakMap"
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e8: volatile.
-		IL_00ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00ef: brfalse IL_0103
+		IL_00be: volatile.
+		IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c5: brfalse IL_00dd
 
-		IL_00f4: ldstr "prototype"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fe: br IL_0117
+		IL_00ca: ldloc.s 9
+		IL_00cc: ldstr "log"
+		IL_00d1: ldloc.s 13
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d8: br IL_00f5
 
-		IL_0103: ldstr "prototype"
-		IL_0108: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:37"
-		IL_010d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00dd: ldloc.s 9
+		IL_00df: ldstr "log"
+		IL_00e4: ldloc.s 13
+		IL_00e6: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:29"
+		IL_00eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0117: stloc.s 11
-		IL_0119: volatile.
-		IL_011b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0120: brfalse IL_0136
+		IL_00f5: pop
+		IL_00f6: ldstr "console"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0105: stloc.s 9
+		IL_0107: ldstr "WeakMap"
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0111: volatile.
+		IL_0113: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0118: brfalse IL_012c
 
-		IL_0125: ldloc.s 11
-		IL_0127: ldstr "constructor"
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0131: br IL_014c
+		IL_011d: ldstr "prototype"
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0127: br IL_0140
 
-		IL_0136: ldloc.s 11
-		IL_0138: ldstr "constructor"
-		IL_013d: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:39"
-		IL_0142: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_012c: ldstr "prototype"
+		IL_0131: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:37"
+		IL_0136: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_014c: stloc.s 11
-		IL_014e: ldstr "WeakMap"
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0158: stloc.s 10
-		IL_015a: ldloc.s 11
-		IL_015c: ldloc.s 10
-		IL_015e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0163: stloc.s 12
-		IL_0165: ldloc.s 12
-		IL_0167: box [System.Runtime]System.Boolean
-		IL_016c: stloc.s 13
-		IL_016e: ldloc.s 9
-		IL_0170: ldstr "log"
-		IL_0175: ldloc.s 13
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017c: pop
-		IL_017d: ldstr "console"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018c: stloc.s 9
-		IL_018e: ldstr "WeakMap"
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0198: stloc.s 10
-		IL_019a: ldstr "Function"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a4: stloc.s 11
-		IL_01a6: ldloc.s 10
-		IL_01a8: ldloc.s 11
-		IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_01af: stloc.s 12
-		IL_01b1: ldloc.s 12
-		IL_01b3: box [System.Runtime]System.Boolean
-		IL_01b8: stloc.s 13
-		IL_01ba: ldloc.s 9
-		IL_01bc: ldstr "log"
-		IL_01c1: ldloc.s 13
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c8: pop
-		IL_01c9: ldstr "console"
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d8: stloc.s 9
-		IL_01da: ldstr "WeakMap"
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_01e9: stloc.s 11
-		IL_01eb: ldstr "Function"
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f5: volatile.
-		IL_01f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_01fc: brfalse IL_0210
+		IL_0140: stloc.s 11
+		IL_0142: volatile.
+		IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0149: brfalse IL_015f
 
-		IL_0201: ldstr "prototype"
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020b: br IL_0224
+		IL_014e: ldloc.s 11
+		IL_0150: ldstr "constructor"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015a: br IL_0175
 
-		IL_0210: ldstr "prototype"
-		IL_0215: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:66"
-		IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_015f: ldloc.s 11
+		IL_0161: ldstr "constructor"
+		IL_0166: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:39"
+		IL_016b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0224: stloc.s 10
-		IL_0226: ldloc.s 11
-		IL_0228: ldloc.s 10
-		IL_022a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_022f: stloc.s 12
-		IL_0231: ldloc.s 12
-		IL_0233: box [System.Runtime]System.Boolean
-		IL_0238: stloc.s 13
-		IL_023a: ldloc.s 9
-		IL_023c: ldstr "log"
-		IL_0241: ldloc.s 13
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0248: pop
-		IL_0249: ldstr "console"
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0258: stloc.s 9
-		IL_025a: ldstr "WeakMap"
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0264: volatile.
-		IL_0266: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_026b: brfalse IL_027f
+		IL_0175: stloc.s 11
+		IL_0177: ldstr "WeakMap"
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0181: stloc.s 10
+		IL_0183: ldloc.s 11
+		IL_0185: ldloc.s 10
+		IL_0187: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_018c: stloc.s 12
+		IL_018e: ldloc.s 12
+		IL_0190: box [System.Runtime]System.Boolean
+		IL_0195: stloc.s 13
+		IL_0197: volatile.
+		IL_0199: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_019e: brfalse IL_01b6
 
-		IL_0270: ldstr "prototype"
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_027a: br IL_0293
+		IL_01a3: ldloc.s 9
+		IL_01a5: ldstr "log"
+		IL_01aa: ldloc.s 13
+		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b1: br IL_01ce
 
-		IL_027f: ldstr "prototype"
-		IL_0284: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:77"
-		IL_0289: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01b6: ldloc.s 9
+		IL_01b8: ldstr "log"
+		IL_01bd: ldloc.s 13
+		IL_01bf: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:44"
+		IL_01c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0293: stloc.s 10
-		IL_0295: ldloc.s 10
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_029c: stloc.s 10
-		IL_029e: ldstr "Object"
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a8: volatile.
-		IL_02aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02af: brfalse IL_02c3
+		IL_01ce: pop
+		IL_01cf: ldstr "console"
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01de: stloc.s 9
+		IL_01e0: ldstr "WeakMap"
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ea: stloc.s 10
+		IL_01ec: ldstr "Function"
+		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f6: stloc.s 11
+		IL_01f8: ldloc.s 10
+		IL_01fa: ldloc.s 11
+		IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0201: stloc.s 12
+		IL_0203: ldloc.s 12
+		IL_0205: box [System.Runtime]System.Boolean
+		IL_020a: stloc.s 13
+		IL_020c: volatile.
+		IL_020e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0213: brfalse IL_022b
 
-		IL_02b4: ldstr "prototype"
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02be: br IL_02d7
+		IL_0218: ldloc.s 9
+		IL_021a: ldstr "log"
+		IL_021f: ldloc.s 13
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0226: br IL_0243
 
-		IL_02c3: ldstr "prototype"
-		IL_02c8: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:82"
-		IL_02cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_022b: ldloc.s 9
+		IL_022d: ldstr "log"
+		IL_0232: ldloc.s 13
+		IL_0234: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:55"
+		IL_0239: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02d7: stloc.s 11
-		IL_02d9: ldloc.s 10
-		IL_02db: ldloc.s 11
-		IL_02dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02e2: stloc.s 12
-		IL_02e4: ldloc.s 12
-		IL_02e6: box [System.Runtime]System.Boolean
-		IL_02eb: stloc.s 13
-		IL_02ed: ldloc.s 9
-		IL_02ef: ldstr "log"
-		IL_02f4: ldloc.s 13
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02fb: pop
-		IL_02fc: ldstr "WeakMap"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0306: ldstr "prototype"
-		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0310: stloc.1
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0316: stloc.s 9
-		IL_0318: ldloc.s 9
-		IL_031a: ldstr "descriptor"
-		IL_031f: ldloc.1
-		IL_0320: ldc.i4.0
-		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_0326: pop
-		IL_0327: ldstr "console"
-		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0336: stloc.s 9
-		IL_0338: volatile.
-		IL_033a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_033f: brfalse IL_0354
+		IL_0243: pop
+		IL_0244: ldstr "console"
+		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0253: stloc.s 9
+		IL_0255: ldstr "WeakMap"
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0264: stloc.s 11
+		IL_0266: ldstr "Function"
+		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0270: volatile.
+		IL_0272: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0277: brfalse IL_028b
 
-		IL_0344: ldloc.1
-		IL_0345: ldstr "writable"
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_034f: br IL_0369
+		IL_027c: ldstr "prototype"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0286: br IL_029f
 
-		IL_0354: ldloc.1
-		IL_0355: ldstr "writable"
-		IL_035a: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:101"
-		IL_035f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_028b: ldstr "prototype"
+		IL_0290: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:66"
+		IL_0295: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0369: stloc.s 11
-		IL_036b: ldloc.s 9
-		IL_036d: ldstr "log"
-		IL_0372: ldloc.s 11
-		IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0379: pop
-		IL_037a: ldstr "console"
-		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0389: stloc.s 11
-		IL_038b: volatile.
-		IL_038d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0392: brfalse IL_03a7
+		IL_029f: stloc.s 10
+		IL_02a1: ldloc.s 11
+		IL_02a3: ldloc.s 10
+		IL_02a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02aa: stloc.s 12
+		IL_02ac: ldloc.s 12
+		IL_02ae: box [System.Runtime]System.Boolean
+		IL_02b3: stloc.s 13
+		IL_02b5: volatile.
+		IL_02b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02bc: brfalse IL_02d4
 
-		IL_0397: ldloc.1
-		IL_0398: ldstr "enumerable"
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03a2: br IL_03bc
+		IL_02c1: ldloc.s 9
+		IL_02c3: ldstr "log"
+		IL_02c8: ldloc.s 13
+		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02cf: br IL_02ec
 
-		IL_03a7: ldloc.1
-		IL_03a8: ldstr "enumerable"
-		IL_03ad: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:108"
-		IL_03b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02d4: ldloc.s 9
+		IL_02d6: ldstr "log"
+		IL_02db: ldloc.s 13
+		IL_02dd: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:69"
+		IL_02e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03bc: stloc.s 9
-		IL_03be: ldloc.s 11
-		IL_03c0: ldstr "log"
-		IL_03c5: ldloc.s 9
-		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03cc: pop
-		IL_03cd: ldstr "console"
-		IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03dc: stloc.s 9
-		IL_03de: volatile.
-		IL_03e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_03e5: brfalse IL_03fa
+		IL_02ec: pop
+		IL_02ed: ldstr "console"
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fc: stloc.s 9
+		IL_02fe: ldstr "WeakMap"
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0308: volatile.
+		IL_030a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_030f: brfalse IL_0323
 
-		IL_03ea: ldloc.1
-		IL_03eb: ldstr "configurable"
-		IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03f5: br IL_040f
+		IL_0314: ldstr "prototype"
+		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_031e: br IL_0337
 
-		IL_03fa: ldloc.1
-		IL_03fb: ldstr "configurable"
-		IL_0400: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:115"
-		IL_0405: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0323: ldstr "prototype"
+		IL_0328: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:77"
+		IL_032d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_040f: stloc.s 11
-		IL_0411: ldloc.s 9
-		IL_0413: ldstr "log"
-		IL_0418: ldloc.s 11
-		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_041f: pop
-		IL_0420: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakMap::.ctor()
-		IL_0425: stloc.2
-		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_042b: stloc.s 11
-		IL_042d: ldloc.s 11
-		IL_042f: ldstr "weakMap"
-		IL_0434: ldloc.2
-		IL_0435: ldc.i4.0
-		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_043b: pop
-		IL_043c: ldstr "console"
-		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_044b: stloc.s 11
-		IL_044d: ldloc.2
-		IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0453: stloc.s 9
-		IL_0455: ldstr "WeakMap"
-		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_045f: volatile.
-		IL_0461: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0466: brfalse IL_047a
+		IL_0337: stloc.s 10
+		IL_0339: ldloc.s 10
+		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0340: stloc.s 10
+		IL_0342: ldstr "Object"
+		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_034c: volatile.
+		IL_034e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0353: brfalse IL_0367
 
-		IL_046b: ldstr "prototype"
-		IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0475: br IL_048e
+		IL_0358: ldstr "prototype"
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0362: br IL_037b
 
-		IL_047a: ldstr "prototype"
-		IL_047f: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:132"
-		IL_0484: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0367: ldstr "prototype"
+		IL_036c: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:82"
+		IL_0371: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_048e: stloc.s 10
-		IL_0490: ldloc.s 9
-		IL_0492: ldloc.s 10
-		IL_0494: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0499: stloc.s 12
-		IL_049b: ldloc.s 12
-		IL_049d: box [System.Runtime]System.Boolean
-		IL_04a2: stloc.s 13
-		IL_04a4: ldloc.s 11
-		IL_04a6: ldstr "log"
-		IL_04ab: ldloc.s 13
-		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04b2: pop
-		IL_04b3: ldstr "console"
-		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c2: stloc.s 11
-		IL_04c4: ldloc.2
-		IL_04c5: stloc.s 14
-		IL_04c7: ldstr "WeakMap"
-		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04d1: stloc.s 10
-		IL_04d3: ldloc.s 14
-		IL_04d5: ldloc.s 10
-		IL_04d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_04dc: stloc.s 12
-		IL_04de: ldloc.s 12
-		IL_04e0: box [System.Runtime]System.Boolean
-		IL_04e5: stloc.s 13
-		IL_04e7: ldloc.s 11
-		IL_04e9: ldstr "log"
-		IL_04ee: ldloc.s 13
-		IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04f5: pop
-		IL_04f6: ldstr "console"
-		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0505: stloc.s 11
-		IL_0507: volatile.
-		IL_0509: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_050e: brfalse IL_0523
+		IL_037b: stloc.s 11
+		IL_037d: ldloc.s 10
+		IL_037f: ldloc.s 11
+		IL_0381: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0386: stloc.s 12
+		IL_0388: ldloc.s 12
+		IL_038a: box [System.Runtime]System.Boolean
+		IL_038f: stloc.s 13
+		IL_0391: volatile.
+		IL_0393: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0398: brfalse IL_03b0
 
-		IL_0513: ldloc.2
-		IL_0514: ldstr "constructor"
-		IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_051e: br IL_0538
+		IL_039d: ldloc.s 9
+		IL_039f: ldstr "log"
+		IL_03a4: ldloc.s 13
+		IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03ab: br IL_03c8
 
-		IL_0523: ldloc.2
-		IL_0524: ldstr "constructor"
-		IL_0529: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:151"
-		IL_052e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03b0: ldloc.s 9
+		IL_03b2: ldstr "log"
+		IL_03b7: ldloc.s 13
+		IL_03b9: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:85"
+		IL_03be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0538: stloc.s 10
-		IL_053a: ldstr "WeakMap"
-		IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0544: stloc.s 9
-		IL_0546: ldloc.s 10
-		IL_0548: ldloc.s 9
-		IL_054a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_054f: stloc.s 12
-		IL_0551: ldloc.s 12
-		IL_0553: box [System.Runtime]System.Boolean
-		IL_0558: stloc.s 13
-		IL_055a: ldloc.s 11
-		IL_055c: ldstr "log"
-		IL_0561: ldloc.s 13
-		IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0568: pop
-		IL_0569: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_056e: stloc.3
-		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0574: stloc.s 11
-		IL_0576: ldloc.s 11
-		IL_0578: ldstr "key"
-		IL_057d: ldloc.3
-		IL_057e: ldc.i4.0
-		IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_0584: pop
-		IL_0585: ldstr "WeakMap"
-		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_058f: volatile.
-		IL_0591: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0596: brfalse IL_05aa
+		IL_03c8: pop
+		IL_03c9: ldstr "WeakMap"
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03d3: ldstr "prototype"
+		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_03dd: stloc.1
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_03e3: stloc.s 9
+		IL_03e5: ldloc.s 9
+		IL_03e7: ldstr "descriptor"
+		IL_03ec: ldloc.1
+		IL_03ed: ldc.i4.0
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_03f3: pop
+		IL_03f4: ldstr "console"
+		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0403: stloc.s 9
+		IL_0405: volatile.
+		IL_0407: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_040c: brfalse IL_0421
 
-		IL_059b: ldstr "prototype"
-		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05a5: br IL_05be
+		IL_0411: ldloc.1
+		IL_0412: ldstr "writable"
+		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_041c: br IL_0436
 
-		IL_05aa: ldstr "prototype"
-		IL_05af: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:168"
-		IL_05b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0421: ldloc.1
+		IL_0422: ldstr "writable"
+		IL_0427: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:101"
+		IL_042c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05be: stloc.s 11
-		IL_05c0: volatile.
-		IL_05c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_05c7: brfalse IL_05dd
+		IL_0436: stloc.s 11
+		IL_0438: volatile.
+		IL_043a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_043f: brfalse IL_0457
 
-		IL_05cc: ldloc.s 11
-		IL_05ce: ldstr "set"
-		IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05d8: br IL_05f3
+		IL_0444: ldloc.s 9
+		IL_0446: ldstr "log"
+		IL_044b: ldloc.s 11
+		IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0452: br IL_046f
 
-		IL_05dd: ldloc.s 11
-		IL_05df: ldstr "set"
-		IL_05e4: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:170"
-		IL_05e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0457: ldloc.s 9
+		IL_0459: ldstr "log"
+		IL_045e: ldloc.s 11
+		IL_0460: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:102"
+		IL_0465: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_05f3: stloc.s 11
-		IL_05f5: ldloc.s 11
-		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05fc: ldstr "call"
-		IL_0601: ldloc.2
-		IL_0602: ldloc.3
-		IL_0603: ldc.r8 7
-		IL_060c: box [System.Runtime]System.Double
-		IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_0616: pop
-		IL_0617: ldstr "console"
-		IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0626: stloc.s 11
-		IL_0628: ldstr "WeakMap"
-		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0632: volatile.
-		IL_0634: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0639: brfalse IL_064d
+		IL_046f: pop
+		IL_0470: ldstr "console"
+		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_047f: stloc.s 11
+		IL_0481: volatile.
+		IL_0483: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0488: brfalse IL_049d
 
-		IL_063e: ldstr "prototype"
-		IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0648: br IL_0661
+		IL_048d: ldloc.1
+		IL_048e: ldstr "enumerable"
+		IL_0493: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0498: br IL_04b2
 
-		IL_064d: ldstr "prototype"
-		IL_0652: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:182"
-		IL_0657: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_049d: ldloc.1
+		IL_049e: ldstr "enumerable"
+		IL_04a3: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:108"
+		IL_04a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0661: stloc.s 9
-		IL_0663: volatile.
-		IL_0665: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_066a: brfalse IL_0680
+		IL_04b2: stloc.s 9
+		IL_04b4: volatile.
+		IL_04b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04bb: brfalse IL_04d3
 
-		IL_066f: ldloc.s 9
-		IL_0671: ldstr "get"
-		IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_067b: br IL_0696
+		IL_04c0: ldloc.s 11
+		IL_04c2: ldstr "log"
+		IL_04c7: ldloc.s 9
+		IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04ce: br IL_04eb
 
-		IL_0680: ldloc.s 9
-		IL_0682: ldstr "get"
-		IL_0687: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:184"
-		IL_068c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04d3: ldloc.s 11
+		IL_04d5: ldstr "log"
+		IL_04da: ldloc.s 9
+		IL_04dc: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:109"
+		IL_04e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0696: stloc.s 9
-		IL_0698: ldloc.s 9
+		IL_04eb: pop
+		IL_04ec: ldstr "console"
+		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04fb: stloc.s 9
+		IL_04fd: volatile.
+		IL_04ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0504: brfalse IL_0519
+
+		IL_0509: ldloc.1
+		IL_050a: ldstr "configurable"
+		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0514: br IL_052e
+
+		IL_0519: ldloc.1
+		IL_051a: ldstr "configurable"
+		IL_051f: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:115"
+		IL_0524: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_052e: stloc.s 11
+		IL_0530: volatile.
+		IL_0532: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0537: brfalse IL_054f
+
+		IL_053c: ldloc.s 9
+		IL_053e: ldstr "log"
+		IL_0543: ldloc.s 11
+		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_054a: br IL_0567
+
+		IL_054f: ldloc.s 9
+		IL_0551: ldstr "log"
+		IL_0556: ldloc.s 11
+		IL_0558: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:116"
+		IL_055d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0567: pop
+		IL_0568: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakMap::.ctor()
+		IL_056d: stloc.2
+		IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_0573: stloc.s 11
+		IL_0575: ldloc.s 11
+		IL_0577: ldstr "weakMap"
+		IL_057c: ldloc.2
+		IL_057d: ldc.i4.0
+		IL_057e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_0583: pop
+		IL_0584: ldstr "console"
+		IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0593: stloc.s 11
+		IL_0595: ldloc.2
+		IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_059b: stloc.s 9
+		IL_059d: ldstr "WeakMap"
+		IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05a7: volatile.
+		IL_05a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05ae: brfalse IL_05c2
+
+		IL_05b3: ldstr "prototype"
+		IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05bd: br IL_05d6
+
+		IL_05c2: ldstr "prototype"
+		IL_05c7: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:132"
+		IL_05cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05d6: stloc.s 10
+		IL_05d8: ldloc.s 9
+		IL_05da: ldloc.s 10
+		IL_05dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05e1: stloc.s 12
+		IL_05e3: ldloc.s 12
+		IL_05e5: box [System.Runtime]System.Boolean
+		IL_05ea: stloc.s 13
+		IL_05ec: volatile.
+		IL_05ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_05f3: brfalse IL_060b
+
+		IL_05f8: ldloc.s 11
+		IL_05fa: ldstr "log"
+		IL_05ff: ldloc.s 13
+		IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0606: br IL_0623
+
+		IL_060b: ldloc.s 11
+		IL_060d: ldstr "log"
+		IL_0612: ldloc.s 13
+		IL_0614: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:135"
+		IL_0619: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0623: pop
+		IL_0624: ldstr "console"
+		IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0633: stloc.s 11
+		IL_0635: ldloc.2
+		IL_0636: stloc.s 14
+		IL_0638: ldstr "WeakMap"
+		IL_063d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0642: stloc.s 10
+		IL_0644: ldloc.s 14
+		IL_0646: ldloc.s 10
+		IL_0648: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_064d: stloc.s 12
+		IL_064f: ldloc.s 12
+		IL_0651: box [System.Runtime]System.Boolean
+		IL_0656: stloc.s 13
+		IL_0658: volatile.
+		IL_065a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_065f: brfalse IL_0677
+
+		IL_0664: ldloc.s 11
+		IL_0666: ldstr "log"
+		IL_066b: ldloc.s 13
+		IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0672: br IL_068f
+
+		IL_0677: ldloc.s 11
+		IL_0679: ldstr "log"
+		IL_067e: ldloc.s 13
+		IL_0680: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:145"
+		IL_0685: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_068f: pop
+		IL_0690: ldstr "console"
+		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_069f: ldstr "call"
-		IL_06a4: ldloc.2
-		IL_06a5: ldloc.3
-		IL_06a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06ab: stloc.s 9
-		IL_06ad: ldloc.s 11
-		IL_06af: ldstr "log"
-		IL_06b4: ldloc.s 9
-		IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06bb: pop
+		IL_069f: stloc.s 11
+		IL_06a1: volatile.
+		IL_06a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_06a8: brfalse IL_06bd
+
+		IL_06ad: ldloc.2
+		IL_06ae: ldstr "constructor"
+		IL_06b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06b8: br IL_06d2
+
+		IL_06bd: ldloc.2
+		IL_06be: ldstr "constructor"
+		IL_06c3: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:151"
+		IL_06c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_06cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06d2: stloc.s 10
+		IL_06d4: ldstr "WeakMap"
+		IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06de: stloc.s 9
+		IL_06e0: ldloc.s 10
+		IL_06e2: ldloc.s 9
+		IL_06e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06e9: stloc.s 12
+		IL_06eb: ldloc.s 12
+		IL_06ed: box [System.Runtime]System.Boolean
+		IL_06f2: stloc.s 13
+		IL_06f4: volatile.
+		IL_06f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_06fb: brfalse IL_0713
+
+		IL_0700: ldloc.s 11
+		IL_0702: ldstr "log"
+		IL_0707: ldloc.s 13
+		IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_070e: br IL_072b
+
+		IL_0713: ldloc.s 11
+		IL_0715: ldstr "log"
+		IL_071a: ldloc.s 13
+		IL_071c: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:156"
+		IL_0721: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_072b: pop
+		IL_072c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0731: stloc.3
+		IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_0737: stloc.s 11
+		IL_0739: ldloc.s 11
+		IL_073b: ldstr "key"
+		IL_0740: ldloc.3
+		IL_0741: ldc.i4.0
+		IL_0742: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_0747: pop
+		IL_0748: ldstr "WeakMap"
+		IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0752: volatile.
+		IL_0754: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0759: brfalse IL_076d
+
+		IL_075e: ldstr "prototype"
+		IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0768: br IL_0781
+
+		IL_076d: ldstr "prototype"
+		IL_0772: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:168"
+		IL_0777: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_077c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0781: stloc.s 11
+		IL_0783: volatile.
+		IL_0785: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_078a: brfalse IL_07a0
+
+		IL_078f: ldloc.s 11
+		IL_0791: ldstr "set"
+		IL_0796: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_079b: br IL_07b6
+
+		IL_07a0: ldloc.s 11
+		IL_07a2: ldstr "set"
+		IL_07a7: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:170"
+		IL_07ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_07b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_07b6: stloc.s 11
+		IL_07b8: ldloc.s 11
+		IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07bf: ldstr "call"
+		IL_07c4: ldloc.2
+		IL_07c5: ldloc.3
+		IL_07c6: ldc.r8 7
+		IL_07cf: box [System.Runtime]System.Double
+		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_07d9: pop
+		IL_07da: ldstr "console"
+		IL_07df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07e9: stloc.s 11
+		IL_07eb: ldstr "WeakMap"
+		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07f5: volatile.
+		IL_07f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_07fc: brfalse IL_0810
+
+		IL_0801: ldstr "prototype"
+		IL_0806: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_080b: br IL_0824
+
+		IL_0810: ldstr "prototype"
+		IL_0815: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:182"
+		IL_081a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0824: stloc.s 9
+		IL_0826: volatile.
+		IL_0828: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_082d: brfalse IL_0843
+
+		IL_0832: ldloc.s 9
+		IL_0834: ldstr "get"
+		IL_0839: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_083e: br IL_0859
+
+		IL_0843: ldloc.s 9
+		IL_0845: ldstr "get"
+		IL_084a: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:184"
+		IL_084f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0854: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0859: stloc.s 9
+		IL_085b: ldloc.s 9
+		IL_085d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0862: ldstr "call"
+		IL_0867: ldloc.2
+		IL_0868: ldloc.3
+		IL_0869: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_086e: stloc.s 9
+		IL_0870: volatile.
+		IL_0872: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0877: brfalse IL_088f
+
+		IL_087c: ldloc.s 11
+		IL_087e: ldstr "log"
+		IL_0883: ldloc.s 9
+		IL_0885: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_088a: br IL_08a7
+
+		IL_088f: ldloc.s 11
+		IL_0891: ldstr "log"
+		IL_0896: ldloc.s 9
+		IL_0898: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:187"
+		IL_089d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_08a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_08a7: pop
 		.try
 		{
-			IL_06bc: nop
-			IL_06bd: ldstr "WeakMap"
-			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06c7: stloc.s 4
-			IL_06c9: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_06ce: stloc.s 9
-			IL_06d0: ldloc.s 9
-			IL_06d2: ldstr "weakMapCtor"
-			IL_06d7: ldloc.s 4
-			IL_06d9: ldc.i4.0
-			IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-			IL_06df: pop
-			IL_06e0: ldloc.s 4
-			IL_06e2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_06ec: pop
-			IL_06ed: ldstr "console"
-			IL_06f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06fc: ldstr "log"
-			IL_0701: ldstr "no-throw"
-			IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_070b: pop
-			IL_070c: leave IL_07eb
+			IL_08a8: nop
+			IL_08a9: ldstr "WeakMap"
+			IL_08ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08b3: stloc.s 4
+			IL_08b5: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+			IL_08ba: stloc.s 9
+			IL_08bc: ldloc.s 9
+			IL_08be: ldstr "weakMapCtor"
+			IL_08c3: ldloc.s 4
+			IL_08c5: ldc.i4.0
+			IL_08c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+			IL_08cb: pop
+			IL_08cc: ldloc.s 4
+			IL_08ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_08d8: pop
+			IL_08d9: ldstr "console"
+			IL_08de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08e8: volatile.
+			IL_08ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_08ef: brfalse IL_0908
+
+			IL_08f4: ldstr "log"
+			IL_08f9: ldstr "no-throw"
+			IL_08fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0903: br IL_0921
+
+			IL_0908: ldstr "log"
+			IL_090d: ldstr "no-throw"
+			IL_0912: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:207"
+			IL_0917: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_091c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0921: pop
+			IL_0922: leave IL_0a2a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0711: stloc.s 5
-			IL_0713: ldloc.s 5
-			IL_0715: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_071a: dup
-			IL_071b: brtrue IL_0731
+			IL_0927: stloc.s 5
+			IL_0929: ldloc.s 5
+			IL_092b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0930: dup
+			IL_0931: brtrue IL_0947
 
-			IL_0720: pop
-			IL_0721: ldloc.s 5
-			IL_0723: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0728: dup
-			IL_0729: brtrue IL_073d
+			IL_0936: pop
+			IL_0937: ldloc.s 5
+			IL_0939: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_093e: dup
+			IL_093f: brtrue IL_0953
 
-			IL_072e: pop
-			IL_072f: rethrow
+			IL_0944: pop
+			IL_0945: rethrow
 
-			IL_0731: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0736: stloc.s 6
-			IL_0738: br IL_073f
+			IL_0947: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_094c: stloc.s 6
+			IL_094e: br IL_0955
 
-			IL_073d: stloc.s 6
+			IL_0953: stloc.s 6
 
-			IL_073f: ldloc.s 6
-			IL_0741: stloc.s 7
-			IL_0743: ldstr "console"
-			IL_0748: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0752: stloc.s 9
-			IL_0754: volatile.
-			IL_0756: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_075b: brfalse IL_0771
+			IL_0955: ldloc.s 6
+			IL_0957: stloc.s 7
+			IL_0959: ldstr "console"
+			IL_095e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0968: stloc.s 9
+			IL_096a: volatile.
+			IL_096c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0971: brfalse IL_0987
 
-			IL_0760: ldloc.s 7
-			IL_0762: ldstr "name"
-			IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_076c: br IL_0787
+			IL_0976: ldloc.s 7
+			IL_0978: ldstr "name"
+			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0982: br IL_099d
 
-			IL_0771: ldloc.s 7
-			IL_0773: ldstr "name"
-			IL_0778: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:220"
-			IL_077d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0987: ldloc.s 7
+			IL_0989: ldstr "name"
+			IL_098e: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:220"
+			IL_0993: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0787: stloc.s 11
-			IL_0789: ldloc.s 11
-			IL_078b: ldstr ": "
-			IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0795: stloc.s 15
-			IL_0797: volatile.
-			IL_0799: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_079e: brfalse IL_07b4
+			IL_099d: stloc.s 11
+			IL_099f: ldloc.s 11
+			IL_09a1: ldstr ": "
+			IL_09a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09ab: stloc.s 15
+			IL_09ad: volatile.
+			IL_09af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_09b4: brfalse IL_09ca
 
-			IL_07a3: ldloc.s 7
-			IL_07a5: ldstr "message"
-			IL_07aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07af: br IL_07ca
+			IL_09b9: ldloc.s 7
+			IL_09bb: ldstr "message"
+			IL_09c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09c5: br IL_09e0
 
-			IL_07b4: ldloc.s 7
-			IL_07b6: ldstr "message"
-			IL_07bb: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:224"
-			IL_07c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_07c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_09ca: ldloc.s 7
+			IL_09cc: ldstr "message"
+			IL_09d1: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:224"
+			IL_09d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_09db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07ca: stloc.s 11
-			IL_07cc: ldloc.s 15
-			IL_07ce: ldloc.s 11
-			IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_07d5: stloc.s 15
-			IL_07d7: ldloc.s 9
-			IL_07d9: ldstr "log"
-			IL_07de: ldloc.s 15
-			IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07e5: pop
-			IL_07e6: leave IL_07eb
+			IL_09e0: stloc.s 11
+			IL_09e2: ldloc.s 15
+			IL_09e4: ldloc.s 11
+			IL_09e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09eb: stloc.s 15
+			IL_09ed: volatile.
+			IL_09ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_09f4: brfalse IL_0a0c
+
+			IL_09f9: ldloc.s 9
+			IL_09fb: ldstr "log"
+			IL_0a00: ldloc.s 15
+			IL_0a02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0a07: br IL_0a24
+
+			IL_0a0c: ldloc.s 9
+			IL_0a0e: ldstr "log"
+			IL_0a13: ldloc.s 15
+			IL_0a15: ldstr "WeakMap_Constructor_Prototype_Surface:Modules.WeakMap_Constructor_Prototype_Surface:__js_module_init__:226"
+			IL_0a1a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0a1f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0a24: pop
+			IL_0a25: leave IL_0a2a
 		} // end handler
 
-		IL_07eb: ldnull
-		IL_07ec: stloc.s 8
-		IL_07ee: ret
+		IL_0a2a: ldnull
+		IL_0a2b: stloc.s 8
+		IL_0a2d: ret
 	} // end of method WeakMap_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.WeakMap_Constructor_Prototype_Surface
@@ -818,6 +999,20 @@
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Delete_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Delete_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 137 (0x89)
+		// Code size: 254 (0xfe)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Delete_Basic/Scope,
@@ -129,40 +129,79 @@
 		IL_0024: pop
 		IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002a: stloc.s 4
-		IL_002c: ldloc.1
-		IL_002d: ldstr "delete"
-		IL_0032: ldloc.2
-		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0038: stloc.s 5
-		IL_003a: ldloc.s 4
-		IL_003c: ldloc.s 5
-		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0043: pop
-		IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0049: stloc.s 4
-		IL_004b: ldloc.1
-		IL_004c: ldstr "has"
-		IL_0051: ldloc.2
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0057: stloc.s 5
-		IL_0059: ldloc.s 4
-		IL_005b: ldloc.s 5
-		IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0062: pop
-		IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0068: stloc.3
-		IL_0069: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006e: stloc.s 4
-		IL_0070: ldloc.1
-		IL_0071: ldstr "delete"
-		IL_0076: ldloc.3
-		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_007c: stloc.s 5
-		IL_007e: ldloc.s 4
-		IL_0080: ldloc.s 5
-		IL_0082: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0087: pop
-		IL_0088: ret
+		IL_002c: volatile.
+		IL_002e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0033: brfalse IL_0049
+
+		IL_0038: ldloc.1
+		IL_0039: ldstr "delete"
+		IL_003e: ldloc.2
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0044: br IL_005f
+
+		IL_0049: ldloc.1
+		IL_004a: ldstr "delete"
+		IL_004f: ldloc.2
+		IL_0050: ldstr "WeakMap_Delete_Basic:Modules.WeakMap_Delete_Basic:__js_module_init__:14"
+		IL_0055: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_005f: stloc.s 5
+		IL_0061: ldloc.s 4
+		IL_0063: ldloc.s 5
+		IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006a: pop
+		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0070: stloc.s 4
+		IL_0072: volatile.
+		IL_0074: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0079: brfalse IL_008f
+
+		IL_007e: ldloc.1
+		IL_007f: ldstr "has"
+		IL_0084: ldloc.2
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008a: br IL_00a5
+
+		IL_008f: ldloc.1
+		IL_0090: ldstr "has"
+		IL_0095: ldloc.2
+		IL_0096: ldstr "WeakMap_Delete_Basic:Modules.WeakMap_Delete_Basic:__js_module_init__:18"
+		IL_009b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a5: stloc.s 5
+		IL_00a7: ldloc.s 4
+		IL_00a9: ldloc.s 5
+		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b0: pop
+		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00b6: stloc.3
+		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bc: stloc.s 4
+		IL_00be: volatile.
+		IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00c5: brfalse IL_00db
+
+		IL_00ca: ldloc.1
+		IL_00cb: ldstr "delete"
+		IL_00d0: ldloc.3
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d6: br IL_00f1
+
+		IL_00db: ldloc.1
+		IL_00dc: ldstr "delete"
+		IL_00e1: ldloc.3
+		IL_00e2: ldstr "WeakMap_Delete_Basic:Modules.WeakMap_Delete_Basic:__js_module_init__:25"
+		IL_00e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00f1: stloc.s 5
+		IL_00f3: ldloc.s 4
+		IL_00f5: ldloc.s 5
+		IL_00f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fc: pop
+		IL_00fd: ret
 	} // end of method WeakMap_Delete_Basic::__js_module_init__
 
 } // end of class Modules.WeakMap_Delete_Basic
@@ -187,4 +226,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Has_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Has_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 106 (0x6a)
+		// Code size: 184 (0xb8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Has_Basic/Scope,
@@ -131,27 +131,53 @@
 		IL_002a: pop
 		IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0030: stloc.s 4
-		IL_0032: ldloc.1
-		IL_0033: ldstr "has"
-		IL_0038: ldloc.2
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_003e: stloc.s 5
-		IL_0040: ldloc.s 4
-		IL_0042: ldloc.s 5
-		IL_0044: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0049: pop
-		IL_004a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004f: stloc.s 4
-		IL_0051: ldloc.1
-		IL_0052: ldstr "has"
-		IL_0057: ldloc.3
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_005d: stloc.s 5
-		IL_005f: ldloc.s 4
-		IL_0061: ldloc.s 5
-		IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0068: pop
-		IL_0069: ret
+		IL_0032: volatile.
+		IL_0034: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0039: brfalse IL_004f
+
+		IL_003e: ldloc.1
+		IL_003f: ldstr "has"
+		IL_0044: ldloc.2
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_004a: br IL_0065
+
+		IL_004f: ldloc.1
+		IL_0050: ldstr "has"
+		IL_0055: ldloc.2
+		IL_0056: ldstr "WeakMap_Has_Basic:Modules.WeakMap_Has_Basic:__js_module_init__:17"
+		IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0065: stloc.s 5
+		IL_0067: ldloc.s 4
+		IL_0069: ldloc.s 5
+		IL_006b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0070: pop
+		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0076: stloc.s 4
+		IL_0078: volatile.
+		IL_007a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007f: brfalse IL_0095
+
+		IL_0084: ldloc.1
+		IL_0085: ldstr "has"
+		IL_008a: ldloc.3
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0090: br IL_00ab
+
+		IL_0095: ldloc.1
+		IL_0096: ldstr "has"
+		IL_009b: ldloc.3
+		IL_009c: ldstr "WeakMap_Has_Basic:Modules.WeakMap_Has_Basic:__js_module_init__:21"
+		IL_00a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00ab: stloc.s 5
+		IL_00ad: ldloc.s 4
+		IL_00af: ldloc.s 5
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b6: pop
+		IL_00b7: ret
 	} // end of method WeakMap_Has_Basic::__js_module_init__
 
 } // end of class Modules.WeakMap_Has_Basic
@@ -176,4 +202,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Object_Keys.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Object_Keys.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 156 (0x9c)
+		// Code size: 234 (0xea)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Object_Keys/Scope,
@@ -145,27 +145,53 @@
 		IL_005c: pop
 		IL_005d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0062: stloc.s 4
-		IL_0064: ldloc.1
-		IL_0065: ldstr "get"
-		IL_006a: ldloc.2
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0070: stloc.s 5
-		IL_0072: ldloc.s 4
-		IL_0074: ldloc.s 5
-		IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007b: pop
-		IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0081: stloc.s 4
-		IL_0083: ldloc.1
-		IL_0084: ldstr "get"
-		IL_0089: ldloc.3
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.s 4
-		IL_0093: ldloc.s 5
-		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009a: pop
-		IL_009b: ret
+		IL_0064: volatile.
+		IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_006b: brfalse IL_0081
+
+		IL_0070: ldloc.1
+		IL_0071: ldstr "get"
+		IL_0076: ldloc.2
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007c: br IL_0097
+
+		IL_0081: ldloc.1
+		IL_0082: ldstr "get"
+		IL_0087: ldloc.2
+		IL_0088: ldstr "WeakMap_Object_Keys:Modules.WeakMap_Object_Keys:__js_module_init__:22"
+		IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0097: stloc.s 5
+		IL_0099: ldloc.s 4
+		IL_009b: ldloc.s 5
+		IL_009d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a2: pop
+		IL_00a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a8: stloc.s 4
+		IL_00aa: volatile.
+		IL_00ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00b1: brfalse IL_00c7
+
+		IL_00b6: ldloc.1
+		IL_00b7: ldstr "get"
+		IL_00bc: ldloc.3
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c2: br IL_00dd
+
+		IL_00c7: ldloc.1
+		IL_00c8: ldstr "get"
+		IL_00cd: ldloc.3
+		IL_00ce: ldstr "WeakMap_Object_Keys:Modules.WeakMap_Object_Keys:__js_module_init__:26"
+		IL_00d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00dd: stloc.s 5
+		IL_00df: ldloc.s 4
+		IL_00e1: ldloc.s 5
+		IL_00e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e8: pop
+		IL_00e9: ret
 	} // end of method WeakMap_Object_Keys::__js_module_init__
 
 } // end of class Modules.WeakMap_Object_Keys
@@ -190,4 +216,13 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Set_Get_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakMap/Snapshots/GeneratorTests.WeakMap_Set_Get_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 67 (0x43)
+		// Code size: 106 (0x6a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakMap_Set_Get_Basic/Scope,
@@ -128,16 +128,29 @@
 		IL_0024: pop
 		IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002a: stloc.3
-		IL_002b: ldloc.1
-		IL_002c: ldstr "get"
-		IL_0031: ldloc.2
-		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0037: stloc.s 4
-		IL_0039: ldloc.3
-		IL_003a: ldloc.s 4
-		IL_003c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0041: pop
-		IL_0042: ret
+		IL_002b: volatile.
+		IL_002d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0032: brfalse IL_0048
+
+		IL_0037: ldloc.1
+		IL_0038: ldstr "get"
+		IL_003d: ldloc.2
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0043: br IL_005e
+
+		IL_0048: ldloc.1
+		IL_0049: ldstr "get"
+		IL_004e: ldloc.2
+		IL_004f: ldstr "WeakMap_Set_Get_Basic:Modules.WeakMap_Set_Get_Basic:__js_module_init__:14"
+		IL_0054: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_005e: stloc.s 4
+		IL_0060: ldloc.3
+		IL_0061: ldloc.s 4
+		IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0068: pop
+		IL_0069: ret
 	} // end of method WeakMap_Set_Get_Basic::__js_module_init__
 
 } // end of class Modules.WeakMap_Set_Get_Basic
@@ -162,4 +175,12 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -231,7 +231,7 @@
 			IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0022: stloc.2
 			IL_0023: volatile.
-			IL_0025: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0025: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_002a: brfalse IL_003f
 
 			IL_002f: ldloc.1
@@ -242,12 +242,12 @@
 			IL_003f: ldloc.1
 			IL_0040: ldstr "deref"
 			IL_0045: ldstr "WeakRef_Deref_KeptObjects:<TwoPhaseDummy_M4>:__js_call__:9"
-			IL_004a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_004a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0054: stloc.3
 			IL_0055: volatile.
-			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_0057: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 			IL_005c: brfalse IL_0071
 
 			IL_0061: ldloc.3
@@ -258,7 +258,7 @@
 			IL_0071: ldloc.3
 			IL_0072: ldstr "name"
 			IL_0077: ldstr "WeakRef_Deref_KeptObjects:<TwoPhaseDummy_M4>:__js_call__:11"
-			IL_007c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+			IL_007c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0086: stloc.3
@@ -271,7 +271,7 @@
 			IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_009a: stloc.2
 			IL_009b: volatile.
-			IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_009d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_00a2: brfalse IL_00b7
 
 			IL_00a7: ldloc.1
@@ -282,12 +282,12 @@
 			IL_00b7: ldloc.1
 			IL_00b8: ldstr "deref"
 			IL_00bd: ldstr "WeakRef_Deref_KeptObjects:<TwoPhaseDummy_M4>:__js_call__:17"
-			IL_00c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_00c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_00cc: stloc.3
 			IL_00cd: volatile.
-			IL_00cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_00cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_00d4: brfalse IL_00e9
 
 			IL_00d9: ldloc.3
@@ -298,7 +298,7 @@
 			IL_00e9: ldloc.3
 			IL_00ea: ldstr "name"
 			IL_00ef: ldstr "WeakRef_Deref_KeptObjects:<TwoPhaseDummy_M4>:__js_call__:19"
-			IL_00f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_00f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00fe: stloc.3
@@ -431,7 +431,7 @@
 			IL_000d: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
 			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0017: volatile.
-			IL_0019: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0019: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_001e: brfalse IL_0032
 
 			IL_0023: ldstr "deref"
@@ -440,7 +440,7 @@
 
 			IL_0032: ldstr "deref"
 			IL_0037: ldstr "WeakRef_Deref_KeptObjects:<TwoPhaseDummy_M5>:__js_call__:6"
-			IL_003c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_003c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0046: stloc.1
@@ -543,7 +543,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 499 (0x1f3)
+		// Code size: 540 (0x21c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakRef_Deref_KeptObjects/Scope,
@@ -629,119 +629,132 @@
 		IL_00c6: ldloc.0
 		IL_00c7: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
 		IL_00cc: stloc.s 9
-		IL_00ce: ldloc.s 7
-		IL_00d0: ldstr "call"
-		IL_00d5: ldloc.s 9
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00dc: stloc.s 9
-		IL_00de: ldloc.s 8
-		IL_00e0: ldloc.s 9
-		IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e7: pop
+		IL_00ce: volatile.
+		IL_00d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00d5: brfalse IL_00ed
+
+		IL_00da: ldloc.s 7
+		IL_00dc: ldstr "call"
+		IL_00e1: ldloc.s 9
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e8: br IL_0105
+
+		IL_00ed: ldloc.s 7
+		IL_00ef: ldstr "call"
+		IL_00f4: ldloc.s 9
+		IL_00f6: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:21"
+		IL_00fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0105: stloc.s 9
+		IL_0107: ldloc.s 8
+		IL_0109: ldloc.s 9
+		IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0110: pop
 		.try
 		{
-			IL_00e8: nop
-			IL_00e9: ldc.r8 123
-			IL_00f2: box [System.Runtime]System.Double
-			IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
-			IL_00fc: pop
-			IL_00fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0102: stloc.s 8
-			IL_0104: ldloc.s 8
-			IL_0106: ldstr "primitive target threw:"
-			IL_010b: ldc.i4.0
-			IL_010c: box [System.Runtime]System.Boolean
-			IL_0111: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0116: pop
-			IL_0117: leave IL_01b2
+			IL_0111: nop
+			IL_0112: ldc.r8 123
+			IL_011b: box [System.Runtime]System.Double
+			IL_0120: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
+			IL_0125: pop
+			IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012b: stloc.s 8
+			IL_012d: ldloc.s 8
+			IL_012f: ldstr "primitive target threw:"
+			IL_0134: ldc.i4.0
+			IL_0135: box [System.Runtime]System.Boolean
+			IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_013f: pop
+			IL_0140: leave IL_01db
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_011c: stloc.2
-			IL_011d: ldloc.2
-			IL_011e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0123: dup
-			IL_0124: brtrue IL_0139
+			IL_0145: stloc.2
+			IL_0146: ldloc.2
+			IL_0147: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_014c: dup
+			IL_014d: brtrue IL_0162
 
-			IL_0129: pop
-			IL_012a: ldloc.2
-			IL_012b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0130: dup
-			IL_0131: brtrue IL_0144
+			IL_0152: pop
+			IL_0153: ldloc.2
+			IL_0154: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0159: dup
+			IL_015a: brtrue IL_016d
 
-			IL_0136: pop
-			IL_0137: rethrow
+			IL_015f: pop
+			IL_0160: rethrow
 
-			IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_013e: stloc.3
-			IL_013f: br IL_0145
+			IL_0162: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0167: stloc.3
+			IL_0168: br IL_016e
 
-			IL_0144: stloc.3
+			IL_016d: stloc.3
 
-			IL_0145: ldloc.3
-			IL_0146: stloc.s 4
-			IL_0148: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_014d: stloc.s 8
-			IL_014f: ldloc.s 8
-			IL_0151: ldstr "primitive target threw:"
-			IL_0156: ldc.i4.1
-			IL_0157: box [System.Runtime]System.Boolean
-			IL_015c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0161: pop
-			IL_0162: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0167: stloc.s 8
-			IL_0169: volatile.
-			IL_016b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-			IL_0170: brfalse IL_0186
+			IL_016e: ldloc.3
+			IL_016f: stloc.s 4
+			IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0176: stloc.s 8
+			IL_0178: ldloc.s 8
+			IL_017a: ldstr "primitive target threw:"
+			IL_017f: ldc.i4.1
+			IL_0180: box [System.Runtime]System.Boolean
+			IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_018a: pop
+			IL_018b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0190: stloc.s 8
+			IL_0192: volatile.
+			IL_0194: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0199: brfalse IL_01af
 
-			IL_0175: ldloc.s 4
-			IL_0177: ldstr "name"
-			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0181: br IL_019c
+			IL_019e: ldloc.s 4
+			IL_01a0: ldstr "name"
+			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01aa: br IL_01c5
 
-			IL_0186: ldloc.s 4
-			IL_0188: ldstr "name"
-			IL_018d: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:53"
-			IL_0192: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01af: ldloc.s 4
+			IL_01b1: ldstr "name"
+			IL_01b6: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:53"
+			IL_01bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_019c: stloc.s 9
-			IL_019e: ldloc.s 8
-			IL_01a0: ldstr "primitive target name:"
-			IL_01a5: ldloc.s 9
-			IL_01a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01ac: pop
-			IL_01ad: leave IL_01b2
+			IL_01c5: stloc.s 9
+			IL_01c7: ldloc.s 8
+			IL_01c9: ldstr "primitive target name:"
+			IL_01ce: ldloc.s 9
+			IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01d5: pop
+			IL_01d6: leave IL_01db
 		} // end handler
 
-		IL_01b2: ldc.i4.1
-		IL_01b3: newarr [System.Runtime]System.Object
-		IL_01b8: dup
-		IL_01b9: ldc.i4.0
-		IL_01ba: ldloc.0
-		IL_01bb: stelem.ref
-		IL_01bc: stloc.s 6
-		IL_01be: ldloc.s 6
-		IL_01c0: ldc.i4.0
-		IL_01c1: ldelem.ref
-		IL_01c2: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_01c7: newobj instance void Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject::.ctor(class Modules.WeakRef_Deref_KeptObjects/Scope)
-		IL_01cc: ldc.i4.0
-		IL_01cd: conv.r8
-		IL_01ce: ldstr ""
-		IL_01d3: ldc.i4.0
-		IL_01d4: ldc.i4.0
-		IL_01d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject>(!!0)
-		IL_01df: stloc.s 10
-		IL_01e1: ldloc.s 10
-		IL_01e3: ldc.i4.0
-		IL_01e4: newarr [System.Runtime]System.Object
-		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_01ee: pop
-		IL_01ef: ldnull
-		IL_01f0: stloc.s 5
-		IL_01f2: ret
+		IL_01db: ldc.i4.1
+		IL_01dc: newarr [System.Runtime]System.Object
+		IL_01e1: dup
+		IL_01e2: ldc.i4.0
+		IL_01e3: ldloc.0
+		IL_01e4: stelem.ref
+		IL_01e5: stloc.s 6
+		IL_01e7: ldloc.s 6
+		IL_01e9: ldc.i4.0
+		IL_01ea: ldelem.ref
+		IL_01eb: castclass Modules.WeakRef_Deref_KeptObjects/Scope
+		IL_01f0: newobj instance void Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject::.ctor(class Modules.WeakRef_Deref_KeptObjects/Scope)
+		IL_01f5: ldc.i4.0
+		IL_01f6: conv.r8
+		IL_01f7: ldstr ""
+		IL_01fc: ldc.i4.0
+		IL_01fd: ldc.i4.0
+		IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0203: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject>(!!0)
+		IL_0208: stloc.s 10
+		IL_020a: ldloc.s 10
+		IL_020c: ldc.i4.0
+		IL_020d: newarr [System.Runtime]System.Object
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0217: pop
+		IL_0218: ldnull
+		IL_0219: stloc.s 5
+		IL_021b: ret
 	} // end of method WeakRef_Deref_KeptObjects::__js_module_init__
 
 } // end of class Modules.WeakRef_Deref_KeptObjects
@@ -779,6 +792,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Add_Has_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Add_Has_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 101 (0x65)
+		// Code size: 218 (0xda)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Add_Has_Basic/Scope,
@@ -121,36 +121,75 @@
 		IL_000c: stloc.1
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
-		IL_0013: ldloc.1
-		IL_0014: ldstr "add"
-		IL_0019: ldloc.2
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_001f: pop
-		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0025: stloc.s 4
-		IL_0027: ldloc.1
-		IL_0028: ldstr "has"
-		IL_002d: ldloc.2
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0033: stloc.s 5
-		IL_0035: ldloc.s 4
-		IL_0037: ldloc.s 5
-		IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_003e: pop
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0044: stloc.3
-		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004a: stloc.s 4
-		IL_004c: ldloc.1
-		IL_004d: ldstr "has"
-		IL_0052: ldloc.3
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0058: stloc.s 5
-		IL_005a: ldloc.s 4
-		IL_005c: ldloc.s 5
-		IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0063: pop
-		IL_0064: ret
+		IL_0013: volatile.
+		IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_001a: brfalse IL_0030
+
+		IL_001f: ldloc.1
+		IL_0020: ldstr "add"
+		IL_0025: ldloc.2
+		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_002b: br IL_0046
+
+		IL_0030: ldloc.1
+		IL_0031: ldstr "add"
+		IL_0036: ldloc.2
+		IL_0037: ldstr "WeakSet_Add_Has_Basic:Modules.WeakSet_Add_Has_Basic:__js_module_init__:10"
+		IL_003c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0046: pop
+		IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004c: stloc.s 4
+		IL_004e: volatile.
+		IL_0050: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0055: brfalse IL_006b
+
+		IL_005a: ldloc.1
+		IL_005b: ldstr "has"
+		IL_0060: ldloc.2
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0066: br IL_0081
+
+		IL_006b: ldloc.1
+		IL_006c: ldstr "has"
+		IL_0071: ldloc.2
+		IL_0072: ldstr "WeakSet_Add_Has_Basic:Modules.WeakSet_Add_Has_Basic:__js_module_init__:13"
+		IL_0077: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0081: stloc.s 5
+		IL_0083: ldloc.s 4
+		IL_0085: ldloc.s 5
+		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008c: pop
+		IL_008d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0092: stloc.3
+		IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0098: stloc.s 4
+		IL_009a: volatile.
+		IL_009c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00a1: brfalse IL_00b7
+
+		IL_00a6: ldloc.1
+		IL_00a7: ldstr "has"
+		IL_00ac: ldloc.3
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b2: br IL_00cd
+
+		IL_00b7: ldloc.1
+		IL_00b8: ldstr "has"
+		IL_00bd: ldloc.3
+		IL_00be: ldstr "WeakSet_Add_Has_Basic:Modules.WeakSet_Add_Has_Basic:__js_module_init__:20"
+		IL_00c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00cd: stloc.s 5
+		IL_00cf: ldloc.s 4
+		IL_00d1: ldloc.s 5
+		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d8: pop
+		IL_00d9: ret
 	} // end of method WeakSet_Add_Has_Basic::__js_module_init__
 
 } // end of class Modules.WeakSet_Add_Has_Basic
@@ -175,4 +214,14 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Constructor_Prototype_Surface.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Constructor_Prototype_Surface.verified.txt
@@ -143,7 +143,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2017 (0x7e1)
+		// Code size: 2592 (0xa20)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Constructor_Prototype_Surface/Scope,
@@ -212,564 +212,745 @@
 		IL_00b5: ldloc.s 12
 		IL_00b7: box [System.Runtime]System.Boolean
 		IL_00bc: stloc.s 13
-		IL_00be: ldloc.s 9
-		IL_00c0: ldstr "log"
-		IL_00c5: ldloc.s 13
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cc: pop
-		IL_00cd: ldstr "console"
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00dc: stloc.s 9
-		IL_00de: ldstr "WeakSet"
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00e8: volatile.
-		IL_00ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00ef: brfalse IL_0103
+		IL_00be: volatile.
+		IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00c5: brfalse IL_00dd
 
-		IL_00f4: ldstr "prototype"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fe: br IL_0117
+		IL_00ca: ldloc.s 9
+		IL_00cc: ldstr "log"
+		IL_00d1: ldloc.s 13
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d8: br IL_00f5
 
-		IL_0103: ldstr "prototype"
-		IL_0108: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:37"
-		IL_010d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00dd: ldloc.s 9
+		IL_00df: ldstr "log"
+		IL_00e4: ldloc.s 13
+		IL_00e6: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:29"
+		IL_00eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0117: stloc.s 11
-		IL_0119: volatile.
-		IL_011b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0120: brfalse IL_0136
+		IL_00f5: pop
+		IL_00f6: ldstr "console"
+		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0105: stloc.s 9
+		IL_0107: ldstr "WeakSet"
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0111: volatile.
+		IL_0113: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0118: brfalse IL_012c
 
-		IL_0125: ldloc.s 11
-		IL_0127: ldstr "constructor"
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0131: br IL_014c
+		IL_011d: ldstr "prototype"
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0127: br IL_0140
 
-		IL_0136: ldloc.s 11
-		IL_0138: ldstr "constructor"
-		IL_013d: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:39"
-		IL_0142: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_012c: ldstr "prototype"
+		IL_0131: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:37"
+		IL_0136: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_014c: stloc.s 11
-		IL_014e: ldstr "WeakSet"
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0158: stloc.s 10
-		IL_015a: ldloc.s 11
-		IL_015c: ldloc.s 10
-		IL_015e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0163: stloc.s 12
-		IL_0165: ldloc.s 12
-		IL_0167: box [System.Runtime]System.Boolean
-		IL_016c: stloc.s 13
-		IL_016e: ldloc.s 9
-		IL_0170: ldstr "log"
-		IL_0175: ldloc.s 13
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_017c: pop
-		IL_017d: ldstr "console"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018c: stloc.s 9
-		IL_018e: ldstr "WeakSet"
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0198: stloc.s 10
-		IL_019a: ldstr "Function"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01a4: stloc.s 11
-		IL_01a6: ldloc.s 10
-		IL_01a8: ldloc.s 11
-		IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_01af: stloc.s 12
-		IL_01b1: ldloc.s 12
-		IL_01b3: box [System.Runtime]System.Boolean
-		IL_01b8: stloc.s 13
-		IL_01ba: ldloc.s 9
-		IL_01bc: ldstr "log"
-		IL_01c1: ldloc.s 13
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c8: pop
-		IL_01c9: ldstr "console"
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01d8: stloc.s 9
-		IL_01da: ldstr "WeakSet"
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_01e9: stloc.s 11
-		IL_01eb: ldstr "Function"
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01f5: volatile.
-		IL_01f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_01fc: brfalse IL_0210
+		IL_0140: stloc.s 11
+		IL_0142: volatile.
+		IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0149: brfalse IL_015f
 
-		IL_0201: ldstr "prototype"
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020b: br IL_0224
+		IL_014e: ldloc.s 11
+		IL_0150: ldstr "constructor"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015a: br IL_0175
 
-		IL_0210: ldstr "prototype"
-		IL_0215: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:66"
-		IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_015f: ldloc.s 11
+		IL_0161: ldstr "constructor"
+		IL_0166: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:39"
+		IL_016b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0224: stloc.s 10
-		IL_0226: ldloc.s 11
-		IL_0228: ldloc.s 10
-		IL_022a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_022f: stloc.s 12
-		IL_0231: ldloc.s 12
-		IL_0233: box [System.Runtime]System.Boolean
-		IL_0238: stloc.s 13
-		IL_023a: ldloc.s 9
-		IL_023c: ldstr "log"
-		IL_0241: ldloc.s 13
-		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0248: pop
-		IL_0249: ldstr "console"
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0258: stloc.s 9
-		IL_025a: ldstr "WeakSet"
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0264: volatile.
-		IL_0266: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_026b: brfalse IL_027f
+		IL_0175: stloc.s 11
+		IL_0177: ldstr "WeakSet"
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0181: stloc.s 10
+		IL_0183: ldloc.s 11
+		IL_0185: ldloc.s 10
+		IL_0187: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_018c: stloc.s 12
+		IL_018e: ldloc.s 12
+		IL_0190: box [System.Runtime]System.Boolean
+		IL_0195: stloc.s 13
+		IL_0197: volatile.
+		IL_0199: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_019e: brfalse IL_01b6
 
-		IL_0270: ldstr "prototype"
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_027a: br IL_0293
+		IL_01a3: ldloc.s 9
+		IL_01a5: ldstr "log"
+		IL_01aa: ldloc.s 13
+		IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b1: br IL_01ce
 
-		IL_027f: ldstr "prototype"
-		IL_0284: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:77"
-		IL_0289: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01b6: ldloc.s 9
+		IL_01b8: ldstr "log"
+		IL_01bd: ldloc.s 13
+		IL_01bf: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:44"
+		IL_01c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0293: stloc.s 10
-		IL_0295: ldloc.s 10
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_029c: stloc.s 10
-		IL_029e: ldstr "Object"
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a8: volatile.
-		IL_02aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02af: brfalse IL_02c3
+		IL_01ce: pop
+		IL_01cf: ldstr "console"
+		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01de: stloc.s 9
+		IL_01e0: ldstr "WeakSet"
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ea: stloc.s 10
+		IL_01ec: ldstr "Function"
+		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01f6: stloc.s 11
+		IL_01f8: ldloc.s 10
+		IL_01fa: ldloc.s 11
+		IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0201: stloc.s 12
+		IL_0203: ldloc.s 12
+		IL_0205: box [System.Runtime]System.Boolean
+		IL_020a: stloc.s 13
+		IL_020c: volatile.
+		IL_020e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0213: brfalse IL_022b
 
-		IL_02b4: ldstr "prototype"
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02be: br IL_02d7
+		IL_0218: ldloc.s 9
+		IL_021a: ldstr "log"
+		IL_021f: ldloc.s 13
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0226: br IL_0243
 
-		IL_02c3: ldstr "prototype"
-		IL_02c8: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:82"
-		IL_02cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_022b: ldloc.s 9
+		IL_022d: ldstr "log"
+		IL_0232: ldloc.s 13
+		IL_0234: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:55"
+		IL_0239: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02d7: stloc.s 11
-		IL_02d9: ldloc.s 10
-		IL_02db: ldloc.s 11
-		IL_02dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02e2: stloc.s 12
-		IL_02e4: ldloc.s 12
-		IL_02e6: box [System.Runtime]System.Boolean
-		IL_02eb: stloc.s 13
-		IL_02ed: ldloc.s 9
-		IL_02ef: ldstr "log"
-		IL_02f4: ldloc.s 13
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02fb: pop
-		IL_02fc: ldstr "WeakSet"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0306: ldstr "prototype"
-		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0310: stloc.1
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0316: stloc.s 9
-		IL_0318: ldloc.s 9
-		IL_031a: ldstr "descriptor"
-		IL_031f: ldloc.1
-		IL_0320: ldc.i4.0
-		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_0326: pop
-		IL_0327: ldstr "console"
-		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0336: stloc.s 9
-		IL_0338: volatile.
-		IL_033a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_033f: brfalse IL_0354
+		IL_0243: pop
+		IL_0244: ldstr "console"
+		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0253: stloc.s 9
+		IL_0255: ldstr "WeakSet"
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0264: stloc.s 11
+		IL_0266: ldstr "Function"
+		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0270: volatile.
+		IL_0272: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0277: brfalse IL_028b
 
-		IL_0344: ldloc.1
-		IL_0345: ldstr "writable"
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_034f: br IL_0369
+		IL_027c: ldstr "prototype"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0286: br IL_029f
 
-		IL_0354: ldloc.1
-		IL_0355: ldstr "writable"
-		IL_035a: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:101"
-		IL_035f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_028b: ldstr "prototype"
+		IL_0290: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:66"
+		IL_0295: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0369: stloc.s 11
-		IL_036b: ldloc.s 9
-		IL_036d: ldstr "log"
-		IL_0372: ldloc.s 11
-		IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0379: pop
-		IL_037a: ldstr "console"
-		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0389: stloc.s 11
-		IL_038b: volatile.
-		IL_038d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0392: brfalse IL_03a7
+		IL_029f: stloc.s 10
+		IL_02a1: ldloc.s 11
+		IL_02a3: ldloc.s 10
+		IL_02a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02aa: stloc.s 12
+		IL_02ac: ldloc.s 12
+		IL_02ae: box [System.Runtime]System.Boolean
+		IL_02b3: stloc.s 13
+		IL_02b5: volatile.
+		IL_02b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02bc: brfalse IL_02d4
 
-		IL_0397: ldloc.1
-		IL_0398: ldstr "enumerable"
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03a2: br IL_03bc
+		IL_02c1: ldloc.s 9
+		IL_02c3: ldstr "log"
+		IL_02c8: ldloc.s 13
+		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02cf: br IL_02ec
 
-		IL_03a7: ldloc.1
-		IL_03a8: ldstr "enumerable"
-		IL_03ad: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:108"
-		IL_03b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02d4: ldloc.s 9
+		IL_02d6: ldstr "log"
+		IL_02db: ldloc.s 13
+		IL_02dd: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:69"
+		IL_02e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03bc: stloc.s 9
-		IL_03be: ldloc.s 11
-		IL_03c0: ldstr "log"
-		IL_03c5: ldloc.s 9
-		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03cc: pop
-		IL_03cd: ldstr "console"
-		IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03dc: stloc.s 9
-		IL_03de: volatile.
-		IL_03e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_03e5: brfalse IL_03fa
+		IL_02ec: pop
+		IL_02ed: ldstr "console"
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fc: stloc.s 9
+		IL_02fe: ldstr "WeakSet"
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0308: volatile.
+		IL_030a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_030f: brfalse IL_0323
 
-		IL_03ea: ldloc.1
-		IL_03eb: ldstr "configurable"
-		IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03f5: br IL_040f
+		IL_0314: ldstr "prototype"
+		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_031e: br IL_0337
 
-		IL_03fa: ldloc.1
-		IL_03fb: ldstr "configurable"
-		IL_0400: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:115"
-		IL_0405: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0323: ldstr "prototype"
+		IL_0328: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:77"
+		IL_032d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_040f: stloc.s 11
-		IL_0411: ldloc.s 9
-		IL_0413: ldstr "log"
-		IL_0418: ldloc.s 11
-		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_041f: pop
-		IL_0420: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakSet::.ctor()
-		IL_0425: stloc.2
-		IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_042b: stloc.s 11
-		IL_042d: ldloc.s 11
-		IL_042f: ldstr "weakSet"
-		IL_0434: ldloc.2
-		IL_0435: ldc.i4.0
-		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_043b: pop
-		IL_043c: ldstr "console"
-		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_044b: stloc.s 11
-		IL_044d: ldloc.2
-		IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0453: stloc.s 9
-		IL_0455: ldstr "WeakSet"
-		IL_045a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_045f: volatile.
-		IL_0461: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0466: brfalse IL_047a
+		IL_0337: stloc.s 10
+		IL_0339: ldloc.s 10
+		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0340: stloc.s 10
+		IL_0342: ldstr "Object"
+		IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_034c: volatile.
+		IL_034e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0353: brfalse IL_0367
 
-		IL_046b: ldstr "prototype"
-		IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0475: br IL_048e
+		IL_0358: ldstr "prototype"
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0362: br IL_037b
 
-		IL_047a: ldstr "prototype"
-		IL_047f: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:132"
-		IL_0484: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0367: ldstr "prototype"
+		IL_036c: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:82"
+		IL_0371: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_048e: stloc.s 10
-		IL_0490: ldloc.s 9
-		IL_0492: ldloc.s 10
-		IL_0494: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0499: stloc.s 12
-		IL_049b: ldloc.s 12
-		IL_049d: box [System.Runtime]System.Boolean
-		IL_04a2: stloc.s 13
-		IL_04a4: ldloc.s 11
-		IL_04a6: ldstr "log"
-		IL_04ab: ldloc.s 13
-		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04b2: pop
-		IL_04b3: ldstr "console"
-		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c2: stloc.s 11
-		IL_04c4: ldloc.2
-		IL_04c5: stloc.s 14
-		IL_04c7: ldstr "WeakSet"
-		IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04d1: stloc.s 10
-		IL_04d3: ldloc.s 14
-		IL_04d5: ldloc.s 10
-		IL_04d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_04dc: stloc.s 12
-		IL_04de: ldloc.s 12
-		IL_04e0: box [System.Runtime]System.Boolean
-		IL_04e5: stloc.s 13
-		IL_04e7: ldloc.s 11
-		IL_04e9: ldstr "log"
-		IL_04ee: ldloc.s 13
-		IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04f5: pop
-		IL_04f6: ldstr "console"
-		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0505: stloc.s 11
-		IL_0507: volatile.
-		IL_0509: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_050e: brfalse IL_0523
+		IL_037b: stloc.s 11
+		IL_037d: ldloc.s 10
+		IL_037f: ldloc.s 11
+		IL_0381: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0386: stloc.s 12
+		IL_0388: ldloc.s 12
+		IL_038a: box [System.Runtime]System.Boolean
+		IL_038f: stloc.s 13
+		IL_0391: volatile.
+		IL_0393: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0398: brfalse IL_03b0
 
-		IL_0513: ldloc.2
-		IL_0514: ldstr "constructor"
-		IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_051e: br IL_0538
+		IL_039d: ldloc.s 9
+		IL_039f: ldstr "log"
+		IL_03a4: ldloc.s 13
+		IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03ab: br IL_03c8
 
-		IL_0523: ldloc.2
-		IL_0524: ldstr "constructor"
-		IL_0529: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:151"
-		IL_052e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03b0: ldloc.s 9
+		IL_03b2: ldstr "log"
+		IL_03b7: ldloc.s 13
+		IL_03b9: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:85"
+		IL_03be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0538: stloc.s 10
-		IL_053a: ldstr "WeakSet"
-		IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0544: stloc.s 9
-		IL_0546: ldloc.s 10
-		IL_0548: ldloc.s 9
-		IL_054a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_054f: stloc.s 12
-		IL_0551: ldloc.s 12
-		IL_0553: box [System.Runtime]System.Boolean
-		IL_0558: stloc.s 13
-		IL_055a: ldloc.s 11
-		IL_055c: ldstr "log"
-		IL_0561: ldloc.s 13
-		IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0568: pop
-		IL_0569: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_056e: stloc.3
-		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-		IL_0574: stloc.s 11
-		IL_0576: ldloc.s 11
-		IL_0578: ldstr "value"
-		IL_057d: ldloc.3
-		IL_057e: ldc.i4.0
-		IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-		IL_0584: pop
-		IL_0585: ldstr "WeakSet"
-		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_058f: volatile.
-		IL_0591: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0596: brfalse IL_05aa
+		IL_03c8: pop
+		IL_03c9: ldstr "WeakSet"
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03d3: ldstr "prototype"
+		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_03dd: stloc.1
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_03e3: stloc.s 9
+		IL_03e5: ldloc.s 9
+		IL_03e7: ldstr "descriptor"
+		IL_03ec: ldloc.1
+		IL_03ed: ldc.i4.0
+		IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_03f3: pop
+		IL_03f4: ldstr "console"
+		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0403: stloc.s 9
+		IL_0405: volatile.
+		IL_0407: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_040c: brfalse IL_0421
 
-		IL_059b: ldstr "prototype"
-		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05a5: br IL_05be
+		IL_0411: ldloc.1
+		IL_0412: ldstr "writable"
+		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_041c: br IL_0436
 
-		IL_05aa: ldstr "prototype"
-		IL_05af: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:168"
-		IL_05b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0421: ldloc.1
+		IL_0422: ldstr "writable"
+		IL_0427: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:101"
+		IL_042c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05be: stloc.s 11
-		IL_05c0: volatile.
-		IL_05c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_05c7: brfalse IL_05dd
+		IL_0436: stloc.s 11
+		IL_0438: volatile.
+		IL_043a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_043f: brfalse IL_0457
 
-		IL_05cc: ldloc.s 11
-		IL_05ce: ldstr "add"
-		IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05d8: br IL_05f3
+		IL_0444: ldloc.s 9
+		IL_0446: ldstr "log"
+		IL_044b: ldloc.s 11
+		IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0452: br IL_046f
 
-		IL_05dd: ldloc.s 11
-		IL_05df: ldstr "add"
-		IL_05e4: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:170"
-		IL_05e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0457: ldloc.s 9
+		IL_0459: ldstr "log"
+		IL_045e: ldloc.s 11
+		IL_0460: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:102"
+		IL_0465: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_05f3: stloc.s 11
-		IL_05f5: ldloc.s 11
-		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05fc: ldstr "call"
-		IL_0601: ldloc.2
-		IL_0602: ldloc.3
-		IL_0603: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0608: pop
-		IL_0609: ldstr "console"
-		IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0618: stloc.s 11
-		IL_061a: ldstr "WeakSet"
-		IL_061f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0624: volatile.
-		IL_0626: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_062b: brfalse IL_063f
+		IL_046f: pop
+		IL_0470: ldstr "console"
+		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_047f: stloc.s 11
+		IL_0481: volatile.
+		IL_0483: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0488: brfalse IL_049d
 
-		IL_0630: ldstr "prototype"
-		IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_063a: br IL_0653
+		IL_048d: ldloc.1
+		IL_048e: ldstr "enumerable"
+		IL_0493: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0498: br IL_04b2
 
-		IL_063f: ldstr "prototype"
-		IL_0644: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:180"
-		IL_0649: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_049d: ldloc.1
+		IL_049e: ldstr "enumerable"
+		IL_04a3: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:108"
+		IL_04a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0653: stloc.s 9
-		IL_0655: volatile.
-		IL_0657: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_065c: brfalse IL_0672
+		IL_04b2: stloc.s 9
+		IL_04b4: volatile.
+		IL_04b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04bb: brfalse IL_04d3
 
-		IL_0661: ldloc.s 9
-		IL_0663: ldstr "has"
-		IL_0668: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_066d: br IL_0688
+		IL_04c0: ldloc.s 11
+		IL_04c2: ldstr "log"
+		IL_04c7: ldloc.s 9
+		IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04ce: br IL_04eb
 
-		IL_0672: ldloc.s 9
-		IL_0674: ldstr "has"
-		IL_0679: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:182"
-		IL_067e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0683: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04d3: ldloc.s 11
+		IL_04d5: ldstr "log"
+		IL_04da: ldloc.s 9
+		IL_04dc: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:109"
+		IL_04e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0688: stloc.s 9
-		IL_068a: ldloc.s 9
-		IL_068c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0691: ldstr "call"
-		IL_0696: ldloc.2
-		IL_0697: ldloc.3
-		IL_0698: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_069d: stloc.s 9
-		IL_069f: ldloc.s 11
-		IL_06a1: ldstr "log"
-		IL_06a6: ldloc.s 9
-		IL_06a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06ad: pop
+		IL_04eb: pop
+		IL_04ec: ldstr "console"
+		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04fb: stloc.s 9
+		IL_04fd: volatile.
+		IL_04ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0504: brfalse IL_0519
+
+		IL_0509: ldloc.1
+		IL_050a: ldstr "configurable"
+		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0514: br IL_052e
+
+		IL_0519: ldloc.1
+		IL_051a: ldstr "configurable"
+		IL_051f: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:115"
+		IL_0524: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_052e: stloc.s 11
+		IL_0530: volatile.
+		IL_0532: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0537: brfalse IL_054f
+
+		IL_053c: ldloc.s 9
+		IL_053e: ldstr "log"
+		IL_0543: ldloc.s 11
+		IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_054a: br IL_0567
+
+		IL_054f: ldloc.s 9
+		IL_0551: ldstr "log"
+		IL_0556: ldloc.s 11
+		IL_0558: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:116"
+		IL_055d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0567: pop
+		IL_0568: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakSet::.ctor()
+		IL_056d: stloc.2
+		IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_0573: stloc.s 11
+		IL_0575: ldloc.s 11
+		IL_0577: ldstr "weakSet"
+		IL_057c: ldloc.2
+		IL_057d: ldc.i4.0
+		IL_057e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_0583: pop
+		IL_0584: ldstr "console"
+		IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0593: stloc.s 11
+		IL_0595: ldloc.2
+		IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_059b: stloc.s 9
+		IL_059d: ldstr "WeakSet"
+		IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05a7: volatile.
+		IL_05a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05ae: brfalse IL_05c2
+
+		IL_05b3: ldstr "prototype"
+		IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05bd: br IL_05d6
+
+		IL_05c2: ldstr "prototype"
+		IL_05c7: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:132"
+		IL_05cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05d6: stloc.s 10
+		IL_05d8: ldloc.s 9
+		IL_05da: ldloc.s 10
+		IL_05dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05e1: stloc.s 12
+		IL_05e3: ldloc.s 12
+		IL_05e5: box [System.Runtime]System.Boolean
+		IL_05ea: stloc.s 13
+		IL_05ec: volatile.
+		IL_05ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_05f3: brfalse IL_060b
+
+		IL_05f8: ldloc.s 11
+		IL_05fa: ldstr "log"
+		IL_05ff: ldloc.s 13
+		IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0606: br IL_0623
+
+		IL_060b: ldloc.s 11
+		IL_060d: ldstr "log"
+		IL_0612: ldloc.s 13
+		IL_0614: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:135"
+		IL_0619: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_061e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0623: pop
+		IL_0624: ldstr "console"
+		IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0633: stloc.s 11
+		IL_0635: ldloc.2
+		IL_0636: stloc.s 14
+		IL_0638: ldstr "WeakSet"
+		IL_063d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0642: stloc.s 10
+		IL_0644: ldloc.s 14
+		IL_0646: ldloc.s 10
+		IL_0648: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_064d: stloc.s 12
+		IL_064f: ldloc.s 12
+		IL_0651: box [System.Runtime]System.Boolean
+		IL_0656: stloc.s 13
+		IL_0658: volatile.
+		IL_065a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_065f: brfalse IL_0677
+
+		IL_0664: ldloc.s 11
+		IL_0666: ldstr "log"
+		IL_066b: ldloc.s 13
+		IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0672: br IL_068f
+
+		IL_0677: ldloc.s 11
+		IL_0679: ldstr "log"
+		IL_067e: ldloc.s 13
+		IL_0680: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:145"
+		IL_0685: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_068f: pop
+		IL_0690: ldstr "console"
+		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_069f: stloc.s 11
+		IL_06a1: volatile.
+		IL_06a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_06a8: brfalse IL_06bd
+
+		IL_06ad: ldloc.2
+		IL_06ae: ldstr "constructor"
+		IL_06b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06b8: br IL_06d2
+
+		IL_06bd: ldloc.2
+		IL_06be: ldstr "constructor"
+		IL_06c3: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:151"
+		IL_06c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_06cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06d2: stloc.s 10
+		IL_06d4: ldstr "WeakSet"
+		IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06de: stloc.s 9
+		IL_06e0: ldloc.s 10
+		IL_06e2: ldloc.s 9
+		IL_06e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06e9: stloc.s 12
+		IL_06eb: ldloc.s 12
+		IL_06ed: box [System.Runtime]System.Boolean
+		IL_06f2: stloc.s 13
+		IL_06f4: volatile.
+		IL_06f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_06fb: brfalse IL_0713
+
+		IL_0700: ldloc.s 11
+		IL_0702: ldstr "log"
+		IL_0707: ldloc.s 13
+		IL_0709: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_070e: br IL_072b
+
+		IL_0713: ldloc.s 11
+		IL_0715: ldstr "log"
+		IL_071a: ldloc.s 13
+		IL_071c: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:156"
+		IL_0721: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_072b: pop
+		IL_072c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0731: stloc.3
+		IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+		IL_0737: stloc.s 11
+		IL_0739: ldloc.s 11
+		IL_073b: ldstr "value"
+		IL_0740: ldloc.3
+		IL_0741: ldc.i4.0
+		IL_0742: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+		IL_0747: pop
+		IL_0748: ldstr "WeakSet"
+		IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0752: volatile.
+		IL_0754: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0759: brfalse IL_076d
+
+		IL_075e: ldstr "prototype"
+		IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0768: br IL_0781
+
+		IL_076d: ldstr "prototype"
+		IL_0772: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:168"
+		IL_0777: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_077c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0781: stloc.s 11
+		IL_0783: volatile.
+		IL_0785: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_078a: brfalse IL_07a0
+
+		IL_078f: ldloc.s 11
+		IL_0791: ldstr "add"
+		IL_0796: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_079b: br IL_07b6
+
+		IL_07a0: ldloc.s 11
+		IL_07a2: ldstr "add"
+		IL_07a7: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:170"
+		IL_07ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_07b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_07b6: stloc.s 11
+		IL_07b8: ldloc.s 11
+		IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07bf: ldstr "call"
+		IL_07c4: ldloc.2
+		IL_07c5: ldloc.3
+		IL_07c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_07cb: pop
+		IL_07cc: ldstr "console"
+		IL_07d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07db: stloc.s 11
+		IL_07dd: ldstr "WeakSet"
+		IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07e7: volatile.
+		IL_07e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_07ee: brfalse IL_0802
+
+		IL_07f3: ldstr "prototype"
+		IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07fd: br IL_0816
+
+		IL_0802: ldstr "prototype"
+		IL_0807: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:180"
+		IL_080c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0811: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0816: stloc.s 9
+		IL_0818: volatile.
+		IL_081a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_081f: brfalse IL_0835
+
+		IL_0824: ldloc.s 9
+		IL_0826: ldstr "has"
+		IL_082b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0830: br IL_084b
+
+		IL_0835: ldloc.s 9
+		IL_0837: ldstr "has"
+		IL_083c: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:182"
+		IL_0841: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0846: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_084b: stloc.s 9
+		IL_084d: ldloc.s 9
+		IL_084f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0854: ldstr "call"
+		IL_0859: ldloc.2
+		IL_085a: ldloc.3
+		IL_085b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0860: stloc.s 9
+		IL_0862: volatile.
+		IL_0864: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0869: brfalse IL_0881
+
+		IL_086e: ldloc.s 11
+		IL_0870: ldstr "log"
+		IL_0875: ldloc.s 9
+		IL_0877: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_087c: br IL_0899
+
+		IL_0881: ldloc.s 11
+		IL_0883: ldstr "log"
+		IL_0888: ldloc.s 9
+		IL_088a: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:185"
+		IL_088f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0894: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0899: pop
 		.try
 		{
-			IL_06ae: nop
-			IL_06af: ldstr "WeakSet"
-			IL_06b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06b9: stloc.s 4
-			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
-			IL_06c0: stloc.s 9
-			IL_06c2: ldloc.s 9
-			IL_06c4: ldstr "weakSetCtor"
-			IL_06c9: ldloc.s 4
-			IL_06cb: ldc.i4.0
-			IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
-			IL_06d1: pop
-			IL_06d2: ldloc.s 4
-			IL_06d4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_06de: pop
-			IL_06df: ldstr "console"
-			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06ee: ldstr "log"
-			IL_06f3: ldstr "no-throw"
-			IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06fd: pop
-			IL_06fe: leave IL_07dd
+			IL_089a: nop
+			IL_089b: ldstr "WeakSet"
+			IL_08a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08a5: stloc.s 4
+			IL_08a7: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::GetGlobalThis()
+			IL_08ac: stloc.s 9
+			IL_08ae: ldloc.s 9
+			IL_08b0: ldstr "weakSetCtor"
+			IL_08b5: ldloc.s 4
+			IL_08b7: ldc.i4.0
+			IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetProperty(object, string, object, bool)
+			IL_08bd: pop
+			IL_08be: ldloc.s 4
+			IL_08c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_08c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_08ca: pop
+			IL_08cb: ldstr "console"
+			IL_08d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08da: volatile.
+			IL_08dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_08e1: brfalse IL_08fa
+
+			IL_08e6: ldstr "log"
+			IL_08eb: ldstr "no-throw"
+			IL_08f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_08f5: br IL_0913
+
+			IL_08fa: ldstr "log"
+			IL_08ff: ldstr "no-throw"
+			IL_0904: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:205"
+			IL_0909: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_090e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0913: pop
+			IL_0914: leave IL_0a1c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0703: stloc.s 5
-			IL_0705: ldloc.s 5
-			IL_0707: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_070c: dup
-			IL_070d: brtrue IL_0723
+			IL_0919: stloc.s 5
+			IL_091b: ldloc.s 5
+			IL_091d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0922: dup
+			IL_0923: brtrue IL_0939
 
-			IL_0712: pop
-			IL_0713: ldloc.s 5
-			IL_0715: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_071a: dup
-			IL_071b: brtrue IL_072f
+			IL_0928: pop
+			IL_0929: ldloc.s 5
+			IL_092b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0930: dup
+			IL_0931: brtrue IL_0945
 
-			IL_0720: pop
-			IL_0721: rethrow
+			IL_0936: pop
+			IL_0937: rethrow
 
-			IL_0723: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0728: stloc.s 6
-			IL_072a: br IL_0731
+			IL_0939: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_093e: stloc.s 6
+			IL_0940: br IL_0947
 
-			IL_072f: stloc.s 6
+			IL_0945: stloc.s 6
 
-			IL_0731: ldloc.s 6
-			IL_0733: stloc.s 7
-			IL_0735: ldstr "console"
-			IL_073a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0744: stloc.s 9
-			IL_0746: volatile.
-			IL_0748: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_074d: brfalse IL_0763
+			IL_0947: ldloc.s 6
+			IL_0949: stloc.s 7
+			IL_094b: ldstr "console"
+			IL_0950: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0955: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_095a: stloc.s 9
+			IL_095c: volatile.
+			IL_095e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_0963: brfalse IL_0979
 
-			IL_0752: ldloc.s 7
-			IL_0754: ldstr "name"
-			IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_075e: br IL_0779
+			IL_0968: ldloc.s 7
+			IL_096a: ldstr "name"
+			IL_096f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0974: br IL_098f
 
-			IL_0763: ldloc.s 7
-			IL_0765: ldstr "name"
-			IL_076a: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:218"
-			IL_076f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0979: ldloc.s 7
+			IL_097b: ldstr "name"
+			IL_0980: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:218"
+			IL_0985: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_098a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0779: stloc.s 11
-			IL_077b: ldloc.s 11
-			IL_077d: ldstr ": "
-			IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0787: stloc.s 15
-			IL_0789: volatile.
-			IL_078b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0790: brfalse IL_07a6
+			IL_098f: stloc.s 11
+			IL_0991: ldloc.s 11
+			IL_0993: ldstr ": "
+			IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_099d: stloc.s 15
+			IL_099f: volatile.
+			IL_09a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_09a6: brfalse IL_09bc
 
-			IL_0795: ldloc.s 7
-			IL_0797: ldstr "message"
-			IL_079c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a1: br IL_07bc
+			IL_09ab: ldloc.s 7
+			IL_09ad: ldstr "message"
+			IL_09b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09b7: br IL_09d2
 
-			IL_07a6: ldloc.s 7
-			IL_07a8: ldstr "message"
-			IL_07ad: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:222"
-			IL_07b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_07b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_09bc: ldloc.s 7
+			IL_09be: ldstr "message"
+			IL_09c3: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:222"
+			IL_09c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_09cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07bc: stloc.s 11
-			IL_07be: ldloc.s 15
-			IL_07c0: ldloc.s 11
-			IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_07c7: stloc.s 15
-			IL_07c9: ldloc.s 9
-			IL_07cb: ldstr "log"
-			IL_07d0: ldloc.s 15
-			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07d7: pop
-			IL_07d8: leave IL_07dd
+			IL_09d2: stloc.s 11
+			IL_09d4: ldloc.s 15
+			IL_09d6: ldloc.s 11
+			IL_09d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09dd: stloc.s 15
+			IL_09df: volatile.
+			IL_09e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_09e6: brfalse IL_09fe
+
+			IL_09eb: ldloc.s 9
+			IL_09ed: ldstr "log"
+			IL_09f2: ldloc.s 15
+			IL_09f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09f9: br IL_0a16
+
+			IL_09fe: ldloc.s 9
+			IL_0a00: ldstr "log"
+			IL_0a05: ldloc.s 15
+			IL_0a07: ldstr "WeakSet_Constructor_Prototype_Surface:Modules.WeakSet_Constructor_Prototype_Surface:__js_module_init__:224"
+			IL_0a0c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0a11: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+			IL_0a16: pop
+			IL_0a17: leave IL_0a1c
 		} // end handler
 
-		IL_07dd: ldnull
-		IL_07de: stloc.s 8
-		IL_07e0: ret
+		IL_0a1c: ldnull
+		IL_0a1d: stloc.s 8
+		IL_0a1f: ret
 	} // end of method WeakSet_Constructor_Prototype_Surface::__js_module_init__
 
 } // end of class Modules.WeakSet_Constructor_Prototype_Surface
@@ -816,6 +997,20 @@
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+	.field assembly static int32 __jroc_dynamicLookup_26
+	.field assembly static int32 __jroc_dynamicLookup_27
+	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
+	.field assembly static int32 __jroc_dynamicLookup_30
+	.field assembly static int32 __jroc_dynamicLookup_31
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Delete_Basic.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Delete_Basic.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 132 (0x84)
+		// Code size: 288 (0x120)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Delete_Basic/Scope,
@@ -121,47 +121,99 @@
 		IL_000c: stloc.1
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0012: stloc.2
-		IL_0013: ldloc.1
-		IL_0014: ldstr "add"
-		IL_0019: ldloc.2
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_001f: pop
-		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0025: stloc.s 4
-		IL_0027: ldloc.1
-		IL_0028: ldstr "delete"
-		IL_002d: ldloc.2
-		IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0033: stloc.s 5
-		IL_0035: ldloc.s 4
-		IL_0037: ldloc.s 5
-		IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_003e: pop
-		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0044: stloc.s 4
-		IL_0046: ldloc.1
-		IL_0047: ldstr "has"
-		IL_004c: ldloc.2
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0052: stloc.s 5
-		IL_0054: ldloc.s 4
-		IL_0056: ldloc.s 5
-		IL_0058: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005d: pop
-		IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0063: stloc.3
-		IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0069: stloc.s 4
+		IL_0013: volatile.
+		IL_0015: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_001a: brfalse IL_0030
+
+		IL_001f: ldloc.1
+		IL_0020: ldstr "add"
+		IL_0025: ldloc.2
+		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_002b: br IL_0046
+
+		IL_0030: ldloc.1
+		IL_0031: ldstr "add"
+		IL_0036: ldloc.2
+		IL_0037: ldstr "WeakSet_Delete_Basic:Modules.WeakSet_Delete_Basic:__js_module_init__:10"
+		IL_003c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0046: pop
+		IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004c: stloc.s 4
+		IL_004e: volatile.
+		IL_0050: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0055: brfalse IL_006b
+
+		IL_005a: ldloc.1
+		IL_005b: ldstr "delete"
+		IL_0060: ldloc.2
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0066: br IL_0081
+
 		IL_006b: ldloc.1
 		IL_006c: ldstr "delete"
-		IL_0071: ldloc.3
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0077: stloc.s 5
-		IL_0079: ldloc.s 4
-		IL_007b: ldloc.s 5
-		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0082: pop
-		IL_0083: ret
+		IL_0071: ldloc.2
+		IL_0072: ldstr "WeakSet_Delete_Basic:Modules.WeakSet_Delete_Basic:__js_module_init__:13"
+		IL_0077: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0081: stloc.s 5
+		IL_0083: ldloc.s 4
+		IL_0085: ldloc.s 5
+		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008c: pop
+		IL_008d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0092: stloc.s 4
+		IL_0094: volatile.
+		IL_0096: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_009b: brfalse IL_00b1
+
+		IL_00a0: ldloc.1
+		IL_00a1: ldstr "has"
+		IL_00a6: ldloc.2
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ac: br IL_00c7
+
+		IL_00b1: ldloc.1
+		IL_00b2: ldstr "has"
+		IL_00b7: ldloc.2
+		IL_00b8: ldstr "WeakSet_Delete_Basic:Modules.WeakSet_Delete_Basic:__js_module_init__:17"
+		IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00c7: stloc.s 5
+		IL_00c9: ldloc.s 4
+		IL_00cb: ldloc.s 5
+		IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d2: pop
+		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00d8: stloc.3
+		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00de: stloc.s 4
+		IL_00e0: volatile.
+		IL_00e2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00e7: brfalse IL_00fd
+
+		IL_00ec: ldloc.1
+		IL_00ed: ldstr "delete"
+		IL_00f2: ldloc.3
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f8: br IL_0113
+
+		IL_00fd: ldloc.1
+		IL_00fe: ldstr "delete"
+		IL_0103: ldloc.3
+		IL_0104: ldstr "WeakSet_Delete_Basic:Modules.WeakSet_Delete_Basic:__js_module_init__:24"
+		IL_0109: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0113: stloc.s 5
+		IL_0115: ldloc.s 4
+		IL_0117: ldloc.s 5
+		IL_0119: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011e: pop
+		IL_011f: ret
 	} // end of method WeakSet_Delete_Basic::__js_module_init__
 
 } // end of class Modules.WeakSet_Delete_Basic
@@ -186,4 +238,15 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Object_Values.verified.txt
+++ b/tests/Jroc.Tests/WeakSet/Snapshots/GeneratorTests.WeakSet_Object_Values.verified.txt
@@ -103,7 +103,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 146 (0x92)
+		// Code size: 302 (0x12e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakSet_Object_Values/Scope,
@@ -131,39 +131,91 @@
 		IL_002e: ldstr "obj2"
 		IL_0033: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_0038: stloc.3
-		IL_0039: ldloc.1
-		IL_003a: ldstr "add"
-		IL_003f: ldloc.2
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0045: pop
-		IL_0046: ldloc.1
-		IL_0047: ldstr "add"
-		IL_004c: ldloc.3
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0052: pop
-		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0058: stloc.s 4
-		IL_005a: ldloc.1
-		IL_005b: ldstr "has"
-		IL_0060: ldloc.2
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0066: stloc.s 5
-		IL_0068: ldloc.s 4
-		IL_006a: ldloc.s 5
-		IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0071: pop
-		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0077: stloc.s 4
+		IL_0039: volatile.
+		IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0040: brfalse IL_0056
+
+		IL_0045: ldloc.1
+		IL_0046: ldstr "add"
+		IL_004b: ldloc.2
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0051: br IL_006c
+
+		IL_0056: ldloc.1
+		IL_0057: ldstr "add"
+		IL_005c: ldloc.2
+		IL_005d: ldstr "WeakSet_Object_Values:Modules.WeakSet_Object_Values:__js_module_init__:15"
+		IL_0062: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_1
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_006c: pop
+		IL_006d: volatile.
+		IL_006f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0074: brfalse IL_008a
+
 		IL_0079: ldloc.1
-		IL_007a: ldstr "has"
+		IL_007a: ldstr "add"
 		IL_007f: ldloc.3
 		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0085: stloc.s 5
-		IL_0087: ldloc.s 4
-		IL_0089: ldloc.s 5
-		IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0090: pop
-		IL_0091: ret
+		IL_0085: br IL_00a0
+
+		IL_008a: ldloc.1
+		IL_008b: ldstr "add"
+		IL_0090: ldloc.3
+		IL_0091: ldstr "WeakSet_Object_Values:Modules.WeakSet_Object_Values:__js_module_init__:17"
+		IL_0096: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00a0: pop
+		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a6: stloc.s 4
+		IL_00a8: volatile.
+		IL_00aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00af: brfalse IL_00c5
+
+		IL_00b4: ldloc.1
+		IL_00b5: ldstr "has"
+		IL_00ba: ldloc.2
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c0: br IL_00db
+
+		IL_00c5: ldloc.1
+		IL_00c6: ldstr "has"
+		IL_00cb: ldloc.2
+		IL_00cc: ldstr "WeakSet_Object_Values:Modules.WeakSet_Object_Values:__js_module_init__:20"
+		IL_00d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00db: stloc.s 5
+		IL_00dd: ldloc.s 4
+		IL_00df: ldloc.s 5
+		IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e6: pop
+		IL_00e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ec: stloc.s 4
+		IL_00ee: volatile.
+		IL_00f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00f5: brfalse IL_010b
+
+		IL_00fa: ldloc.1
+		IL_00fb: ldstr "has"
+		IL_0100: ldloc.3
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0106: br IL_0121
+
+		IL_010b: ldloc.1
+		IL_010c: ldstr "has"
+		IL_0111: ldloc.3
+		IL_0112: ldstr "WeakSet_Object_Values:Modules.WeakSet_Object_Values:__js_module_init__:24"
+		IL_0117: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0121: stloc.s 5
+		IL_0123: ldloc.s 4
+		IL_0125: ldloc.s 5
+		IL_0127: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_012c: pop
+		IL_012d: ret
 	} // end of method WeakSet_Object_Values::__js_module_init__
 
 } // end of class Modules.WeakSet_Object_Values
@@ -188,4 +240,15 @@
 	} // end of method Program::Main
 
 } // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_1
+	.field assembly static int32 __jroc_dynamicLookup_2
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+
+} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/performance/Benchmarks/DynamicLookupInlineCacheBenchmarks.cs
+++ b/tests/performance/Benchmarks/DynamicLookupInlineCacheBenchmarks.cs
@@ -22,6 +22,19 @@ public class DynamicLookupInlineCacheBenchmarks
     private const string PropertyInvalidationSite =
         "benchmark:property-invalidation";
     private const string CallHitSite = "benchmark:call-hit";
+    private const string Call1HitSite = "benchmark:call1-hit";
+    private const string Call1SharedPrototypeHitSite =
+        "benchmark:call1-shared-prototype-hit";
+    private const string Call1ReassignmentSite =
+        "benchmark:call1-reassignment";
+    private const string Call1PolymorphicSite =
+        "benchmark:call1-polymorphic";
+    private const string Call1MegamorphicSite =
+        "benchmark:call1-megamorphic";
+    private const string Call1AccessorSite =
+        "benchmark:call1-accessor";
+    private const string Call1ProxySite =
+        "benchmark:call1-proxy";
     private const string PolymorphicSite = "benchmark:polymorphic";
     private const string MegamorphicSite = "benchmark:megamorphic";
     private const string StringSite = "benchmark:string";
@@ -30,6 +43,13 @@ public class DynamicLookupInlineCacheBenchmarks
     private static int _propertyMissTerminal;
     private static int _propertyInvalidationTerminal;
     private static int _callHitTerminal;
+    private static int _call1HitTerminal;
+    private static int _call1SharedPrototypeHitTerminal;
+    private static int _call1ReassignmentTerminal;
+    private static int _call1PolymorphicTerminal;
+    private static int _call1MegamorphicTerminal;
+    private static int _call1AccessorTerminal;
+    private static int _call1ProxyTerminal;
     private static int _polymorphicTerminal;
     private static int _megamorphicTerminal;
     private static int _stringTerminal;
@@ -48,12 +68,26 @@ public class DynamicLookupInlineCacheBenchmarks
         CreateSameShapeReceivers(SameShapeReceiverCount);
     private readonly JavaScriptRuntime.Array _array =
         new(new object?[] { 1d, 2d });
+    private readonly JavaScriptRuntime.Array _call1Receiver = new();
+    private readonly JavaScriptRuntime.Array
+        _call1SharedPrototypeReceiver = new();
+    private readonly JavaScriptRuntime.Array _call1ReassignmentReceiver = new();
+    private readonly JavaScriptRuntime.Array _call1AccessorReceiver = new();
+    private JsObject[] _call1PolymorphicReceivers = null!;
+    private JsObject[] _call1MegamorphicReceivers = null!;
+    private JavaScriptRuntime.Proxy _call1Proxy = null!;
+    private JsObject _call1ReassignmentPrototype = null!;
+    private object _call1FirstFunction = null!;
+    private object _call1SecondFunction = null!;
     private RuntimeAgentCluster? _cluster;
     private IDisposable? _scope;
     private int _polymorphicIndex;
     private int _megamorphicIndex;
     private int _sameShapeIndex;
+    private int _call1PolymorphicIndex;
+    private int _call1MegamorphicIndex;
     private bool _invalidationToggle;
+    private bool _call1ReassignmentToggle;
 
     private const int SameShapeReceiverCount = 10_000;
     private const string SameShapeSite = "benchmark:same-shape";
@@ -78,6 +112,68 @@ public class DynamicLookupInlineCacheBenchmarks
             BuiltinDelegateFunctionAdapter
                 .FromDelegate(function));
 
+        BuiltinFunction1 call1Function =
+            static (_, argument0) => argument0;
+        _call1FirstFunction =
+            BuiltinDelegateFunctionAdapter
+                .FromDelegate(call1Function);
+        BuiltinFunction1 secondCall1Function =
+            static (_, argument0) => argument0;
+        _call1SecondFunction =
+            BuiltinDelegateFunctionAdapter
+                .FromDelegate(secondCall1Function);
+        var call1Prototype = new JsObject();
+        call1Prototype.SetValue(MethodName, _call1FirstFunction);
+        PrototypeChain.SetPrototype(_call1Receiver, call1Prototype);
+        JavaScriptRuntime.Array.Prototype.SetValue(
+            "benchmarkPhase4Method",
+            _call1FirstFunction);
+        PrototypeChain.SetPrototype(
+            _call1SharedPrototypeReceiver,
+            JavaScriptRuntime.Array.Prototype);
+
+        _call1ReassignmentPrototype = new JsObject();
+        _call1ReassignmentPrototype.SetValue(
+            MethodName,
+            _call1FirstFunction);
+        PrototypeChain.SetPrototype(
+            _call1ReassignmentReceiver,
+            _call1ReassignmentPrototype);
+
+        var call1AccessorPrototype = new JsObject();
+        BuiltinFunction0 call1Getter = _ => _call1FirstFunction;
+        PropertyDescriptorStore.DefineOrUpdate(
+            call1AccessorPrototype,
+            MethodName,
+            new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Accessor,
+                Get = BuiltinDelegateFunctionAdapter
+                    .FromDelegate(call1Getter),
+                Enumerable = true,
+                Configurable = true
+            });
+        PrototypeChain.SetPrototype(
+            _call1AccessorReceiver,
+            call1AccessorPrototype);
+
+        var proxyTarget = new JsObject();
+        proxyTarget.SetValue(MethodName, _call1FirstFunction);
+        _call1Proxy = new JavaScriptRuntime.Proxy(
+            proxyTarget,
+            new JsObject());
+
+        _call1PolymorphicReceivers =
+            CreateCall1Receivers(
+                DynamicLookupInlineCacheSite
+                    .MaxPolymorphicEntries,
+                call1Prototype);
+        _call1MegamorphicReceivers =
+            CreateCall1Receivers(
+                DynamicLookupInlineCacheSite
+                    .MaxPolymorphicEntries + 1,
+                call1Prototype);
+
         _ = DynamicLookupInlineCache.GetItem(
             _receiver,
             PropertyName,
@@ -88,6 +184,44 @@ public class DynamicLookupInlineCacheBenchmarks
             MethodName,
             CallHitSite,
             ref _callHitTerminal);
+        _ = DynamicLookupInlineCache.CallMember1(
+            _call1Receiver,
+            MethodName,
+            "argument",
+            Call1HitSite,
+            ref _call1HitTerminal);
+        _ = DynamicLookupInlineCache.CallMember1(
+            _call1SharedPrototypeReceiver,
+            "benchmarkPhase4Method",
+            "argument",
+            Call1SharedPrototypeHitSite,
+            ref _call1SharedPrototypeHitTerminal);
+        _ = DynamicLookupInlineCache.CallMember1(
+            _call1ReassignmentReceiver,
+            MethodName,
+            "argument",
+            Call1ReassignmentSite,
+            ref _call1ReassignmentTerminal);
+
+        foreach (var receiver in _call1PolymorphicReceivers)
+        {
+            _ = DynamicLookupInlineCache.CallMember1(
+                receiver,
+                MethodName,
+                "argument",
+                Call1PolymorphicSite,
+                ref _call1PolymorphicTerminal);
+        }
+
+        foreach (var receiver in _call1MegamorphicReceivers)
+        {
+            _ = DynamicLookupInlineCache.CallMember1(
+                receiver,
+                MethodName,
+                "argument",
+                Call1MegamorphicSite,
+                ref _call1MegamorphicTerminal);
+        }
 
         foreach (var receiver in _polymorphicReceivers)
         {
@@ -183,6 +317,105 @@ public class DynamicLookupInlineCacheBenchmarks
             MethodName,
             CallHitSite,
             ref _callHitTerminal);
+
+    [Benchmark]
+    public object? GenericCallMember1()
+        => ObjectRuntime.CallMember1(
+            _call1Receiver,
+            MethodName,
+            "argument");
+
+    [Benchmark]
+    public object? CachedCallMember1PrototypeHit()
+        => DynamicLookupInlineCache.CallMember1(
+            _call1Receiver,
+            MethodName,
+            "argument",
+            Call1HitSite,
+            ref _call1HitTerminal);
+
+    [Benchmark]
+    public object? CachedCallMember1SharedArrayPrototypeHit()
+        => DynamicLookupInlineCache.CallMember1(
+            _call1SharedPrototypeReceiver,
+            "benchmarkPhase4Method",
+            "argument",
+            Call1SharedPrototypeHitSite,
+            ref _call1SharedPrototypeHitTerminal);
+
+    [Benchmark]
+    public object? CachedCallMember1PrototypeReassignment()
+    {
+        _call1ReassignmentToggle =
+            !_call1ReassignmentToggle;
+        _call1ReassignmentPrototype.SetValue(
+            MethodName,
+            _call1ReassignmentToggle
+                ? _call1FirstFunction
+                : _call1SecondFunction);
+        return DynamicLookupInlineCache.CallMember1(
+            _call1ReassignmentReceiver,
+            MethodName,
+            "argument",
+            Call1ReassignmentSite,
+            ref _call1ReassignmentTerminal);
+    }
+
+    [Benchmark]
+    public object? CachedCallMember1PolymorphicHit()
+    {
+        var receiver =
+            _call1PolymorphicReceivers[
+                _call1PolymorphicIndex++
+                % _call1PolymorphicReceivers.Length];
+        return DynamicLookupInlineCache.CallMember1(
+            receiver,
+            MethodName,
+            "argument",
+            Call1PolymorphicSite,
+            ref _call1PolymorphicTerminal);
+    }
+
+    [Benchmark]
+    public object? CallMember1MegamorphicFallback()
+    {
+        var receiver =
+            _call1MegamorphicReceivers[
+                _call1MegamorphicIndex++
+                % _call1MegamorphicReceivers.Length];
+        if (Volatile.Read(ref _call1MegamorphicTerminal) != 0)
+        {
+            return ObjectRuntime.CallMember1(
+                receiver,
+                MethodName,
+                "argument");
+        }
+
+        return DynamicLookupInlineCache.CallMember1(
+            receiver,
+            MethodName,
+            "argument",
+            Call1MegamorphicSite,
+            ref _call1MegamorphicTerminal);
+    }
+
+    [Benchmark]
+    public object? CallMember1AccessorFallback()
+        => DynamicLookupInlineCache.CallMember1(
+            _call1AccessorReceiver,
+            MethodName,
+            "argument",
+            Call1AccessorSite,
+            ref _call1AccessorTerminal);
+
+    [Benchmark]
+    public object? CallMember1ProxyFallback()
+        => DynamicLookupInlineCache.CallMember1(
+            _call1Proxy,
+            MethodName,
+            "argument",
+            Call1ProxySite,
+            ref _call1ProxyTerminal);
 
     [Benchmark]
     public object CachedPolymorphicHit()
@@ -316,6 +549,26 @@ public class DynamicLookupInlineCacheBenchmarks
                         PropertyName,
                         $"value:{index}");
                     return receiver;
+                })
+            .ToArray();
+
+    private static JsObject[] CreateCall1Receivers(
+        int count,
+        JsObject prototype)
+        => Enumerable
+            .Range(0, count)
+            .Select(
+                index =>
+                {
+                    var receiver =
+                        new JavaScriptRuntime.Array();
+                    receiver.SetValue(
+                        $"shape{index}",
+                        true);
+                    PrototypeChain.SetPrototype(
+                        receiver,
+                        prototype);
+                    return (JsObject)receiver;
                 })
             .ToArray();
 }

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -185,7 +185,8 @@ npm run perf:phased:kracken-ai-astar:il
 
 The IL report records method size, dynamic-cache property reads, generic
 item/property reads, generic numeric `Array.length` reads, explicit boxing,
-arity-1 dispatch inside `findGraphNode`, and arity-1 calls to `findGraphNode`
+generic and cached arity-1 dispatch inside `findGraphNode`, and generic and
+cached arity-1 calls to `findGraphNode`
 from other generated callables. These are method/path counters rather than
 whole-assembly totals.
 
@@ -331,6 +332,34 @@ generic property algorithm, while accessors, inherited properties, Proxies,
 symbols, descriptor changes, deletion, and exotic receivers remain generic.
 The normal end-to-end comparisons show the resulting throughput is currently
 flat; later phases must not treat this foundation as a measured speedup.
+
+Phase 4 shape-keyed `CallMember1` candidate recorded on the same Intel host on
+2026-08-22:
+
+- source: Phase 3 merge `aa07cb174d980c8b59efba3cbe3fc86959d9b5a5`
+  plus the Phase 4 working-tree changes;
+- host: Intel Xeon 6975P-C, Ubuntu 24.04.4, 8 logical / 4 physical cores;
+  runtime: .NET 10.0.11; BenchmarkDotNet 0.15.8;
+- generated IL contains two
+  `DynamicLookupInlineCache.CallMember1(object, string, object, string,
+  int32&)` calls for the two `findGraphNode` sites and retains two
+  `ObjectRuntime.CallMember1` terminal fallback branches;
+- focused normal controls: direct-prototype hit 16.39 ns / 0 B, shared
+  `%Array.prototype%` hit 16.89 ns / 0 B, four-shape polymorphic hit 19.23 ns /
+  0 B, and generic `CallMember1` 104.05 ns / 32 B;
+- sequential JROC-only exact-scenario runs: parent 4.636 s mean / 4.676 s
+  median, N=21, 57,887,544 B/op; candidate 4.685 s mean / 4.712 s median,
+  N=20, 56,893,608 B/op. The 1.1% timing difference is within the overlapping
+  distributions and is not claimed as a throughput change; allocation is
+  993,936 B/op lower;
+- the 32 B generic-call allocation difference attributes approximately
+  31,060 cached arity-1 calls per operation. At the focused 87.16 ns
+  generic-versus-hit delta, the isolated expected saving is about 2.7 ms
+  (0.06% of the scenario), below this workload's observed run-to-run noise.
+  The original Phase 4 end-to-end speed gate is therefore not measurable
+  after the earlier phases reduced the scenario from 17.5 s and 2.31 GB/op;
+  the structural, fixed-arity, and zero-allocation gates remain directly
+  verified.
 
 #### Cube-focused guardrail workflow
 Runs only the Dromaeo cube phased scenarios and prints the execution counters we track for issue #1327:


### PR DESCRIPTION
## Summary

- route generated `LIRCallMember1` sites through the realm-owned dynamic
  lookup cache with a terminal generic bypass
- cache own plain-data slots by receiver shape and direct-prototype methods by
  receiver shape, prototype identity, prototype lookup version, and weak
  callable identity
- support the measured exact-`Array` receiver path for
  `openList.findGraphNode(neighbor)` and
  `closedList.findGraphNode(neighbor)`
- preserve generic semantics for own shadowing, reassignment, deletion,
  accessors, prototype mutation, proxies, symbols, deeper prototype chains,
  primitive receivers, and unsupported exotics
- invoke valid hits through fixed-arity `CallableOperations.Call1` without an
  `object[]`

## Generated-code evidence

The unmodified `kracken-ai-astar` fixture now contains two
`DynamicLookupInlineCache.CallMember1(object, string, object, string, int32&)`
sites for the two `findGraphNode` calls. Each site retains its
`ObjectRuntime.CallMember1` terminal fallback branch.

## Focused performance

Normal BenchmarkDotNet controls on the same Intel Xeon 6975P-C host:

| Path | Mean | Allocated |
| --- | ---: | ---: |
| Direct-prototype cached hit | 16.39 ns | 0 B |
| Shared `%Array.prototype%` cached hit | 16.89 ns | 0 B |
| Four-shape polymorphic cached hit | 19.23 ns | 0 B |
| Generic `CallMember1` | 104.05 ns | 32 B |

Sequential JROC-only exact-scenario runs:

| Revision | Mean | Median | N | Allocated/op |
| --- | ---: | ---: | ---: | ---: |
| Phase 3 parent `aa07cb174` | 4.636 s | 4.676 s | 21 | 57,887,544 B |
| Phase 4 candidate | 4.685 s | 4.712 s | 20 | 56,893,608 B |

The 1.1% timing difference is within the overlapping distributions and is not
claimed as a throughput change. Allocation is 993,936 B/op lower, attributing
about 31,060 cached calls per operation. Applying the focused 87.16 ns
generic-versus-hit delta predicts about 2.7 ms (0.06%) isolated savings, below
the scenario's observed run-to-run noise. The original Phase 4 end-to-end
speed gate is therefore no longer measurable after Phases 1-3 reduced the
workload from 17.5 s and 2.31 GB/op; the structural and zero-allocation gates
are directly verified.

## Validation

- focused cache/runtime suite: 27 passed
- relevant Object/Proxy/Reflect test262 selection: 362 passed
- full `Jroc.Tests`: 3,658 passed, 1 skipped
- Release solution build with warnings as errors: 0 warnings, 0 errors
- independent code review: no high-confidence findings

The expected generator snapshots were regenerated for the new guarded
`CallMember1` IL.

Closes #1963
Part of #1958
