### PR TITLE
perf: add AOT constructor shape specialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf(compiler/runtime): implement issue #1965 (Phase 5 of #1958) with
+  conservative ES5 constructor-layout inference, generated `JsObject`
+  subclasses, specialized static `new` allocation, direct typed reads, and
+  `isinst`-guarded getters with full dynamic fallback. Generated fields mirror
+  ordinary storage, and live descriptor/value validation preserves delete,
+  accessor, plain-write, prototype, dynamic-addition, enumeration, `new.target`,
+  and constructor-return semantics. The exact Kraken A* guardrail now reports
+  two guarded `GraphNode.pos` reads and zero `DynamicLookupInlineCache.GetItem`
+  reads in `findGraphNode`.
 - perf(compiler/runtime): implement issue #1958 Phase 4 with shape-keyed
   `CallMember1` caches for own methods and direct prototype methods, including
   the hot `Array.prototype.findGraphNode` path. Generated sites use fixed-arity

--- a/docs/compiler/ObjectLiteralTypeInference.md
+++ b/docs/compiler/ObjectLiteralTypeInference.md
@@ -9,6 +9,11 @@ any literal that could observe a behavioral difference is left on the generic
 path, and even specialized literals keep their `JsObject` base storage in sync so
 every dynamic runtime path still sees correct values.
 
+The same generated-type machinery also supports eligible ES5 constructor
+functions (issue #1965). Constructor layouts are described separately below
+because their receiver flow and mutation rules are more permissive than the
+closed-world object-literal proof.
+
 ## Phases
 
 | Phase | Issue | What it does |
@@ -45,6 +50,62 @@ class Modules.<Module>/ObjectLiterals/L1C18_eligible : JsObject
   generic-path reads (e.g. destructuring reads), and any access from bindings
   that do not qualify for early binding. Eliding the mirror for fully
   early-bound shapes is a follow-up (#1439).
+
+## ES5 constructor layouts (#1965)
+
+For an ordinary constructor such as:
+
+```js
+function GraphNode(x, y, wall) {
+    this.x = x;
+    this.y = y;
+    this.wall = wall;
+    this.pos = { x, y };
+}
+```
+
+the symbol table records a `ConstructorShapeInfo` when the body begins with a
+contiguous prefix of unconditional top-level `this.<identifier> = value`
+assignments. `TypeGenerator` emits a dedicated
+`ObjectLiterals/Ctor_L<line>C<column>_<name>` subclass of `JsObject` with
+object-typed fields and generated accessors.
+
+Statically known `new Constructor(...)` sites allocate that generated type,
+then invoke the normal generated function body with the allocated receiver.
+The runtime helper still resolves `newTarget.prototype`, establishes the
+constructor invocation context, and applies the ordinary object-return
+override rule. Calling the same function without `new` remains valid:
+constructor-body field stores require both an `isinst` hit and the active
+generated-construction receiver marker, and prove that no receiver or prototype
+descriptor can intercept the write. Otherwise they fall back to ordinary
+JavaScript assignment, including inherited setters/non-writable properties and
+normal calls on custom or previously specialized receivers. Constructor-body
+`this.member` reads are likewise guarded because the function remains callable
+with an arbitrary receiver.
+
+Constructor layouts are rejected conservatively for conditional or late
+initialization, computed `this` keys, deletion, `Object.defineProperty(this,
+...)`, `this` escaping before the initialization prefix completes, explicit
+return values, async/generator functions, or reassigned constructor bindings.
+Ineligible functions retain the existing construction path.
+
+Reads use two tiers:
+
+- **Tier 1:** a stable binding initialized directly by a known specialized
+  `new` uses the generated getter.
+- **Tier 2:** a parameter or other receiver with one known candidate layout
+  uses an `isinst`-guarded getter and ordinary `ObjectRuntime.GetItem` fallback.
+  Candidate layouts propagate through direct calls and prototype-method
+  parameters; a unique parameter member candidate can also specialize related
+  unknown receivers in the same callable. This covers both `obj.pos` and
+  `this[i].pos` in Kraken A* `findGraphNode`.
+
+Generated constructor getters validate that the mirrored base storage still
+contains the same plain default data property before returning a field.
+Delete, accessor/descriptor conversion, and plain dynamic writes therefore
+fall back to complete lookup rather than returning stale data. Shape storage
+continues to define own-key order, so enumeration and later dynamic additions
+preserve ordinary JavaScript ordering.
 
 ## Eligibility (phase 1)
 
@@ -188,13 +249,23 @@ Object-literal read microbenchmark (1000 literals × 20k iterations of
 ≈ **5× faster** and **44% fewer allocations** for literal-heavy read loops.
 Identical computed results confirm behavioral parity.
 
-Kraken `ai-astar` attribution note: its central `var astar = { … }` namespace
-literal does receive a specialized type, but it is constructed exactly once and
-is `var`-bound with method-invoked members, so its accesses stay on the dynamic
-path and this feature contributes little there; the constructor-created
-`GraphNode` objects that dominate `ai-astar` are covered by the
-constructor-shape work (#1426). Direct measured run of the compiled scenario:
-~2.9–3.8 s wall, ~70.6 MB allocated.
+Kraken `ai-astar` attribution note: issue #1965 now specializes the
+constructor-created `GraphNode` objects. The exact IL guardrail reports two
+guarded `pos` getters and zero `DynamicLookupInlineCache.GetItem` calls in
+`findGraphNode`.
+
+A sequential same-host BenchmarkDotNet comparison against Phase 4 commit
+`71bf78438` used three launches with three measured iterations each
+(`N = 9`) on an Intel Xeon 6975P-C, Ubuntu 24.04, .NET 10.0.11, and
+BenchmarkDotNet 0.15.8:
+
+| Variant | Mean | Median | Allocated |
+| --- | ---: | ---: | ---: |
+| Phase 4 baseline | 4.889 s | 4.900 s | 56,893,608 B |
+| Phase 5 candidate | 3.063 s | 2.946 s | 56,971,416 B |
+
+The candidate is **37.3% faster by mean** and **39.9% faster by median**.
+Managed allocation increased by 77,808 bytes (0.14%).
 
 ## Test coverage
 
@@ -207,3 +278,8 @@ constructor-shape work (#1426). Direct measured run of the compiled scenario:
 - `tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_DestructuredParameterInference_Parity.js` — config-style literal propagation into a simple object-destructuring parameter with unboxed numeric bindings
 - `tests/Jroc.Tests/SymbolTable/ObjectLiteralShapeAnalysisTests.cs` — phase 6 slot analysis: propagation, canonicalization (order-insensitive signature), safe/conflicting parameter writes, method-call and spread-shift fallback
 - `tests/Jroc.Tests/ObjectLiteralTypeGenerationGroundworkTests.cs` — generated type metadata contract, reordered same-shape literals sharing one generated type
+- `tests/Jroc.Tests/SymbolTable/ConstructorShapeAnalysisTests.cs` — constructor eligibility/disqualification and binding/parameter candidate propagation
+- `tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_GraphNode.js` — typed allocation, body execution, prototype, ordinary-call, `new.target`, and return-override semantics
+- `tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_GuardedParameterRead.js` — guarded parameter hit and plain-object fallback
+- `tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_MutationFallback.js` — plain writes, delete, accessors/descriptors, prototype mutation, dynamic additions, and enumeration
+- `tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_PrototypeSetSemantics.js` — inherited setters, inherited writable/non-writable data properties, strict failure, and custom-receiver constructor calls

--- a/docs/runtime/DynamicLookupInlineCaches.md
+++ b/docs/runtime/DynamicLookupInlineCaches.md
@@ -21,6 +21,12 @@ guard, so the unmodified
 Kraken A* `openList.findGraphNode(neighbor)` and
 `closedList.findGraphNode(neighbor)` sites resolve once and then invoke through
 `CallableOperations.Call1` without an argument array.
+Phase 5 (#1965) moves eligible ES5 constructor layouts ahead of these caches.
+Proven instances use generated typed getters; uncertain receivers with one
+known constructor layout use an `isinst` guard and the same generated getter,
+with `ObjectRuntime.GetItem` on a type miss. The getter revalidates mirrored
+plain-data storage before returning its field, so descriptor or value mutation
+falls back safely. These guarded hits never enter `DynamicLookupInlineCache`.
 Sections below describe this current contract; historical Phase 0/1 sections
 that still describe identity-only behavior are updated in place rather than
 kept as a separate legacy description, since the generated call surface and

--- a/scripts/runKrackenAStarGuardrails.js
+++ b/scripts/runKrackenAStarGuardrails.js
@@ -3,7 +3,6 @@
 
 const childProcess = require("node:child_process");
 const fs = require("node:fs");
-const os = require("node:os");
 const path = require("node:path");
 
 const TARGET_SCENARIO = "kracken-ai-astar";
@@ -676,6 +675,10 @@ function inspectHotMethodIl(il, source) {
       body,
       /ObjectRuntime::(?:GetItem|GetProperty)\(/g
     ),
+    guardedConstructorFieldReads: countMatches(
+      body,
+      /isinst [^\r\n]*\/ObjectLiterals\/Ctor_[^\r\n]+[\s\S]{0,160}?callvirt instance object [^\r\n]*::get_[A-Za-z_$][A-Za-z0-9_$]*\(\)/g
+    ),
     arrayLengthGenericNumericReads: countMatches(
       body,
       /ObjectRuntime::GetItemAsNumber\(/g
@@ -708,8 +711,10 @@ function inspectHotMethodIl(il, source) {
 
 function runIlInspection(repoRoot, keepArtifacts) {
   runChecked("ilspycmd", ["--version"], { cwd: repoRoot, stdio: "pipe" });
+  const artifactsDirectory = path.join(repoRoot, "artifacts");
+  fs.mkdirSync(artifactsDirectory, { recursive: true });
   const artifactRoot = fs.mkdtempSync(
-    path.join(os.tmpdir(), "jroc-kracken-ai-astar-")
+    path.join(artifactsDirectory, "jroc-kracken-ai-astar-")
   );
   try {
     const source = composeFixture(repoRoot);
@@ -763,6 +768,9 @@ function printIlCounters(result) {
   );
   console.log(
     `Generic item/property reads:              ${result.genericItemPropertyReads}`
+  );
+  console.log(
+    `Guarded constructor field reads:          ${result.guardedConstructorFieldReads}`
   );
   console.log(
     `Generic numeric Array.length reads:       ${result.arrayLengthGenericNumericReads}`

--- a/scripts/runKrackenAStarGuardrails.test.js
+++ b/scripts/runKrackenAStarGuardrails.test.js
@@ -223,9 +223,12 @@ test("counts only the canonical findGraphNode method and its call sites", () => 
     codeSize: 42,
     dynamicCachePropertyReads: 2,
     genericItemPropertyReads: 1,
+    guardedConstructorFieldReads: 0,
     arrayLengthGenericNumericReads: 1,
     boxInstructions: 0,
     arity1MemberDispatches: 0,
+    cachedArity1MemberDispatches: 0,
     findGraphNodeArity1CallSites: 1,
+    cachedFindGraphNodeArity1CallSites: 0,
   });
 });

--- a/src/Compiler/IL/LIRInstructionInfo.cs
+++ b/src/Compiler/IL/LIRInstructionInfo.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using Jroc.IR;
+using Jroc.SymbolTables;
 
 namespace Jroc.IL;
 
@@ -176,6 +177,7 @@ internal static partial class LIRInstructionInfo
         typeof(LIRExpNumber),
         typeof(LIRGeneratorStateSwitch),
         typeof(LIRGetInferredMember),
+        typeof(LIRGetGuardedInferredMember),
         typeof(LIRGetInt32ArrayElement),
         typeof(LIRGetInt32ArrayLength),
         typeof(LIRGetIntrinsicGlobal),
@@ -225,6 +227,7 @@ internal static partial class LIRInstructionInfo
         typeof(LIRRightShift),
         typeof(LIRSequencePoint),
         typeof(LIRSetInferredMember),
+        typeof(LIRSetGuardedInferredMember),
         typeof(LIRSetInt32ArrayElement),
         typeof(LIRSetItem),
         typeof(LIRSetJsArrayElement),
@@ -404,6 +407,15 @@ internal static partial class LIRInstructionInfo
                     : LIRInstructionEffects.None);
         }
 
+        if (instruction is LIRGetInferredMember
+            {
+                Shape: ConstructorShapeInfo
+            })
+        {
+            return LIRInstructionEffects.EmitsInternalControlFlow
+                | CallEffects;
+        }
+
         return _staticEffectsByType.GetOrAdd(
             instruction.GetType(),
             static (_, value) => GetStaticEffects(value),
@@ -517,6 +529,8 @@ internal static partial class LIRInstructionInfo
 
             LIRCallGuardedStringIntrinsic
                 or LIRCallGuardedIntrinsicMember
+                or LIRGetGuardedInferredMember
+                or LIRSetGuardedInferredMember
                 => LIRInstructionEffects.EmitsInternalControlFlow
                     | CallEffects,
 

--- a/src/Compiler/IL/LIRStackScheduler.cs
+++ b/src/Compiler/IL/LIRStackScheduler.cs
@@ -1802,7 +1802,9 @@ internal static class LIRStackScheduler
             return true;
         }
 
-        return instruction is LIRCallTypedMember typed
+        return instruction is LIRCallIntrinsicStatic genericIntrinsic
+                && IsGeneratedReceiverConstruction(genericIntrinsic)
+            || instruction is LIRCallTypedMember typed
                 && typed.ReturnClrType != typeof(void)
             || instruction is LIRCallUserClassInstanceMethod
             {
@@ -1810,6 +1812,17 @@ internal static class LIRStackScheduler
                 RequiresPrivateBrandCheck: false
             };
     }
+
+    private static bool IsGeneratedReceiverConstruction(
+        LIRCallIntrinsicStatic instruction)
+        => instruction.GenericTypeArgument is not null
+            && string.Equals(
+                instruction.IntrinsicName,
+                nameof(JavaScriptRuntime.Function),
+                StringComparison.Ordinal)
+            && instruction.MethodName.StartsWith(
+                "ConstructGeneratedFunctionWithReceiver",
+                StringComparison.Ordinal);
 
     internal static bool IsSupportedScheduledInlineCallProducer(
         LIRInstruction instruction)

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.ArrayAndObjectLiterals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.ArrayAndObjectLiterals.cs
@@ -1,6 +1,7 @@
 using Jroc.IR;
 using Jroc.Services.ILGenerators;
 using Jroc.Services.TwoPhaseCompilation;
+using Jroc.SymbolTables;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
@@ -100,8 +101,13 @@ internal sealed partial class LIRToILCompiler
 
             case LIRGetInferredMember getInferredMember:
                 {
-                    // The generated getter is pure; skip entirely when the result is unused.
-                    if (!IsMaterialized(getInferredMember.Result, allocation))
+                    var resultMaterialized = IsMaterialized(
+                        getInferredMember.Result,
+                        allocation);
+                    // Object-literal getters are pure. Constructor-shape getters can
+                    // fall back to dynamic lookup after mutation and must still run.
+                    if (!resultMaterialized
+                        && getInferredMember.Shape is not ConstructorShapeInfo)
                     {
                         return true;
                     }
@@ -118,7 +124,86 @@ internal sealed partial class LIRToILCompiler
                     ilEncoder.Token(metadata.TypeHandle);
                     ilEncoder.OpCode(ILOpCode.Callvirt);
                     ilEncoder.Token(getterHandle);
-                    EmitStoreTemp(getInferredMember.Result, ilEncoder, allocation);
+                    if (resultMaterialized)
+                    {
+                        EmitStoreTemp(
+                            getInferredMember.Result,
+                            ilEncoder,
+                            allocation);
+                    }
+                    else
+                    {
+                        ilEncoder.OpCode(ILOpCode.Pop);
+                    }
+                    return true;
+                }
+
+            case LIRGetGuardedInferredMember guarded:
+                {
+                    var resultMaterialized = IsMaterialized(
+                        guarded.Result,
+                        allocation);
+
+                    var metadata = GetObjectLiteralTypeMetadata(guarded.Shape);
+                    if (!metadata.GetterHandlesByMemberName.TryGetValue(
+                            guarded.MemberName,
+                            out var getterHandle))
+                    {
+                        throw new InvalidOperationException(
+                            $"Missing generated constructor-shape getter metadata for member '{guarded.MemberName}'.");
+                    }
+
+                    var fallback = ilEncoder.DefineLabel();
+                    var done = ilEncoder.DefineLabel();
+                    EmitLoadTempAsObject(
+                        guarded.Receiver,
+                        ilEncoder,
+                        allocation,
+                        methodDescriptor);
+                    ilEncoder.OpCode(ILOpCode.Isinst);
+                    ilEncoder.Token(metadata.TypeHandle);
+                    ilEncoder.OpCode(ILOpCode.Dup);
+                    ilEncoder.Branch(ILOpCode.Brfalse, fallback);
+                    ilEncoder.OpCode(ILOpCode.Callvirt);
+                    ilEncoder.Token(getterHandle);
+                    if (resultMaterialized)
+                    {
+                        EmitStoreTemp(
+                            guarded.Result,
+                            ilEncoder,
+                            allocation);
+                    }
+                    else
+                    {
+                        ilEncoder.OpCode(ILOpCode.Pop);
+                    }
+                    ilEncoder.Branch(ILOpCode.Br, done);
+
+                    ilEncoder.MarkLabel(fallback);
+                    ilEncoder.OpCode(ILOpCode.Pop);
+                    EmitLoadTempAsObject(
+                        guarded.Receiver,
+                        ilEncoder,
+                        allocation,
+                        methodDescriptor);
+                    ilEncoder.Ldstr(_metadataBuilder, guarded.MemberName);
+                    ilEncoder.OpCode(ILOpCode.Call);
+                    ilEncoder.Token(_memberRefRegistry.GetOrAddMethod(
+                        typeof(JavaScriptRuntime.ObjectRuntime),
+                        nameof(JavaScriptRuntime.ObjectRuntime.GetItem),
+                        new[] { typeof(object), typeof(string) }));
+                    if (resultMaterialized)
+                    {
+                        EmitStoreTemp(
+                            guarded.Result,
+                            ilEncoder,
+                            allocation);
+                    }
+                    else
+                    {
+                        ilEncoder.OpCode(ILOpCode.Pop);
+                    }
+                    ilEncoder.MarkLabel(done);
                     return true;
                 }
 
@@ -142,6 +227,94 @@ internal sealed partial class LIRToILCompiler
                     EmitLoadTempAsClrType(setInferredMember.Value, memberClrType, ilEncoder, allocation, methodDescriptor);
                     ilEncoder.OpCode(ILOpCode.Callvirt);
                     ilEncoder.Token(setterHandle);
+                    return true;
+                }
+
+            case LIRSetGuardedInferredMember guarded:
+                {
+                    var metadata = GetObjectLiteralTypeMetadata(
+                        guarded.Shape);
+                    if (!metadata.SetterHandlesByMemberName.TryGetValue(
+                            guarded.MemberName,
+                            out var setterHandle))
+                    {
+                        throw new InvalidOperationException(
+                            $"Missing generated constructor-shape setter metadata for member '{guarded.MemberName}'.");
+                    }
+
+                    var fallback = ilEncoder.DefineLabel();
+                    var done = ilEncoder.DefineLabel();
+                    EmitLoadTempAsObject(
+                        guarded.Receiver,
+                        ilEncoder,
+                        allocation,
+                        methodDescriptor);
+                    ilEncoder.OpCode(ILOpCode.Isinst);
+                    ilEncoder.Token(metadata.TypeHandle);
+                    ilEncoder.OpCode(ILOpCode.Dup);
+                    ilEncoder.Branch(ILOpCode.Brfalse, fallback);
+                    ilEncoder.OpCode(ILOpCode.Dup);
+                    ilEncoder.OpCode(ILOpCode.Call);
+                    ilEncoder.Token(_memberRefRegistry.GetOrAddMethod(
+                        typeof(JavaScriptRuntime.Function),
+                        nameof(JavaScriptRuntime.Function
+                            .IsCurrentGeneratedConstructionReceiver),
+                        new[] { typeof(object) }));
+                    ilEncoder.Branch(ILOpCode.Brfalse, fallback);
+                    ilEncoder.OpCode(ILOpCode.Dup);
+                    ilEncoder.Ldstr(
+                        _metadataBuilder,
+                        guarded.MemberName);
+                    ilEncoder.OpCode(ILOpCode.Call);
+                    ilEncoder.Token(_memberRefRegistry.GetOrAddMethod(
+                        typeof(JavaScriptRuntime.ObjectRuntime),
+                        nameof(JavaScriptRuntime.ObjectRuntime
+                            .CanUseSpecializedDataPropertySetter),
+                        new[]
+                        {
+                            typeof(object),
+                            typeof(string)
+                        }));
+                    ilEncoder.Branch(ILOpCode.Brfalse, fallback);
+                    EmitLoadTempAsObject(
+                        guarded.Value,
+                        ilEncoder,
+                        allocation,
+                        methodDescriptor);
+                    ilEncoder.OpCode(ILOpCode.Callvirt);
+                    ilEncoder.Token(setterHandle);
+                    ilEncoder.Branch(ILOpCode.Br, done);
+
+                    ilEncoder.MarkLabel(fallback);
+                    ilEncoder.OpCode(ILOpCode.Pop);
+                    EmitLoadTempAsObject(
+                        guarded.Receiver,
+                        ilEncoder,
+                        allocation,
+                        methodDescriptor);
+                    ilEncoder.Ldstr(
+                        _metadataBuilder,
+                        guarded.MemberName);
+                    EmitLoadTempAsObject(
+                        guarded.Value,
+                        ilEncoder,
+                        allocation,
+                        methodDescriptor);
+                    ilEncoder.LoadConstantI4(
+                        guarded.Strict ? 1 : 0);
+                    ilEncoder.OpCode(ILOpCode.Call);
+                    ilEncoder.Token(_memberRefRegistry.GetOrAddMethod(
+                        typeof(JavaScriptRuntime.ObjectRuntime),
+                        nameof(JavaScriptRuntime.ObjectRuntime.SetItem),
+                        new[]
+                        {
+                            typeof(object),
+                            typeof(string),
+                            typeof(object),
+                            typeof(bool)
+                        }));
+                    ilEncoder.OpCode(ILOpCode.Pop);
+                    ilEncoder.MarkLabel(done);
                     return true;
                 }
 
@@ -283,7 +456,7 @@ internal sealed partial class LIRToILCompiler
             }
         }
     }
-    private Jroc.Services.VariableBindings.ObjectLiteralTypeMetadata GetObjectLiteralTypeMetadata(Jroc.SymbolTables.ObjectLiteralShapeInfo shape)
+    private Jroc.Services.VariableBindings.ObjectLiteralTypeMetadata GetObjectLiteralTypeMetadata(Jroc.SymbolTables.InferredObjectShapeInfo shape)
     {
         if (!_variableRegistry.TryGetObjectLiteralType(shape, out var metadata))
         {

--- a/src/Compiler/IL/LIRToILCompiler.IntrinsicStaticCalls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.IntrinsicStaticCalls.cs
@@ -317,40 +317,61 @@ internal sealed partial class LIRToILCompiler
         MethodDescriptor methodDescriptor,
         bool leaveResultOnStack)
     {
-        if (instruction.Arguments.Count != 1)
+        var methods = intrinsicType
+            .GetMethods(
+                System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.Static)
+            .Where(method =>
+                method.IsGenericMethodDefinition
+                && method.GetGenericArguments().Length == 1
+                && string.Equals(
+                    method.Name,
+                    instruction.MethodName,
+                    StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var chosen = ResolveIntrinsicStaticMethod(
+            methods,
+            instruction.Arguments);
+        if (chosen is null)
         {
             throw new InvalidOperationException(
-                $"Generic intrinsic call {intrinsicType.FullName}.{instruction.MethodName} must have exactly one argument.");
+                $"No matching generic static method found: {intrinsicType.FullName}.{instruction.MethodName} with {instruction.Arguments.Count} argument(s)");
         }
 
-        EmitLoadTemp(instruction.Arguments[0], ilEncoder, allocation, methodDescriptor);
-
-        MethodSpecificationHandle methodSpec;
-        if (genericTypeArgument.TypeHandle.Kind == HandleKind.TypeSpecification
-            && genericTypeArgument.ClrType is { } constructedType)
+        var parameters = chosen.GetParameters();
+        for (var i = 0; i < instruction.Arguments.Count; i++)
         {
-            methodSpec = _memberRefRegistry.GetOrAddGenericUnaryMethod(
-                intrinsicType,
-                instruction.MethodName,
-                constructedType);
-        }
-        else
-        {
-            var typeHandle = genericTypeArgument.TypeHandle;
-            var isValueType = false;
-            if (typeHandle.IsNil)
+            if (parameters[i].ParameterType.IsGenericParameter)
             {
-                var clrType = genericTypeArgument.ClrType ?? typeof(object);
-                typeHandle = _memberRefRegistry.GetOrAddTypeHandle(clrType);
-                isValueType = clrType.IsValueType;
+                EmitLoadTemp(
+                    instruction.Arguments[i],
+                    ilEncoder,
+                    allocation,
+                    methodDescriptor);
             }
-
-            methodSpec = _memberRefRegistry.GetOrAddGenericUnaryMethod(
-                intrinsicType,
-                instruction.MethodName,
-                typeHandle,
-                isValueType);
+            else
+            {
+                EmitLoadTempForParameter(
+                    instruction.Arguments[i],
+                    parameters[i].ParameterType,
+                    ilEncoder,
+                    allocation,
+                    methodDescriptor);
+            }
         }
+
+        var typeHandle = genericTypeArgument.TypeHandle;
+        var isValueType = false;
+        if (typeHandle.IsNil)
+        {
+            var clrType = genericTypeArgument.ClrType ?? typeof(object);
+            typeHandle = _memberRefRegistry.GetOrAddTypeHandle(clrType);
+            isValueType = clrType.IsValueType;
+        }
+        var methodSpec = _memberRefRegistry.GetOrAddGenericMethod(
+            chosen,
+            typeHandle,
+            isValueType);
         ilEncoder.OpCode(ILOpCode.Call);
         ilEncoder.Token(methodSpec);
 

--- a/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
+++ b/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
@@ -659,10 +659,16 @@ internal sealed partial class LIRToILCompiler
                     // Early-bound member read: receiver load + castclass + callvirt getter.
                     LIRGetInferredMember getInferredMember => 1 + EstimateTempConstructionPeak(getInferredMember.Receiver),
 
+                    LIRGetGuardedInferredMember guarded => 1 + EstimateTempConstructionPeak(guarded.Receiver),
+
                     // Early-bound member write: receiver stays on stack while the value is built.
                     LIRSetInferredMember setInferredMember => Math.Max(
                         EstimateTempConstructionPeak(setInferredMember.Receiver),
                         1 + EstimateTempConstructionPeak(setInferredMember.Value)),
+
+                    LIRSetGuardedInferredMember guarded => Math.Max(
+                        EstimateTempConstructionPeak(guarded.Receiver),
+                        1 + EstimateTempConstructionPeak(guarded.Value)),
 
                     // Inline item get: receiver + index
                     // Load order matters because receiver remains on stack while index is evaluated.

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -601,6 +601,12 @@ internal sealed partial class LIRToILCompiler
             case LIRGetInferredMember getInferredMember:
                 throw new InvalidOperationException(
                     $"Early-bound object-literal member read '{getInferredMember.MemberName}' must be materialized.");
+            case LIRGetGuardedInferredMember guarded:
+                throw new InvalidOperationException(
+                    $"Guarded constructor member read '{guarded.MemberName}' must be materialized.");
+            case LIRSetGuardedInferredMember guarded:
+                throw new InvalidOperationException(
+                    $"Guarded constructor member write '{guarded.MemberName}' cannot define a temp.");
             case LIRGetLength getLength:
                 {
                     // Emit inline: call JavaScriptRuntime.ObjectRuntime.GetLength(object)

--- a/src/Compiler/IL/TempLocalAllocator.cs
+++ b/src/Compiler/IL/TempLocalAllocator.cs
@@ -578,7 +578,11 @@ internal static partial class LIRInstructionInfo
                 VisitInferredObjectPropertyValues(value.Properties, ref visitor); break;
             case LIRGetInferredMember value:
                 visitor.Visit(value.Receiver); break;
+            case LIRGetGuardedInferredMember value:
+                visitor.Visit(value.Receiver); break;
             case LIRSetInferredMember value:
+                visitor.Visit(value.Receiver); visitor.Visit(value.Value); break;
+            case LIRSetGuardedInferredMember value:
                 visitor.Visit(value.Receiver); visitor.Visit(value.Value); break;
             case LIRGetLength value:
                 visitor.Visit(value.Object); break;
@@ -1112,6 +1116,9 @@ internal static partial class LIRInstructionInfo
                 return true;
             case LIRGetInferredMember getInferredMember:
                 defined = getInferredMember.Result;
+                return true;
+            case LIRGetGuardedInferredMember guarded:
+                defined = guarded.Result;
                 return true;
             case LIRGetLength getLength:
                 defined = getLength.Result;

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
@@ -124,12 +124,11 @@ public sealed partial class HIRToLIRLowerer
                     constructorShape,
                     Array.Empty<InferredObjectProperty>(),
                     receiver));
-            DefineTempStorage(
-                receiver,
-                new ValueStorage(
-                    ValueStorageKind.Reference,
-                    typeof(object),
-                    constructorShape.GeneratedClrTypeHandle));
+            var receiverStorage = new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object),
+                constructorShape.GeneratedClrTypeHandle);
+            DefineTempStorage(receiver, receiverStorage);
 
             resultTempVar = CreateTempVariable();
             var helperArguments = new List<TempVariable>(
@@ -154,13 +153,9 @@ public sealed partial class HIRToLIRLowerer
                         .ConstructGeneratedFunctionWithReceiverArray)
                     : $"ConstructGeneratedFunctionWithReceiver{arguments.Count}",
                 helperArguments,
-                resultTempVar));
-            DefineTempStorage(
                 resultTempVar,
-                new ValueStorage(
-                    ValueStorageKind.Reference,
-                    typeof(object),
-                    constructorShape.GeneratedClrTypeHandle));
+                receiverStorage));
+            DefineTempStorage(resultTempVar, receiverStorage);
             return true;
         }
 

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
@@ -73,6 +73,97 @@ public sealed partial class HIRToLIRLowerer
             return TryLowerDynamicNewExpression(newExpr, out resultTempVar);
         }
 
+        if (calleeVar?.Name.BindingInfo.ConstructorShape is
+                {
+                    IsEligible: true
+                } constructorShape
+            && !constructorShape.GeneratedClrTypeHandle.IsNil)
+        {
+            if (!TryLowerExpression(calleeVar, out var constructorValue))
+            {
+                return false;
+            }
+            constructorValue = EnsureObject(constructorValue);
+
+            var useInlineArguments =
+                newExpr.Arguments.Count
+                    <= JavaScriptRuntime.JsCallArguments.InlineCapacity
+                && newExpr.Arguments.All(
+                    static argument =>
+                        argument is not HIRSpreadElement);
+            var arguments = new List<TempVariable>();
+            TempVariable? argumentsArray = null;
+            if (useInlineArguments)
+            {
+                arguments.Capacity = newExpr.Arguments.Count;
+                foreach (var argument in newExpr.Arguments)
+                {
+                    if (!TryLowerExpression(
+                            argument,
+                            out var argumentTemp))
+                    {
+                        return false;
+                    }
+                    arguments.Add(EnsureObject(argumentTemp));
+                }
+            }
+            else if (!TryLowerCallArgumentsToArgsArray(
+                         newExpr.Arguments,
+                         out var loweredArgumentsArray))
+            {
+                return false;
+            }
+            else
+            {
+                argumentsArray = loweredArgumentsArray;
+            }
+
+            var receiver = CreateTempVariable();
+            _methodBodyIR.Instructions.Add(
+                new LIRNewInferredJsObject(
+                    constructorShape,
+                    Array.Empty<InferredObjectProperty>(),
+                    receiver));
+            DefineTempStorage(
+                receiver,
+                new ValueStorage(
+                    ValueStorageKind.Reference,
+                    typeof(object),
+                    constructorShape.GeneratedClrTypeHandle));
+
+            resultTempVar = CreateTempVariable();
+            var helperArguments = new List<TempVariable>(
+                (argumentsArray.HasValue ? 1 : arguments.Count) + 3)
+            {
+                constructorValue,
+                receiver,
+                constructorValue
+            };
+            if (argumentsArray.HasValue)
+            {
+                helperArguments.Add(argumentsArray.Value);
+            }
+            else
+            {
+                helperArguments.AddRange(arguments);
+            }
+            _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
+                nameof(JavaScriptRuntime.Function),
+                argumentsArray.HasValue
+                    ? nameof(JavaScriptRuntime.Function
+                        .ConstructGeneratedFunctionWithReceiverArray)
+                    : $"ConstructGeneratedFunctionWithReceiver{arguments.Count}",
+                helperArguments,
+                resultTempVar));
+            DefineTempStorage(
+                resultTempVar,
+                new ValueStorage(
+                    ValueStorageKind.Reference,
+                    typeof(object),
+                    constructorShape.GeneratedClrTypeHandle));
+            return true;
+        }
+
         if (calleeVar?.Name.Kind == BindingKind.Global
             && string.Equals(ctorName, "Function", StringComparison.Ordinal)
             && TryGetDynamicFunctionSyntaxErrorMessage(newExpr.Arguments, out var syntaxErrorMessage)

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAccess.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAccess.cs
@@ -40,6 +40,57 @@ public sealed partial class HIRToLIRLowerer
             return true;
         }
 
+        if (TryGetDirectConstructorMember(
+                propAccessExpr.Object,
+                propAccessExpr.PropertyName,
+                out var directConstructorShape,
+                out var directConstructorMember))
+        {
+            if (!TryLowerExpression(
+                    propAccessExpr.Object,
+                    out var directReceiver))
+            {
+                return false;
+            }
+
+            _methodBodyIR.Instructions.Add(new LIRGetInferredMember(
+                directConstructorShape,
+                directConstructorMember.Name,
+                EnsureObject(directReceiver),
+                resultTempVar));
+            DefineTempStorage(
+                resultTempVar,
+                GetInferredMemberStorage(directConstructorMember));
+            return true;
+        }
+
+        if (TryGetGuardedConstructorMember(
+                propAccessExpr.Object,
+                propAccessExpr.PropertyName,
+                out var guardedConstructorShape,
+                out var guardedConstructorMember))
+        {
+            if (!TryLowerExpression(
+                    propAccessExpr.Object,
+                    out var guardedReceiver))
+            {
+                return false;
+            }
+
+            _methodBodyIR.Instructions.Add(
+                new LIRGetGuardedInferredMember(
+                    guardedConstructorShape,
+                    guardedConstructorMember.Name,
+                    EnsureObject(guardedReceiver),
+                    resultTempVar));
+            DefineTempStorage(
+                resultTempVar,
+                new ValueStorage(
+                    ValueStorageKind.Reference,
+                    typeof(object)));
+            return true;
+        }
+
         // Intrinsic object property read: support well-known Symbol properties (e.g., Symbol.iterator).
         // We lower this as a static intrinsic call so `Symbol` does not need to be representable
         // as a normal runtime value.
@@ -884,6 +935,94 @@ public sealed partial class HIRToLIRLowerer
         return clrType == typeof(double) || clrType == typeof(bool)
             ? new ValueStorage(ValueStorageKind.UnboxedValue, clrType)
             : new ValueStorage(ValueStorageKind.Reference, clrType);
+    }
+
+    private bool TryGetDirectConstructorMember(
+        HIRExpression objectExpression,
+        string propertyName,
+        out ConstructorShapeInfo shape,
+        out ObjectLiteralMemberInfo member)
+    {
+        shape = null!;
+        member = null!;
+        ConstructorShapeInfo? candidate = objectExpression switch
+        {
+            HIRVariableExpression variable
+                when variable.Name.BindingInfo.Kind is
+                    BindingKind.Const or BindingKind.Let =>
+                variable.Name.BindingInfo.ConstructedShape,
+            _ => null
+        };
+        if (candidate is not { IsEligible: true }
+            || candidate.GeneratedClrTypeHandle.IsNil
+            || !candidate.TryGetMember(propertyName, out member))
+        {
+            return false;
+        }
+
+        shape = candidate;
+        return true;
+    }
+
+    private bool TryGetGuardedConstructorMember(
+        HIRExpression objectExpression,
+        string propertyName,
+        out ConstructorShapeInfo shape,
+        out ObjectLiteralMemberInfo member)
+    {
+        shape = null!;
+        member = null!;
+        var candidates = new HashSet<ConstructorShapeInfo>(
+            ReferenceEqualityComparer.Instance);
+
+        if (objectExpression is HIRThisExpression
+            && _scope?.ConstructorShape is { } thisShape)
+        {
+            candidates.Add(thisShape);
+        }
+        else if (objectExpression is HIRVariableExpression variable)
+        {
+            foreach (var candidate in variable.Name.BindingInfo
+                         .ConstructorShapeCandidates)
+            {
+                candidates.Add(candidate);
+            }
+        }
+
+        if (_scope != null)
+        {
+            foreach (var binding in _scope.Bindings.Values)
+            {
+                if (!_scope.Parameters.Contains(binding.Name))
+                {
+                    continue;
+                }
+
+                foreach (var candidate in binding
+                             .ConstructorShapeCandidates)
+                {
+                    if (candidate.TryGetMember(propertyName, out _))
+                    {
+                        candidates.Add(candidate);
+                    }
+                }
+            }
+        }
+
+        var matching = candidates
+            .Where(candidate =>
+                candidate.IsEligible
+                && !candidate.GeneratedClrTypeHandle.IsNil
+                && candidate.TryGetMember(propertyName, out _))
+            .ToArray();
+        if (matching.Length != 1
+            || !matching[0].TryGetMember(propertyName, out member))
+        {
+            return false;
+        }
+
+        shape = matching[0];
+        return true;
     }
 
     /// <summary>

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAssignments.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAssignments.cs
@@ -136,6 +136,37 @@ public sealed partial class HIRToLIRLowerer
     {
         resultTempVar = default;
 
+        if (assignExpr.Object is HIRThisExpression
+            && _scope?.ConstructorShape is
+                {
+                    IsEligible: true
+                } constructorShape
+            && constructorShape.TryGetMember(
+                assignExpr.PropertyName,
+                out var constructorMember))
+        {
+            if (assignExpr.Operator != Acornima.Operator.Assignment
+                || !TryLowerExpression(
+                    assignExpr.Object,
+                    out var constructorReceiver)
+                || !TryLowerExpression(
+                    assignExpr.Value,
+                    out var constructorValue))
+            {
+                return false;
+            }
+
+            _methodBodyIR.Instructions.Add(
+                new LIRSetGuardedInferredMember(
+                    constructorShape,
+                    constructorMember.Name,
+                    EnsureObject(constructorReceiver),
+                    EnsureObject(constructorValue),
+                    UsesStrictAssignmentSemantics()));
+            resultTempVar = constructorValue;
+            return true;
+        }
+
         // Early-bound object-literal member write (phase 4, #1432). All write forms must go
         // through the generated setter so the typed backing field and JsObject storage stay
         // in sync; a generic SetItem would leave the backing field stale.
@@ -263,7 +294,7 @@ public sealed partial class HIRToLIRLowerer
     /// </summary>
     private bool TryLowerInferredMemberAssignment(
         HIRPropertyAssignmentExpression assignExpr,
-        ObjectLiteralShapeInfo shape,
+        InferredObjectShapeInfo shape,
         ObjectLiteralMemberInfo member,
         out TempVariable resultTempVar)
     {

--- a/src/Compiler/IR/LIR/LIRArrayInstructions.cs
+++ b/src/Compiler/IR/LIR/LIRArrayInstructions.cs
@@ -148,7 +148,7 @@ public record LIRNewJsObject(IReadOnlyList<ObjectProperty> Properties, TempVaria
 /// IL emitter: newobj generated::.ctor(), then for each property stfld + JsObject mirror setter.
 /// </summary>
 public record LIRNewInferredJsObject(
-    ObjectLiteralShapeInfo Shape,
+    InferredObjectShapeInfo Shape,
     IReadOnlyList<InferredObjectProperty> Properties,
     TempVariable Result) : LIRInstruction;
 
@@ -158,7 +158,7 @@ public record LIRNewInferredJsObject(
 /// The result carries the member's stable CLR type (unboxed double/bool, string, or object).
 /// </summary>
 public record LIRGetInferredMember(
-    ObjectLiteralShapeInfo Shape,
+    InferredObjectShapeInfo Shape,
     string MemberName,
     TempVariable Receiver,
     TempVariable Result) : LIRInstruction;
@@ -170,7 +170,30 @@ public record LIRGetInferredMember(
 /// mirrors the value into JsObject storage, keeping dynamic views in sync.
 /// </summary>
 public record LIRSetInferredMember(
-    ObjectLiteralShapeInfo Shape,
+    InferredObjectShapeInfo Shape,
     string MemberName,
     TempVariable Receiver,
     TempVariable Value) : LIRInstruction;
+
+/// <summary>
+/// Runtime-guarded constructor-body write. Ordinary calls to a constructor
+/// function can supply a non-specialized receiver, so the miss path preserves
+/// normal JavaScript assignment semantics.
+/// </summary>
+public record LIRSetGuardedInferredMember(
+    ConstructorShapeInfo Shape,
+    string MemberName,
+    TempVariable Receiver,
+    TempVariable Value,
+    bool Strict) : LIRInstruction;
+
+/// <summary>
+/// Runtime-guarded read of a member declared by a generated constructor layout.
+/// The specialized getter is used when the receiver has the generated CLR type;
+/// otherwise emission falls back to ordinary dynamic property lookup.
+/// </summary>
+public record LIRGetGuardedInferredMember(
+    ConstructorShapeInfo Shape,
+    string MemberName,
+    TempVariable Receiver,
+    TempVariable Result) : LIRInstruction;

--- a/src/Compiler/Services/TypeGenerator.cs
+++ b/src/Compiler/Services/TypeGenerator.cs
@@ -53,7 +53,8 @@ namespace Jroc.Services
             MethodDefinitionHandle ExpectedCtor,
             string? MemberName = null,
             FieldDefinitionHandle AccessorField = default,
-            Type? AccessorClrType = null);
+            Type? AccessorClrType = null,
+            bool ValidateSpecializedRead = false);
 
         public TypeGenerator(
             MetadataBuilder metadataBuilder,
@@ -124,7 +125,12 @@ namespace Jroc.Services
                 {
                     DeferredConstructorKind.Scope => EmitScopeConstructor(tb, item.ScopeKey, item.IsAsync, item.IsGenerator),
                     DeferredConstructorKind.ObjectLiteral => EmitObjectLiteralConstructor(tb),
-                    DeferredConstructorKind.ObjectLiteralGetter => EmitObjectLiteralGetter(tb, item.MemberName!, item.AccessorField, item.AccessorClrType!),
+                    DeferredConstructorKind.ObjectLiteralGetter => EmitObjectLiteralGetter(
+                        tb,
+                        item.MemberName!,
+                        item.AccessorField,
+                        item.AccessorClrType!,
+                        item.ValidateSpecializedRead),
                     DeferredConstructorKind.ObjectLiteralSetter => EmitObjectLiteralSetter(tb, item.MemberName!, item.AccessorField, item.AccessorClrType!),
                     _ => throw new InvalidOperationException($"Unknown deferred constructor kind '{item.Kind}'.")
                 };
@@ -202,6 +208,13 @@ namespace Jroc.Services
                 && !shape.GeneratedClrTypeHandle.IsNil)
             {
                 return shape.GeneratedClrTypeHandle;
+            }
+
+            if (!binding.RequiresRuntimeTemporalDeadZoneChecks
+                && binding.ConstructedShape is { IsEligible: true } constructedShape
+                && !constructedShape.GeneratedClrTypeHandle.IsNil)
+            {
+                return constructedShape.GeneratedClrTypeHandle;
             }
 
             return default;
@@ -444,7 +457,7 @@ namespace Jroc.Services
             TypeDefinitionHandle moduleTypeHandle,
             NestedTypeRelationshipRegistry nestedTypeRegistry)
         {
-            var groups = GetObjectLiteralShapeGroups(root);
+            var groups = GetInferredObjectShapeGroups(root);
             if (groups.Count == 0)
             {
                 return;
@@ -470,7 +483,7 @@ namespace Jroc.Services
 
         private void PlanObjectLiteralTypeHandles(Scope root)
         {
-            var groups = GetObjectLiteralShapeGroups(root);
+            var groups = GetInferredObjectShapeGroups(root);
             if (groups.Count == 0)
             {
                 return;
@@ -490,11 +503,11 @@ namespace Jroc.Services
             }
         }
 
-        private static List<List<ObjectLiteralShapeInfo>> GetObjectLiteralShapeGroups(Scope root)
+        private static List<List<InferredObjectShapeInfo>> GetInferredObjectShapeGroups(Scope root)
         {
             // A single shape object can be referenced by more than one binding, so deduplicate by
             // reference. Structurally identical shapes share one generated CLR type.
-            return EnumerateEligibleObjectLiteralShapes(root)
+            var objectLiteralGroups = EnumerateEligibleObjectLiteralShapes(root)
                 .Distinct(ReferenceEqualityComparer.Instance)
                 .Cast<ObjectLiteralShapeInfo>()
                 .GroupBy(static shape => shape.GetStructuralSignatureKey(), StringComparer.Ordinal)
@@ -503,12 +516,24 @@ namespace Jroc.Services
                     .ThenBy(static shape => shape.Literal.Location.Start.Column)
                     .ThenBy(static shape => shape.Binding.Name, StringComparer.Ordinal)
                     .ThenBy(static shape => GetRegistryScopeName(shape.Binding.DeclaringScope), StringComparer.Ordinal)
+                    .Cast<InferredObjectShapeInfo>()
                     .ToList())
-                .OrderBy(static group => group[0].Literal.Location.Start.Line)
-                .ThenBy(static group => group[0].Literal.Location.Start.Column)
+                .OrderBy(static group => group[0].SourceNode.Location.Start.Line)
+                .ThenBy(static group => group[0].SourceNode.Location.Start.Column)
                 .ThenBy(static group => group[0].Binding.Name, StringComparer.Ordinal)
                 .ThenBy(static group => GetRegistryScopeName(group[0].Binding.DeclaringScope), StringComparer.Ordinal)
                 .ToList();
+
+            var constructorGroups = EnumerateEligibleConstructorShapes(root)
+                .Distinct(ReferenceEqualityComparer.Instance)
+                .Cast<ConstructorShapeInfo>()
+                .OrderBy(static shape => shape.SourceNode.Location.Start.Line)
+                .ThenBy(static shape => shape.SourceNode.Location.Start.Column)
+                .ThenBy(static shape => shape.Binding.Name, StringComparer.Ordinal)
+                .Select(static shape => new List<InferredObjectShapeInfo> { shape });
+
+            objectLiteralGroups.AddRange(constructorGroups);
+            return objectLiteralGroups;
         }
 
         private static int CountScopeTypeDefinitions(Scope root)
@@ -527,14 +552,16 @@ namespace Jroc.Services
         }
 
         private void CreateObjectLiteralType(
-            IReadOnlyList<ObjectLiteralShapeInfo> shapeGroup,
+            IReadOnlyList<InferredObjectShapeInfo> shapeGroup,
             TypeDefinitionHandle containerHandle,
             NestedTypeRelationshipRegistry nestedTypeRegistry)
         {
             // The representative (first, deterministically ordered) shape names the type and drives
             // field/member layout; every shape in the group shares the generated type and metadata.
             var shape = shapeGroup[0];
-            var typeName = GetObjectLiteralTypeName(shape);
+            var typeName = GetInferredObjectTypeName(shape);
+            var validateSpecializedReads =
+                shape is ConstructorShapeInfo;
             var tb = new TypeBuilder(_metadataBuilder, string.Empty, typeName);
             var fieldHandlesByName = new Dictionary<string, FieldDefinitionHandle>(StringComparer.Ordinal);
             var fieldClrTypesByName = new Dictionary<string, Type>(StringComparer.Ordinal);
@@ -597,7 +624,8 @@ namespace Jroc.Services
                     ExpectedCtor: getterHandle,
                     MemberName: member.Name,
                     AccessorField: fieldHandle,
-                    AccessorClrType: fieldClrType));
+                    AccessorClrType: fieldClrType,
+                    ValidateSpecializedRead: validateSpecializedReads));
 
                 var setterHandle = MetadataTokens.MethodDefinitionHandle(_nextDeferredCtorRow++);
                 setterHandlesByName[member.Name] = setterHandle;
@@ -676,7 +704,8 @@ namespace Jroc.Services
             TypeBuilder tb,
             string memberName,
             FieldDefinitionHandle fieldHandle,
-            Type fieldClrType)
+            Type fieldClrType,
+            bool validateSpecializedRead)
         {
             var sig = new BlobBuilder();
             new BlobEncoder(sig)
@@ -685,11 +714,54 @@ namespace Jroc.Services
             var sigHandle = _metadataBuilder.GetOrAddBlob(sig);
 
             var ilBuilder = new BlobBuilder();
-            var encoder = new InstructionEncoder(ilBuilder);
-            encoder.OpCode(ILOpCode.Ldarg_0);
-            encoder.OpCode(ILOpCode.Ldfld);
-            encoder.Token(fieldHandle);
-            encoder.OpCode(ILOpCode.Ret);
+            var controlFlow = validateSpecializedRead
+                ? new ControlFlowBuilder()
+                : null;
+            var encoder = controlFlow == null
+                ? new InstructionEncoder(ilBuilder)
+                : new InstructionEncoder(ilBuilder, controlFlow);
+            if (validateSpecializedRead)
+            {
+                if (fieldClrType != typeof(object))
+                {
+                    throw new InvalidOperationException(
+                        "Constructor-shape fields must remain object-typed until typed fallback conversion is implemented.");
+                }
+
+                var fallback = encoder.DefineLabel();
+                encoder.OpCode(ILOpCode.Ldarg_0);
+                encoder.Ldstr(_metadataBuilder, memberName);
+                encoder.OpCode(ILOpCode.Ldarg_0);
+                encoder.OpCode(ILOpCode.Ldfld);
+                encoder.Token(fieldHandle);
+                encoder.OpCode(ILOpCode.Call);
+                encoder.Token(_memberReferenceRegistry.GetOrAddMethod(
+                    typeof(JavaScriptRuntime.JsObject),
+                    nameof(JavaScriptRuntime.JsObject.IsSpecializedDataPropertyCurrent),
+                    new[] { typeof(string), typeof(object) }));
+                encoder.Branch(ILOpCode.Brfalse, fallback);
+                encoder.OpCode(ILOpCode.Ldarg_0);
+                encoder.OpCode(ILOpCode.Ldfld);
+                encoder.Token(fieldHandle);
+                encoder.OpCode(ILOpCode.Ret);
+
+                encoder.MarkLabel(fallback);
+                encoder.OpCode(ILOpCode.Ldarg_0);
+                encoder.Ldstr(_metadataBuilder, memberName);
+                encoder.OpCode(ILOpCode.Call);
+                encoder.Token(_memberReferenceRegistry.GetOrAddMethod(
+                    typeof(JavaScriptRuntime.ObjectRuntime),
+                    nameof(JavaScriptRuntime.ObjectRuntime.GetItem),
+                    new[] { typeof(object), typeof(string) }));
+                encoder.OpCode(ILOpCode.Ret);
+            }
+            else
+            {
+                encoder.OpCode(ILOpCode.Ldarg_0);
+                encoder.OpCode(ILOpCode.Ldfld);
+                encoder.Token(fieldHandle);
+                encoder.OpCode(ILOpCode.Ret);
+            }
 
             var bodyOffset = _methodBodyStream.AddMethodBody(
                 encoder,
@@ -852,13 +924,43 @@ namespace Jroc.Services
             }
         }
 
-        private static string GetObjectLiteralTypeName(ObjectLiteralShapeInfo shape)
+        private static IEnumerable<ConstructorShapeInfo> EnumerateEligibleConstructorShapes(
+            Scope scope)
         {
+            foreach (var binding in scope.Bindings.Values)
+            {
+                if (binding.ConstructorShape is { IsEligible: true } shape)
+                {
+                    yield return shape;
+                }
+            }
+
+            foreach (var child in scope.Children)
+            {
+                foreach (var shape in EnumerateEligibleConstructorShapes(child))
+                {
+                    yield return shape;
+                }
+            }
+        }
+
+        private static string GetInferredObjectTypeName(
+            InferredObjectShapeInfo shape)
+        {
+            if (shape is ConstructorShapeInfo)
+            {
+                var constructorLocation = shape.SourceNode.Location.Start;
+                var constructorName = SanitizeClrIdentifier(
+                    shape.Binding.Name);
+                return $"Ctor_L{constructorLocation.Line}C{constructorLocation.Column + 1}_{constructorName}";
+            }
+
+            var literalShape = (ObjectLiteralShapeInfo)shape;
             // Nested under Modules.<Module>/ObjectLiterals, so the name only needs to be unique
             // within its module. The literal's start position guarantees that; the binding name
             // is included for readability.
-            var loc = shape.Literal.Location.Start;
-            var bindingName = SanitizeClrIdentifier(shape.Binding.Name);
+            var loc = literalShape.Literal.Location.Start;
+            var bindingName = SanitizeClrIdentifier(literalShape.Binding.Name);
             return $"L{loc.Line}C{loc.Column + 1}_{bindingName}";
         }
 

--- a/src/Compiler/Services/VariableBindings/ObjectLiteralTypeMetadata.cs
+++ b/src/Compiler/Services/VariableBindings/ObjectLiteralTypeMetadata.cs
@@ -10,7 +10,7 @@ namespace Jroc.Services.VariableBindings;
 public sealed class ObjectLiteralTypeMetadata
 {
     public ObjectLiteralTypeMetadata(
-        ObjectLiteralShapeInfo shape,
+        InferredObjectShapeInfo shape,
         string typeName,
         TypeDefinitionHandle typeHandle,
         MethodDefinitionHandle constructorHandle,
@@ -29,7 +29,7 @@ public sealed class ObjectLiteralTypeMetadata
         SetterHandlesByMemberName = setterHandlesByMemberName;
     }
 
-    public ObjectLiteralShapeInfo Shape { get; }
+    public InferredObjectShapeInfo Shape { get; }
 
     public string TypeName { get; }
 

--- a/src/Compiler/Services/VariableBindings/VariableRegistry.cs
+++ b/src/Compiler/Services/VariableBindings/VariableRegistry.cs
@@ -24,7 +24,7 @@ namespace Jroc.Services.VariableBindings
         private readonly ScopeMetadataRegistry _scopeMetadata;
         // Track uncaptured variables (no scope backing field, will use local variables)
         private readonly Dictionary<string, HashSet<string>> _uncapturedVariables = new();
-        private readonly Dictionary<ObjectLiteralShapeInfo, ObjectLiteralTypeMetadata> _objectLiteralTypes = new(ReferenceEqualityComparer.Instance);
+        private readonly Dictionary<InferredObjectShapeInfo, ObjectLiteralTypeMetadata> _objectLiteralTypes = new(ReferenceEqualityComparer.Instance);
 
         /// <summary>
         /// Creates a new VariableRegistry with an internal ScopeMetadataRegistry.
@@ -51,7 +51,7 @@ namespace Jroc.Services.VariableBindings
         /// Registers the generated CLR metadata for an eligible object literal shape.
         /// </summary>
         public void RegisterObjectLiteralType(
-            ObjectLiteralShapeInfo shape,
+            InferredObjectShapeInfo shape,
             string typeName,
             TypeDefinitionHandle typeHandle,
             MethodDefinitionHandle constructorHandle,
@@ -63,7 +63,7 @@ namespace Jroc.Services.VariableBindings
             if (shape == null) throw new ArgumentNullException(nameof(shape));
             if (!shape.IsEligible)
             {
-                throw new ArgumentException("Only eligible object literal shapes can be registered.", nameof(shape));
+                throw new ArgumentException("Only eligible inferred object shapes can be registered.", nameof(shape));
             }
             if (typeHandle.IsNil)
             {
@@ -87,7 +87,7 @@ namespace Jroc.Services.VariableBindings
             _objectLiteralTypes[shape] = metadata;
         }
 
-        public bool TryGetObjectLiteralType(ObjectLiteralShapeInfo shape, out ObjectLiteralTypeMetadata metadata)
+        public bool TryGetObjectLiteralType(InferredObjectShapeInfo shape, out ObjectLiteralTypeMetadata metadata)
             => _objectLiteralTypes.TryGetValue(shape, out metadata!);
 
         public IReadOnlyCollection<ObjectLiteralTypeMetadata> GetObjectLiteralTypes()

--- a/src/Compiler/SymbolTable/BindingInfo.cs
+++ b/src/Compiler/SymbolTable/BindingInfo.cs
@@ -155,6 +155,24 @@ public class BindingInfo
     public ObjectLiteralShapeInfo? ObjectLiteralShape { get; set; }
 
     /// <summary>
+    /// Eligible ES5 constructor layout introduced by this function binding.
+    /// </summary>
+    public ConstructorShapeInfo? ConstructorShape { get; set; }
+
+    /// <summary>
+    /// Exact generated constructor layout for a stable binding initialized by
+    /// <c>new Constructor(...)</c>.
+    /// </summary>
+    public ConstructorShapeInfo? ConstructedShape { get; set; }
+
+    /// <summary>
+    /// Constructor layouts that may flow into this binding. Candidate layouts always
+    /// require a runtime type guard unless <see cref="ConstructedShape"/> is set.
+    /// </summary>
+    public HashSet<ConstructorShapeInfo> ConstructorShapeCandidates { get; } =
+        new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
     /// Whole-program policy for function-valued binding initialization. HIR carries this
     /// semantic decision into lowering; LIR never inspects the source AST to derive it.
     /// </summary>

--- a/src/Compiler/SymbolTable/ObjectLiteralShapeInfo.cs
+++ b/src/Compiler/SymbolTable/ObjectLiteralShapeInfo.cs
@@ -40,25 +40,24 @@ public sealed class ObjectLiteralMemberInfo
 }
 
 /// <summary>
-/// Result of the compile-time eligibility analysis for a single object literal bound
-/// to a local/module binding. When <see cref="IsEligible"/> is true, later phases may
-/// generate a specialized CLR type and early-bind member accesses; otherwise the
-/// literal must compile exactly as today (plain JsObject).
+/// Shared metadata for JavaScript object layouts that may use generated CLR storage.
 /// </summary>
-public sealed class ObjectLiteralShapeInfo
+public abstract class InferredObjectShapeInfo
 {
-    public ObjectLiteralShapeInfo(ObjectExpression literal, BindingInfo binding, IReadOnlyList<ObjectLiteralMemberInfo> members)
+    protected InferredObjectShapeInfo(
+        Node sourceNode,
+        BindingInfo binding,
+        IReadOnlyList<ObjectLiteralMemberInfo> members)
     {
-        Literal = literal;
+        SourceNode = sourceNode;
         Binding = binding;
         Members = members;
         IsEligible = true;
     }
 
-    /// <summary>The object literal expression this shape describes.</summary>
-    public ObjectExpression Literal { get; }
+    public Node SourceNode { get; }
 
-    /// <summary>The binding the literal is assigned to at its declaration.</summary>
+    /// <summary>The binding that introduces this layout.</summary>
     public BindingInfo Binding { get; }
 
     /// <summary>Members in literal source order.</summary>
@@ -141,4 +140,46 @@ public sealed class ObjectLiteralShapeInfo
         member = null!;
         return false;
     }
+}
+
+/// <summary>
+/// Result of the compile-time eligibility analysis for a single object literal bound
+/// to a local/module binding. When <see cref="InferredObjectShapeInfo.IsEligible"/> is
+/// true, later phases may generate a specialized CLR type and early-bind member access.
+/// </summary>
+public sealed class ObjectLiteralShapeInfo : InferredObjectShapeInfo
+{
+    public ObjectLiteralShapeInfo(
+        ObjectExpression literal,
+        BindingInfo binding,
+        IReadOnlyList<ObjectLiteralMemberInfo> members)
+        : base(literal, binding, members)
+    {
+        Literal = literal;
+    }
+
+    /// <summary>The object literal expression this shape describes.</summary>
+    public ObjectExpression Literal { get; }
+}
+
+/// <summary>
+/// Layout inferred from the unconditional initialization prefix of an ES5-style
+/// constructor function.
+/// </summary>
+public sealed class ConstructorShapeInfo : InferredObjectShapeInfo
+{
+    public ConstructorShapeInfo(
+        Node constructorNode,
+        Scope constructorScope,
+        BindingInfo binding,
+        IReadOnlyList<ObjectLiteralMemberInfo> members)
+        : base(constructorNode, binding, members)
+    {
+        ConstructorNode = constructorNode;
+        ConstructorScope = constructorScope;
+    }
+
+    public Node ConstructorNode { get; }
+
+    public Scope ConstructorScope { get; }
 }

--- a/src/Compiler/SymbolTable/Scope.cs
+++ b/src/Compiler/SymbolTable/Scope.cs
@@ -178,6 +178,11 @@ public class Scope
     public ClassSemantics? ClassSemantics { get; set; }
 
     /// <summary>
+    /// Eligible ES5 constructor layout for this function body, when present.
+    /// </summary>
+    public ConstructorShapeInfo? ConstructorShape { get; set; }
+
+    /// <summary>
     /// For synthetic dynamic functions created from <c>Function(...)</c> / <c>new Function(...)</c>,
     /// points at the original constructor call/new site in the source AST.
     /// </summary>

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.ConstructorShapes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.ConstructorShapes.cs
@@ -1,0 +1,642 @@
+using Acornima;
+using Acornima.Ast;
+
+namespace Jroc.SymbolTables;
+
+public partial class SymbolTableBuilder
+{
+    private void AnalyzeConstructorShapes(Scope root)
+    {
+        foreach (var scope in EnumerateScopes(root))
+        {
+            scope.ConstructorShape = null;
+            foreach (var binding in scope.Bindings.Values)
+            {
+                binding.ConstructorShape = null;
+                binding.ConstructedShape = null;
+                binding.ConstructorShapeCandidates.Clear();
+            }
+        }
+
+        foreach (var scope in EnumerateScopes(root))
+        {
+            foreach (var binding in scope.Bindings.Values)
+            {
+                if (!TryGetConstructorFunction(binding, root, out var constructorNode, out var constructorScope, out var body)
+                    || constructorScope.IsAsync
+                    || constructorScope.IsGenerator
+                    || constructorScope.IsMethodDefinition
+                    || binding.HasNonInitializationWrite)
+                {
+                    continue;
+                }
+
+                var shape = AnalyzeConstructorBody(
+                    constructorNode,
+                    constructorScope,
+                    binding,
+                    body);
+                binding.ConstructorShape = shape;
+                constructorScope.ConstructorShape = shape;
+            }
+        }
+
+        InferConstructorShapeCandidates(root);
+    }
+
+    private static bool TryGetConstructorFunction(
+        BindingInfo binding,
+        Scope root,
+        out Node constructorNode,
+        out Scope constructorScope,
+        out BlockStatement body)
+    {
+        constructorNode = null!;
+        constructorScope = null!;
+        body = null!;
+
+        switch (binding.DeclarationNode)
+        {
+            case FunctionDeclaration function
+                when function.Body is BlockStatement functionBody:
+                constructorNode = function;
+                body = functionBody;
+                break;
+            case VariableDeclarator
+            {
+                Init: FunctionExpression function
+            } when function.Body is BlockStatement functionBody:
+                constructorNode = function;
+                body = functionBody;
+                break;
+            default:
+                return false;
+        }
+
+        constructorScope = FindScopeByAstNode(root, constructorNode)!;
+        return constructorScope != null;
+    }
+
+    private static ConstructorShapeInfo AnalyzeConstructorBody(
+        Node constructorNode,
+        Scope constructorScope,
+        BindingInfo binding,
+        BlockStatement body)
+    {
+        var members = new List<ObjectLiteralMemberInfo>();
+        var initializerAssignments = new HashSet<AssignmentExpression>(
+            ReferenceEqualityComparer.Instance);
+        var seenNames = new HashSet<string>(StringComparer.Ordinal);
+        var initializationPrefixEnded = false;
+
+        foreach (var statement in body.Body)
+        {
+            if (TryGetTopLevelThisAssignment(
+                    statement,
+                    out var assignment,
+                    out var memberName,
+                    out var value))
+            {
+                if (initializationPrefixEnded)
+                {
+                    var lateShape = new ConstructorShapeInfo(
+                        constructorNode,
+                        constructorScope,
+                        binding,
+                        members);
+                    lateShape.Disqualify(
+                        $"member '{memberName}' is initialized after the unconditional top-level prefix");
+                    return lateShape;
+                }
+
+                if (!seenNames.Add(memberName))
+                {
+                    var duplicateShape = new ConstructorShapeInfo(
+                        constructorNode,
+                        constructorScope,
+                        binding,
+                        members);
+                    duplicateShape.Disqualify(
+                        $"member '{memberName}' is initialized more than once");
+                    return duplicateShape;
+                }
+
+                if (ContainsThisOutsideNestedFunctions(value))
+                {
+                    var escapingShape = new ConstructorShapeInfo(
+                        constructorNode,
+                        constructorScope,
+                        binding,
+                        members);
+                    escapingShape.Disqualify(
+                        $"this escapes while initializing member '{memberName}'");
+                    return escapingShape;
+                }
+
+                initializerAssignments.Add(assignment);
+                members.Add(new ObjectLiteralMemberInfo(
+                    memberName,
+                    value,
+                    clrType: null,
+                    isFunction: false));
+                continue;
+            }
+
+            initializationPrefixEnded = true;
+        }
+
+        var shape = new ConstructorShapeInfo(
+            constructorNode,
+            constructorScope,
+            binding,
+            members);
+        var pending = new Stack<(Node Node, bool InsideArrow)>();
+        pending.Push((body, false));
+        while (pending.Count > 0 && shape.IsEligible)
+        {
+            var (node, insideArrow) = pending.Pop();
+            if (!ReferenceEquals(node, body)
+                && node is FunctionDeclaration
+                    or FunctionExpression
+                    or ClassDeclaration
+                    or ClassExpression)
+            {
+                continue;
+            }
+
+            var childInsideArrow =
+                insideArrow || node is ArrowFunctionExpression;
+
+            switch (node)
+            {
+                case AssignmentExpression assignment
+                    when TryGetThisMember(assignment.Left, out var name, out var computed):
+                    if (computed)
+                    {
+                        shape.Disqualify("computed this-member initialization");
+                    }
+                    else if (!initializerAssignments.Contains(assignment))
+                    {
+                        shape.Disqualify(
+                            $"member '{name}' is initialized conditionally or outside the top-level prefix");
+                    }
+                    break;
+
+                case UpdateExpression update
+                    when TryGetThisMember(update.Argument, out var updateName, out _):
+                    shape.Disqualify(
+                        $"member '{updateName}' is updated outside supported initialization");
+                    break;
+
+                case UnaryExpression
+                {
+                    Operator: Operator.Delete,
+                    Argument: var argument
+                } when TryGetThisMember(argument, out var deletedName, out _):
+                    shape.Disqualify($"delete this.{deletedName}");
+                    break;
+
+                case CallExpression call
+                    when IsObjectDefinePropertyOnThis(call):
+                    shape.Disqualify("Object.defineProperty(this, ...) is not supported");
+                    break;
+
+                case ReturnStatement
+                {
+                    Argument: not null
+                } when !insideArrow:
+                    shape.Disqualify("explicit constructor return value may override the receiver");
+                    break;
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                pending.Push((child, childInsideArrow));
+            }
+        }
+
+        if (shape.IsEligible && members.Count == 0)
+        {
+            shape.Disqualify(
+                "constructor has no unconditional top-level this-member initializers");
+        }
+
+        return shape;
+    }
+
+    private static bool TryGetTopLevelThisAssignment(
+        Statement statement,
+        out AssignmentExpression assignment,
+        out string memberName,
+        out Node value)
+    {
+        assignment = null!;
+        memberName = string.Empty;
+        value = null!;
+        if (statement is not ExpressionStatement
+            {
+                Expression: AssignmentExpression
+                {
+                    Operator: Operator.Assignment
+                } candidate
+            }
+            || !TryGetThisMember(candidate.Left, out memberName, out var computed)
+            || computed)
+        {
+            return false;
+        }
+
+        assignment = candidate;
+        value = candidate.Right;
+        return true;
+    }
+
+    private static bool TryGetThisMember(
+        Node node,
+        out string memberName,
+        out bool computed)
+    {
+        memberName = string.Empty;
+        computed = false;
+        if (node is not MemberExpression
+            {
+                Object: ThisExpression
+            } member)
+        {
+            return false;
+        }
+
+        computed = member.Computed;
+        if (!member.Computed && member.Property is Identifier identifier)
+        {
+            memberName = identifier.Name;
+        }
+        else
+        {
+            memberName = "<computed>";
+        }
+
+        return true;
+    }
+
+    private static bool ContainsThisOutsideNestedFunctions(Node node)
+    {
+        var pending = new Stack<Node>();
+        pending.Push(node);
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+            if (!ReferenceEquals(current, node)
+                && current is FunctionDeclaration
+                    or FunctionExpression
+                    or ClassDeclaration
+                    or ClassExpression)
+            {
+                continue;
+            }
+
+            if (current is ThisExpression)
+            {
+                return true;
+            }
+
+            foreach (var child in current.ChildNodes)
+            {
+                pending.Push(child);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsObjectDefinePropertyOnThis(CallExpression call)
+        => call.Callee is MemberExpression
+            {
+                Computed: false,
+                Object: Identifier
+                {
+                    Name: "Object"
+                },
+                Property: Identifier
+                {
+                    Name: "defineProperty"
+                }
+            }
+            && call.Arguments.Count > 0
+            && call.Arguments[0] is ThisExpression;
+
+    private void InferConstructorShapeCandidates(Scope root)
+    {
+        var prototypeMethods = FindPrototypeMethodScopes(root);
+        var eligibleShapes = EnumerateScopes(root)
+            .SelectMany(static scope => scope.Bindings.Values)
+            .Select(static binding => binding.ConstructorShape)
+            .Where(static shape => shape is { IsEligible: true })
+            .Cast<ConstructorShapeInfo>()
+            .Distinct(ReferenceEqualityComparer.Instance)
+            .Cast<ConstructorShapeInfo>()
+            .ToArray();
+
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var scope in EnumerateScopes(root))
+            {
+                VisitScope(scope);
+            }
+        }
+        while (changed);
+
+        void VisitScope(Scope scope)
+        {
+            var pending = new Stack<(Node Node, bool IsRoot)>();
+            pending.Push((scope.AstNode, true));
+            while (pending.Count > 0)
+            {
+                var (node, isRoot) = pending.Pop();
+                if (!isRoot
+                    && scope.Children.Any(child => ReferenceEquals(child.AstNode, node)))
+                {
+                    continue;
+                }
+
+                switch (node)
+                {
+                    case VariableDeclarator
+                    {
+                        Id: Identifier identifier,
+                        Init: Expression initializer
+                    }:
+                        changed |= AddExpressionCandidates(
+                            TryResolveBinding(scope, identifier.Name),
+                            initializer,
+                            scope,
+                            allowExact: true);
+                        break;
+
+                    case AssignmentExpression
+                    {
+                        Operator: Operator.Assignment,
+                        Left: Identifier identifier,
+                        Right: Expression value
+                    }:
+                        changed |= AddExpressionCandidates(
+                            TryResolveBinding(scope, identifier.Name),
+                            value,
+                            scope,
+                            allowExact: false);
+                        break;
+
+                    case CallExpression call:
+                        if (TryGetCandidateCallTarget(
+                                call,
+                                scope,
+                                prototypeMethods,
+                                out var targetScope))
+                        {
+                            changed |= AddParameterCandidates(
+                                call,
+                                scope,
+                                targetScope);
+                        }
+                        break;
+
+                    case MemberExpression
+                    {
+                        Computed: false,
+                        Object: Identifier receiver,
+                        Property: Identifier property
+                    }:
+                        var receiverBinding =
+                            TryResolveBinding(scope, receiver.Name);
+                        if (receiverBinding != null
+                            && receiverBinding.DeclaringScope.Parameters.Contains(
+                                receiverBinding.Name))
+                        {
+                            var matches = eligibleShapes
+                                .Where(shape => shape.TryGetMember(
+                                    property.Name,
+                                    out _))
+                                .ToArray();
+                            if (matches.Length == 1)
+                            {
+                                changed |= receiverBinding
+                                    .ConstructorShapeCandidates
+                                    .Add(matches[0]);
+                            }
+                        }
+                        break;
+                }
+
+                foreach (var child in node.ChildNodes)
+                {
+                    pending.Push((child, false));
+                }
+            }
+        }
+
+        bool AddExpressionCandidates(
+            BindingInfo? target,
+            Expression expression,
+            Scope expressionScope,
+            bool allowExact)
+        {
+            if (target == null)
+            {
+                return false;
+            }
+
+            var candidates = GetExpressionCandidates(
+                expression,
+                expressionScope)
+                .Distinct(ReferenceEqualityComparer.Instance)
+                .Cast<ConstructorShapeInfo>()
+                .ToArray();
+            var added = false;
+            foreach (var candidate in candidates)
+            {
+                added |= target.ConstructorShapeCandidates.Add(candidate);
+            }
+
+            if (allowExact
+                && !target.HasNonInitializationWrite
+                && candidates.Length == 1
+                && expression is NewExpression)
+            {
+                target.ConstructedShape = candidates[0];
+            }
+
+            return added;
+        }
+
+        IEnumerable<ConstructorShapeInfo> GetExpressionCandidates(
+            Expression expression,
+            Scope expressionScope)
+        {
+            if (expression is Identifier identifier
+                && TryResolveBinding(expressionScope, identifier.Name)
+                    is { } source)
+            {
+                if (source.ConstructedShape is { IsEligible: true } exact)
+                {
+                    yield return exact;
+                }
+                foreach (var candidate in source.ConstructorShapeCandidates)
+                {
+                    yield return candidate;
+                }
+                yield break;
+            }
+
+            if (expression is NewExpression
+                {
+                    Callee: Identifier constructor
+                }
+                && TryResolveBinding(expressionScope, constructor.Name)
+                    ?.ConstructorShape is
+                    {
+                        IsEligible: true
+                    } shape)
+            {
+                yield return shape;
+            }
+        }
+
+        bool AddParameterCandidates(
+            CallExpression call,
+            Scope callScope,
+            Scope targetScope)
+        {
+            if (!TryGetSimpleParameterNames(
+                    targetScope.AstNode,
+                    out var parameterNames))
+            {
+                return false;
+            }
+
+            var added = false;
+            for (var index = 0;
+                 index < parameterNames.Count
+                 && index < call.Arguments.Count;
+                 index++)
+            {
+                if (call.Arguments[index] is not Expression argument
+                    || !targetScope.Bindings.TryGetValue(
+                        parameterNames[index],
+                        out var parameterBinding))
+                {
+                    continue;
+                }
+
+                foreach (var candidate in GetExpressionCandidates(
+                             argument,
+                             callScope))
+                {
+                    added |= parameterBinding
+                        .ConstructorShapeCandidates
+                        .Add(candidate);
+                }
+            }
+
+            return added;
+        }
+    }
+
+    private static Dictionary<string, Scope> FindPrototypeMethodScopes(
+        Scope root)
+    {
+        var result = new Dictionary<string, Scope>(StringComparer.Ordinal);
+        foreach (var scope in EnumerateScopes(root))
+        {
+            var pending = new Stack<(Node Node, bool IsRoot)>();
+            pending.Push((scope.AstNode, true));
+            while (pending.Count > 0)
+            {
+                var (node, isRoot) = pending.Pop();
+                if (!isRoot
+                    && scope.Children.Any(child => ReferenceEquals(
+                        child.AstNode,
+                        node)))
+                {
+                    continue;
+                }
+
+                if (node is AssignmentExpression
+                    {
+                        Operator: Operator.Assignment,
+                        Left: MemberExpression
+                        {
+                            Computed: false,
+                            Object: MemberExpression
+                            {
+                                Computed: false,
+                                Property: Identifier
+                                {
+                                    Name: "prototype"
+                                }
+                            },
+                            Property: Identifier method
+                        },
+                        Right: FunctionExpression function
+                    })
+                {
+                    var functionScope = FindScopeByAstNode(root, function);
+                    if (functionScope != null)
+                    {
+                        result.TryAdd(method.Name, functionScope);
+                    }
+                }
+
+                foreach (var child in node.ChildNodes)
+                {
+                    pending.Push((child, false));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private bool TryGetCandidateCallTarget(
+        CallExpression call,
+        Scope callScope,
+        IReadOnlyDictionary<string, Scope> prototypeMethods,
+        out Scope targetScope)
+    {
+        targetScope = null!;
+        if (call.Callee is Identifier direct
+            && TryResolveBinding(callScope, direct.Name) is { } binding)
+        {
+            var node = binding.DeclarationNode switch
+            {
+                FunctionDeclaration function => (Node)function,
+                VariableDeclarator
+                {
+                    Init: FunctionExpression function
+                } => function,
+                _ => null
+            };
+            targetScope = node == null
+                ? null!
+                : FindScopeByAstNode(
+                    FindRootScope(callScope)!,
+                    node)!;
+            return targetScope != null;
+        }
+
+        if (call.Callee is MemberExpression
+            {
+                Computed: false,
+                Property: Identifier method
+            }
+            && prototypeMethods.TryGetValue(
+                method.Name,
+                out targetScope!))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferenceFixedPoint.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferenceFixedPoint.cs
@@ -27,6 +27,7 @@ public partial class SymbolTableBuilder
             InferClassInstanceFieldClrTypes(root);
             InferCallableReturnClrTypes(root);
             AnalyzeObjectLiteralShapes(root);
+            AnalyzeConstructorShapes(root);
 
             var after = CaptureInferenceState(root);
             if (string.Equals(before, after, StringComparison.Ordinal))

--- a/src/Compiler/Utilities/Ecma335/MemberReferenceRegistry.cs
+++ b/src/Compiler/Utilities/Ecma335/MemberReferenceRegistry.cs
@@ -250,6 +250,48 @@ namespace Jroc.Utilities.Ecma335
             return methodSpec;
         }
 
+        public MethodSpecificationHandle GetOrAddGenericMethod(
+            MethodInfo method,
+            EntityHandle typeArgument,
+            bool isValueType)
+        {
+            ArgumentNullException.ThrowIfNull(method);
+            if (!method.IsGenericMethodDefinition
+                || method.GetGenericArguments().Length != 1)
+            {
+                throw new ArgumentException(
+                    $"Method '{method}' must define exactly one generic parameter.",
+                    nameof(method));
+            }
+
+            var declaringType = method.DeclaringType
+                ?? throw new ArgumentException(
+                    $"Method '{method}' has no declaring type.",
+                    nameof(method));
+            var key =
+                $"{declaringType.FullName}::{method}<{typeArgument.Kind}:{MetadataTokens.GetToken(typeArgument)}>";
+            if (_methodSpecCache.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            var methodRef = _metadataBuilder.AddMemberReference(
+                GetOrAddDeclaringTypeHandle(declaringType),
+                _metadataBuilder.GetOrAddString(method.Name),
+                BuildMethodSignature(method));
+
+            var specificationBuilder = new BlobBuilder();
+            new BlobEncoder(specificationBuilder)
+                .MethodSpecificationSignature(1)
+                .AddArgument()
+                .Type(typeArgument, isValueType);
+            var methodSpec = _metadataBuilder.AddMethodSpecification(
+                methodRef,
+                _metadataBuilder.GetOrAddBlob(specificationBuilder));
+            _methodSpecCache[key] = methodSpec;
+            return methodSpec;
+        }
+
         /// <summary>
         /// Gets or creates a closed reference to
         /// <c>T RequireObject&lt;T&gt;(RequireDelegate, object)</c>.
@@ -595,22 +637,7 @@ namespace Jroc.Utilities.Ecma335
                         }
                     });
 
-            var signature =  _metadataBuilder.GetOrAddBlob(sigBuilder);
-
-            if (genericParamCount > 0)
-            {
-                // For generic methods, we need to wrap the signature in a GenericMethodSignature
-                var genericSigBuilder = new BlobBuilder();
-                var genericTypeArgumentsEncoder = new BlobEncoder(genericSigBuilder).MethodSpecificationSignature(genericParamCount);
-                for (int genericTypeIndex = 0; genericTypeIndex < genericParamCount; genericTypeIndex++)
-                {
-                    genericTypeArgumentsEncoder.AddArgument().Object();
-                }
-
-                signature = _metadataBuilder.GetOrAddBlob(genericSigBuilder);
-            }
-
-            return signature;
+            return _metadataBuilder.GetOrAddBlob(sigBuilder);
         }
 
         private BlobHandle BuildConstructorSignature(ConstructorInfo ctor)
@@ -664,10 +691,19 @@ namespace Jroc.Utilities.Ecma335
 
         private void EncodeSignatureType(SignatureTypeEncoder encoder, Type type)
         {
-            // Generic type parameters (e.g., T, TResult from Func<T, TResult>)
+            // Generic parameters declared by methods use !!n; parameters declared
+            // by generic types use !n.
             if (type.IsGenericParameter)
             {
-                encoder.GenericTypeParameter(type.GenericParameterPosition);
+                if (type.DeclaringMethod is not null)
+                {
+                    encoder.GenericMethodTypeParameter(
+                        type.GenericParameterPosition);
+                }
+                else
+                {
+                    encoder.GenericTypeParameter(type.GenericParameterPosition);
+                }
                 return;
             }
 

--- a/src/JavaScriptRuntime/CallableOperations.cs
+++ b/src/JavaScriptRuntime/CallableOperations.cs
@@ -121,6 +121,20 @@ public static class CallableOperations
         object?[]? arguments,
         object? newTarget)
     {
+        var callArguments = JsCallArguments.FromArray(arguments);
+        return ConstructWithReceiver(
+            functionObject,
+            receiver,
+            callArguments,
+            newTarget);
+    }
+
+    internal static object? ConstructWithReceiver(
+        JsFunctionObject functionObject,
+        object receiver,
+        in JsCallArguments arguments,
+        object? newTarget)
+    {
         ArgumentNullException.ThrowIfNull(functionObject);
         ArgumentNullException.ThrowIfNull(receiver);
         if (!functionObject.IsConstructor)
@@ -128,11 +142,10 @@ public static class CallableOperations
             throw new TypeError("Value is not a constructor");
         }
 
-        var callArguments = JsCallArguments.FromArray(arguments);
         var result = InvokeConstructBody(
             functionObject,
             receiver,
-            callArguments,
+            arguments,
             newTarget);
         return TypeUtilities.IsConstructorReturnOverride(result)
             ? result

--- a/src/JavaScriptRuntime/Function.cs
+++ b/src/JavaScriptRuntime/Function.cs
@@ -14,6 +14,9 @@ namespace JavaScriptRuntime
 [IntrinsicObject("Function")]
 public static class Function
 {
+        [ThreadStatic]
+        private static Stack<object>? _generatedConstructionReceivers;
+
     private static readonly BuiltinFunction0 _restrictedPropertyThrower =
         static _ => throw new TypeError("Cannot access restricted function property");
 
@@ -722,6 +725,152 @@ public static class Function
                 RuntimeServices.SetCurrentThis(previousThis);
             }
         }
+
+        public static object? ConstructGeneratedFunctionWithReceiver0(
+            object constructor,
+            object receiver,
+            object? newTarget)
+            => ConstructGeneratedFunctionWithReceiver(
+                constructor,
+                receiver,
+                JsCallArguments.Empty,
+                newTarget);
+
+        public static object? ConstructGeneratedFunctionWithReceiver1(
+            object constructor,
+            object receiver,
+            object? newTarget,
+            object? argument0)
+            => ConstructGeneratedFunctionWithReceiver(
+                constructor,
+                receiver,
+                JsCallArguments.From(argument0),
+                newTarget);
+
+        public static object? ConstructGeneratedFunctionWithReceiver2(
+            object constructor,
+            object receiver,
+            object? newTarget,
+            object? argument0,
+            object? argument1)
+            => ConstructGeneratedFunctionWithReceiver(
+                constructor,
+                receiver,
+                JsCallArguments.From(argument0, argument1),
+                newTarget);
+
+        public static object? ConstructGeneratedFunctionWithReceiver3(
+            object constructor,
+            object receiver,
+            object? newTarget,
+            object? argument0,
+            object? argument1,
+            object? argument2)
+            => ConstructGeneratedFunctionWithReceiver(
+                constructor,
+                receiver,
+                JsCallArguments.From(argument0, argument1, argument2),
+                newTarget);
+
+        public static object? ConstructGeneratedFunctionWithReceiver4(
+            object constructor,
+            object receiver,
+            object? newTarget,
+            object? argument0,
+            object? argument1,
+            object? argument2,
+            object? argument3)
+            => ConstructGeneratedFunctionWithReceiver(
+                constructor,
+                receiver,
+                JsCallArguments.From(
+                    argument0,
+                    argument1,
+                    argument2,
+                    argument3),
+                newTarget);
+
+        public static object? ConstructGeneratedFunctionWithReceiver5(
+            object constructor,
+            object receiver,
+            object? newTarget,
+            object? argument0,
+            object? argument1,
+            object? argument2,
+            object? argument3,
+            object? argument4)
+            => ConstructGeneratedFunctionWithReceiver(
+                constructor,
+                receiver,
+                JsCallArguments.From(
+                    argument0,
+                    argument1,
+                    argument2,
+                    argument3,
+                    argument4),
+                newTarget);
+
+        public static object? ConstructGeneratedFunctionWithReceiverArray(
+            object constructor,
+            object receiver,
+            object? newTarget,
+            object?[]? arguments)
+            => ConstructGeneratedFunctionWithReceiver(
+                constructor,
+                receiver,
+                JsCallArguments.FromArray(arguments),
+                newTarget);
+
+        private static object? ConstructGeneratedFunctionWithReceiver(
+            object constructor,
+            object receiver,
+            in JsCallArguments arguments,
+            object? newTarget)
+        {
+            if (constructor is not JsFunctionObject functionObject
+                || !functionObject.IsConstructor)
+            {
+                throw new TypeError("Value is not a constructor");
+            }
+
+            PrototypeChain.SetPrototype(
+                receiver,
+                GlobalThis.ObjectPrototypeValue);
+            var prototypeSource = newTarget is null or JsNull
+                ? constructor
+                : newTarget;
+            var prototype = ObjectRuntime.GetItem(
+                prototypeSource,
+                "prototype");
+            if (TypeUtilities.IsConstructorReturnOverride(prototype))
+            {
+                PrototypeChain.SetPrototype(receiver, prototype);
+            }
+
+            var previousThis = RuntimeServices.SetCurrentThis(receiver);
+            (_generatedConstructionReceivers ??= new()).Push(receiver);
+            try
+            {
+                return CallableOperations.ConstructWithReceiver(
+                    functionObject,
+                    receiver,
+                    arguments,
+                    newTarget);
+            }
+            finally
+            {
+                _generatedConstructionReceivers.Pop();
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
+        }
+
+        public static bool IsCurrentGeneratedConstructionReceiver(
+            object receiver)
+            => _generatedConstructionReceivers is
+                {
+                    Count: > 0
+                } receivers
+                && ReferenceEquals(receivers.Peek(), receiver);
 
         internal static void DefineMetadataProperty(object target, string propName, object? value)
         {

--- a/src/JavaScriptRuntime/Function.cs
+++ b/src/JavaScriptRuntime/Function.cs
@@ -726,53 +726,53 @@ public static class Function
             }
         }
 
-        public static object? ConstructGeneratedFunctionWithReceiver0(
+        public static T ConstructGeneratedFunctionWithReceiver0<T>(
             object constructor,
             object receiver,
             object? newTarget)
-            => ConstructGeneratedFunctionWithReceiver(
+            => (T)ConstructGeneratedFunctionWithReceiver(
                 constructor,
                 receiver,
                 JsCallArguments.Empty,
-                newTarget);
+                newTarget)!;
 
-        public static object? ConstructGeneratedFunctionWithReceiver1(
+        public static T ConstructGeneratedFunctionWithReceiver1<T>(
             object constructor,
             object receiver,
             object? newTarget,
             object? argument0)
-            => ConstructGeneratedFunctionWithReceiver(
+            => (T)ConstructGeneratedFunctionWithReceiver(
                 constructor,
                 receiver,
                 JsCallArguments.From(argument0),
-                newTarget);
+                newTarget)!;
 
-        public static object? ConstructGeneratedFunctionWithReceiver2(
+        public static T ConstructGeneratedFunctionWithReceiver2<T>(
             object constructor,
             object receiver,
             object? newTarget,
             object? argument0,
             object? argument1)
-            => ConstructGeneratedFunctionWithReceiver(
+            => (T)ConstructGeneratedFunctionWithReceiver(
                 constructor,
                 receiver,
                 JsCallArguments.From(argument0, argument1),
-                newTarget);
+                newTarget)!;
 
-        public static object? ConstructGeneratedFunctionWithReceiver3(
+        public static T ConstructGeneratedFunctionWithReceiver3<T>(
             object constructor,
             object receiver,
             object? newTarget,
             object? argument0,
             object? argument1,
             object? argument2)
-            => ConstructGeneratedFunctionWithReceiver(
+            => (T)ConstructGeneratedFunctionWithReceiver(
                 constructor,
                 receiver,
                 JsCallArguments.From(argument0, argument1, argument2),
-                newTarget);
+                newTarget)!;
 
-        public static object? ConstructGeneratedFunctionWithReceiver4(
+        public static T ConstructGeneratedFunctionWithReceiver4<T>(
             object constructor,
             object receiver,
             object? newTarget,
@@ -780,7 +780,7 @@ public static class Function
             object? argument1,
             object? argument2,
             object? argument3)
-            => ConstructGeneratedFunctionWithReceiver(
+            => (T)ConstructGeneratedFunctionWithReceiver(
                 constructor,
                 receiver,
                 JsCallArguments.From(
@@ -788,9 +788,9 @@ public static class Function
                     argument1,
                     argument2,
                     argument3),
-                newTarget);
+                newTarget)!;
 
-        public static object? ConstructGeneratedFunctionWithReceiver5(
+        public static T ConstructGeneratedFunctionWithReceiver5<T>(
             object constructor,
             object receiver,
             object? newTarget,
@@ -799,7 +799,7 @@ public static class Function
             object? argument2,
             object? argument3,
             object? argument4)
-            => ConstructGeneratedFunctionWithReceiver(
+            => (T)ConstructGeneratedFunctionWithReceiver(
                 constructor,
                 receiver,
                 JsCallArguments.From(
@@ -808,18 +808,18 @@ public static class Function
                     argument2,
                     argument3,
                     argument4),
-                newTarget);
+                newTarget)!;
 
-        public static object? ConstructGeneratedFunctionWithReceiverArray(
+        public static T ConstructGeneratedFunctionWithReceiverArray<T>(
             object constructor,
             object receiver,
             object? newTarget,
             object?[]? arguments)
-            => ConstructGeneratedFunctionWithReceiver(
+            => (T)ConstructGeneratedFunctionWithReceiver(
                 constructor,
                 receiver,
                 JsCallArguments.FromArray(arguments),
-                newTarget);
+                newTarget)!;
 
         private static object? ConstructGeneratedFunctionWithReceiver(
             object constructor,

--- a/src/JavaScriptRuntime/JsObject.Descriptors.cs
+++ b/src/JavaScriptRuntime/JsObject.Descriptors.cs
@@ -91,6 +91,17 @@ public partial class JsObject
     }
 
     /// <summary>
+    /// Validates that a generated CLR backing field still mirrors an ordinary own
+    /// data property. Generated constructor-shape getters use this before returning
+    /// the field so structural mutations fall back to full JavaScript lookup.
+    /// </summary>
+    public bool IsSpecializedDataPropertyCurrent(
+        string key,
+        object? expectedValue)
+        => TryGetOwnPlainDataSlot(key, out _, out _, out var currentValue)
+            && Operators.SameValue(currentValue, expectedValue);
+
+    /// <summary>
     /// Re-validates and reads the current value of a slot previously resolved by
     /// <see cref="TryGetOwnPlainDataSlot"/>. Safe to call on every inline-cache
     /// hit for any receiver sharing <paramref name="expectedShape"/>: it never

--- a/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
@@ -4452,6 +4452,54 @@ namespace JavaScriptRuntime
         }
 
         /// <summary>
+        /// Returns whether a generated constructor-shape setter can create an ordinary
+        /// own data property without bypassing observable ECMAScript [[Set]] behavior.
+        /// </summary>
+        public static bool CanUseSpecializedDataPropertySetter(object receiver, string propName)
+        {
+            if (receiver is not JsObject
+                || receiver is JavaScriptRuntime.Proxy
+                || !IsExtensibleInternal(receiver)
+                || PropertyDescriptorStore.TryGetOwn(receiver, propName, out _)
+                || HasOwnValue(receiver, propName))
+            {
+                return false;
+            }
+
+            const int MaxPrototypeChainDepth = 1024;
+            var prototype = PrototypeChain.GetPrototypeOrNull(receiver);
+            for (var depth = 0;
+                 prototype is not null && prototype is not JsNull;
+                 prototype = PrototypeChain.GetPrototypeOrNull(prototype))
+            {
+                if (ReferenceEquals(prototype, receiver)
+                    || ++depth > MaxPrototypeChainDepth
+                    || prototype is JavaScriptRuntime.Proxy
+                    || prototype is IExoticJsObject)
+                {
+                    return false;
+                }
+
+                if (PropertyDescriptorStore.TryGetOwn(
+                        prototype,
+                        propName,
+                        out var descriptor))
+                {
+                    return descriptor.Kind == JsPropertyDescriptorKind.Data
+                        && descriptor.Writable;
+                }
+
+                if (prototype is IDictionary<string, object?> dictionary
+                    && dictionary.ContainsKey(propName))
+                {
+                    return true;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Gets an iterator for for..of using the iterator protocol.
         /// Supports:
         ///  - Arrays, strings, typed arrays

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ReportsFailureWithRepro.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/RunnerCliTests.RunMvp_ReportsFailureWithRepro.verified.txt
@@ -6,7 +6,7 @@ output <temp>/runner-output
 discovered 7
 selected-files 1
 selected-cases 1
-RUNTIME-MISMATCH test/language/mvp/fail-positive.js [non-strict] expected positive but runtime rejected (JavaScript threw non-error value 'JavaScriptRuntime.JsObject')
+RUNTIME-MISMATCH test/language/mvp/fail-positive.js [non-strict] expected positive but runtime rejected (JavaScript threw non-error value 'Modules.input+ObjectLiterals+Ctor_L1C1_Test262Error')
 REPRO node scripts/test262/runMvp.js --root "<temp>/test262-root" --file "test/language/mvp/fail-positive.js" --variant non-strict
 SUMMARY matched=0 unexpected=1 not-run=0 selected=1 classified=1 runtime-mismatch=1
 REPORT <temp>/runner-output/summary.json
@@ -78,7 +78,7 @@ summary.json:
         "kind": "runtime-mismatch",
         "verdict": "unexpected",
         "phase": "runtime",
-        "detail": "expected positive but runtime rejected (JavaScript threw non-error value 'JavaScriptRuntime.JsObject')"
+        "detail": "expected positive but runtime rejected (JavaScript threw non-error value 'Modules.input+ObjectLiterals+Ctor_L1C1_Test262Error')"
       },
       "reasons": [],
       "observed": {
@@ -92,7 +92,7 @@ summary.json:
           "status": "rejected",
           "exitCode": 1,
           "errorType": null,
-          "summary": "JavaScript threw non-error value 'JavaScriptRuntime.JsObject'"
+          "summary": "JavaScript threw non-error value 'Modules.input+ObjectLiterals+Ctor_L1C1_Test262Error'"
         }
       },
       "repro": {

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
@@ -262,7 +262,7 @@
 			IL_0014: ldloc.0
 			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_001a: volatile.
-			IL_001c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_001c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0021: brfalse IL_0036
 
 			IL_0026: ldstr "resolve"
@@ -273,7 +273,7 @@
 			IL_0036: ldstr "resolve"
 			IL_003b: ldarg.2
 			IL_003c: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL:<TwoPhaseDummy_M6>:__js_call__:6"
-			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
 			IL_004b: stloc.0
@@ -428,7 +428,7 @@
 		IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0055: stloc.s 5
 		IL_0057: volatile.
-		IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 		IL_005e: brfalse IL_0078
 
 		IL_0063: ldloc.1
@@ -441,7 +441,7 @@
 		IL_0079: ldstr "value"
 		IL_007e: ldstr "child"
 		IL_0083: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL:Modules.CommonJS_Require_Captures_Shadowed_Global_URL:__js_module_init__:16"
-		IL_0088: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0088: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
 		IL_0092: stloc.2
@@ -606,20 +606,42 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 26 (0x1a)
+			// Header size: 12
+			// Code size: 87 (0x57)
 			.maxstack 8
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "base"
-			IL_0010: ldarg.2
-			IL_0011: ldc.i4.1
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0017: pop
-			IL_0018: ldnull
-			IL_0019: ret
+			IL_000b: isinst Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/ObjectLiterals/Ctor_L3C1_LocalURL
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "base"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/ObjectLiterals/Ctor_L3C1_LocalURL::set_base(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "base"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method LocalURL::__js_call__
 
 	} // end of class LocalURL
@@ -781,7 +803,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -796,7 +818,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
 			IL_0036: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL_Lib:<TwoPhaseDummy_M8>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -840,6 +862,77 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L3C1_LocalURL
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _base
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L3C1_LocalURL::.ctor
+
+			.method public hidebysig 
+				instance object get_base () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "base"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/ObjectLiterals/Ctor_L3C1_LocalURL::_base
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/ObjectLiterals/Ctor_L3C1_LocalURL::_base
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "base"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L3C1_LocalURL::get_base
+
+			.method public hidebysig 
+				instance void set_base (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/ObjectLiterals/Ctor_L3C1_LocalURL::_base
+				IL_0007: ldarg.0
+				IL_0008: ldstr "base"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L3C1_LocalURL::set_base
+
+		} // end of class Ctor_L3C1_LocalURL
+
+
+	} // end of class ObjectLiterals
+
 
 	// Methods
 	.method public hidebysig static 
@@ -882,7 +975,7 @@
 		IL_0025: nop
 		IL_0026: nop
 		IL_0027: volatile.
-		IL_0029: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0029: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 		IL_002e: brfalse IL_0043
 
 		IL_0033: ldloc.1
@@ -893,7 +986,7 @@
 		IL_0043: ldloc.1
 		IL_0044: ldstr "prototype"
 		IL_0049: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL_Lib:Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib:__js_module_init__:9"
-		IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0058: stloc.3
@@ -954,10 +1047,10 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Function/ExecutionTests.cs
@@ -336,5 +336,17 @@ namespace Jroc.Tests.Function
 
         [Fact]
         public Task Function_ExplicitReceiverAbi() { var testName = nameof(Function_ExplicitReceiverAbi); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Function_ConstructorShape_GraphNode() { var testName = nameof(Function_ConstructorShape_GraphNode); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Function_ConstructorShape_GuardedParameterRead() { var testName = nameof(Function_ConstructorShape_GuardedParameterRead); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Function_ConstructorShape_MutationFallback() { var testName = nameof(Function_ConstructorShape_MutationFallback); return ExecutionTest(testName); }
+
+        [Fact]
+        public Task Function_ConstructorShape_PrototypeSetSemantics() { var testName = nameof(Function_ConstructorShape_PrototypeSetSemantics); return ExecutionTest(testName); }
     }
 }

--- a/tests/Jroc.Tests/Function/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Function/GeneratorTests.cs
@@ -401,6 +401,18 @@ namespace Jroc.Tests.Function
         [Fact]
         public Task Function_ExplicitReceiverAbi() { var testName = nameof(Function_ExplicitReceiverAbi); return GenerateTest(testName); }
 
+        [Fact]
+        public Task Function_ConstructorShape_GraphNode() { var testName = nameof(Function_ConstructorShape_GraphNode); return GenerateTest(testName); }
+
+        [Fact]
+        public Task Function_ConstructorShape_GuardedParameterRead() { var testName = nameof(Function_ConstructorShape_GuardedParameterRead); return GenerateTest(testName); }
+
+        [Fact]
+        public Task Function_ConstructorShape_MutationFallback() { var testName = nameof(Function_ConstructorShape_MutationFallback); return GenerateTest(testName); }
+
+        [Fact]
+        public Task Function_ConstructorShape_PrototypeSetSemantics() { var testName = nameof(Function_ConstructorShape_PrototypeSetSemantics); return GenerateTest(testName); }
+
         private static void AssertSignature(
             Type moduleType,
             string functionName,

--- a/tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_GraphNode.js
+++ b/tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_GraphNode.js
@@ -1,0 +1,37 @@
+function GraphNode(x, y, isWall) {
+    this.x = x;
+    this.y = y;
+    this._isWall = isWall;
+    this.pos = { x: x, y: y };
+    this.debug = "";
+}
+
+GraphNode.prototype.describe = function () {
+    return this.x + "," + this.y;
+};
+
+var node = new GraphNode(3, 4, false);
+console.log(node.describe());
+console.log(node.pos.x, node.pos.y, node._isWall, node.debug);
+console.log(node instanceof GraphNode);
+console.log(Object.getPrototypeOf(node) === GraphNode.prototype);
+console.log(Object.keys(node).join(","));
+
+Object.freeze(node);
+GraphNode.call(node, 9, 10, true);
+console.log(node.x, node.y, node._isWall);
+
+var ordinaryReceiver = {};
+GraphNode.call(ordinaryReceiver, 7, 8, true);
+console.log(ordinaryReceiver.x, ordinaryReceiver.y, ordinaryReceiver._isWall);
+
+function NewTargetCheck() {
+    this.matches = new.target === NewTargetCheck;
+}
+console.log(new NewTargetCheck().matches);
+
+function OverrideResult() {
+    this.value = "receiver";
+    return { value: "override" };
+}
+console.log(new OverrideResult().value);

--- a/tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_GuardedParameterRead.js
+++ b/tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_GuardedParameterRead.js
@@ -1,0 +1,11 @@
+function GraphNode(pos) {
+    this.pos = pos;
+}
+
+function readPos(obj) {
+    return obj.pos;
+}
+
+var node = new GraphNode("typed");
+console.log(readPos(node));
+console.log(readPos({ pos: "fallback" }));

--- a/tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_MutationFallback.js
+++ b/tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_MutationFallback.js
@@ -1,0 +1,43 @@
+function GraphNode(pos) {
+    this.pos = pos;
+}
+
+function readPos(obj) {
+    return obj.pos;
+}
+
+var node = new GraphNode("initial");
+console.log(readPos(node));
+
+node.pos = "plain-write";
+console.log(readPos(node));
+
+delete node.pos;
+GraphNode.prototype.pos = "prototype";
+console.log(readPos(node));
+
+var getterCalls = 0;
+Object.defineProperty(node, "pos", {
+    configurable: true,
+    get: function () {
+        getterCalls++;
+        return "accessor";
+    }
+});
+console.log(readPos(node));
+node.pos;
+console.log(getterCalls);
+
+Object.defineProperty(node, "pos", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: "descriptor-data"
+});
+console.log(readPos(node));
+
+Object.setPrototypeOf(node, { pos: "other-prototype" });
+console.log(readPos(node));
+
+node.extra = 1;
+console.log(readPos(node), Object.keys(node).join(","));

--- a/tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_PrototypeSetSemantics.js
+++ b/tests/Jroc.Tests/Function/JavaScript/Function_ConstructorShape_PrototypeSetSemantics.js
@@ -1,0 +1,81 @@
+"use strict";
+
+var setterCalls = 0;
+var setterValue = "";
+
+function SetterConstructor(value) {
+    this.value = value;
+}
+
+Object.defineProperty(SetterConstructor.prototype, "value", {
+    configurable: true,
+    get: function () { return "getter:" + setterValue; },
+    set: function (value) {
+        setterCalls++;
+        setterValue = value;
+    }
+});
+
+var setterInstance = new SetterConstructor("setter");
+console.log(
+    setterCalls,
+    setterValue,
+    setterInstance.value,
+    Object.prototype.hasOwnProperty.call(setterInstance, "value"));
+
+function ReadOnlyConstructor(value) {
+    this.value = value;
+}
+
+Object.defineProperty(ReadOnlyConstructor.prototype, "value", {
+    configurable: true,
+    enumerable: true,
+    writable: false,
+    value: "prototype-read-only"
+});
+
+try {
+    new ReadOnlyConstructor("own");
+    console.log("missing strict error");
+} catch (error) {
+    console.log(error.name);
+}
+
+function WritableConstructor(value) {
+    this.value = value;
+}
+
+Object.defineProperty(WritableConstructor.prototype, "value", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: "prototype-writable"
+});
+
+var writableInstance = new WritableConstructor("own");
+console.log(
+    writableInstance.value,
+    WritableConstructor.prototype.value,
+    Object.prototype.hasOwnProperty.call(writableInstance, "value"));
+
+function ReadingConstructor(value) {
+    this.value = value;
+    console.log(this.value);
+}
+
+new ReadingConstructor("generated receiver");
+ReadingConstructor.call({ value: "custom receiver" }, "updated custom receiver");
+
+function PreInitConstructor(value) {
+    this.value = value;
+}
+
+try {
+    preInit.value;
+    console.log("missing pre-initialization error");
+} catch (error) {
+    console.log(error.name);
+}
+
+var preInit = new PreInitConstructor("initialized");
+console.log(preInit.value);

--- a/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructorShape_GraphNode.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructorShape_GraphNode.verified.txt
@@ -1,0 +1,9 @@
+3,4
+3 4 false 
+true
+true
+x,y,_isWall,pos,debug
+3 4 false
+7 8 true
+true
+override

--- a/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructorShape_GuardedParameterRead.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructorShape_GuardedParameterRead.verified.txt
@@ -1,0 +1,2 @@
+typed
+fallback

--- a/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructorShape_MutationFallback.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructorShape_MutationFallback.verified.txt
@@ -1,0 +1,8 @@
+initial
+plain-write
+prototype
+accessor
+2
+descriptor-data
+descriptor-data
+descriptor-data pos,extra

--- a/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructorShape_PrototypeSetSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_ConstructorShape_PrototypeSetSemantics.verified.txt
@@ -1,0 +1,7 @@
+1 setter getter:setter false
+TypeError
+own prototype-writable true
+generated receiver
+updated custom receiver
+TypeError
+initialized

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
@@ -229,7 +229,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -244,7 +244,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
 			IL_0036: ldstr "Function_CallableReflection_ProxyIntegration:<TwoPhaseDummy_M4>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -776,7 +776,7 @@
 			IL_002c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0031: stloc.2
 			IL_0032: volatile.
-			IL_0034: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0034: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_0039: brfalse IL_004f
 
 			IL_003e: ldarg.s thisArgument
@@ -787,7 +787,7 @@
 			IL_004f: ldarg.s thisArgument
 			IL_0051: ldstr "base"
 			IL_0056: ldstr "Function_CallableReflection_ProxyIntegration:<TwoPhaseDummy_M8>:__js_call__:9"
-			IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0065: stloc.0
@@ -975,20 +975,42 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 26 (0x1a)
+			// Header size: 12
+			// Code size: 87 (0x57)
 			.maxstack 8
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "value"
-			IL_0010: ldarg.2
-			IL_0011: ldc.i4.1
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0017: pop
-			IL_0018: ldnull
-			IL_0019: ret
+			IL_000b: isinst Modules.Function_CallableReflection_ProxyIntegration/ObjectLiterals/Ctor_L74C1_Constructor
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_CallableReflection_ProxyIntegration/ObjectLiterals/Ctor_L74C1_Constructor::set_value(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "value"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method Constructor::__js_call__
 
 	} // end of class Constructor
@@ -1861,6 +1883,77 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L74C1_Constructor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L74C1_Constructor::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_CallableReflection_ProxyIntegration/ObjectLiterals/Ctor_L74C1_Constructor::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_CallableReflection_ProxyIntegration/ObjectLiterals/Ctor_L74C1_Constructor::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L74C1_Constructor::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_CallableReflection_ProxyIntegration/ObjectLiterals/Ctor_L74C1_Constructor::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L74C1_Constructor::set_value
+
+		} // end of class Ctor_L74C1_Constructor
+
+
+	} // end of class ObjectLiterals
+
 
 	// Methods
 	.method public hidebysig static 
@@ -2110,7 +2203,7 @@
 		IL_01c9: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 		IL_01ce: stloc.s 41
 		IL_01d0: volatile.
-		IL_01d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_01d2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 		IL_01d7: brfalse IL_01ec
 
 		IL_01dc: ldloc.2
@@ -2121,7 +2214,7 @@
 		IL_01ec: ldloc.2
 		IL_01ed: ldstr "get"
 		IL_01f2: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:62"
-		IL_01f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_01f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0201: stloc.s 36
@@ -2132,7 +2225,7 @@
 		IL_020d: ldstr "accessor"
 		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
 		IL_0217: volatile.
-		IL_0219: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0219: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 		IL_021e: brfalse IL_0232
 
 		IL_0223: ldstr "get"
@@ -2141,7 +2234,7 @@
 
 		IL_0232: ldstr "get"
 		IL_0237: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:67"
-		IL_023c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_023c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0246: stloc.s 42
@@ -2153,7 +2246,7 @@
 		IL_0255: box [System.Runtime]System.Boolean
 		IL_025a: stloc.s 44
 		IL_025c: volatile.
-		IL_025e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_025e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 		IL_0263: brfalse IL_0278
 
 		IL_0268: ldloc.2
@@ -2164,7 +2257,7 @@
 		IL_0278: ldloc.2
 		IL_0279: ldstr "set"
 		IL_027e: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:71"
-		IL_0283: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0283: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_028d: stloc.s 42
@@ -2175,7 +2268,7 @@
 		IL_0299: ldstr "accessor"
 		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
 		IL_02a3: volatile.
-		IL_02a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_02a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 		IL_02aa: brfalse IL_02be
 
 		IL_02af: ldstr "set"
@@ -2184,7 +2277,7 @@
 
 		IL_02be: ldstr "set"
 		IL_02c3: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:76"
-		IL_02c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_02c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_02d2: stloc.s 36
@@ -2198,7 +2291,7 @@
 		IL_02e8: ldloc.0
 		IL_02e9: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
 		IL_02ee: volatile.
-		IL_02f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_02f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 		IL_02f5: brfalse IL_0309
 
 		IL_02fa: ldstr "accessor"
@@ -2207,12 +2300,12 @@
 
 		IL_0309: ldstr "accessor"
 		IL_030e: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:81"
-		IL_0313: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0313: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_031d: stloc.s 36
 		IL_031f: volatile.
-		IL_0321: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0321: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 		IL_0326: brfalse IL_033b
 
 		IL_032b: ldloc.3
@@ -2223,12 +2316,12 @@
 		IL_033b: ldloc.3
 		IL_033c: ldstr "custom"
 		IL_0341: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:83"
-		IL_0346: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0346: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0350: stloc.s 42
 		IL_0352: volatile.
-		IL_0354: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0354: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 		IL_0359: brfalse IL_036e
 
 		IL_035e: ldloc.3
@@ -2239,7 +2332,7 @@
 		IL_036e: ldloc.3
 		IL_036f: ldstr "accessor"
 		IL_0374: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:85"
-		IL_0379: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0379: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0383: stloc.s 46
@@ -2287,7 +2380,7 @@
 		IL_03d1: ldloc.s 46
 		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_03d8: volatile.
-		IL_03da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_03da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 		IL_03df: brfalse IL_03f8
 
 		IL_03e4: ldstr "join"
@@ -2298,7 +2391,7 @@
 		IL_03f8: ldstr "join"
 		IL_03fd: ldstr ","
 		IL_0402: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:94"
-		IL_0407: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0407: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
 		IL_0411: stloc.s 46
@@ -2417,7 +2510,7 @@
 		IL_053c: box [System.Runtime]System.Boolean
 		IL_0541: stloc.s 45
 		IL_0543: volatile.
-		IL_0545: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0545: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 		IL_054a: brfalse IL_055f
 
 		IL_054f: ldloc.2
@@ -2428,7 +2521,7 @@
 		IL_055f: ldloc.2
 		IL_0560: ldstr "get"
 		IL_0565: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:116"
-		IL_056a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_056a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 		IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0574: stloc.s 36
@@ -2443,7 +2536,7 @@
 		IL_058f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
 		IL_0594: pop
 		IL_0595: volatile.
-		IL_0597: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0597: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 		IL_059c: brfalse IL_05b1
 
 		IL_05a1: ldloc.2
@@ -2454,7 +2547,7 @@
 		IL_05b1: ldloc.2
 		IL_05b2: ldstr "get"
 		IL_05b7: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:122"
-		IL_05bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_05bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_05c6: stloc.s 36
@@ -2464,7 +2557,7 @@
 		IL_05d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_05d5: stloc.s 40
 		IL_05d7: volatile.
-		IL_05d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_05d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 		IL_05de: brfalse IL_05f3
 
 		IL_05e3: ldloc.2
@@ -2475,7 +2568,7 @@
 		IL_05f3: ldloc.2
 		IL_05f4: ldstr "get"
 		IL_05f9: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:128"
-		IL_05fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_05fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 		IL_0603: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0608: stloc.s 36
@@ -2512,7 +2605,7 @@
 		IL_0664: box [System.Runtime]System.Boolean
 		IL_0669: stloc.s 44
 		IL_066b: volatile.
-		IL_066d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_066d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 		IL_0672: brfalse IL_0687
 
 		IL_0677: ldloc.1
@@ -2523,7 +2616,7 @@
 		IL_0687: ldloc.1
 		IL_0688: ldstr "marker"
 		IL_068d: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:146"
-		IL_0692: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0692: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 		IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_069c: stloc.s 36
@@ -2631,7 +2724,7 @@
 		IL_07ca: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 		IL_07cf: stloc.s 41
 		IL_07d1: volatile.
-		IL_07d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_07d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 		IL_07d8: brfalse IL_07fc
 
 		IL_07dd: ldloc.s 6
@@ -2646,7 +2739,7 @@
 		IL_0803: ldc.r8 5
 		IL_080c: box [System.Runtime]System.Double
 		IL_0811: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:185"
-		IL_0816: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0816: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 		IL_081b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
 		IL_0820: stloc.s 42
@@ -2773,7 +2866,7 @@
 		IL_0973: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
 		IL_0978: stloc.s 41
 		IL_097a: volatile.
-		IL_097c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_097c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 		IL_0981: brfalse IL_0997
 
 		IL_0986: ldloc.s 9
@@ -2784,12 +2877,12 @@
 		IL_0997: ldloc.s 9
 		IL_0999: ldstr "targetMatches"
 		IL_099e: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:231"
-		IL_09a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_09a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 		IL_09a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_09ad: stloc.s 42
 		IL_09af: volatile.
-		IL_09b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_09b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 		IL_09b6: brfalse IL_09cc
 
 		IL_09bb: ldloc.s 9
@@ -2800,12 +2893,12 @@
 		IL_09cc: ldloc.s 9
 		IL_09ce: ldstr "argument"
 		IL_09d3: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:233"
-		IL_09d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_09d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 		IL_09dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_09e2: stloc.s 36
 		IL_09e4: volatile.
-		IL_09e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_09e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 		IL_09eb: brfalse IL_0a01
 
 		IL_09f0: ldloc.s 9
@@ -2816,7 +2909,7 @@
 		IL_0a01: ldloc.s 9
 		IL_0a03: ldstr "newTargetMatches"
 		IL_0a08: ldstr "Function_CallableReflection_ProxyIntegration:Modules.Function_CallableReflection_ProxyIntegration:__js_module_init__:235"
-		IL_0a0d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0a0d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 		IL_0a12: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0a17: stloc.s 46
@@ -3300,7 +3393,6 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
@@ -3318,6 +3410,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
 	.field assembly static int32 __jroc_dynamicLookup_28
+	.field assembly static int32 __jroc_dynamicLookup_29
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CommonArityDynamicDispatch.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CommonArityDynamicDispatch.verified.txt
@@ -271,7 +271,7 @@
 			IL_0016: ldloc.0
 			IL_0017: ldfld object Modules.Function_CommonArityDynamicDispatch/collect/Scope::arguments
 			IL_001c: volatile.
-			IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_0023: brfalse IL_0037
 
 			IL_0028: ldstr "length"
@@ -280,7 +280,7 @@
 
 			IL_0037: ldstr "length"
 			IL_003c: ldstr "Function_CommonArityDynamicDispatch:<TwoPhaseDummy_M4>:__js_call__:4"
-			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004b: stloc.3
@@ -301,7 +301,7 @@
 			IL_007a: ldloc.0
 			IL_007b: ldfld object Modules.Function_CommonArityDynamicDispatch/collect/Scope::arguments
 			IL_0080: volatile.
-			IL_0082: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0082: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_0087: brfalse IL_009b
 
 			IL_008c: ldstr "length"
@@ -310,7 +310,7 @@
 
 			IL_009b: ldstr "length"
 			IL_00a0: ldstr "Function_CommonArityDynamicDispatch:<TwoPhaseDummy_M4>:__js_call__:16"
-			IL_00a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_00a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00af: stloc.3
@@ -330,7 +330,7 @@
 			IL_00ce: ldloc.0
 			IL_00cf: ldfld object Modules.Function_CommonArityDynamicDispatch/collect/Scope::arguments
 			IL_00d4: volatile.
-			IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_00db: brfalse IL_00ef
 
 			IL_00e0: ldstr "length"
@@ -339,7 +339,7 @@
 
 			IL_00ef: ldstr "length"
 			IL_00f4: ldstr "Function_CommonArityDynamicDispatch:<TwoPhaseDummy_M4>:__js_call__:27"
-			IL_00f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_00f9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0103: stloc.3
@@ -679,7 +679,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 210 (0xd2)
+			// Code size: 332 (0x14c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_CommonArityDynamicDispatch/Box/Scope,
@@ -700,7 +700,7 @@
 			IL_0016: ldloc.0
 			IL_0017: ldfld object Modules.Function_CommonArityDynamicDispatch/Box/Scope::arguments
 			IL_001c: volatile.
-			IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_0023: brfalse IL_0037
 
 			IL_0028: ldstr "length"
@@ -709,54 +709,98 @@
 
 			IL_0037: ldstr "length"
 			IL_003c: ldstr "Function_CommonArityDynamicDispatch:<TwoPhaseDummy_M6>:__js_call__:5"
-			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_004b: stloc.1
 			IL_004c: ldarg.1
 			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0057: ldstr "count"
-			IL_005c: ldloc.1
-			IL_005d: ldc.i4.1
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0063: pop
-			IL_0064: ldloc.0
-			IL_0065: ldfld object Modules.Function_CommonArityDynamicDispatch/Box/Scope::arguments
-			IL_006a: ldloc.0
-			IL_006b: ldfld object Modules.Function_CommonArityDynamicDispatch/Box/Scope::arguments
-			IL_0070: volatile.
-			IL_0072: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0077: brfalse IL_008b
+			IL_0057: isinst Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments
+			IL_005c: dup
+			IL_005d: brfalse IL_0088
 
-			IL_007c: ldstr "length"
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0086: br IL_009f
+			IL_0062: dup
+			IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0068: brfalse IL_0088
 
-			IL_008b: ldstr "length"
-			IL_0090: ldstr "Function_CommonArityDynamicDispatch:<TwoPhaseDummy_M6>:__js_call__:13"
-			IL_0095: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_006d: dup
+			IL_006e: ldstr "count"
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0078: brfalse IL_0088
 
-			IL_009f: stloc.1
-			IL_00a0: ldloc.1
-			IL_00a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00a6: ldc.r8 1
-			IL_00af: sub
-			IL_00b0: stloc.2
-			IL_00b1: ldloc.2
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00b7: stloc.1
-			IL_00b8: ldarg.1
-			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_00c3: ldstr "last"
-			IL_00c8: ldloc.1
-			IL_00c9: ldc.i4.1
-			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_00cf: pop
-			IL_00d0: ldnull
-			IL_00d1: ret
+			IL_007d: ldloc.1
+			IL_007e: callvirt instance void Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments::set_count(object)
+			IL_0083: br IL_00a1
+
+			IL_0088: pop
+			IL_0089: ldarg.1
+			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0094: ldstr "count"
+			IL_0099: ldloc.1
+			IL_009a: ldc.i4.1
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_00a0: pop
+
+			IL_00a1: ldloc.0
+			IL_00a2: ldfld object Modules.Function_CommonArityDynamicDispatch/Box/Scope::arguments
+			IL_00a7: ldloc.0
+			IL_00a8: ldfld object Modules.Function_CommonArityDynamicDispatch/Box/Scope::arguments
+			IL_00ad: volatile.
+			IL_00af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_00b4: brfalse IL_00c8
+
+			IL_00b9: ldstr "length"
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c3: br IL_00dc
+
+			IL_00c8: ldstr "length"
+			IL_00cd: ldstr "Function_CommonArityDynamicDispatch:<TwoPhaseDummy_M6>:__js_call__:12"
+			IL_00d2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_00dc: stloc.1
+			IL_00dd: ldloc.1
+			IL_00de: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00e3: ldc.r8 1
+			IL_00ec: sub
+			IL_00ed: stloc.2
+			IL_00ee: ldloc.2
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00f4: stloc.1
+			IL_00f5: ldarg.1
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0100: isinst Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments
+			IL_0105: dup
+			IL_0106: brfalse IL_0131
+
+			IL_010b: dup
+			IL_010c: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0111: brfalse IL_0131
+
+			IL_0116: dup
+			IL_0117: ldstr "last"
+			IL_011c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0121: brfalse IL_0131
+
+			IL_0126: ldloc.1
+			IL_0127: callvirt instance void Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments::set_last(object)
+			IL_012c: br IL_014a
+
+			IL_0131: pop
+			IL_0132: ldarg.1
+			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_013d: ldstr "last"
+			IL_0142: ldloc.1
+			IL_0143: ldc.i4.1
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0149: pop
+
+			IL_014a: ldnull
+			IL_014b: ret
 		} // end of method Box::__js_call__
 
 	} // end of class Box
@@ -789,6 +833,229 @@
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
+
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L35C1_Box
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _count
+			.field private object _last
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L35C1_Box::.ctor
+
+			.method public hidebysig 
+				instance object get_count () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "count"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_Box::_count
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_Box::_count
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "count"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L35C1_Box::get_count
+
+			.method public hidebysig 
+				instance void set_count (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_Box::_count
+				IL_0007: ldarg.0
+				IL_0008: ldstr "count"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L35C1_Box::set_count
+
+			.method public hidebysig 
+				instance object get_last () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "last"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_Box::_last
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_Box::_last
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "last"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L35C1_Box::get_last
+
+			.method public hidebysig 
+				instance void set_last (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_Box::_last
+				IL_0007: ldarg.0
+				IL_0008: ldstr "last"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L35C1_Box::set_last
+
+		} // end of class Ctor_L35C1_Box
+
+		.class nested public auto ansi beforefieldinit Ctor_L35C1_arguments
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _count
+			.field private object _last
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L35C1_arguments::.ctor
+
+			.method public hidebysig 
+				instance object get_count () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "count"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments::_count
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments::_count
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "count"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L35C1_arguments::get_count
+
+			.method public hidebysig 
+				instance void set_count (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments::_count
+				IL_0007: ldarg.0
+				IL_0008: ldstr "count"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L35C1_arguments::set_count
+
+			.method public hidebysig 
+				instance object get_last () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "last"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments::_last
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments::_last
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "last"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L35C1_arguments::get_last
+
+			.method public hidebysig 
+				instance void set_last (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_CommonArityDynamicDispatch/ObjectLiterals/Ctor_L35C1_arguments::_last
+				IL_0007: ldarg.0
+				IL_0008: ldstr "last"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L35C1_arguments::set_last
+
+		} // end of class Ctor_L35C1_arguments
+
+
+	} // end of class ObjectLiterals
 
 
 	// Methods
@@ -1231,7 +1498,7 @@
 		IL_0627: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_062c: stloc.s 13
 		IL_062e: volatile.
-		IL_0630: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0630: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 		IL_0635: brfalse IL_064b
 
 		IL_063a: ldloc.s 7
@@ -1242,7 +1509,7 @@
 		IL_064b: ldloc.s 7
 		IL_064d: ldstr "count"
 		IL_0652: ldstr "Function_CommonArityDynamicDispatch:Modules.Function_CommonArityDynamicDispatch:__js_module_init__:240"
-		IL_0657: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0657: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 		IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0661: stloc.s 14
@@ -1253,7 +1520,7 @@
 		IL_066d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0672: stloc.s 13
 		IL_0674: volatile.
-		IL_0676: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0676: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 		IL_067b: brfalse IL_0691
 
 		IL_0680: ldloc.s 8
@@ -1264,7 +1531,7 @@
 		IL_0691: ldloc.s 8
 		IL_0693: ldstr "last"
 		IL_0698: ldstr "Function_CommonArityDynamicDispatch:Modules.Function_CommonArityDynamicDispatch:__js_module_init__:245"
-		IL_069d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_069d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 		IL_06a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_06a7: stloc.s 14
@@ -1275,7 +1542,7 @@
 		IL_06b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_06b8: stloc.s 13
 		IL_06ba: volatile.
-		IL_06bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_06bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 		IL_06c1: brfalse IL_06d7
 
 		IL_06c6: ldloc.s 9
@@ -1286,7 +1553,7 @@
 		IL_06d7: ldloc.s 9
 		IL_06d9: ldstr "last"
 		IL_06de: ldstr "Function_CommonArityDynamicDispatch:Modules.Function_CommonArityDynamicDispatch:__js_module_init__:250"
-		IL_06e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_06e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 		IL_06e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_06ed: stloc.s 14
@@ -1297,7 +1564,7 @@
 		IL_06f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_06fe: stloc.s 13
 		IL_0700: volatile.
-		IL_0702: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0702: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 		IL_0707: brfalse IL_071d
 
 		IL_070c: ldloc.s 10
@@ -1308,7 +1575,7 @@
 		IL_071d: ldloc.s 10
 		IL_071f: ldstr "count"
 		IL_0724: ldstr "Function_CommonArityDynamicDispatch:Modules.Function_CommonArityDynamicDispatch:__js_module_init__:255"
-		IL_0729: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0729: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0733: stloc.s 14
@@ -1390,15 +1657,15 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_7
-	.field assembly static int32 __jroc_dynamicLookup_8
-	.field assembly static int32 __jroc_dynamicLookup_9
-	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
 	.field assembly static int32 __jroc_dynamicLookup_12
 	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -2228,7 +2228,7 @@
 		IL_015a: box [System.Runtime]System.Double
 		IL_015f: ldc.r8 3
 		IL_0168: box [System.Runtime]System.Double
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2(object, object, object, object, object)
+		IL_016d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2<class Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point>(object, object, object, object, object)
 		IL_0172: stloc.s 7
 		IL_0174: ldloc.s 7
 		IL_0176: ldstr "x"
@@ -2924,7 +2924,7 @@
 		IL_09f3: box [System.Runtime]System.Double
 		IL_09f8: ldc.r8 1
 		IL_0a01: box [System.Runtime]System.Double
-		IL_0a06: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2(object, object, object, object, object)
+		IL_0a06: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2<class Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point>(object, object, object, object, object)
 		IL_0a0b: stloc.s 19
 		IL_0a0d: volatile.
 		IL_0a0f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -227,28 +227,72 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 50 (0x32)
+			// Header size: 12
+			// Code size: 172 (0xac)
 			.maxstack 8
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "x"
-			IL_0010: ldarg.2
-			IL_0011: ldc.i4.1
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0017: pop
-			IL_0018: ldarg.1
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0023: ldstr "y"
-			IL_0028: ldarg.3
-			IL_0029: ldc.i4.1
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_002f: pop
-			IL_0030: ldnull
-			IL_0031: ret
+			IL_000b: isinst Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "x"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::set_x(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "x"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldarg.1
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0060: isinst Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point
+			IL_0065: dup
+			IL_0066: brfalse IL_0091
+
+			IL_006b: dup
+			IL_006c: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0071: brfalse IL_0091
+
+			IL_0076: dup
+			IL_0077: ldstr "y"
+			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0081: brfalse IL_0091
+
+			IL_0086: ldarg.3
+			IL_0087: callvirt instance void Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::set_y(object)
+			IL_008c: br IL_00aa
+
+			IL_0091: pop
+			IL_0092: ldarg.1
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_009d: ldstr "y"
+			IL_00a2: ldarg.3
+			IL_00a3: ldc.i4.1
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_00a9: pop
+
+			IL_00aa: ldnull
+			IL_00ab: ret
 		} // end of method Point::__js_call__
 
 	} // end of class Point
@@ -404,7 +448,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -419,12 +463,12 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "x"
 			IL_0036: ldstr "Function_ConstructedInstance_ObjectSemantics:<TwoPhaseDummy_M5>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
 			IL_0046: volatile.
-			IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0048: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_004d: brfalse IL_006c
 
 			IL_0052: ldarg.1
@@ -439,7 +483,7 @@
 			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0077: ldstr "y"
 			IL_007c: ldstr "Function_ConstructedInstance_ObjectSemantics:<TwoPhaseDummy_M5>:__js_call__:6"
-			IL_0081: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0081: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_008b: stloc.1
@@ -1814,7 +1858,7 @@
 			IL_0000: ldarg.0
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_000d: brfalse IL_0021
 
 			IL_0012: ldstr "sum"
@@ -1823,7 +1867,7 @@
 
 			IL_0021: ldstr "sum"
 			IL_0026: ldstr "Function_ConstructedInstance_ObjectSemantics:<TwoPhaseDummy_M14>:read:3"
-			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0035: stloc.0
@@ -1875,6 +1919,121 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L3C1_Point
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _x
+			.field private object _y
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L3C1_Point::.ctor
+
+			.method public hidebysig 
+				instance object get_x () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "x"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::_x
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::_x
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "x"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L3C1_Point::get_x
+
+			.method public hidebysig 
+				instance void set_x (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::_x
+				IL_0007: ldarg.0
+				IL_0008: ldstr "x"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L3C1_Point::set_x
+
+			.method public hidebysig 
+				instance object get_y () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "y"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::_y
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::_y
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "y"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L3C1_Point::get_y
+
+			.method public hidebysig 
+				instance void set_y (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::_y
+				IL_0007: ldarg.0
+				IL_0008: ldstr "y"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L3C1_Point::set_y
+
+		} // end of class Ctor_L3C1_Point
+
+
+	} // end of class ObjectLiterals
+
 
 	// Methods
 	.method public hidebysig static 
@@ -1887,7 +2046,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2662 (0xa66)
+		// Code size: 2641 (0xa51)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
@@ -1897,7 +2056,7 @@
 			[4] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject,
 			[5] class Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject,
 			[6] class Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject,
-			[7] object,
+			[7] class Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point,
 			[8] object,
 			[9] object,
 			[10] object,
@@ -1909,14 +2068,15 @@
 			[16] object[],
 			[17] object,
 			[18] class Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject,
-			[19] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[20] bool,
-			[21] object,
+			[19] class Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point,
+			[20] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[21] bool,
 			[22] object,
 			[23] object,
 			[24] object,
-			[25] class [System.Runtime]System.Type,
-			[26] class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
+			[25] object,
+			[26] class [System.Runtime]System.Type,
+			[27] class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -2023,7 +2183,7 @@
 		IL_00e0: nop
 		IL_00e1: nop
 		IL_00e2: volatile.
-		IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 		IL_00e9: brfalse IL_00fe
 
 		IL_00ee: ldloc.1
@@ -2034,7 +2194,7 @@
 		IL_00fe: ldloc.1
 		IL_00ff: ldstr "prototype"
 		IL_0104: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:24"
-		IL_0109: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0109: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0113: stloc.s 17
@@ -2059,742 +2219,736 @@
 		IL_013f: ldc.i4.1
 		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
 		IL_0145: pop
-		IL_0146: ldloc.1
-		IL_0147: dup
-		IL_0148: ldc.r8 2
-		IL_0151: box [System.Runtime]System.Double
-		IL_0156: ldc.r8 3
-		IL_015f: box [System.Runtime]System.Double
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_0169: stloc.s 7
-		IL_016b: ldloc.s 7
-		IL_016d: ldstr "x"
-		IL_0172: ldc.r8 5
-		IL_017b: ldc.i4.1
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0181: pop
-		IL_0182: ldloc.s 7
-		IL_0184: ldstr "z"
-		IL_0189: ldc.r8 4
-		IL_0192: ldc.i4.1
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0198: pop
-		IL_0199: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_019e: stloc.s 19
-		IL_01a0: ldloc.s 7
-		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a7: volatile.
-		IL_01a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_01ae: brfalse IL_01c2
+		IL_0146: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::.ctor()
+		IL_014b: stloc.s 19
+		IL_014d: ldloc.1
+		IL_014e: ldloc.s 19
+		IL_0150: ldloc.1
+		IL_0151: ldc.r8 2
+		IL_015a: box [System.Runtime]System.Double
+		IL_015f: ldc.r8 3
+		IL_0168: box [System.Runtime]System.Double
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2(object, object, object, object, object)
+		IL_0172: stloc.s 7
+		IL_0174: ldloc.s 7
+		IL_0176: ldstr "x"
+		IL_017b: ldc.r8 5
+		IL_0184: ldc.i4.1
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_018a: pop
+		IL_018b: ldloc.s 7
+		IL_018d: ldstr "z"
+		IL_0192: ldc.r8 4
+		IL_019b: ldc.i4.1
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_01a1: pop
+		IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a7: stloc.s 20
+		IL_01a9: ldloc.s 7
+		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b0: volatile.
+		IL_01b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01b7: brfalse IL_01cb
 
-		IL_01b3: ldstr "sum"
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01bd: br IL_01d6
+		IL_01bc: ldstr "sum"
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01c6: br IL_01df
 
-		IL_01c2: ldstr "sum"
-		IL_01c7: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:47"
-		IL_01cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01cb: ldstr "sum"
+		IL_01d0: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:48"
+		IL_01d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_01d6: stloc.s 17
-		IL_01d8: ldloc.s 19
-		IL_01da: ldloc.s 17
-		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e1: pop
-		IL_01e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e7: stloc.s 19
-		IL_01e9: ldloc.s 7
-		IL_01eb: ldloc.1
-		IL_01ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_01f1: stloc.s 20
-		IL_01f3: ldloc.s 20
-		IL_01f5: box [System.Runtime]System.Boolean
+		IL_01df: stloc.s 17
+		IL_01e1: ldloc.s 20
+		IL_01e3: ldloc.s 17
+		IL_01e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ea: pop
+		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f0: stloc.s 20
+		IL_01f2: ldloc.s 7
+		IL_01f4: ldloc.1
+		IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
 		IL_01fa: stloc.s 21
-		IL_01fc: ldloc.s 19
-		IL_01fe: ldloc.s 21
-		IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0205: pop
-		IL_0206: ldloc.s 7
-		IL_0208: ldstr "x"
-		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0212: stloc.s 8
-		IL_0214: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0219: stloc.s 19
-		IL_021b: volatile.
-		IL_021d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0222: brfalse IL_0238
+		IL_01fc: ldloc.s 21
+		IL_01fe: box [System.Runtime]System.Boolean
+		IL_0203: stloc.s 22
+		IL_0205: ldloc.s 20
+		IL_0207: ldloc.s 22
+		IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_020e: pop
+		IL_020f: ldloc.s 7
+		IL_0211: ldstr "x"
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_021b: stloc.s 8
+		IL_021d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0222: stloc.s 20
+		IL_0224: volatile.
+		IL_0226: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_022b: brfalse IL_0241
 
-		IL_0227: ldloc.s 8
-		IL_0229: ldstr "value"
-		IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0233: br IL_024e
+		IL_0230: ldloc.s 8
+		IL_0232: ldstr "value"
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_023c: br IL_0257
 
-		IL_0238: ldloc.s 8
-		IL_023a: ldstr "value"
-		IL_023f: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:61"
-		IL_0244: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0241: ldloc.s 8
+		IL_0243: ldstr "value"
+		IL_0248: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:62"
+		IL_024d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_024e: stloc.s 17
-		IL_0250: volatile.
-		IL_0252: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0257: brfalse IL_026d
+		IL_0257: stloc.s 17
+		IL_0259: volatile.
+		IL_025b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0260: brfalse IL_0276
 
-		IL_025c: ldloc.s 8
-		IL_025e: ldstr "writable"
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0268: br IL_0283
+		IL_0265: ldloc.s 8
+		IL_0267: ldstr "writable"
+		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0271: br IL_028c
 
-		IL_026d: ldloc.s 8
-		IL_026f: ldstr "writable"
-		IL_0274: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:63"
-		IL_0279: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0276: ldloc.s 8
+		IL_0278: ldstr "writable"
+		IL_027d: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:64"
+		IL_0282: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0283: stloc.s 22
-		IL_0285: volatile.
-		IL_0287: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_028c: brfalse IL_02a2
+		IL_028c: stloc.s 23
+		IL_028e: volatile.
+		IL_0290: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0295: brfalse IL_02ab
 
-		IL_0291: ldloc.s 8
-		IL_0293: ldstr "enumerable"
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_029d: br IL_02b8
+		IL_029a: ldloc.s 8
+		IL_029c: ldstr "enumerable"
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a6: br IL_02c1
 
-		IL_02a2: ldloc.s 8
-		IL_02a4: ldstr "enumerable"
-		IL_02a9: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:65"
-		IL_02ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02ab: ldloc.s 8
+		IL_02ad: ldstr "enumerable"
+		IL_02b2: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:66"
+		IL_02b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02b8: stloc.s 23
-		IL_02ba: volatile.
-		IL_02bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_02c1: brfalse IL_02d7
+		IL_02c1: stloc.s 24
+		IL_02c3: volatile.
+		IL_02c5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_02ca: brfalse IL_02e0
 
-		IL_02c6: ldloc.s 8
-		IL_02c8: ldstr "configurable"
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d2: br IL_02ed
+		IL_02cf: ldloc.s 8
+		IL_02d1: ldstr "configurable"
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02db: br IL_02f6
 
-		IL_02d7: ldloc.s 8
-		IL_02d9: ldstr "configurable"
-		IL_02de: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:67"
-		IL_02e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02e0: ldloc.s 8
+		IL_02e2: ldstr "configurable"
+		IL_02e7: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:68"
+		IL_02ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02ed: stloc.s 24
-		IL_02ef: ldloc.s 19
-		IL_02f1: ldc.i4.4
-		IL_02f2: newarr [System.Runtime]System.Object
-		IL_02f7: dup
-		IL_02f8: ldc.i4.0
-		IL_02f9: ldloc.s 17
-		IL_02fb: stelem.ref
-		IL_02fc: dup
-		IL_02fd: ldc.i4.1
-		IL_02fe: ldloc.s 22
-		IL_0300: stelem.ref
-		IL_0301: dup
-		IL_0302: ldc.i4.2
-		IL_0303: ldloc.s 23
-		IL_0305: stelem.ref
-		IL_0306: dup
-		IL_0307: ldc.i4.3
-		IL_0308: ldloc.s 24
-		IL_030a: stelem.ref
-		IL_030b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0310: pop
-		IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0316: stloc.s 19
-		IL_0318: ldloc.s 7
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0324: volatile.
-		IL_0326: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_032b: brfalse IL_0344
+		IL_02f6: stloc.s 25
+		IL_02f8: ldloc.s 20
+		IL_02fa: ldc.i4.4
+		IL_02fb: newarr [System.Runtime]System.Object
+		IL_0300: dup
+		IL_0301: ldc.i4.0
+		IL_0302: ldloc.s 17
+		IL_0304: stelem.ref
+		IL_0305: dup
+		IL_0306: ldc.i4.1
+		IL_0307: ldloc.s 23
+		IL_0309: stelem.ref
+		IL_030a: dup
+		IL_030b: ldc.i4.2
+		IL_030c: ldloc.s 24
+		IL_030e: stelem.ref
+		IL_030f: dup
+		IL_0310: ldc.i4.3
+		IL_0311: ldloc.s 25
+		IL_0313: stelem.ref
+		IL_0314: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0319: pop
+		IL_031a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_031f: stloc.s 20
+		IL_0321: ldloc.s 7
+		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_032d: volatile.
+		IL_032f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0334: brfalse IL_034d
 
-		IL_0330: ldstr "join"
-		IL_0335: ldstr ","
-		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_033f: br IL_035d
+		IL_0339: ldstr "join"
+		IL_033e: ldstr ","
+		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0348: br IL_0366
 
-		IL_0344: ldstr "join"
-		IL_0349: ldstr ","
-		IL_034e: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:74"
-		IL_0353: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_034d: ldstr "join"
+		IL_0352: ldstr ","
+		IL_0357: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:75"
+		IL_035c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_035d: stloc.s 24
-		IL_035f: ldloc.s 19
-		IL_0361: ldloc.s 24
-		IL_0363: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0368: pop
-		IL_0369: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_036e: stloc.s 19
-		IL_0370: ldloc.s 7
-		IL_0372: ldstr "y"
-		IL_0377: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_037c: stloc.s 20
-		IL_037e: ldloc.s 20
-		IL_0380: box [System.Runtime]System.Boolean
+		IL_0366: stloc.s 25
+		IL_0368: ldloc.s 20
+		IL_036a: ldloc.s 25
+		IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0371: pop
+		IL_0372: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0377: stloc.s 20
+		IL_0379: ldloc.s 7
+		IL_037b: ldstr "y"
+		IL_0380: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
 		IL_0385: stloc.s 21
-		IL_0387: ldloc.s 19
-		IL_0389: ldloc.s 21
-		IL_038b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0390: pop
-		IL_0391: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0396: stloc.s 19
-		IL_0398: ldloc.s 7
-		IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03a4: volatile.
-		IL_03a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_03ab: brfalse IL_03c4
+		IL_0387: ldloc.s 21
+		IL_0389: box [System.Runtime]System.Boolean
+		IL_038e: stloc.s 22
+		IL_0390: ldloc.s 20
+		IL_0392: ldloc.s 22
+		IL_0394: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0399: pop
+		IL_039a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_039f: stloc.s 20
+		IL_03a1: ldloc.s 7
+		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03ad: volatile.
+		IL_03af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_03b4: brfalse IL_03cd
 
-		IL_03b0: ldstr "join"
-		IL_03b5: ldstr ","
-		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03bf: br IL_03dd
+		IL_03b9: ldstr "join"
+		IL_03be: ldstr ","
+		IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03c8: br IL_03e6
 
-		IL_03c4: ldstr "join"
-		IL_03c9: ldstr ","
-		IL_03ce: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:88"
-		IL_03d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_03cd: ldstr "join"
+		IL_03d2: ldstr ","
+		IL_03d7: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:89"
+		IL_03dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_03dd: stloc.s 24
-		IL_03df: ldloc.s 19
-		IL_03e1: ldloc.s 24
-		IL_03e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03e8: pop
-		IL_03e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03ee: stloc.s 19
-		IL_03f0: volatile.
-		IL_03f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_03f7: brfalse IL_040d
-
-		IL_03fc: ldloc.s 7
-		IL_03fe: ldstr "y"
-		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0408: br IL_0423
-
-		IL_040d: ldloc.s 7
-		IL_040f: ldstr "y"
-		IL_0414: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:93"
-		IL_0419: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0423: stloc.s 24
-		IL_0425: ldloc.s 24
-		IL_0427: ldnull
-		IL_0428: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_042d: stloc.s 20
-		IL_042f: ldloc.s 20
-		IL_0431: box [System.Runtime]System.Boolean
-		IL_0436: stloc.s 21
-		IL_0438: ldloc.s 19
-		IL_043a: ldloc.s 21
-		IL_043c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0441: pop
+		IL_03e6: stloc.s 25
+		IL_03e8: ldloc.s 20
+		IL_03ea: ldloc.s 25
+		IL_03ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03f1: pop
+		IL_03f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03f7: stloc.s 20
+		IL_03f9: ldloc.s 7
+		IL_03fb: castclass Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point
+		IL_0400: callvirt instance object Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::get_y()
+		IL_0405: stloc.s 25
+		IL_0407: ldloc.s 25
+		IL_0409: ldnull
+		IL_040a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_040f: stloc.s 21
+		IL_0411: ldloc.s 21
+		IL_0413: box [System.Runtime]System.Boolean
+		IL_0418: stloc.s 22
+		IL_041a: ldloc.s 20
+		IL_041c: ldloc.s 22
+		IL_041e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0423: pop
+		IL_0424: ldloc.s 7
+		IL_0426: ldstr "y"
+		IL_042b: ldc.r8 8
+		IL_0434: ldc.i4.1
+		IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_043a: pop
+		IL_043b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0440: stloc.s 20
 		IL_0442: ldloc.s 7
-		IL_0444: ldstr "y"
-		IL_0449: ldc.r8 8
-		IL_0452: ldc.i4.1
-		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0458: pop
-		IL_0459: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_045e: stloc.s 19
-		IL_0460: ldloc.s 7
-		IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_046c: volatile.
-		IL_046e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0473: brfalse IL_048c
+		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_044e: volatile.
+		IL_0450: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0455: brfalse IL_046e
 
-		IL_0478: ldstr "join"
-		IL_047d: ldstr ","
-		IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0487: br IL_04a5
+		IL_045a: ldstr "join"
+		IL_045f: ldstr ","
+		IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0469: br IL_0487
 
-		IL_048c: ldstr "join"
-		IL_0491: ldstr ","
-		IL_0496: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:107"
-		IL_049b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_046e: ldstr "join"
+		IL_0473: ldstr ","
+		IL_0478: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:107"
+		IL_047d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_04a5: stloc.s 24
-		IL_04a7: ldloc.s 19
-		IL_04a9: ldloc.s 24
-		IL_04ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04b0: pop
-		IL_04b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04b6: stloc.s 19
-		IL_04b8: ldloc.s 7
-		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_04bf: stloc.s 24
-		IL_04c1: volatile.
-		IL_04c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_04c8: brfalse IL_04dd
+		IL_0487: stloc.s 25
+		IL_0489: ldloc.s 20
+		IL_048b: ldloc.s 25
+		IL_048d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0492: pop
+		IL_0493: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0498: stloc.s 20
+		IL_049a: ldloc.s 7
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_04a1: stloc.s 25
+		IL_04a3: volatile.
+		IL_04a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_04aa: brfalse IL_04bf
 
-		IL_04cd: ldloc.1
-		IL_04ce: ldstr "prototype"
-		IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04d8: br IL_04f2
+		IL_04af: ldloc.1
+		IL_04b0: ldstr "prototype"
+		IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04ba: br IL_04d4
 
-		IL_04dd: ldloc.1
-		IL_04de: ldstr "prototype"
-		IL_04e3: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:113"
-		IL_04e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04bf: ldloc.1
+		IL_04c0: ldstr "prototype"
+		IL_04c5: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:113"
+		IL_04ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04f2: stloc.s 23
-		IL_04f4: ldloc.s 24
-		IL_04f6: ldloc.s 23
-		IL_04f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04fd: stloc.s 20
-		IL_04ff: ldloc.s 20
-		IL_0501: box [System.Runtime]System.Boolean
-		IL_0506: stloc.s 21
-		IL_0508: ldloc.s 19
-		IL_050a: ldloc.s 21
-		IL_050c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0511: pop
-		IL_0512: volatile.
-		IL_0514: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0519: brfalse IL_052e
+		IL_04d4: stloc.s 24
+		IL_04d6: ldloc.s 25
+		IL_04d8: ldloc.s 24
+		IL_04da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04df: stloc.s 21
+		IL_04e1: ldloc.s 21
+		IL_04e3: box [System.Runtime]System.Boolean
+		IL_04e8: stloc.s 22
+		IL_04ea: ldloc.s 20
+		IL_04ec: ldloc.s 22
+		IL_04ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04f3: pop
+		IL_04f4: volatile.
+		IL_04f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_04fb: brfalse IL_0510
 
-		IL_051e: ldloc.1
-		IL_051f: ldstr "prototype"
-		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0529: br IL_0543
+		IL_0500: ldloc.1
+		IL_0501: ldstr "prototype"
+		IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050b: br IL_0525
 
-		IL_052e: ldloc.1
-		IL_052f: ldstr "prototype"
-		IL_0534: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:119"
-		IL_0539: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0510: ldloc.1
+		IL_0511: ldstr "prototype"
+		IL_0516: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:119"
+		IL_051b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0543: stloc.s 23
-		IL_0545: ldloc.s 23
-		IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
-		IL_054c: stloc.s 9
-		IL_054e: ldloc.s 9
-		IL_0550: ldstr "kind"
-		IL_0555: ldstr "bridge"
-		IL_055a: ldc.i4.1
-		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0560: pop
-		IL_0561: ldloc.s 7
-		IL_0563: ldloc.s 9
-		IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_056a: pop
-		IL_056b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0570: stloc.s 19
-		IL_0572: volatile.
-		IL_0574: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0579: brfalse IL_058f
+		IL_0525: stloc.s 24
+		IL_0527: ldloc.s 24
+		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.Object::create(object)
+		IL_052e: stloc.s 9
+		IL_0530: ldloc.s 9
+		IL_0532: ldstr "kind"
+		IL_0537: ldstr "bridge"
+		IL_053c: ldc.i4.1
+		IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0542: pop
+		IL_0543: ldloc.s 7
+		IL_0545: ldloc.s 9
+		IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_054c: pop
+		IL_054d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0552: stloc.s 20
+		IL_0554: volatile.
+		IL_0556: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_055b: brfalse IL_0571
 
-		IL_057e: ldloc.s 7
-		IL_0580: ldstr "kind"
-		IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_058a: br IL_05a5
+		IL_0560: ldloc.s 7
+		IL_0562: ldstr "kind"
+		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_056c: br IL_0587
 
-		IL_058f: ldloc.s 7
-		IL_0591: ldstr "kind"
-		IL_0596: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:131"
-		IL_059b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0571: ldloc.s 7
+		IL_0573: ldstr "kind"
+		IL_0578: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:131"
+		IL_057d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05a5: stloc.s 23
-		IL_05a7: ldloc.s 19
-		IL_05a9: ldloc.s 23
-		IL_05ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05b0: pop
-		IL_05b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05b6: stloc.s 19
-		IL_05b8: ldloc.s 7
-		IL_05ba: ldloc.1
-		IL_05bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05c0: stloc.s 20
-		IL_05c2: ldloc.s 20
-		IL_05c4: box [System.Runtime]System.Boolean
-		IL_05c9: stloc.s 21
-		IL_05cb: ldloc.s 19
-		IL_05cd: ldloc.s 21
-		IL_05cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05d4: pop
-		IL_05d5: nop
-		IL_05d6: nop
-		IL_05d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05dc: stloc.s 19
-		IL_05de: ldloc.2
-		IL_05df: dup
-		IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_05e5: stloc.s 23
-		IL_05e7: volatile.
-		IL_05e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_05ee: brfalse IL_0604
+		IL_0587: stloc.s 24
+		IL_0589: ldloc.s 20
+		IL_058b: ldloc.s 24
+		IL_058d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0592: pop
+		IL_0593: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0598: stloc.s 20
+		IL_059a: ldloc.s 7
+		IL_059c: ldloc.1
+		IL_059d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_05a2: stloc.s 21
+		IL_05a4: ldloc.s 21
+		IL_05a6: box [System.Runtime]System.Boolean
+		IL_05ab: stloc.s 22
+		IL_05ad: ldloc.s 20
+		IL_05af: ldloc.s 22
+		IL_05b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05b6: pop
+		IL_05b7: nop
+		IL_05b8: nop
+		IL_05b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05be: stloc.s 20
+		IL_05c0: ldloc.2
+		IL_05c1: dup
+		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_05c7: stloc.s 24
+		IL_05c9: volatile.
+		IL_05cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_05d0: brfalse IL_05e6
 
-		IL_05f3: ldloc.s 23
-		IL_05f5: ldstr "override"
-		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ff: br IL_061a
+		IL_05d5: ldloc.s 24
+		IL_05d7: ldstr "override"
+		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05e1: br IL_05fc
 
-		IL_0604: ldloc.s 23
-		IL_0606: ldstr "override"
-		IL_060b: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:144"
-		IL_0610: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05e6: ldloc.s 24
+		IL_05e8: ldstr "override"
+		IL_05ed: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:144"
+		IL_05f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_061a: stloc.s 23
-		IL_061c: ldloc.s 19
-		IL_061e: ldloc.s 23
-		IL_0620: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0625: pop
-		IL_0626: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_062b: stloc.s 19
-		IL_062d: ldloc.3
-		IL_062e: dup
-		IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_0634: stloc.s 23
-		IL_0636: volatile.
-		IL_0638: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_063d: brfalse IL_0653
+		IL_05fc: stloc.s 24
+		IL_05fe: ldloc.s 20
+		IL_0600: ldloc.s 24
+		IL_0602: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0607: pop
+		IL_0608: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_060d: stloc.s 20
+		IL_060f: ldloc.3
+		IL_0610: dup
+		IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0616: stloc.s 24
+		IL_0618: volatile.
+		IL_061a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_061f: brfalse IL_0635
 
-		IL_0642: ldloc.s 23
-		IL_0644: ldstr "kept"
-		IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_064e: br IL_0669
+		IL_0624: ldloc.s 24
+		IL_0626: ldstr "kept"
+		IL_062b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0630: br IL_064b
 
-		IL_0653: ldloc.s 23
-		IL_0655: ldstr "kept"
-		IL_065a: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:150"
-		IL_065f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0664: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0635: ldloc.s 24
+		IL_0637: ldstr "kept"
+		IL_063c: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:150"
+		IL_0641: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0669: stloc.s 23
-		IL_066b: ldloc.s 19
-		IL_066d: ldloc.s 23
-		IL_066f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0674: pop
-		IL_0675: nop
-		IL_0676: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_067b: stloc.s 16
-		IL_067d: ldloc.s 4
-		IL_067f: ldloc.s 16
-		IL_0681: ldc.r8 10
-		IL_068a: box [System.Runtime]System.Double
-		IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0694: stloc.s 10
-		IL_0696: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_069b: stloc.s 19
-		IL_069d: ldloc.s 10
-		IL_069f: dup
-		IL_06a0: ldc.r8 5
-		IL_06a9: box [System.Runtime]System.Double
-		IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_06b3: stloc.s 23
-		IL_06b5: volatile.
-		IL_06b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_06bc: brfalse IL_06d2
+		IL_064b: stloc.s 24
+		IL_064d: ldloc.s 20
+		IL_064f: ldloc.s 24
+		IL_0651: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0656: pop
+		IL_0657: nop
+		IL_0658: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_065d: stloc.s 16
+		IL_065f: ldloc.s 4
+		IL_0661: ldloc.s 16
+		IL_0663: ldc.r8 10
+		IL_066c: box [System.Runtime]System.Double
+		IL_0671: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0676: stloc.s 10
+		IL_0678: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_067d: stloc.s 20
+		IL_067f: ldloc.s 10
+		IL_0681: dup
+		IL_0682: ldc.r8 5
+		IL_068b: box [System.Runtime]System.Double
+		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0695: stloc.s 24
+		IL_0697: volatile.
+		IL_0699: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_069e: brfalse IL_06b4
 
-		IL_06c1: ldloc.s 23
-		IL_06c3: ldstr "value"
-		IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06cd: br IL_06e8
+		IL_06a3: ldloc.s 24
+		IL_06a5: ldstr "value"
+		IL_06aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06af: br IL_06ca
 
-		IL_06d2: ldloc.s 23
-		IL_06d4: ldstr "value"
-		IL_06d9: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:165"
-		IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06b4: ldloc.s 24
+		IL_06b6: ldstr "value"
+		IL_06bb: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:165"
+		IL_06c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06e8: stloc.s 23
-		IL_06ea: ldloc.s 19
-		IL_06ec: ldloc.s 23
-		IL_06ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06f3: pop
-		IL_06f4: ldloc.1
-		IL_06f5: ldstr "bind"
-		IL_06fa: ldc.i4.0
-		IL_06fb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0700: ldc.r8 10
-		IL_0709: box [System.Runtime]System.Double
-		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0713: stloc.s 11
-		IL_0715: ldloc.s 11
-		IL_0717: dup
-		IL_0718: ldc.r8 5
-		IL_0721: box [System.Runtime]System.Double
-		IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_072b: stloc.s 12
-		IL_072d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0732: stloc.s 19
-		IL_0734: ldloc.s 12
-		IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_073b: volatile.
-		IL_073d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0742: brfalse IL_0756
+		IL_06ca: stloc.s 24
+		IL_06cc: ldloc.s 20
+		IL_06ce: ldloc.s 24
+		IL_06d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06d5: pop
+		IL_06d6: ldloc.1
+		IL_06d7: ldstr "bind"
+		IL_06dc: ldc.i4.0
+		IL_06dd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_06e2: ldc.r8 10
+		IL_06eb: box [System.Runtime]System.Double
+		IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_06f5: stloc.s 11
+		IL_06f7: ldloc.s 11
+		IL_06f9: dup
+		IL_06fa: ldc.r8 5
+		IL_0703: box [System.Runtime]System.Double
+		IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_070d: stloc.s 12
+		IL_070f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0714: stloc.s 20
+		IL_0716: ldloc.s 12
+		IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_071d: volatile.
+		IL_071f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0724: brfalse IL_0738
 
-		IL_0747: ldstr "sum"
-		IL_074c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0751: br IL_076a
+		IL_0729: ldstr "sum"
+		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0733: br IL_074c
 
-		IL_0756: ldstr "sum"
-		IL_075b: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:182"
-		IL_0760: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0738: ldstr "sum"
+		IL_073d: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:182"
+		IL_0742: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_076a: stloc.s 23
-		IL_076c: ldloc.s 19
-		IL_076e: ldloc.s 23
-		IL_0770: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0775: pop
-		IL_0776: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_077b: stloc.s 19
-		IL_077d: ldloc.s 12
-		IL_077f: ldloc.1
-		IL_0780: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0785: stloc.s 20
-		IL_0787: ldloc.s 20
-		IL_0789: box [System.Runtime]System.Boolean
-		IL_078e: stloc.s 21
-		IL_0790: ldloc.s 19
-		IL_0792: ldloc.s 21
-		IL_0794: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0799: pop
-		IL_079a: ldc.i4.1
-		IL_079b: newarr [System.Runtime]System.Object
-		IL_07a0: dup
-		IL_07a1: ldc.i4.0
-		IL_07a2: ldloc.0
-		IL_07a3: stelem.ref
-		IL_07a4: stloc.s 16
-		IL_07a6: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject::.ctor()
-		IL_07ab: ldc.i4.1
-		IL_07ac: conv.r8
-		IL_07ad: ldstr ""
-		IL_07b2: ldc.i4.0
-		IL_07b3: ldc.i4.0
-		IL_07b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0)
-		IL_07be: stloc.s 13
-		IL_07c0: ldloc.s 13
-		IL_07c2: dup
-		IL_07c3: ldc.r8 9
-		IL_07cc: box [System.Runtime]System.Double
-		IL_07d1: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_07d6: stloc.s 14
-		IL_07d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07dd: stloc.s 19
-		IL_07df: volatile.
-		IL_07e1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_07e6: brfalse IL_07fc
+		IL_074c: stloc.s 24
+		IL_074e: ldloc.s 20
+		IL_0750: ldloc.s 24
+		IL_0752: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0757: pop
+		IL_0758: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_075d: stloc.s 20
+		IL_075f: ldloc.s 12
+		IL_0761: ldloc.1
+		IL_0762: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0767: stloc.s 21
+		IL_0769: ldloc.s 21
+		IL_076b: box [System.Runtime]System.Boolean
+		IL_0770: stloc.s 22
+		IL_0772: ldloc.s 20
+		IL_0774: ldloc.s 22
+		IL_0776: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_077b: pop
+		IL_077c: ldc.i4.1
+		IL_077d: newarr [System.Runtime]System.Object
+		IL_0782: dup
+		IL_0783: ldc.i4.0
+		IL_0784: ldloc.0
+		IL_0785: stelem.ref
+		IL_0786: stloc.s 16
+		IL_0788: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject::.ctor()
+		IL_078d: ldc.i4.1
+		IL_078e: conv.r8
+		IL_078f: ldstr ""
+		IL_0794: ldc.i4.0
+		IL_0795: ldc.i4.0
+		IL_0796: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_079b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0)
+		IL_07a0: stloc.s 13
+		IL_07a2: ldloc.s 13
+		IL_07a4: dup
+		IL_07a5: ldc.r8 9
+		IL_07ae: box [System.Runtime]System.Double
+		IL_07b3: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_07b8: stloc.s 14
+		IL_07ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07bf: stloc.s 20
+		IL_07c1: volatile.
+		IL_07c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_07c8: brfalse IL_07de
 
-		IL_07eb: ldloc.s 14
-		IL_07ed: ldstr "value"
-		IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07f7: br IL_0812
+		IL_07cd: ldloc.s 14
+		IL_07cf: ldstr "value"
+		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07d9: br IL_07f4
 
-		IL_07fc: ldloc.s 14
-		IL_07fe: ldstr "value"
-		IL_0803: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:201"
-		IL_0808: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_080d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07de: ldloc.s 14
+		IL_07e0: ldstr "value"
+		IL_07e5: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:201"
+		IL_07ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_07ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0812: stloc.s 23
-		IL_0814: ldloc.s 19
-		IL_0816: ldloc.s 23
-		IL_0818: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_081d: pop
-		IL_081e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0823: stloc.s 19
-		IL_0825: ldloc.s 14
-		IL_0827: ldloc.s 13
-		IL_0829: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_082e: stloc.s 20
-		IL_0830: ldloc.s 20
-		IL_0832: box [System.Runtime]System.Boolean
-		IL_0837: stloc.s 21
-		IL_0839: ldloc.s 19
-		IL_083b: ldloc.s 21
-		IL_083d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0842: pop
-		IL_0843: nop
+		IL_07f4: stloc.s 24
+		IL_07f6: ldloc.s 20
+		IL_07f8: ldloc.s 24
+		IL_07fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07ff: pop
+		IL_0800: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0805: stloc.s 20
+		IL_0807: ldloc.s 14
+		IL_0809: ldloc.s 13
+		IL_080b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0810: stloc.s 21
+		IL_0812: ldloc.s 21
+		IL_0814: box [System.Runtime]System.Boolean
+		IL_0819: stloc.s 22
+		IL_081b: ldloc.s 20
+		IL_081d: ldloc.s 22
+		IL_081f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0824: pop
+		IL_0825: nop
+		IL_0826: ldloc.s 5
+		IL_0828: ldstr "prototype"
+		IL_082d: ldc.r8 3
+		IL_0836: ldc.i4.1
+		IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_083c: pop
+		IL_083d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0842: stloc.s 20
 		IL_0844: ldloc.s 5
-		IL_0846: ldstr "prototype"
-		IL_084b: ldc.r8 3
-		IL_0854: ldc.i4.1
-		IL_0855: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_085a: pop
-		IL_085b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0860: stloc.s 19
-		IL_0862: ldloc.s 5
-		IL_0864: dup
-		IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_086a: stloc.s 23
-		IL_086c: ldloc.s 23
-		IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0873: stloc.s 23
-		IL_0875: ldstr "Object"
-		IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_087f: volatile.
-		IL_0881: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0886: brfalse IL_089a
+		IL_0846: dup
+		IL_0847: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_084c: stloc.s 24
+		IL_084e: ldloc.s 24
+		IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0855: stloc.s 24
+		IL_0857: ldstr "Object"
+		IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0861: volatile.
+		IL_0863: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0868: brfalse IL_087c
 
-		IL_088b: ldstr "prototype"
-		IL_0890: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0895: br IL_08ae
+		IL_086d: ldstr "prototype"
+		IL_0872: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0877: br IL_0890
 
-		IL_089a: ldstr "prototype"
-		IL_089f: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:220"
-		IL_08a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_08a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_087c: ldstr "prototype"
+		IL_0881: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:220"
+		IL_0886: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_08ae: stloc.s 24
-		IL_08b0: ldloc.s 23
-		IL_08b2: ldloc.s 24
-		IL_08b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_08b9: stloc.s 20
-		IL_08bb: ldloc.s 20
-		IL_08bd: box [System.Runtime]System.Boolean
-		IL_08c2: stloc.s 21
-		IL_08c4: ldloc.s 19
-		IL_08c6: ldloc.s 21
-		IL_08c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08cd: pop
-		IL_08ce: nop
-		IL_08cf: ldloc.s 6
-		IL_08d1: ldstr "prototype"
-		IL_08d6: ldc.i4.0
-		IL_08d7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_08dc: ldc.i4.1
-		IL_08dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_08e2: pop
-		IL_08e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08e8: stloc.s 19
-		IL_08ea: ldloc.s 6
-		IL_08ec: dup
-		IL_08ed: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_08f2: stloc.s 24
-		IL_08f4: ldloc.s 24
-		IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_08fb: stloc.s 24
-		IL_08fd: ldstr "Object"
-		IL_0902: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0907: volatile.
-		IL_0909: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_090e: brfalse IL_0922
+		IL_0890: stloc.s 25
+		IL_0892: ldloc.s 24
+		IL_0894: ldloc.s 25
+		IL_0896: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_089b: stloc.s 21
+		IL_089d: ldloc.s 21
+		IL_089f: box [System.Runtime]System.Boolean
+		IL_08a4: stloc.s 22
+		IL_08a6: ldloc.s 20
+		IL_08a8: ldloc.s 22
+		IL_08aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08af: pop
+		IL_08b0: nop
+		IL_08b1: ldloc.s 6
+		IL_08b3: ldstr "prototype"
+		IL_08b8: ldc.i4.0
+		IL_08b9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_08be: ldc.i4.1
+		IL_08bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_08c4: pop
+		IL_08c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08ca: stloc.s 20
+		IL_08cc: ldloc.s 6
+		IL_08ce: dup
+		IL_08cf: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_08d4: stloc.s 25
+		IL_08d6: ldloc.s 25
+		IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_08dd: stloc.s 25
+		IL_08df: ldstr "Object"
+		IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08e9: volatile.
+		IL_08eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_08f0: brfalse IL_0904
 
-		IL_0913: ldstr "prototype"
-		IL_0918: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_091d: br IL_0936
+		IL_08f5: ldstr "prototype"
+		IL_08fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08ff: br IL_0918
 
-		IL_0922: ldstr "prototype"
-		IL_0927: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:237"
-		IL_092c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0931: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0904: ldstr "prototype"
+		IL_0909: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:237"
+		IL_090e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0936: stloc.s 23
-		IL_0938: ldloc.s 24
-		IL_093a: ldloc.s 23
-		IL_093c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0941: stloc.s 20
-		IL_0943: ldloc.s 20
-		IL_0945: box [System.Runtime]System.Boolean
-		IL_094a: stloc.s 21
-		IL_094c: ldloc.s 19
-		IL_094e: ldloc.s 21
-		IL_0950: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0955: pop
-		IL_0956: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_095b: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0960: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_0965: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_096a: stloc.s 25
-		IL_096c: volatile.
-		IL_096e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0973: brfalse IL_0989
+		IL_0918: stloc.s 24
+		IL_091a: ldloc.s 25
+		IL_091c: ldloc.s 24
+		IL_091e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0923: stloc.s 21
+		IL_0925: ldloc.s 21
+		IL_0927: box [System.Runtime]System.Boolean
+		IL_092c: stloc.s 22
+		IL_092e: ldloc.s 20
+		IL_0930: ldloc.s 22
+		IL_0932: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0937: pop
+		IL_0938: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_093d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0942: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_0947: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_094c: stloc.s 26
+		IL_094e: volatile.
+		IL_0950: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0955: brfalse IL_096b
 
-		IL_0978: ldloc.s 25
-		IL_097a: ldstr "prototype"
-		IL_097f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0984: br IL_099f
+		IL_095a: ldloc.s 26
+		IL_095c: ldstr "prototype"
+		IL_0961: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0966: br IL_0981
 
-		IL_0989: ldloc.s 25
-		IL_098b: ldstr "prototype"
-		IL_0990: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:244"
-		IL_0995: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_099a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_096b: ldloc.s 26
+		IL_096d: ldstr "prototype"
+		IL_0972: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:244"
+		IL_0977: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_097c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_099f: pop
-		IL_09a0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_09a5: stloc.s 16
-		IL_09a7: ldloc.s 25
-		IL_09a9: ldstr "read"
-		IL_09ae: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject::.ctor()
-		IL_09b3: ldc.i4.1
-		IL_09b4: conv.r8
-		IL_09b5: ldstr "read"
-		IL_09ba: ldc.i4.0
-		IL_09bb: ldc.i4.1
-		IL_09bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_09c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0)
-		IL_09c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_09cb: pop
-		IL_09cc: ldc.i4.1
-		IL_09cd: newarr [System.Runtime]System.Object
-		IL_09d2: dup
-		IL_09d3: ldc.i4.0
-		IL_09d4: ldloc.0
-		IL_09d5: stelem.ref
-		IL_09d6: stloc.s 16
-		IL_09d8: ldloc.s 16
-		IL_09da: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject::.ctor(object[])
-		IL_09df: ldloc.s 25
-		IL_09e1: ldloc.s 16
-		IL_09e3: ldc.i4.0
-		IL_09e4: conv.r8
-		IL_09e5: ldc.i4.0
-		IL_09e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_09eb: castclass Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
-		IL_09f0: stloc.s 26
-		IL_09f2: ldloc.s 26
-		IL_09f4: stloc.s 15
-		IL_09f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09fb: stloc.s 19
-		IL_09fd: ldloc.1
-		IL_09fe: dup
-		IL_09ff: ldc.r8 6
-		IL_0a08: box [System.Runtime]System.Double
-		IL_0a0d: ldc.r8 1
-		IL_0a16: box [System.Runtime]System.Double
-		IL_0a1b: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_0a20: stloc.s 23
-		IL_0a22: volatile.
-		IL_0a24: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0a29: brfalse IL_0a41
+		IL_0981: pop
+		IL_0982: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0987: stloc.s 16
+		IL_0989: ldloc.s 26
+		IL_098b: ldstr "read"
+		IL_0990: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject::.ctor()
+		IL_0995: ldc.i4.1
+		IL_0996: conv.r8
+		IL_0997: ldstr "read"
+		IL_099c: ldc.i4.0
+		IL_099d: ldc.i4.1
+		IL_099e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_09a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0)
+		IL_09a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_09ad: pop
+		IL_09ae: ldc.i4.1
+		IL_09af: newarr [System.Runtime]System.Object
+		IL_09b4: dup
+		IL_09b5: ldc.i4.0
+		IL_09b6: ldloc.0
+		IL_09b7: stelem.ref
+		IL_09b8: stloc.s 16
+		IL_09ba: ldloc.s 16
+		IL_09bc: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject::.ctor(object[])
+		IL_09c1: ldloc.s 26
+		IL_09c3: ldloc.s 16
+		IL_09c5: ldc.i4.0
+		IL_09c6: conv.r8
+		IL_09c7: ldc.i4.0
+		IL_09c8: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_09cd: castclass Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
+		IL_09d2: stloc.s 27
+		IL_09d4: ldloc.s 27
+		IL_09d6: stloc.s 15
+		IL_09d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_09dd: stloc.s 20
+		IL_09df: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::.ctor()
+		IL_09e4: stloc.s 19
+		IL_09e6: ldloc.1
+		IL_09e7: ldloc.s 19
+		IL_09e9: ldloc.1
+		IL_09ea: ldc.r8 6
+		IL_09f3: box [System.Runtime]System.Double
+		IL_09f8: ldc.r8 1
+		IL_0a01: box [System.Runtime]System.Double
+		IL_0a06: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2(object, object, object, object, object)
+		IL_0a0b: stloc.s 19
+		IL_0a0d: volatile.
+		IL_0a0f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0a14: brfalse IL_0a2c
 
-		IL_0a2e: ldloc.s 15
-		IL_0a30: ldstr "read"
-		IL_0a35: ldloc.s 23
-		IL_0a37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0a3c: br IL_0a59
+		IL_0a19: ldloc.s 15
+		IL_0a1b: ldstr "read"
+		IL_0a20: ldloc.s 19
+		IL_0a22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a27: br IL_0a44
 
-		IL_0a41: ldloc.s 15
-		IL_0a43: ldstr "read"
-		IL_0a48: ldloc.s 23
-		IL_0a4a: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:260"
-		IL_0a4f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0a54: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0a2c: ldloc.s 15
+		IL_0a2e: ldstr "read"
+		IL_0a33: ldloc.s 19
+		IL_0a35: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:261"
+		IL_0a3a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0a59: stloc.s 23
-		IL_0a5b: ldloc.s 19
-		IL_0a5d: ldloc.s 23
-		IL_0a5f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0a64: pop
-		IL_0a65: ret
+		IL_0a44: stloc.s 24
+		IL_0a46: ldloc.s 20
+		IL_0a48: ldloc.s 24
+		IL_0a4a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0a4f: pop
+		IL_0a50: ret
 	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
 
 } // end of class Modules.Function_ConstructedInstance_ObjectSemantics
@@ -2824,8 +2978,6 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_13
-	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16
 	.field assembly static int32 __jroc_dynamicLookup_17
@@ -2849,6 +3001,7 @@
 	.field assembly static int32 __jroc_dynamicLookup_35
 	.field assembly static int32 __jroc_dynamicLookup_36
 	.field assembly static int32 __jroc_dynamicLookup_37
+	.field assembly static int32 __jroc_dynamicLookup_38
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_GraphNode.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_GraphNode.verified.txt
@@ -1548,7 +1548,7 @@
 		IL_0121: box [System.Runtime]System.Double
 		IL_0126: ldc.i4.0
 		IL_0127: box [System.Runtime]System.Boolean
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+		IL_012c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode>(object, object, object, object, object, object)
 		IL_0131: stloc.3
 		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0137: stloc.s 10
@@ -1906,7 +1906,7 @@
 		IL_0542: ldloc.s 12
 		IL_0544: ldloc.s 16
 		IL_0546: ldloc.s 12
-		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver0(object, object, object)
+		IL_0548: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver0<class Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L28C1_NewTargetCheck>(object, object, object)
 		IL_054d: volatile.
 		IL_054f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 		IL_0554: brfalse IL_0568

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_GraphNode.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_GraphNode.verified.txt
@@ -1,0 +1,2000 @@
+﻿// IL code: Function_ConstructorShape_GraphNode
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi abstract sealed beforefieldinit Function_ConstructorShape_GraphNode
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit Scripts
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit Function_ConstructorShape_GraphNode
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig static 
+				void Run (
+					string[] args
+				) cil managed 
+			{
+				.param [1]
+					.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+						01 00 00 00
+					)
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldftn void Modules.Function_ConstructorShape_GraphNode::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+				IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+				IL_000c: ldstr "Function_ConstructorShape_GraphNode"
+				IL_0011: ldarg.0
+				IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+				IL_0017: ret
+			} // end of method Function_ConstructorShape_GraphNode::Run
+
+		} // end of class Function_ConstructorShape_GraphNode
+
+
+	} // end of class Scripts
+
+
+	// Methods
+	.method public hidebysig static 
+		void Run (
+			string[] args
+		) cil managed 
+	{
+		.param [1]
+			.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+				01 00 00 00
+			)
+		// Header size: 1
+		// Code size: 24 (0x18)
+		.maxstack 8
+
+		IL_0000: ldnull
+		IL_0001: ldftn void Modules.Function_ConstructorShape_GraphNode::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_000c: ldstr "Function_ConstructorShape_GraphNode"
+		IL_0011: ldarg.0
+		IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+		IL_0017: ret
+	} // end of method Function_ConstructorShape_GraphNode::Run
+
+} // end of class Function_ConstructorShape_GraphNode
+
+.class private auto ansi beforefieldinit Modules.Function_ConstructorShape_GraphNode
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit GraphNode
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: ldarg.2
+				IL_001f: ldc.i4.2
+				IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0025: call object Modules.Function_ConstructorShape_GraphNode/GraphNode::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object, object, object)
+				IL_002a: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: ldarg.2
+				IL_001f: ldc.i4.2
+				IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0025: call object Modules.Function_ConstructorShape_GraphNode/GraphNode::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object, object, object)
+				IL_002a: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext,
+				object x,
+				object y,
+				object isWall
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 467 (0x1d3)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "x"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::set_x(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "x"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.0
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldarg.1
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0060: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+			IL_0065: dup
+			IL_0066: brfalse IL_0091
+
+			IL_006b: dup
+			IL_006c: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0071: brfalse IL_0091
+
+			IL_0076: dup
+			IL_0077: ldstr "y"
+			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0081: brfalse IL_0091
+
+			IL_0086: ldarg.3
+			IL_0087: callvirt instance void Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::set_y(object)
+			IL_008c: br IL_00aa
+
+			IL_0091: pop
+			IL_0092: ldarg.1
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_009d: ldstr "y"
+			IL_00a2: ldarg.3
+			IL_00a3: ldc.i4.0
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_00a9: pop
+
+			IL_00aa: ldarg.1
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_00b5: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+			IL_00ba: dup
+			IL_00bb: brfalse IL_00e7
+
+			IL_00c0: dup
+			IL_00c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_00c6: brfalse IL_00e7
+
+			IL_00cb: dup
+			IL_00cc: ldstr "_isWall"
+			IL_00d1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_00d6: brfalse IL_00e7
+
+			IL_00db: ldarg.s isWall
+			IL_00dd: callvirt instance void Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::set__isWall(object)
+			IL_00e2: br IL_0101
+
+			IL_00e7: pop
+			IL_00e8: ldarg.1
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_00f3: ldstr "_isWall"
+			IL_00f8: ldarg.s isWall
+			IL_00fa: ldc.i4.0
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0100: pop
+
+			IL_0101: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0106: dup
+			IL_0107: ldstr "x"
+			IL_010c: ldarg.2
+			IL_010d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0112: dup
+			IL_0113: ldstr "y"
+			IL_0118: ldarg.3
+			IL_0119: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_011e: stloc.0
+			IL_011f: ldarg.1
+			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_012a: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+			IL_012f: dup
+			IL_0130: brfalse IL_015b
+
+			IL_0135: dup
+			IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_013b: brfalse IL_015b
+
+			IL_0140: dup
+			IL_0141: ldstr "pos"
+			IL_0146: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_014b: brfalse IL_015b
+
+			IL_0150: ldloc.0
+			IL_0151: callvirt instance void Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::set_pos(object)
+			IL_0156: br IL_0174
+
+			IL_015b: pop
+			IL_015c: ldarg.1
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0167: ldstr "pos"
+			IL_016c: ldloc.0
+			IL_016d: ldc.i4.0
+			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0173: pop
+
+			IL_0174: ldarg.1
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_017f: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+			IL_0184: dup
+			IL_0185: brfalse IL_01b4
+
+			IL_018a: dup
+			IL_018b: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0190: brfalse IL_01b4
+
+			IL_0195: dup
+			IL_0196: ldstr "debug"
+			IL_019b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_01a0: brfalse IL_01b4
+
+			IL_01a5: ldstr ""
+			IL_01aa: callvirt instance void Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::set_debug(object)
+			IL_01af: br IL_01d1
+
+			IL_01b4: pop
+			IL_01b5: ldarg.1
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_01c0: ldstr "debug"
+			IL_01c5: ldstr ""
+			IL_01ca: ldc.i4.0
+			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_01d0: pop
+
+			IL_01d1: ldnull
+			IL_01d2: ret
+		} // end of method GraphNode::__js_call__
+
+	} // end of class GraphNode
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L9C31
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 22 (0x16)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: call object Modules.Function_ConstructorShape_GraphNode/FunctionExpression_L9C31::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0015: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 22 (0x16)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: call object Modules.Function_ConstructorShape_GraphNode/FunctionExpression_L9C31::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0015: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 162 (0xa2)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object
+			)
+
+			IL_0000: volatile.
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0007: brfalse IL_0026
+
+			IL_000c: ldarg.1
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0017: ldstr "x"
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0021: br IL_0045
+
+			IL_0026: ldarg.1
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0031: ldstr "x"
+			IL_0036: ldstr "Function_ConstructorShape_GraphNode:<TwoPhaseDummy_M5>:__js_call__:3"
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0045: stloc.0
+			IL_0046: ldloc.0
+			IL_0047: ldstr ","
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0051: stloc.1
+			IL_0052: volatile.
+			IL_0054: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0059: brfalse IL_0078
+
+			IL_005e: ldarg.1
+			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0069: ldstr "y"
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0073: br IL_0097
+
+			IL_0078: ldarg.1
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0083: ldstr "y"
+			IL_0088: ldstr "Function_ConstructorShape_GraphNode:<TwoPhaseDummy_M5>:__js_call__:8"
+			IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0097: stloc.0
+			IL_0098: ldloc.1
+			IL_0099: ldloc.0
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_009f: stloc.1
+			IL_00a0: ldloc.1
+			IL_00a1: ret
+		} // end of method FunctionExpression_L9C31::__js_call__
+
+	} // end of class FunctionExpression_L9C31
+
+	.class nested public auto ansi abstract sealed beforefieldinit NewTargetCheck
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ConstructorShape_GraphNode/Scope _environment0_Function_ConstructorShape_GraphNode
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ConstructorShape_GraphNode/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.s 9
+				IL_0009: ldc.i4.1
+				IL_000a: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000f: ldarg.0
+				IL_0010: ldarg.1
+				IL_0011: stfld class Modules.Function_ConstructorShape_GraphNode/Scope Modules.Function_ConstructorShape_GraphNode/NewTargetCheck/FunctionObject::_environment0_Function_ConstructorShape_GraphNode
+				IL_0016: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_GraphNode/Scope Modules.Function_ConstructorShape_GraphNode/NewTargetCheck/FunctionObject::_environment0_Function_ConstructorShape_GraphNode
+				IL_0006: ldnull
+				IL_0007: ldc.i4.s 9
+				IL_0009: ldarg.1
+				IL_000a: ldarg.2
+				IL_000b: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0010: ldarg.0
+				IL_0011: ldnull
+				IL_0012: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0017: call object Modules.Function_ConstructorShape_GraphNode/NewTargetCheck::__js_call__(class Modules.Function_ConstructorShape_GraphNode/Scope, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_001c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_GraphNode/Scope Modules.Function_ConstructorShape_GraphNode/NewTargetCheck/FunctionObject::_environment0_Function_ConstructorShape_GraphNode
+				IL_0006: ldarg.3
+				IL_0007: ldc.i4.s 9
+				IL_0009: ldarg.1
+				IL_000a: ldarg.2
+				IL_000b: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0010: ldarg.0
+				IL_0011: ldarg.3
+				IL_0012: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0017: call object Modules.Function_ConstructorShape_GraphNode/NewTargetCheck::__js_call__(class Modules.Function_ConstructorShape_GraphNode/Scope, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_001c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Function_ConstructorShape_GraphNode/Scope scope,
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0a 00 00 02
+			)
+			// Header size: 12
+			// Code size: 111 (0x6f)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] bool,
+				[3] object
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: stloc.0
+			IL_0002: ldarg.0
+			IL_0003: ldfld object Modules.Function_ConstructorShape_GraphNode/Scope::NewTargetCheck
+			IL_0008: stloc.1
+			IL_0009: ldloc.0
+			IL_000a: ldloc.1
+			IL_000b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0010: stloc.2
+			IL_0011: ldloc.2
+			IL_0012: box [System.Runtime]System.Boolean
+			IL_0017: stloc.3
+			IL_0018: ldarg.2
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0023: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L28C1_NewTargetCheck
+			IL_0028: dup
+			IL_0029: brfalse IL_0054
+
+			IL_002e: dup
+			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0034: brfalse IL_0054
+
+			IL_0039: dup
+			IL_003a: ldstr "matches"
+			IL_003f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0044: brfalse IL_0054
+
+			IL_0049: ldloc.3
+			IL_004a: callvirt instance void Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L28C1_NewTargetCheck::set_matches(object)
+			IL_004f: br IL_006d
+
+			IL_0054: pop
+			IL_0055: ldarg.2
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0060: ldstr "matches"
+			IL_0065: ldloc.3
+			IL_0066: ldc.i4.0
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_006c: pop
+
+			IL_006d: ldnull
+			IL_006e: ret
+		} // end of method NewTargetCheck::__js_call__
+
+	} // end of class NewTargetCheck
+
+	.class nested public auto ansi abstract sealed beforefieldinit OverrideResult
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ConstructorShape_GraphNode/Scope _environment0_Function_ConstructorShape_GraphNode
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ConstructorShape_GraphNode/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 22 (0x16)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ldarg.0
+				IL_000f: ldarg.1
+				IL_0010: stfld class Modules.Function_ConstructorShape_GraphNode/Scope Modules.Function_ConstructorShape_GraphNode/OverrideResult/FunctionObject::_environment0_Function_ConstructorShape_GraphNode
+				IL_0015: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_GraphNode/Scope Modules.Function_ConstructorShape_GraphNode/OverrideResult/FunctionObject::_environment0_Function_ConstructorShape_GraphNode
+				IL_0006: ldnull
+				IL_0007: ldc.i4.1
+				IL_0008: ldarg.1
+				IL_0009: ldarg.2
+				IL_000a: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_000f: ldarg.0
+				IL_0010: ldnull
+				IL_0011: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0016: call object Modules.Function_ConstructorShape_GraphNode/OverrideResult::__js_call__(class Modules.Function_ConstructorShape_GraphNode/Scope, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_001b: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_GraphNode/Scope Modules.Function_ConstructorShape_GraphNode/OverrideResult/FunctionObject::_environment0_Function_ConstructorShape_GraphNode
+				IL_0006: ldarg.3
+				IL_0007: ldc.i4.1
+				IL_0008: ldarg.1
+				IL_0009: ldarg.2
+				IL_000a: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_000f: ldarg.0
+				IL_0010: ldarg.3
+				IL_0011: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0016: call object Modules.Function_ConstructorShape_GraphNode/OverrideResult::__js_call__(class Modules.Function_ConstructorShape_GraphNode/Scope, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_001b: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Function_ConstructorShape_GraphNode/Scope scope,
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0a 00 00 02
+			)
+			// Header size: 1
+			// Code size: 50 (0x32)
+			.maxstack 8
+
+			IL_0000: ldarg.2
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: ldstr "value"
+			IL_0010: ldstr "receiver"
+			IL_0015: ldc.i4.0
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_001b: pop
+			IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: ldstr "override"
+			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0031: ret
+		} // end of method OverrideResult::__js_call__
+
+	} // end of class OverrideResult
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 5d 53 63 6f 70 65 20 47 72 61 70 68 4e 6f
+			64 65 3d 7b 47 72 61 70 68 4e 6f 64 65 7d 2c 20
+			4e 65 77 54 61 72 67 65 74 43 68 65 63 6b 3d 7b
+			4e 65 77 54 61 72 67 65 74 43 68 65 63 6b 7d 2c
+			20 4f 76 65 72 72 69 64 65 52 65 73 75 6c 74 3d
+			7b 4f 76 65 72 72 69 64 65 52 65 73 75 6c 74 7d
+			00 00
+		)
+		// Fields
+		.field public object GraphNode
+		.field public object NewTargetCheck
+		.field public object OverrideResult
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L1C1_GraphNode
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _x
+			.field private object _y
+			.field private object __isWall
+			.field private object _pos
+			.field private object _debug
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L1C1_GraphNode::.ctor
+
+			.method public hidebysig 
+				instance object get_x () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "x"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_x
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_x
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "x"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L1C1_GraphNode::get_x
+
+			.method public hidebysig 
+				instance void set_x (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_x
+				IL_0007: ldarg.0
+				IL_0008: ldstr "x"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L1C1_GraphNode::set_x
+
+			.method public hidebysig 
+				instance object get_y () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "y"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_y
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_y
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "y"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L1C1_GraphNode::get_y
+
+			.method public hidebysig 
+				instance void set_y (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_y
+				IL_0007: ldarg.0
+				IL_0008: ldstr "y"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L1C1_GraphNode::set_y
+
+			.method public hidebysig 
+				instance object get__isWall () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "_isWall"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::__isWall
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::__isWall
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "_isWall"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L1C1_GraphNode::get__isWall
+
+			.method public hidebysig 
+				instance void set__isWall (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::__isWall
+				IL_0007: ldarg.0
+				IL_0008: ldstr "_isWall"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L1C1_GraphNode::set__isWall
+
+			.method public hidebysig 
+				instance object get_pos () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "pos"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_pos
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_pos
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "pos"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L1C1_GraphNode::get_pos
+
+			.method public hidebysig 
+				instance void set_pos (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_pos
+				IL_0007: ldarg.0
+				IL_0008: ldstr "pos"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L1C1_GraphNode::set_pos
+
+			.method public hidebysig 
+				instance object get_debug () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "debug"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_debug
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_debug
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "debug"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L1C1_GraphNode::get_debug
+
+			.method public hidebysig 
+				instance void set_debug (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::_debug
+				IL_0007: ldarg.0
+				IL_0008: ldstr "debug"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L1C1_GraphNode::set_debug
+
+		} // end of class Ctor_L1C1_GraphNode
+
+		.class nested public auto ansi beforefieldinit Ctor_L28C1_NewTargetCheck
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _matches
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L28C1_NewTargetCheck::.ctor
+
+			.method public hidebysig 
+				instance object get_matches () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "matches"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L28C1_NewTargetCheck::_matches
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L28C1_NewTargetCheck::_matches
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "matches"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L28C1_NewTargetCheck::get_matches
+
+			.method public hidebysig 
+				instance void set_matches (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L28C1_NewTargetCheck::_matches
+				IL_0007: ldarg.0
+				IL_0008: ldstr "matches"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L28C1_NewTargetCheck::set_matches
+
+		} // end of class Ctor_L28C1_NewTargetCheck
+
+
+	} // end of class ObjectLiterals
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 1497 (0x5d9)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Function_ConstructorShape_GraphNode/Scope,
+			[1] class Modules.Function_ConstructorShape_GraphNode/GraphNode/FunctionObject,
+			[2] class Modules.Function_ConstructorShape_GraphNode/OverrideResult/FunctionObject,
+			[3] class Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[5] object[],
+			[6] class Modules.Function_ConstructorShape_GraphNode/NewTargetCheck/FunctionObject,
+			[7] object,
+			[8] class Modules.Function_ConstructorShape_GraphNode/FunctionExpression_L9C31/FunctionObject,
+			[9] class Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode,
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[11] object,
+			[12] object,
+			[13] object,
+			[14] bool,
+			[15] object,
+			[16] class Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L28C1_NewTargetCheck
+		)
+
+		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
+		IL_0005: newobj instance void Modules.Function_ConstructorShape_GraphNode/Scope::.ctor()
+		IL_000a: stloc.0
+		IL_000b: ldc.i4.1
+		IL_000c: newarr [System.Runtime]System.Object
+		IL_0011: dup
+		IL_0012: ldc.i4.0
+		IL_0013: ldloc.0
+		IL_0014: stelem.ref
+		IL_0015: stloc.s 5
+		IL_0017: newobj instance void Modules.Function_ConstructorShape_GraphNode/GraphNode/FunctionObject::.ctor()
+		IL_001c: ldc.i4.3
+		IL_001d: conv.r8
+		IL_001e: ldstr "GraphNode"
+		IL_0023: ldc.i4.0
+		IL_0024: ldc.i4.0
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_GraphNode/GraphNode/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructorShape_GraphNode/GraphNode/FunctionObject>(!!0)
+		IL_002f: stloc.1
+		IL_0030: ldc.i4.1
+		IL_0031: newarr [System.Runtime]System.Object
+		IL_0036: dup
+		IL_0037: ldc.i4.0
+		IL_0038: ldloc.0
+		IL_0039: stelem.ref
+		IL_003a: stloc.s 5
+		IL_003c: ldloc.s 5
+		IL_003e: ldc.i4.0
+		IL_003f: ldelem.ref
+		IL_0040: castclass Modules.Function_ConstructorShape_GraphNode/Scope
+		IL_0045: newobj instance void Modules.Function_ConstructorShape_GraphNode/NewTargetCheck/FunctionObject::.ctor(class Modules.Function_ConstructorShape_GraphNode/Scope)
+		IL_004a: ldc.i4.0
+		IL_004b: conv.r8
+		IL_004c: ldstr "NewTargetCheck"
+		IL_0051: ldc.i4.0
+		IL_0052: ldc.i4.0
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_GraphNode/NewTargetCheck/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructorShape_GraphNode/NewTargetCheck/FunctionObject>(!!0)
+		IL_005d: stloc.s 6
+		IL_005f: ldloc.0
+		IL_0060: ldloc.s 6
+		IL_0062: stfld object Modules.Function_ConstructorShape_GraphNode/Scope::NewTargetCheck
+		IL_0067: ldc.i4.1
+		IL_0068: newarr [System.Runtime]System.Object
+		IL_006d: dup
+		IL_006e: ldc.i4.0
+		IL_006f: ldloc.0
+		IL_0070: stelem.ref
+		IL_0071: stloc.s 5
+		IL_0073: ldloc.s 5
+		IL_0075: ldc.i4.0
+		IL_0076: ldelem.ref
+		IL_0077: castclass Modules.Function_ConstructorShape_GraphNode/Scope
+		IL_007c: newobj instance void Modules.Function_ConstructorShape_GraphNode/OverrideResult/FunctionObject::.ctor(class Modules.Function_ConstructorShape_GraphNode/Scope)
+		IL_0081: ldc.i4.0
+		IL_0082: conv.r8
+		IL_0083: ldstr "OverrideResult"
+		IL_0088: ldc.i4.0
+		IL_0089: ldc.i4.0
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_GraphNode/OverrideResult/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructorShape_GraphNode/OverrideResult/FunctionObject>(!!0)
+		IL_0094: stloc.2
+		IL_0095: nop
+		IL_0096: volatile.
+		IL_0098: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_009d: brfalse IL_00b2
+
+		IL_00a2: ldloc.1
+		IL_00a3: ldstr "prototype"
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ad: br IL_00c7
+
+		IL_00b2: ldloc.1
+		IL_00b3: ldstr "prototype"
+		IL_00b8: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:13"
+		IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_00c7: stloc.s 7
+		IL_00c9: ldc.i4.1
+		IL_00ca: newarr [System.Runtime]System.Object
+		IL_00cf: dup
+		IL_00d0: ldc.i4.0
+		IL_00d1: ldloc.0
+		IL_00d2: stelem.ref
+		IL_00d3: stloc.s 5
+		IL_00d5: newobj instance void Modules.Function_ConstructorShape_GraphNode/FunctionExpression_L9C31/FunctionObject::.ctor()
+		IL_00da: ldc.i4.0
+		IL_00db: conv.r8
+		IL_00dc: ldstr ""
+		IL_00e1: ldc.i4.0
+		IL_00e2: ldc.i4.0
+		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_GraphNode/FunctionExpression_L9C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructorShape_GraphNode/FunctionExpression_L9C31/FunctionObject>(!!0)
+		IL_00ed: stloc.s 8
+		IL_00ef: ldloc.s 7
+		IL_00f1: ldstr "describe"
+		IL_00f6: ldloc.s 8
+		IL_00f8: ldc.i4.0
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00fe: pop
+		IL_00ff: newobj instance void Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::.ctor()
+		IL_0104: stloc.s 9
+		IL_0106: ldloc.1
+		IL_0107: ldloc.s 9
+		IL_0109: ldloc.1
+		IL_010a: ldc.r8 3
+		IL_0113: box [System.Runtime]System.Double
+		IL_0118: ldc.r8 4
+		IL_0121: box [System.Runtime]System.Double
+		IL_0126: ldc.i4.0
+		IL_0127: box [System.Runtime]System.Boolean
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+		IL_0131: stloc.3
+		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0137: stloc.s 10
+		IL_0139: ldloc.3
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013f: volatile.
+		IL_0141: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0146: brfalse IL_015a
+
+		IL_014b: ldstr "describe"
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0155: br IL_016e
+
+		IL_015a: ldstr "describe"
+		IL_015f: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:31"
+		IL_0164: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_016e: stloc.s 7
+		IL_0170: ldloc.s 10
+		IL_0172: ldloc.s 7
+		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0179: pop
+		IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017f: stloc.s 10
+		IL_0181: ldloc.3
+		IL_0182: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+		IL_0187: dup
+		IL_0188: brfalse IL_0199
+
+		IL_018d: callvirt instance object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::get_pos()
+		IL_0192: stloc.s 7
+		IL_0194: br IL_01a7
+
+		IL_0199: pop
+		IL_019a: ldloc.3
+		IL_019b: ldstr "pos"
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a5: stloc.s 7
+
+		IL_01a7: volatile.
+		IL_01a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_01ae: brfalse IL_01c4
+
+		IL_01b3: ldloc.s 7
+		IL_01b5: ldstr "x"
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01bf: br IL_01da
+
+		IL_01c4: ldloc.s 7
+		IL_01c6: ldstr "x"
+		IL_01cb: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:37"
+		IL_01d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_01da: stloc.s 7
+		IL_01dc: ldloc.3
+		IL_01dd: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+		IL_01e2: dup
+		IL_01e3: brfalse IL_01f4
+
+		IL_01e8: callvirt instance object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::get_pos()
+		IL_01ed: stloc.s 11
+		IL_01ef: br IL_0202
+
+		IL_01f4: pop
+		IL_01f5: ldloc.3
+		IL_01f6: ldstr "pos"
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0200: stloc.s 11
+
+		IL_0202: volatile.
+		IL_0204: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0209: brfalse IL_021f
+
+		IL_020e: ldloc.s 11
+		IL_0210: ldstr "y"
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_021a: br IL_0235
+
+		IL_021f: ldloc.s 11
+		IL_0221: ldstr "y"
+		IL_0226: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:40"
+		IL_022b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0235: stloc.s 11
+		IL_0237: ldloc.3
+		IL_0238: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+		IL_023d: dup
+		IL_023e: brfalse IL_024f
+
+		IL_0243: callvirt instance object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::get__isWall()
+		IL_0248: stloc.s 12
+		IL_024a: br IL_025d
+
+		IL_024f: pop
+		IL_0250: ldloc.3
+		IL_0251: ldstr "_isWall"
+		IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_025b: stloc.s 12
+
+		IL_025d: ldloc.3
+		IL_025e: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+		IL_0263: dup
+		IL_0264: brfalse IL_0275
+
+		IL_0269: callvirt instance object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::get_debug()
+		IL_026e: stloc.s 13
+		IL_0270: br IL_0283
+
+		IL_0275: pop
+		IL_0276: ldloc.3
+		IL_0277: ldstr "debug"
+		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0281: stloc.s 13
+
+		IL_0283: ldloc.s 10
+		IL_0285: ldc.i4.4
+		IL_0286: newarr [System.Runtime]System.Object
+		IL_028b: dup
+		IL_028c: ldc.i4.0
+		IL_028d: ldloc.s 7
+		IL_028f: stelem.ref
+		IL_0290: dup
+		IL_0291: ldc.i4.1
+		IL_0292: ldloc.s 11
+		IL_0294: stelem.ref
+		IL_0295: dup
+		IL_0296: ldc.i4.2
+		IL_0297: ldloc.s 12
+		IL_0299: stelem.ref
+		IL_029a: dup
+		IL_029b: ldc.i4.3
+		IL_029c: ldloc.s 13
+		IL_029e: stelem.ref
+		IL_029f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_02a4: pop
+		IL_02a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02aa: stloc.s 10
+		IL_02ac: ldloc.3
+		IL_02ad: stloc.s 9
+		IL_02af: ldloc.s 9
+		IL_02b1: ldloc.1
+		IL_02b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_02b7: stloc.s 14
+		IL_02b9: ldloc.s 14
+		IL_02bb: box [System.Runtime]System.Boolean
+		IL_02c0: stloc.s 15
+		IL_02c2: ldloc.s 10
+		IL_02c4: ldloc.s 15
+		IL_02c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02cb: pop
+		IL_02cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d1: stloc.s 10
+		IL_02d3: ldloc.3
+		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_02d9: stloc.s 13
+		IL_02db: volatile.
+		IL_02dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_02e2: brfalse IL_02f7
+
+		IL_02e7: ldloc.1
+		IL_02e8: ldstr "prototype"
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02f2: br IL_030c
+
+		IL_02f7: ldloc.1
+		IL_02f8: ldstr "prototype"
+		IL_02fd: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:54"
+		IL_0302: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_030c: stloc.s 12
+		IL_030e: ldloc.s 13
+		IL_0310: ldloc.s 12
+		IL_0312: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0317: stloc.s 14
+		IL_0319: ldloc.s 14
+		IL_031b: box [System.Runtime]System.Boolean
+		IL_0320: stloc.s 15
+		IL_0322: ldloc.s 10
+		IL_0324: ldloc.s 15
+		IL_0326: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_032b: pop
+		IL_032c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0331: stloc.s 10
+		IL_0333: ldloc.3
+		IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033e: volatile.
+		IL_0340: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0345: brfalse IL_035e
+
+		IL_034a: ldstr "join"
+		IL_034f: ldstr ","
+		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0359: br IL_0377
+
+		IL_035e: ldstr "join"
+		IL_0363: ldstr ","
+		IL_0368: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:63"
+		IL_036d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0377: stloc.s 12
+		IL_0379: ldloc.s 10
+		IL_037b: ldloc.s 12
+		IL_037d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0382: pop
+		IL_0383: ldloc.3
+		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_0389: pop
+		IL_038a: ldloc.1
+		IL_038b: ldstr "call"
+		IL_0390: ldloc.3
+		IL_0391: ldc.r8 9
+		IL_039a: box [System.Runtime]System.Double
+		IL_039f: ldc.r8 10
+		IL_03a8: box [System.Runtime]System.Double
+		IL_03ad: ldc.i4.1
+		IL_03ae: box [System.Runtime]System.Boolean
+		IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember4(object, string, object, object, object, object)
+		IL_03b8: pop
+		IL_03b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03be: stloc.s 10
+		IL_03c0: ldloc.3
+		IL_03c1: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+		IL_03c6: dup
+		IL_03c7: brfalse IL_03d8
+
+		IL_03cc: callvirt instance object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::get_x()
+		IL_03d1: stloc.s 12
+		IL_03d3: br IL_03e6
+
+		IL_03d8: pop
+		IL_03d9: ldloc.3
+		IL_03da: ldstr "x"
+		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03e4: stloc.s 12
+
+		IL_03e6: ldloc.3
+		IL_03e7: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+		IL_03ec: dup
+		IL_03ed: brfalse IL_03fe
+
+		IL_03f2: callvirt instance object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::get_y()
+		IL_03f7: stloc.s 13
+		IL_03f9: br IL_040c
+
+		IL_03fe: pop
+		IL_03ff: ldloc.3
+		IL_0400: ldstr "y"
+		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_040a: stloc.s 13
+
+		IL_040c: ldloc.3
+		IL_040d: isinst Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode
+		IL_0412: dup
+		IL_0413: brfalse IL_0424
+
+		IL_0418: callvirt instance object Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L1C1_GraphNode::get__isWall()
+		IL_041d: stloc.s 11
+		IL_041f: br IL_0432
+
+		IL_0424: pop
+		IL_0425: ldloc.3
+		IL_0426: ldstr "_isWall"
+		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0430: stloc.s 11
+
+		IL_0432: ldloc.s 10
+		IL_0434: ldloc.s 12
+		IL_0436: ldloc.s 13
+		IL_0438: ldloc.s 11
+		IL_043a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_043f: pop
+		IL_0440: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0445: stloc.s 4
+		IL_0447: ldloc.1
+		IL_0448: ldstr "call"
+		IL_044d: ldloc.s 4
+		IL_044f: ldc.r8 7
+		IL_0458: box [System.Runtime]System.Double
+		IL_045d: ldc.r8 8
+		IL_0466: box [System.Runtime]System.Double
+		IL_046b: ldc.i4.1
+		IL_046c: box [System.Runtime]System.Boolean
+		IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember4(object, string, object, object, object, object)
+		IL_0476: pop
+		IL_0477: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_047c: stloc.s 10
+		IL_047e: volatile.
+		IL_0480: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0485: brfalse IL_049b
+
+		IL_048a: ldloc.s 4
+		IL_048c: ldstr "x"
+		IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0496: br IL_04b1
+
+		IL_049b: ldloc.s 4
+		IL_049d: ldstr "x"
+		IL_04a2: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:95"
+		IL_04a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04b1: stloc.s 11
+		IL_04b3: volatile.
+		IL_04b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_04ba: brfalse IL_04d0
+
+		IL_04bf: ldloc.s 4
+		IL_04c1: ldstr "y"
+		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04cb: br IL_04e6
+
+		IL_04d0: ldloc.s 4
+		IL_04d2: ldstr "y"
+		IL_04d7: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:97"
+		IL_04dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04e6: stloc.s 13
+		IL_04e8: volatile.
+		IL_04ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_04ef: brfalse IL_0505
+
+		IL_04f4: ldloc.s 4
+		IL_04f6: ldstr "_isWall"
+		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0500: br IL_051b
+
+		IL_0505: ldloc.s 4
+		IL_0507: ldstr "_isWall"
+		IL_050c: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:99"
+		IL_0511: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_051b: stloc.s 12
+		IL_051d: ldloc.s 10
+		IL_051f: ldloc.s 11
+		IL_0521: ldloc.s 13
+		IL_0523: ldloc.s 12
+		IL_0525: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_052a: pop
+		IL_052b: nop
+		IL_052c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0531: stloc.s 10
+		IL_0533: ldloc.0
+		IL_0534: ldfld object Modules.Function_ConstructorShape_GraphNode/Scope::NewTargetCheck
+		IL_0539: stloc.s 12
+		IL_053b: newobj instance void Modules.Function_ConstructorShape_GraphNode/ObjectLiterals/Ctor_L28C1_NewTargetCheck::.ctor()
+		IL_0540: stloc.s 16
+		IL_0542: ldloc.s 12
+		IL_0544: ldloc.s 16
+		IL_0546: ldloc.s 12
+		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver0(object, object, object)
+		IL_054d: volatile.
+		IL_054f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0554: brfalse IL_0568
+
+		IL_0559: ldstr "matches"
+		IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0563: br IL_057c
+
+		IL_0568: ldstr "matches"
+		IL_056d: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:108"
+		IL_0572: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_057c: stloc.s 12
+		IL_057e: ldloc.s 10
+		IL_0580: ldloc.s 12
+		IL_0582: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0587: pop
+		IL_0588: nop
+		IL_0589: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_058e: stloc.s 10
+		IL_0590: ldloc.2
+		IL_0591: dup
+		IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0597: stloc.s 12
+		IL_0599: volatile.
+		IL_059b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_05a0: brfalse IL_05b6
+
+		IL_05a5: ldloc.s 12
+		IL_05a7: ldstr "value"
+		IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05b1: br IL_05cc
+
+		IL_05b6: ldloc.s 12
+		IL_05b8: ldstr "value"
+		IL_05bd: ldstr "Function_ConstructorShape_GraphNode:Modules.Function_ConstructorShape_GraphNode:__js_module_init__:115"
+		IL_05c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05cc: stloc.s 12
+		IL_05ce: ldloc.s 10
+		IL_05d0: ldloc.s 12
+		IL_05d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05d7: pop
+		IL_05d8: ret
+	} // end of method Function_ConstructorShape_GraphNode::__js_module_init__
+
+} // end of class Modules.Function_ConstructorShape_GraphNode
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main (
+			string[] args
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: ldarg.0
+		IL_0001: call void Function_ConstructorShape_GraphNode::Run(string[])
+		IL_0006: ret
+	} // end of method Program::Main
+
+} // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_12
+	.field assembly static int32 __jroc_dynamicLookup_13
+	.field assembly static int32 __jroc_dynamicLookup_14
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+
+} // end of class Jroc.Generated.DynamicLookupSites
+

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_GuardedParameterRead.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_GuardedParameterRead.verified.txt
@@ -615,7 +615,7 @@
 		IL_005a: ldloc.s 5
 		IL_005c: ldloc.1
 		IL_005d: ldstr "typed"
-		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode>(object, object, object, object)
 		IL_0067: stloc.3
 		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_006d: stloc.s 6

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_GuardedParameterRead.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_GuardedParameterRead.verified.txt
@@ -1,0 +1,671 @@
+﻿// IL code: Function_ConstructorShape_GuardedParameterRead
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi abstract sealed beforefieldinit Function_ConstructorShape_GuardedParameterRead
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit Scripts
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit Function_ConstructorShape_GuardedParameterRead
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig static 
+				void Run (
+					string[] args
+				) cil managed 
+			{
+				.param [1]
+					.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+						01 00 00 00
+					)
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldftn void Modules.Function_ConstructorShape_GuardedParameterRead::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+				IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+				IL_000c: ldstr "Function_ConstructorShape_GuardedParameterRead"
+				IL_0011: ldarg.0
+				IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+				IL_0017: ret
+			} // end of method Function_ConstructorShape_GuardedParameterRead::Run
+
+		} // end of class Function_ConstructorShape_GuardedParameterRead
+
+
+	} // end of class Scripts
+
+
+	// Methods
+	.method public hidebysig static 
+		void Run (
+			string[] args
+		) cil managed 
+	{
+		.param [1]
+			.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+				01 00 00 00
+			)
+		// Header size: 1
+		// Code size: 24 (0x18)
+		.maxstack 8
+
+		IL_0000: ldnull
+		IL_0001: ldftn void Modules.Function_ConstructorShape_GuardedParameterRead::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_000c: ldstr "Function_ConstructorShape_GuardedParameterRead"
+		IL_0011: ldarg.0
+		IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+		IL_0017: ret
+	} // end of method Function_ConstructorShape_GuardedParameterRead::Run
+
+} // end of class Function_ConstructorShape_GuardedParameterRead
+
+.class private auto ansi beforefieldinit Modules.Function_ConstructorShape_GuardedParameterRead
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit GraphNode
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001c: call object Modules.Function_ConstructorShape_GuardedParameterRead/GraphNode::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, string)
+				IL_0021: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001c: call object Modules.Function_ConstructorShape_GuardedParameterRead/GraphNode::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, string)
+				IL_0021: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext,
+				string pos
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 87 (0x57)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: isinst Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "pos"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode::set_pos(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "pos"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.0
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
+		} // end of method GraphNode::__js_call__
+
+	} // end of class GraphNode
+
+	.class nested public auto ansi abstract sealed beforefieldinit readPos
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_ConstructorShape_GuardedParameterRead/readPos::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_ConstructorShape_GuardedParameterRead/readPos::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object obj
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 38 (0x26)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: isinst Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode
+			IL_0006: dup
+			IL_0007: brfalse IL_0017
+
+			IL_000c: callvirt instance object Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode::get_pos()
+			IL_0011: stloc.0
+			IL_0012: br IL_0024
+
+			IL_0017: pop
+			IL_0018: ldarg.1
+			IL_0019: ldstr "pos"
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0023: stloc.0
+
+			IL_0024: ldloc.0
+			IL_0025: ret
+		} // end of method readPos::__js_call__
+
+	} // end of class readPos
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 2e 53 63 6f 70 65 20 47 72 61 70 68 4e 6f
+			64 65 3d 7b 47 72 61 70 68 4e 6f 64 65 7d 2c 20
+			72 65 61 64 50 6f 73 3d 7b 72 65 61 64 50 6f 73
+			7d 00 00
+		)
+		// Fields
+		.field public object GraphNode
+		.field public object readPos
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L1C1_GraphNode
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _pos
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L1C1_GraphNode::.ctor
+
+			.method public hidebysig 
+				instance object get_pos () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "pos"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode::_pos
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode::_pos
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "pos"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L1C1_GraphNode::get_pos
+
+			.method public hidebysig 
+				instance void set_pos (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode::_pos
+				IL_0007: ldarg.0
+				IL_0008: ldstr "pos"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L1C1_GraphNode::set_pos
+
+		} // end of class Ctor_L1C1_GraphNode
+
+
+	} // end of class ObjectLiterals
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 181 (0xb5)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Function_ConstructorShape_GuardedParameterRead/Scope,
+			[1] class Modules.Function_ConstructorShape_GuardedParameterRead/GraphNode/FunctionObject,
+			[2] class Modules.Function_ConstructorShape_GuardedParameterRead/readPos/FunctionObject,
+			[3] class Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode,
+			[4] object[],
+			[5] class Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[7] object,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		)
+
+		IL_0000: newobj instance void Modules.Function_ConstructorShape_GuardedParameterRead/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldloc.0
+		IL_000f: stelem.ref
+		IL_0010: stloc.s 4
+		IL_0012: newobj instance void Modules.Function_ConstructorShape_GuardedParameterRead/GraphNode/FunctionObject::.ctor()
+		IL_0017: ldc.i4.1
+		IL_0018: conv.r8
+		IL_0019: ldstr "GraphNode"
+		IL_001e: ldc.i4.0
+		IL_001f: ldc.i4.0
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_GuardedParameterRead/GraphNode/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructorShape_GuardedParameterRead/GraphNode/FunctionObject>(!!0)
+		IL_002a: stloc.1
+		IL_002b: ldc.i4.1
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldloc.0
+		IL_0034: stelem.ref
+		IL_0035: stloc.s 4
+		IL_0037: newobj instance void Modules.Function_ConstructorShape_GuardedParameterRead/readPos/FunctionObject::.ctor()
+		IL_003c: ldc.i4.1
+		IL_003d: conv.r8
+		IL_003e: ldstr "readPos"
+		IL_0043: ldc.i4.0
+		IL_0044: ldc.i4.0
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_GuardedParameterRead/readPos/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructorShape_GuardedParameterRead/readPos/FunctionObject>(!!0)
+		IL_004f: stloc.2
+		IL_0050: nop
+		IL_0051: nop
+		IL_0052: newobj instance void Modules.Function_ConstructorShape_GuardedParameterRead/ObjectLiterals/Ctor_L1C1_GraphNode::.ctor()
+		IL_0057: stloc.s 5
+		IL_0059: ldloc.1
+		IL_005a: ldloc.s 5
+		IL_005c: ldloc.1
+		IL_005d: ldstr "typed"
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0067: stloc.3
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: stloc.s 6
+		IL_006f: ldnull
+		IL_0070: ldloc.3
+		IL_0071: call object Modules.Function_ConstructorShape_GuardedParameterRead/readPos::__js_call__(object, object)
+		IL_0076: stloc.s 7
+		IL_0078: ldloc.s 6
+		IL_007a: ldloc.s 7
+		IL_007c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0081: pop
+		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0087: stloc.s 6
+		IL_0089: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_008e: dup
+		IL_008f: ldstr "pos"
+		IL_0094: ldstr "fallback"
+		IL_0099: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_009e: stloc.s 8
+		IL_00a0: ldnull
+		IL_00a1: ldloc.s 8
+		IL_00a3: call object Modules.Function_ConstructorShape_GuardedParameterRead/readPos::__js_call__(object, object)
+		IL_00a8: stloc.s 7
+		IL_00aa: ldloc.s 6
+		IL_00ac: ldloc.s 7
+		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b3: pop
+		IL_00b4: ret
+	} // end of method Function_ConstructorShape_GuardedParameterRead::__js_module_init__
+
+} // end of class Modules.Function_ConstructorShape_GuardedParameterRead
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main (
+			string[] args
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: ldarg.0
+		IL_0001: call void Function_ConstructorShape_GuardedParameterRead::Run(string[])
+		IL_0006: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_MutationFallback.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_MutationFallback.verified.txt
@@ -796,7 +796,7 @@
 		IL_005f: ldloc.s 5
 		IL_0061: ldloc.1
 		IL_0062: ldstr "initial"
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode>(object, object, object, object)
 		IL_006c: stloc.3
 		IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0072: stloc.s 6

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_MutationFallback.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_MutationFallback.verified.txt
@@ -1,0 +1,1055 @@
+﻿// IL code: Function_ConstructorShape_MutationFallback
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi abstract sealed beforefieldinit Function_ConstructorShape_MutationFallback
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit Scripts
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit Function_ConstructorShape_MutationFallback
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig static 
+				void Run (
+					string[] args
+				) cil managed 
+			{
+				.param [1]
+					.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+						01 00 00 00
+					)
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldftn void Modules.Function_ConstructorShape_MutationFallback::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+				IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+				IL_000c: ldstr "Function_ConstructorShape_MutationFallback"
+				IL_0011: ldarg.0
+				IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+				IL_0017: ret
+			} // end of method Function_ConstructorShape_MutationFallback::Run
+
+		} // end of class Function_ConstructorShape_MutationFallback
+
+
+	} // end of class Scripts
+
+
+	// Methods
+	.method public hidebysig static 
+		void Run (
+			string[] args
+		) cil managed 
+	{
+		.param [1]
+			.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+				01 00 00 00
+			)
+		// Header size: 1
+		// Code size: 24 (0x18)
+		.maxstack 8
+
+		IL_0000: ldnull
+		IL_0001: ldftn void Modules.Function_ConstructorShape_MutationFallback::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_000c: ldstr "Function_ConstructorShape_MutationFallback"
+		IL_0011: ldarg.0
+		IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+		IL_0017: ret
+	} // end of method Function_ConstructorShape_MutationFallback::Run
+
+} // end of class Function_ConstructorShape_MutationFallback
+
+.class private auto ansi beforefieldinit Modules.Function_ConstructorShape_MutationFallback
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit GraphNode
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_MutationFallback/GraphNode::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_MutationFallback/GraphNode::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext,
+				object pos
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 87 (0x57)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: isinst Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "pos"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode::set_pos(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "pos"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.0
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
+		} // end of method GraphNode::__js_call__
+
+	} // end of class GraphNode
+
+	.class nested public auto ansi abstract sealed beforefieldinit readPos
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_ConstructorShape_MutationFallback/readPos::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_ConstructorShape_MutationFallback/readPos::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object obj
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 38 (0x26)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: isinst Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode
+			IL_0006: dup
+			IL_0007: brfalse IL_0017
+
+			IL_000c: callvirt instance object Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode::get_pos()
+			IL_0011: stloc.0
+			IL_0012: br IL_0024
+
+			IL_0017: pop
+			IL_0018: ldarg.1
+			IL_0019: ldstr "pos"
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0023: stloc.0
+
+			IL_0024: ldloc.0
+			IL_0025: ret
+		} // end of method readPos::__js_call__
+
+	} // end of class readPos
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L22C9
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ConstructorShape_MutationFallback/Scope _environment0_Function_ConstructorShape_MutationFallback
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ConstructorShape_MutationFallback/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_ConstructorShape_MutationFallback/Scope Modules.Function_ConstructorShape_MutationFallback/FunctionExpression_L22C9/FunctionObject::_environment0_Function_ConstructorShape_MutationFallback
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_MutationFallback/Scope Modules.Function_ConstructorShape_MutationFallback/FunctionExpression_L22C9/FunctionObject::_environment0_Function_ConstructorShape_MutationFallback
+				IL_0006: ldnull
+				IL_0007: call object Modules.Function_ConstructorShape_MutationFallback/FunctionExpression_L22C9::__js_call__(class Modules.Function_ConstructorShape_MutationFallback/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_MutationFallback/Scope Modules.Function_ConstructorShape_MutationFallback/FunctionExpression_L22C9/FunctionObject::_environment0_Function_ConstructorShape_MutationFallback
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_ConstructorShape_MutationFallback/FunctionExpression_L22C9::__js_call__(class Modules.Function_ConstructorShape_MutationFallback/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Function_ConstructorShape_MutationFallback/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 09 00 00 02
+			)
+			// Header size: 12
+			// Code size: 42 (0x2a)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Function_ConstructorShape_MutationFallback/Scope::getterCalls
+			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000b: ldc.r8 1
+			IL_0014: add
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: box [System.Runtime]System.Double
+			IL_001c: stloc.1
+			IL_001d: ldarg.0
+			IL_001e: ldloc.1
+			IL_001f: stfld object Modules.Function_ConstructorShape_MutationFallback/Scope::getterCalls
+			IL_0024: ldstr "accessor"
+			IL_0029: ret
+		} // end of method FunctionExpression_L22C9::__js_call__
+
+	} // end of class FunctionExpression_L22C9
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 49 53 63 6f 70 65 20 47 72 61 70 68 4e 6f
+			64 65 3d 7b 47 72 61 70 68 4e 6f 64 65 7d 2c 20
+			72 65 61 64 50 6f 73 3d 7b 72 65 61 64 50 6f 73
+			7d 2c 20 67 65 74 74 65 72 43 61 6c 6c 73 3d 7b
+			67 65 74 74 65 72 43 61 6c 6c 73 7d 00 00
+		)
+		// Fields
+		.field public object GraphNode
+		.field public object readPos
+		.field public object getterCalls
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L1C1_GraphNode
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _pos
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L1C1_GraphNode::.ctor
+
+			.method public hidebysig 
+				instance object get_pos () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "pos"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode::_pos
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode::_pos
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "pos"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L1C1_GraphNode::get_pos
+
+			.method public hidebysig 
+				instance void set_pos (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode::_pos
+				IL_0007: ldarg.0
+				IL_0008: ldstr "pos"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L1C1_GraphNode::set_pos
+
+		} // end of class Ctor_L1C1_GraphNode
+
+
+	} // end of class ObjectLiterals
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 758 (0x2f6)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Function_ConstructorShape_MutationFallback/Scope,
+			[1] class Modules.Function_ConstructorShape_MutationFallback/GraphNode/FunctionObject,
+			[2] class Modules.Function_ConstructorShape_MutationFallback/readPos/FunctionObject,
+			[3] class Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode,
+			[4] object[],
+			[5] class Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[7] object,
+			[8] bool,
+			[9] class Modules.Function_ConstructorShape_MutationFallback/FunctionExpression_L22C9/FunctionObject,
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[11] object
+		)
+
+		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
+		IL_0005: newobj instance void Modules.Function_ConstructorShape_MutationFallback/Scope::.ctor()
+		IL_000a: stloc.0
+		IL_000b: ldc.i4.1
+		IL_000c: newarr [System.Runtime]System.Object
+		IL_0011: dup
+		IL_0012: ldc.i4.0
+		IL_0013: ldloc.0
+		IL_0014: stelem.ref
+		IL_0015: stloc.s 4
+		IL_0017: newobj instance void Modules.Function_ConstructorShape_MutationFallback/GraphNode/FunctionObject::.ctor()
+		IL_001c: ldc.i4.1
+		IL_001d: conv.r8
+		IL_001e: ldstr "GraphNode"
+		IL_0023: ldc.i4.0
+		IL_0024: ldc.i4.0
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_MutationFallback/GraphNode/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructorShape_MutationFallback/GraphNode/FunctionObject>(!!0)
+		IL_002f: stloc.1
+		IL_0030: ldc.i4.1
+		IL_0031: newarr [System.Runtime]System.Object
+		IL_0036: dup
+		IL_0037: ldc.i4.0
+		IL_0038: ldloc.0
+		IL_0039: stelem.ref
+		IL_003a: stloc.s 4
+		IL_003c: newobj instance void Modules.Function_ConstructorShape_MutationFallback/readPos/FunctionObject::.ctor()
+		IL_0041: ldc.i4.1
+		IL_0042: conv.r8
+		IL_0043: ldstr "readPos"
+		IL_0048: ldc.i4.0
+		IL_0049: ldc.i4.0
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_MutationFallback/readPos/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructorShape_MutationFallback/readPos/FunctionObject>(!!0)
+		IL_0054: stloc.2
+		IL_0055: nop
+		IL_0056: nop
+		IL_0057: newobj instance void Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode::.ctor()
+		IL_005c: stloc.s 5
+		IL_005e: ldloc.1
+		IL_005f: ldloc.s 5
+		IL_0061: ldloc.1
+		IL_0062: ldstr "initial"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_006c: stloc.3
+		IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0072: stloc.s 6
+		IL_0074: ldnull
+		IL_0075: ldloc.3
+		IL_0076: call object Modules.Function_ConstructorShape_MutationFallback/readPos::__js_call__(object, object)
+		IL_007b: stloc.s 7
+		IL_007d: ldloc.s 6
+		IL_007f: ldloc.s 7
+		IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0086: pop
+		IL_0087: ldloc.3
+		IL_0088: ldstr "pos"
+		IL_008d: ldstr "plain-write"
+		IL_0092: ldc.i4.0
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0098: pop
+		IL_0099: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009e: stloc.s 6
+		IL_00a0: ldnull
+		IL_00a1: ldloc.3
+		IL_00a2: call object Modules.Function_ConstructorShape_MutationFallback/readPos::__js_call__(object, object)
+		IL_00a7: stloc.s 7
+		IL_00a9: ldloc.s 6
+		IL_00ab: ldloc.s 7
+		IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b2: pop
+		IL_00b3: ldloc.3
+		IL_00b4: ldstr "pos"
+		IL_00b9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeletePropertyNonStrict(object, object)
+		IL_00be: stloc.s 8
+		IL_00c0: volatile.
+		IL_00c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00c7: brfalse IL_00dc
+
+		IL_00cc: ldloc.1
+		IL_00cd: ldstr "prototype"
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d7: br IL_00f1
+
+		IL_00dc: ldloc.1
+		IL_00dd: ldstr "prototype"
+		IL_00e2: ldstr "Function_ConstructorShape_MutationFallback:Modules.Function_ConstructorShape_MutationFallback:__js_module_init__:34"
+		IL_00e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_00f1: stloc.s 7
+		IL_00f3: ldloc.s 7
+		IL_00f5: ldstr "pos"
+		IL_00fa: ldstr "prototype"
+		IL_00ff: ldc.i4.0
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0105: pop
+		IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010b: stloc.s 6
+		IL_010d: ldnull
+		IL_010e: ldloc.3
+		IL_010f: call object Modules.Function_ConstructorShape_MutationFallback/readPos::__js_call__(object, object)
+		IL_0114: stloc.s 7
+		IL_0116: ldloc.s 6
+		IL_0118: ldloc.s 7
+		IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011f: pop
+		IL_0120: ldloc.0
+		IL_0121: ldc.r8 0.0
+		IL_012a: box [System.Runtime]System.Double
+		IL_012f: stfld object Modules.Function_ConstructorShape_MutationFallback/Scope::getterCalls
+		IL_0134: ldc.i4.1
+		IL_0135: newarr [System.Runtime]System.Object
+		IL_013a: dup
+		IL_013b: ldc.i4.0
+		IL_013c: ldloc.0
+		IL_013d: stelem.ref
+		IL_013e: stloc.s 4
+		IL_0140: ldloc.s 4
+		IL_0142: ldc.i4.0
+		IL_0143: ldelem.ref
+		IL_0144: castclass Modules.Function_ConstructorShape_MutationFallback/Scope
+		IL_0149: newobj instance void Modules.Function_ConstructorShape_MutationFallback/FunctionExpression_L22C9/FunctionObject::.ctor(class Modules.Function_ConstructorShape_MutationFallback/Scope)
+		IL_014e: ldc.i4.0
+		IL_014f: conv.r8
+		IL_0150: ldstr ""
+		IL_0155: ldc.i4.0
+		IL_0156: ldc.i4.0
+		IL_0157: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_MutationFallback/FunctionExpression_L22C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_015c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructorShape_MutationFallback/FunctionExpression_L22C9/FunctionObject>(!!0)
+		IL_0161: stloc.s 9
+		IL_0163: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0168: dup
+		IL_0169: ldstr "configurable"
+		IL_016e: ldc.i4.1
+		IL_016f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0174: dup
+		IL_0175: ldstr "get"
+		IL_017a: ldloc.s 9
+		IL_017c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0181: stloc.s 10
+		IL_0183: ldloc.3
+		IL_0184: ldstr "pos"
+		IL_0189: ldloc.s 10
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0190: pop
+		IL_0191: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0196: stloc.s 6
+		IL_0198: ldnull
+		IL_0199: ldloc.3
+		IL_019a: call object Modules.Function_ConstructorShape_MutationFallback/readPos::__js_call__(object, object)
+		IL_019f: stloc.s 7
+		IL_01a1: ldloc.s 6
+		IL_01a3: ldloc.s 7
+		IL_01a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01aa: pop
+		IL_01ab: ldloc.3
+		IL_01ac: isinst Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode
+		IL_01b1: dup
+		IL_01b2: brfalse IL_01c2
+
+		IL_01b7: callvirt instance object Modules.Function_ConstructorShape_MutationFallback/ObjectLiterals/Ctor_L1C1_GraphNode::get_pos()
+		IL_01bc: pop
+		IL_01bd: br IL_01cf
+
+		IL_01c2: pop
+		IL_01c3: ldloc.3
+		IL_01c4: ldstr "pos"
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ce: pop
+
+		IL_01cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01d4: stloc.s 6
+		IL_01d6: ldloc.0
+		IL_01d7: ldfld object Modules.Function_ConstructorShape_MutationFallback/Scope::getterCalls
+		IL_01dc: stloc.s 7
+		IL_01de: ldloc.s 6
+		IL_01e0: ldloc.s 7
+		IL_01e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01e7: pop
+		IL_01e8: ldloc.3
+		IL_01e9: ldstr "pos"
+		IL_01ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01f3: dup
+		IL_01f4: ldstr "configurable"
+		IL_01f9: ldc.i4.1
+		IL_01fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_01ff: dup
+		IL_0200: ldstr "enumerable"
+		IL_0205: ldc.i4.1
+		IL_0206: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_020b: dup
+		IL_020c: ldstr "writable"
+		IL_0211: ldc.i4.1
+		IL_0212: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0217: dup
+		IL_0218: ldstr "value"
+		IL_021d: ldstr "descriptor-data"
+		IL_0222: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_022c: pop
+		IL_022d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0232: stloc.s 6
+		IL_0234: ldnull
+		IL_0235: ldloc.3
+		IL_0236: call object Modules.Function_ConstructorShape_MutationFallback/readPos::__js_call__(object, object)
+		IL_023b: stloc.s 7
+		IL_023d: ldloc.s 6
+		IL_023f: ldloc.s 7
+		IL_0241: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0246: pop
+		IL_0247: ldloc.3
+		IL_0248: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_024d: dup
+		IL_024e: ldstr "pos"
+		IL_0253: ldstr "other-prototype"
+		IL_0258: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0262: pop
+		IL_0263: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0268: stloc.s 6
+		IL_026a: ldnull
+		IL_026b: ldloc.3
+		IL_026c: call object Modules.Function_ConstructorShape_MutationFallback/readPos::__js_call__(object, object)
+		IL_0271: stloc.s 7
+		IL_0273: ldloc.s 6
+		IL_0275: ldloc.s 7
+		IL_0277: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_027c: pop
+		IL_027d: ldloc.3
+		IL_027e: ldstr "extra"
+		IL_0283: ldc.r8 1
+		IL_028c: ldc.i4.0
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0292: pop
+		IL_0293: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0298: stloc.s 6
+		IL_029a: ldnull
+		IL_029b: ldloc.3
+		IL_029c: call object Modules.Function_ConstructorShape_MutationFallback/readPos::__js_call__(object, object)
+		IL_02a1: stloc.s 7
+		IL_02a3: ldloc.3
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ae: volatile.
+		IL_02b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02b5: brfalse IL_02ce
+
+		IL_02ba: ldstr "join"
+		IL_02bf: ldstr ","
+		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c9: br IL_02e7
+
+		IL_02ce: ldstr "join"
+		IL_02d3: ldstr ","
+		IL_02d8: ldstr "Function_ConstructorShape_MutationFallback:Modules.Function_ConstructorShape_MutationFallback:__js_module_init__:98"
+		IL_02dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_02e7: stloc.s 11
+		IL_02e9: ldloc.s 6
+		IL_02eb: ldloc.s 7
+		IL_02ed: ldloc.s 11
+		IL_02ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02f4: pop
+		IL_02f5: ret
+	} // end of method Function_ConstructorShape_MutationFallback::__js_module_init__
+
+} // end of class Modules.Function_ConstructorShape_MutationFallback
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main (
+			string[] args
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: ldarg.0
+		IL_0001: call void Function_ConstructorShape_MutationFallback::Run(string[])
+		IL_0006: ret
+	} // end of method Program::Main
+
+} // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+
+} // end of class Jroc.Generated.DynamicLookupSites
+

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_PrototypeSetSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_PrototypeSetSemantics.verified.txt
@@ -2040,7 +2040,7 @@
 		IL_0197: ldloc.s 21
 		IL_0199: ldloc.1
 		IL_019a: ldstr "setter"
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor>(object, object, object, object)
 		IL_01a4: stloc.s 6
 		IL_01a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_01ab: stloc.s 22
@@ -2174,7 +2174,7 @@
 			IL_0318: ldloc.s 26
 			IL_031a: ldloc.2
 			IL_031b: ldstr "own"
-			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+			IL_0320: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L26C1_ReadOnlyConstructor>(object, object, object, object)
 			IL_0325: pop
 			IL_0326: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_032b: stloc.s 22
@@ -2280,7 +2280,7 @@
 		IL_0442: ldloc.s 27
 		IL_0444: ldloc.3
 		IL_0445: ldstr "own"
-		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_044a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor>(object, object, object, object)
 		IL_044f: stloc.s 10
 		IL_0451: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0456: stloc.s 22
@@ -2383,7 +2383,7 @@
 		IL_058a: ldloc.s 28
 		IL_058c: ldloc.s 4
 		IL_058e: ldstr "generated receiver"
-		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0593: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor>(object, object, object, object)
 		IL_0598: pop
 		IL_0599: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_059e: dup
@@ -2480,7 +2480,7 @@
 		IL_068b: ldloc.s 29
 		IL_068d: ldloc.s 5
 		IL_068f: ldstr "initialized"
-		IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0694: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor>(object, object, object, object)
 		IL_0699: stloc.s 29
 		IL_069b: ldloc.s 29
 		IL_069d: stloc.s 11

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_PrototypeSetSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructorShape_PrototypeSetSemantics.verified.txt
@@ -1,0 +1,2553 @@
+﻿// IL code: Function_ConstructorShape_PrototypeSetSemantics
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi abstract sealed beforefieldinit Function_ConstructorShape_PrototypeSetSemantics
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit Scripts
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit Function_ConstructorShape_PrototypeSetSemantics
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig static 
+				void Run (
+					string[] args
+				) cil managed 
+			{
+				.param [1]
+					.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+						01 00 00 00
+					)
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldftn void Modules.Function_ConstructorShape_PrototypeSetSemantics::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+				IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+				IL_000c: ldstr "Function_ConstructorShape_PrototypeSetSemantics"
+				IL_0011: ldarg.0
+				IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+				IL_0017: ret
+			} // end of method Function_ConstructorShape_PrototypeSetSemantics::Run
+
+		} // end of class Function_ConstructorShape_PrototypeSetSemantics
+
+
+	} // end of class Scripts
+
+
+	// Methods
+	.method public hidebysig static 
+		void Run (
+			string[] args
+		) cil managed 
+	{
+		.param [1]
+			.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+				01 00 00 00
+			)
+		// Header size: 1
+		// Code size: 24 (0x18)
+		.maxstack 8
+
+		IL_0000: ldnull
+		IL_0001: ldftn void Modules.Function_ConstructorShape_PrototypeSetSemantics::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_000c: ldstr "Function_ConstructorShape_PrototypeSetSemantics"
+		IL_0011: ldarg.0
+		IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+		IL_0017: ret
+	} // end of method Function_ConstructorShape_PrototypeSetSemantics::Run
+
+} // end of class Function_ConstructorShape_PrototypeSetSemantics
+
+.class private auto ansi beforefieldinit Modules.Function_ConstructorShape_PrototypeSetSemantics
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit SetterConstructor
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/SetterConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/SetterConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 87 (0x57)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor::set_value(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "value"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
+		} // end of method SetterConstructor::__js_call__
+
+	} // end of class SetterConstructor
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L12C9
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope _environment0_Function_ConstructorShape_PrototypeSetSemantics
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L12C9/FunctionObject::_environment0_Function_ConstructorShape_PrototypeSetSemantics
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L12C9/FunctionObject::_environment0_Function_ConstructorShape_PrototypeSetSemantics
+				IL_0006: ldnull
+				IL_0007: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L12C9::__js_call__(class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L12C9/FunctionObject::_environment0_Function_ConstructorShape_PrototypeSetSemantics
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L12C9::__js_call__(class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0d 00 00 02
+			)
+			// Header size: 12
+			// Code size: 21 (0x15)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope::setterValue
+			IL_0006: stloc.0
+			IL_0007: ldstr "getter:"
+			IL_000c: ldloc.0
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0012: stloc.1
+			IL_0013: ldloc.1
+			IL_0014: ret
+		} // end of method FunctionExpression_L12C9::__js_call__
+
+	} // end of class FunctionExpression_L12C9
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L13C9
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope _environment0_Function_ConstructorShape_PrototypeSetSemantics
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L13C9/FunctionObject::_environment0_Function_ConstructorShape_PrototypeSetSemantics
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L13C9/FunctionObject::_environment0_Function_ConstructorShape_PrototypeSetSemantics
+				IL_0006: ldnull
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L13C9::__js_call__(class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L13C9/FunctionObject::_environment0_Function_ConstructorShape_PrototypeSetSemantics
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L13C9::__js_call__(class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope scope,
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 0d 00 00 02
+			)
+			// Header size: 12
+			// Code size: 45 (0x2d)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope::setterCalls
+			IL_0006: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_000b: ldc.r8 1
+			IL_0014: add
+			IL_0015: stloc.0
+			IL_0016: ldloc.0
+			IL_0017: box [System.Runtime]System.Double
+			IL_001c: stloc.1
+			IL_001d: ldarg.0
+			IL_001e: ldloc.1
+			IL_001f: stfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope::setterCalls
+			IL_0024: ldarg.0
+			IL_0025: ldarg.2
+			IL_0026: stfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope::setterValue
+			IL_002b: ldnull
+			IL_002c: ret
+		} // end of method FunctionExpression_L13C9::__js_call__
+
+	} // end of class FunctionExpression_L13C9
+
+	.class nested public auto ansi abstract sealed beforefieldinit ReadOnlyConstructor
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadOnlyConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadOnlyConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 87 (0x57)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L26C1_ReadOnlyConstructor
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L26C1_ReadOnlyConstructor::set_value(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "value"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
+		} // end of method ReadOnlyConstructor::__js_call__
+
+	} // end of class ReadOnlyConstructor
+
+	.class nested public auto ansi abstract sealed beforefieldinit WritableConstructor
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/WritableConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/WritableConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 87 (0x57)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor::set_value(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "value"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
+		} // end of method WritableConstructor::__js_call__
+
+	} // end of class WritableConstructor
+
+	.class nested public auto ansi abstract sealed beforefieldinit ReadingConstructor
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadingConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadingConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_001c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 157 (0x9d)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[1] object
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor::set_value(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "value"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_005a: stloc.0
+			IL_005b: ldarg.1
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0066: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor
+			IL_006b: dup
+			IL_006c: brfalse IL_007c
+
+			IL_0071: callvirt instance object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor::get_value()
+			IL_0076: stloc.1
+			IL_0077: br IL_0093
+
+			IL_007c: pop
+			IL_007d: ldarg.1
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0088: ldstr "value"
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0092: stloc.1
+
+			IL_0093: ldloc.0
+			IL_0094: ldloc.1
+			IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_009a: pop
+			IL_009b: ldnull
+			IL_009c: ret
+		} // end of method ReadingConstructor::__js_call__
+
+	} // end of class ReadingConstructor
+
+	.class nested public auto ansi abstract sealed beforefieldinit PreInitConstructor
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001c: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/PreInitConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, string)
+				IL_0021: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: ldarg.2
+				IL_0011: ldc.i4.0
+				IL_0012: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0017: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001c: call object Modules.Function_ConstructorShape_PrototypeSetSemantics/PreInitConstructor::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, string)
+				IL_0021: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext,
+				string 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 87 (0x57)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor::set_value(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "value"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
+		} // end of method PreInitConstructor::__js_call__
+
+	} // end of class PreInitConstructor
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 81 09 53 63 6f 70 65 20 73 65 74 74 65 72
+			43 61 6c 6c 73 3d 7b 73 65 74 74 65 72 43 61 6c
+			6c 73 7d 2c 20 73 65 74 74 65 72 56 61 6c 75 65
+			3d 7b 73 65 74 74 65 72 56 61 6c 75 65 7d 2c 20
+			53 65 74 74 65 72 43 6f 6e 73 74 72 75 63 74 6f
+			72 3d 7b 53 65 74 74 65 72 43 6f 6e 73 74 72 75
+			63 74 6f 72 7d 2c 20 52 65 61 64 4f 6e 6c 79 43
+			6f 6e 73 74 72 75 63 74 6f 72 3d 7b 52 65 61 64
+			4f 6e 6c 79 43 6f 6e 73 74 72 75 63 74 6f 72 7d
+			2c 20 57 72 69 74 61 62 6c 65 43 6f 6e 73 74 72
+			75 63 74 6f 72 3d 7b 57 72 69 74 61 62 6c 65 43
+			6f 6e 73 74 72 75 63 74 6f 72 7d 2c 20 52 65 61
+			64 69 6e 67 43 6f 6e 73 74 72 75 63 74 6f 72 3d
+			7b 52 65 61 64 69 6e 67 43 6f 6e 73 74 72 75 63
+			74 6f 72 7d 2c 20 50 72 65 49 6e 69 74 43 6f 6e
+			73 74 72 75 63 74 6f 72 3d 7b 50 72 65 49 6e 69
+			74 43 6f 6e 73 74 72 75 63 74 6f 72 7d 00 00
+		)
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L37C4
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L37C4::.ctor
+
+		} // end of class Block_L37C4
+
+		.class nested public auto ansi beforefieldinit Block_L40C16
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L40C16::.ctor
+
+		} // end of class Block_L40C16
+
+		.class nested public auto ansi beforefieldinit Block_L73C4
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L73C4::.ctor
+
+		} // end of class Block_L73C4
+
+		.class nested public auto ansi beforefieldinit Block_L76C16
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L76C16::.ctor
+
+		} // end of class Block_L76C16
+
+
+		// Fields
+		.field public object setterCalls
+		.field public object setterValue
+		.field public object SetterConstructor
+		.field public object ReadOnlyConstructor
+		.field public object WritableConstructor
+		.field public object ReadingConstructor
+		.field public object PreInitConstructor
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L6C1_SetterConstructor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L6C1_SetterConstructor::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L6C1_SetterConstructor::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L6C1_SetterConstructor::set_value
+
+		} // end of class Ctor_L6C1_SetterConstructor
+
+		.class nested public auto ansi beforefieldinit Ctor_L26C1_ReadOnlyConstructor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L26C1_ReadOnlyConstructor::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L26C1_ReadOnlyConstructor::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L26C1_ReadOnlyConstructor::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L26C1_ReadOnlyConstructor::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L26C1_ReadOnlyConstructor::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L26C1_ReadOnlyConstructor::set_value
+
+		} // end of class Ctor_L26C1_ReadOnlyConstructor
+
+		.class nested public auto ansi beforefieldinit Ctor_L44C1_WritableConstructor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L44C1_WritableConstructor::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L44C1_WritableConstructor::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L44C1_WritableConstructor::set_value
+
+		} // end of class Ctor_L44C1_WritableConstructor
+
+		.class nested public auto ansi beforefieldinit Ctor_L61C1_ReadingConstructor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L61C1_ReadingConstructor::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L61C1_ReadingConstructor::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L61C1_ReadingConstructor::set_value
+
+		} // end of class Ctor_L61C1_ReadingConstructor
+
+		.class nested public auto ansi beforefieldinit Ctor_L69C1_PreInitConstructor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L69C1_PreInitConstructor::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L69C1_PreInitConstructor::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L69C1_PreInitConstructor::set_value
+
+		} // end of class Ctor_L69C1_PreInitConstructor
+
+
+	} // end of class ObjectLiterals
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 1756 (0x6dc)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope,
+			[1] class Modules.Function_ConstructorShape_PrototypeSetSemantics/SetterConstructor/FunctionObject,
+			[2] class Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadOnlyConstructor/FunctionObject,
+			[3] class Modules.Function_ConstructorShape_PrototypeSetSemantics/WritableConstructor/FunctionObject,
+			[4] class Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadingConstructor/FunctionObject,
+			[5] class Modules.Function_ConstructorShape_PrototypeSetSemantics/PreInitConstructor/FunctionObject,
+			[6] class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor,
+			[7] class [System.Runtime]System.Exception,
+			[8] object,
+			[9] object,
+			[10] class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor,
+			[11] object,
+			[12] class [System.Runtime]System.Exception,
+			[13] object,
+			[14] object,
+			[15] object,
+			[16] object[],
+			[17] object,
+			[18] class Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L12C9/FunctionObject,
+			[19] class Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L13C9/FunctionObject,
+			[20] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[21] class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor,
+			[22] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[23] object,
+			[24] object,
+			[25] object,
+			[26] class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L26C1_ReadOnlyConstructor,
+			[27] class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor,
+			[28] class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor,
+			[29] class Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor
+		)
+
+		IL_0000: ldnull
+		IL_0001: stloc.s 11
+		IL_0003: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope::.ctor()
+		IL_0008: stloc.0
+		IL_0009: ldc.i4.1
+		IL_000a: newarr [System.Runtime]System.Object
+		IL_000f: dup
+		IL_0010: ldc.i4.0
+		IL_0011: ldloc.0
+		IL_0012: stelem.ref
+		IL_0013: stloc.s 16
+		IL_0015: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/SetterConstructor/FunctionObject::.ctor()
+		IL_001a: ldc.i4.1
+		IL_001b: conv.r8
+		IL_001c: ldstr "SetterConstructor"
+		IL_0021: ldc.i4.0
+		IL_0022: ldc.i4.1
+		IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_PrototypeSetSemantics/SetterConstructor/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0028: stloc.1
+		IL_0029: ldc.i4.1
+		IL_002a: newarr [System.Runtime]System.Object
+		IL_002f: dup
+		IL_0030: ldc.i4.0
+		IL_0031: ldloc.0
+		IL_0032: stelem.ref
+		IL_0033: stloc.s 16
+		IL_0035: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadOnlyConstructor/FunctionObject::.ctor()
+		IL_003a: ldc.i4.1
+		IL_003b: conv.r8
+		IL_003c: ldstr "ReadOnlyConstructor"
+		IL_0041: ldc.i4.0
+		IL_0042: ldc.i4.1
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadOnlyConstructor/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0048: stloc.2
+		IL_0049: ldc.i4.1
+		IL_004a: newarr [System.Runtime]System.Object
+		IL_004f: dup
+		IL_0050: ldc.i4.0
+		IL_0051: ldloc.0
+		IL_0052: stelem.ref
+		IL_0053: stloc.s 16
+		IL_0055: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/WritableConstructor/FunctionObject::.ctor()
+		IL_005a: ldc.i4.1
+		IL_005b: conv.r8
+		IL_005c: ldstr "WritableConstructor"
+		IL_0061: ldc.i4.0
+		IL_0062: ldc.i4.1
+		IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_PrototypeSetSemantics/WritableConstructor/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0068: stloc.3
+		IL_0069: ldc.i4.1
+		IL_006a: newarr [System.Runtime]System.Object
+		IL_006f: dup
+		IL_0070: ldc.i4.0
+		IL_0071: ldloc.0
+		IL_0072: stelem.ref
+		IL_0073: stloc.s 16
+		IL_0075: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadingConstructor/FunctionObject::.ctor()
+		IL_007a: ldc.i4.1
+		IL_007b: conv.r8
+		IL_007c: ldstr "ReadingConstructor"
+		IL_0081: ldc.i4.0
+		IL_0082: ldc.i4.1
+		IL_0083: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_PrototypeSetSemantics/ReadingConstructor/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0088: stloc.s 4
+		IL_008a: ldc.i4.1
+		IL_008b: newarr [System.Runtime]System.Object
+		IL_0090: dup
+		IL_0091: ldc.i4.0
+		IL_0092: ldloc.0
+		IL_0093: stelem.ref
+		IL_0094: stloc.s 16
+		IL_0096: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/PreInitConstructor/FunctionObject::.ctor()
+		IL_009b: ldc.i4.1
+		IL_009c: conv.r8
+		IL_009d: ldstr "PreInitConstructor"
+		IL_00a2: ldc.i4.0
+		IL_00a3: ldc.i4.1
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_PrototypeSetSemantics/PreInitConstructor/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a9: stloc.s 5
+		IL_00ab: nop
+		IL_00ac: ldloc.0
+		IL_00ad: ldc.r8 0.0
+		IL_00b6: box [System.Runtime]System.Double
+		IL_00bb: stfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope::setterCalls
+		IL_00c0: ldloc.0
+		IL_00c1: ldstr ""
+		IL_00c6: stfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope::setterValue
+		IL_00cb: nop
+		IL_00cc: volatile.
+		IL_00ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_00d3: brfalse IL_00e8
+
+		IL_00d8: ldloc.1
+		IL_00d9: ldstr "prototype"
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e3: br IL_00fd
+
+		IL_00e8: ldloc.1
+		IL_00e9: ldstr "prototype"
+		IL_00ee: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:29"
+		IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_00fd: stloc.s 17
+		IL_00ff: ldc.i4.1
+		IL_0100: newarr [System.Runtime]System.Object
+		IL_0105: dup
+		IL_0106: ldc.i4.0
+		IL_0107: ldloc.0
+		IL_0108: stelem.ref
+		IL_0109: stloc.s 16
+		IL_010b: ldloc.s 16
+		IL_010d: ldc.i4.0
+		IL_010e: ldelem.ref
+		IL_010f: castclass Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope
+		IL_0114: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L12C9/FunctionObject::.ctor(class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope)
+		IL_0119: ldc.i4.0
+		IL_011a: conv.r8
+		IL_011b: ldstr ""
+		IL_0120: ldc.i4.0
+		IL_0121: ldc.i4.1
+		IL_0122: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L12C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0127: stloc.s 18
+		IL_0129: ldc.i4.1
+		IL_012a: newarr [System.Runtime]System.Object
+		IL_012f: dup
+		IL_0130: ldc.i4.0
+		IL_0131: ldloc.0
+		IL_0132: stelem.ref
+		IL_0133: stloc.s 16
+		IL_0135: ldloc.s 16
+		IL_0137: ldc.i4.0
+		IL_0138: ldelem.ref
+		IL_0139: castclass Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope
+		IL_013e: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L13C9/FunctionObject::.ctor(class Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope)
+		IL_0143: ldc.i4.1
+		IL_0144: conv.r8
+		IL_0145: ldstr ""
+		IL_014a: ldc.i4.0
+		IL_014b: ldc.i4.1
+		IL_014c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructorShape_PrototypeSetSemantics/FunctionExpression_L13C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0151: stloc.s 19
+		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0158: dup
+		IL_0159: ldstr "configurable"
+		IL_015e: ldc.i4.1
+		IL_015f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0164: dup
+		IL_0165: ldstr "get"
+		IL_016a: ldloc.s 18
+		IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0171: dup
+		IL_0172: ldstr "set"
+		IL_0177: ldloc.s 19
+		IL_0179: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_017e: stloc.s 20
+		IL_0180: ldloc.s 17
+		IL_0182: ldstr "value"
+		IL_0187: ldloc.s 20
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_018e: pop
+		IL_018f: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor::.ctor()
+		IL_0194: stloc.s 21
+		IL_0196: ldloc.1
+		IL_0197: ldloc.s 21
+		IL_0199: ldloc.1
+		IL_019a: ldstr "setter"
+		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_01a4: stloc.s 6
+		IL_01a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ab: stloc.s 22
+		IL_01ad: ldloc.0
+		IL_01ae: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope::setterCalls
+		IL_01b3: stloc.s 17
+		IL_01b5: ldloc.0
+		IL_01b6: ldfld object Modules.Function_ConstructorShape_PrototypeSetSemantics/Scope::setterValue
+		IL_01bb: stloc.s 23
+		IL_01bd: ldloc.s 6
+		IL_01bf: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor
+		IL_01c4: dup
+		IL_01c5: brfalse IL_01d6
+
+		IL_01ca: callvirt instance object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L6C1_SetterConstructor::get_value()
+		IL_01cf: stloc.s 24
+		IL_01d1: br IL_01e5
+
+		IL_01d6: pop
+		IL_01d7: ldloc.s 6
+		IL_01d9: ldstr "value"
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e3: stloc.s 24
+
+		IL_01e5: ldstr "Object"
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ef: volatile.
+		IL_01f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01f6: brfalse IL_020a
+
+		IL_01fb: ldstr "prototype"
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0205: br IL_021e
+
+		IL_020a: ldstr "prototype"
+		IL_020f: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:51"
+		IL_0214: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_021e: stloc.s 25
+		IL_0220: volatile.
+		IL_0222: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0227: brfalse IL_023d
+
+		IL_022c: ldloc.s 25
+		IL_022e: ldstr "hasOwnProperty"
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0238: br IL_0253
+
+		IL_023d: ldloc.s 25
+		IL_023f: ldstr "hasOwnProperty"
+		IL_0244: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:53"
+		IL_0249: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0253: stloc.s 25
+		IL_0255: ldloc.s 25
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025c: ldstr "call"
+		IL_0261: ldloc.s 6
+		IL_0263: ldstr "value"
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_026d: stloc.s 25
+		IL_026f: ldloc.s 22
+		IL_0271: ldc.i4.4
+		IL_0272: newarr [System.Runtime]System.Object
+		IL_0277: dup
+		IL_0278: ldc.i4.0
+		IL_0279: ldloc.s 17
+		IL_027b: stelem.ref
+		IL_027c: dup
+		IL_027d: ldc.i4.1
+		IL_027e: ldloc.s 23
+		IL_0280: stelem.ref
+		IL_0281: dup
+		IL_0282: ldc.i4.2
+		IL_0283: ldloc.s 24
+		IL_0285: stelem.ref
+		IL_0286: dup
+		IL_0287: ldc.i4.3
+		IL_0288: ldloc.s 25
+		IL_028a: stelem.ref
+		IL_028b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0290: pop
+		IL_0291: nop
+		IL_0292: volatile.
+		IL_0294: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0299: brfalse IL_02ae
+
+		IL_029e: ldloc.2
+		IL_029f: ldstr "prototype"
+		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a9: br IL_02c3
+
+		IL_02ae: ldloc.2
+		IL_02af: ldstr "prototype"
+		IL_02b4: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:61"
+		IL_02b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02c3: stloc.s 25
+		IL_02c5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02ca: dup
+		IL_02cb: ldstr "configurable"
+		IL_02d0: ldc.i4.1
+		IL_02d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_02d6: dup
+		IL_02d7: ldstr "enumerable"
+		IL_02dc: ldc.i4.1
+		IL_02dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_02e2: dup
+		IL_02e3: ldstr "writable"
+		IL_02e8: ldc.i4.0
+		IL_02e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_02ee: dup
+		IL_02ef: ldstr "value"
+		IL_02f4: ldstr "prototype-read-only"
+		IL_02f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02fe: stloc.s 20
+		IL_0300: ldloc.s 25
+		IL_0302: ldstr "value"
+		IL_0307: ldloc.s 20
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_030e: pop
+		.try
+		{
+			IL_030f: nop
+			IL_0310: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L26C1_ReadOnlyConstructor::.ctor()
+			IL_0315: stloc.s 26
+			IL_0317: ldloc.2
+			IL_0318: ldloc.s 26
+			IL_031a: ldloc.2
+			IL_031b: ldstr "own"
+			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+			IL_0325: pop
+			IL_0326: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_032b: stloc.s 22
+			IL_032d: ldloc.s 22
+			IL_032f: ldstr "missing strict error"
+			IL_0334: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0339: pop
+			IL_033a: leave IL_03bc
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_033f: stloc.s 7
+			IL_0341: ldloc.s 7
+			IL_0343: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0348: dup
+			IL_0349: brtrue IL_035f
+
+			IL_034e: pop
+			IL_034f: ldloc.s 7
+			IL_0351: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0356: dup
+			IL_0357: brtrue IL_036b
+
+			IL_035c: pop
+			IL_035d: rethrow
+
+			IL_035f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0364: stloc.s 8
+			IL_0366: br IL_036d
+
+			IL_036b: stloc.s 8
+
+			IL_036d: ldloc.s 8
+			IL_036f: stloc.s 9
+			IL_0371: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0376: stloc.s 22
+			IL_0378: volatile.
+			IL_037a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_037f: brfalse IL_0395
+
+			IL_0384: ldloc.s 9
+			IL_0386: ldstr "name"
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0390: br IL_03ab
+
+			IL_0395: ldloc.s 9
+			IL_0397: ldstr "name"
+			IL_039c: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:90"
+			IL_03a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_03ab: stloc.s 25
+			IL_03ad: ldloc.s 22
+			IL_03af: ldloc.s 25
+			IL_03b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03b6: pop
+			IL_03b7: leave IL_03bc
+		} // end handler
+
+		IL_03bc: nop
+		IL_03bd: volatile.
+		IL_03bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_03c4: brfalse IL_03d9
+
+		IL_03c9: ldloc.3
+		IL_03ca: ldstr "prototype"
+		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03d4: br IL_03ee
+
+		IL_03d9: ldloc.3
+		IL_03da: ldstr "prototype"
+		IL_03df: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:99"
+		IL_03e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_03ee: stloc.s 25
+		IL_03f0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03f5: dup
+		IL_03f6: ldstr "configurable"
+		IL_03fb: ldc.i4.1
+		IL_03fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0401: dup
+		IL_0402: ldstr "enumerable"
+		IL_0407: ldc.i4.1
+		IL_0408: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_040d: dup
+		IL_040e: ldstr "writable"
+		IL_0413: ldc.i4.1
+		IL_0414: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0419: dup
+		IL_041a: ldstr "value"
+		IL_041f: ldstr "prototype-writable"
+		IL_0424: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0429: stloc.s 20
+		IL_042b: ldloc.s 25
+		IL_042d: ldstr "value"
+		IL_0432: ldloc.s 20
+		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0439: pop
+		IL_043a: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor::.ctor()
+		IL_043f: stloc.s 27
+		IL_0441: ldloc.3
+		IL_0442: ldloc.s 27
+		IL_0444: ldloc.3
+		IL_0445: ldstr "own"
+		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_044f: stloc.s 10
+		IL_0451: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0456: stloc.s 22
+		IL_0458: ldloc.s 10
+		IL_045a: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor
+		IL_045f: dup
+		IL_0460: brfalse IL_0471
+
+		IL_0465: callvirt instance object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L44C1_WritableConstructor::get_value()
+		IL_046a: stloc.s 25
+		IL_046c: br IL_0480
+
+		IL_0471: pop
+		IL_0472: ldloc.s 10
+		IL_0474: ldstr "value"
+		IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_047e: stloc.s 25
+
+		IL_0480: volatile.
+		IL_0482: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0487: brfalse IL_049c
+
+		IL_048c: ldloc.3
+		IL_048d: ldstr "prototype"
+		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0497: br IL_04b1
+
+		IL_049c: ldloc.3
+		IL_049d: ldstr "prototype"
+		IL_04a2: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:116"
+		IL_04a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04b1: stloc.s 24
+		IL_04b3: volatile.
+		IL_04b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_04ba: brfalse IL_04d0
+
+		IL_04bf: ldloc.s 24
+		IL_04c1: ldstr "value"
+		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04cb: br IL_04e6
+
+		IL_04d0: ldloc.s 24
+		IL_04d2: ldstr "value"
+		IL_04d7: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:118"
+		IL_04dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04e6: stloc.s 24
+		IL_04e8: ldstr "Object"
+		IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04f2: volatile.
+		IL_04f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_04f9: brfalse IL_050d
+
+		IL_04fe: ldstr "prototype"
+		IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0508: br IL_0521
+
+		IL_050d: ldstr "prototype"
+		IL_0512: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:122"
+		IL_0517: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0521: stloc.s 23
+		IL_0523: volatile.
+		IL_0525: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_052a: brfalse IL_0540
+
+		IL_052f: ldloc.s 23
+		IL_0531: ldstr "hasOwnProperty"
+		IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_053b: br IL_0556
+
+		IL_0540: ldloc.s 23
+		IL_0542: ldstr "hasOwnProperty"
+		IL_0547: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:124"
+		IL_054c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0556: stloc.s 23
+		IL_0558: ldloc.s 23
+		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_055f: ldstr "call"
+		IL_0564: ldloc.s 10
+		IL_0566: ldstr "value"
+		IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0570: stloc.s 23
+		IL_0572: ldloc.s 22
+		IL_0574: ldloc.s 25
+		IL_0576: ldloc.s 24
+		IL_0578: ldloc.s 23
+		IL_057a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_057f: pop
+		IL_0580: nop
+		IL_0581: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L61C1_ReadingConstructor::.ctor()
+		IL_0586: stloc.s 28
+		IL_0588: ldloc.s 4
+		IL_058a: ldloc.s 28
+		IL_058c: ldloc.s 4
+		IL_058e: ldstr "generated receiver"
+		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0598: pop
+		IL_0599: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_059e: dup
+		IL_059f: ldstr "value"
+		IL_05a4: ldstr "custom receiver"
+		IL_05a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_05ae: stloc.s 20
+		IL_05b0: ldloc.s 4
+		IL_05b2: ldstr "call"
+		IL_05b7: ldloc.s 20
+		IL_05b9: ldstr "updated custom receiver"
+		IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05c3: pop
+		IL_05c4: nop
+		.try
+		{
+			IL_05c5: nop
+			IL_05c6: ldloc.s 11
+			IL_05c8: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor
+			IL_05cd: dup
+			IL_05ce: brfalse IL_05de
+
+			IL_05d3: callvirt instance object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor::get_value()
+			IL_05d8: pop
+			IL_05d9: br IL_05ec
+
+			IL_05de: pop
+			IL_05df: ldloc.s 11
+			IL_05e1: ldstr "value"
+			IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05eb: pop
+
+			IL_05ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05f1: stloc.s 22
+			IL_05f3: ldloc.s 22
+			IL_05f5: ldstr "missing pre-initialization error"
+			IL_05fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05ff: pop
+			IL_0600: leave IL_0682
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_0605: stloc.s 12
+			IL_0607: ldloc.s 12
+			IL_0609: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_060e: dup
+			IL_060f: brtrue IL_0625
+
+			IL_0614: pop
+			IL_0615: ldloc.s 12
+			IL_0617: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_061c: dup
+			IL_061d: brtrue IL_0631
+
+			IL_0622: pop
+			IL_0623: rethrow
+
+			IL_0625: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_062a: stloc.s 13
+			IL_062c: br IL_0633
+
+			IL_0631: stloc.s 13
+
+			IL_0633: ldloc.s 13
+			IL_0635: stloc.s 14
+			IL_0637: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_063c: stloc.s 22
+			IL_063e: volatile.
+			IL_0640: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0645: brfalse IL_065b
+
+			IL_064a: ldloc.s 14
+			IL_064c: ldstr "name"
+			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0656: br IL_0671
+
+			IL_065b: ldloc.s 14
+			IL_065d: ldstr "name"
+			IL_0662: ldstr "Function_ConstructorShape_PrototypeSetSemantics:Modules.Function_ConstructorShape_PrototypeSetSemantics:__js_module_init__:159"
+			IL_0667: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0671: stloc.s 23
+			IL_0673: ldloc.s 22
+			IL_0675: ldloc.s 23
+			IL_0677: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_067c: pop
+			IL_067d: leave IL_0682
+		} // end handler
+
+		IL_0682: newobj instance void Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor::.ctor()
+		IL_0687: stloc.s 29
+		IL_0689: ldloc.s 5
+		IL_068b: ldloc.s 29
+		IL_068d: ldloc.s 5
+		IL_068f: ldstr "initialized"
+		IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0699: stloc.s 29
+		IL_069b: ldloc.s 29
+		IL_069d: stloc.s 11
+		IL_069f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06a4: stloc.s 22
+		IL_06a6: ldloc.s 11
+		IL_06a8: isinst Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor
+		IL_06ad: dup
+		IL_06ae: brfalse IL_06bf
+
+		IL_06b3: callvirt instance object Modules.Function_ConstructorShape_PrototypeSetSemantics/ObjectLiterals/Ctor_L69C1_PreInitConstructor::get_value()
+		IL_06b8: stloc.s 23
+		IL_06ba: br IL_06ce
+
+		IL_06bf: pop
+		IL_06c0: ldloc.s 11
+		IL_06c2: ldstr "value"
+		IL_06c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06cc: stloc.s 23
+
+		IL_06ce: ldloc.s 22
+		IL_06d0: ldloc.s 23
+		IL_06d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06d7: pop
+		IL_06d8: ldnull
+		IL_06d9: stloc.s 15
+		IL_06db: ret
+	} // end of method Function_ConstructorShape_PrototypeSetSemantics::__js_module_init__
+
+} // end of class Modules.Function_ConstructorShape_PrototypeSetSemantics
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main (
+			string[] args
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: ldarg.0
+		IL_0001: call void Function_ConstructorShape_PrototypeSetSemantics::Run(string[])
+		IL_0006: ret
+	} // end of method Program::Main
+
+} // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_15
+	.field assembly static int32 __jroc_dynamicLookup_16
+	.field assembly static int32 __jroc_dynamicLookup_17
+	.field assembly static int32 __jroc_dynamicLookup_18
+	.field assembly static int32 __jroc_dynamicLookup_19
+	.field assembly static int32 __jroc_dynamicLookup_20
+	.field assembly static int32 __jroc_dynamicLookup_21
+	.field assembly static int32 __jroc_dynamicLookup_22
+	.field assembly static int32 __jroc_dynamicLookup_23
+	.field assembly static int32 __jroc_dynamicLookup_24
+	.field assembly static int32 __jroc_dynamicLookup_25
+
+} // end of class Jroc.Generated.DynamicLookupSites
+

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
@@ -221,7 +221,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 174 (0xae)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -230,23 +230,67 @@
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "value"
-			IL_0010: ldarg.2
-			IL_0011: ldc.i4.1
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0017: pop
-			IL_0018: ldarg.0
-			IL_0019: stloc.0
-			IL_001a: ldarg.1
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0025: ldstr "seenNewTarget"
-			IL_002a: ldloc.0
-			IL_002b: ldc.i4.1
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0031: pop
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_000b: isinst Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::set_value(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "value"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldarg.0
+			IL_0056: stloc.0
+			IL_0057: ldarg.1
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0062: isinst Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver
+			IL_0067: dup
+			IL_0068: brfalse IL_0093
+
+			IL_006d: dup
+			IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0073: brfalse IL_0093
+
+			IL_0078: dup
+			IL_0079: ldstr "seenNewTarget"
+			IL_007e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0083: brfalse IL_0093
+
+			IL_0088: ldloc.0
+			IL_0089: callvirt instance void Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::set_seenNewTarget(object)
+			IL_008e: br IL_00ac
+
+			IL_0093: pop
+			IL_0094: ldarg.1
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_009f: ldstr "seenNewTarget"
+			IL_00a4: ldloc.0
+			IL_00a5: ldc.i4.1
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_00ab: pop
+
+			IL_00ac: ldnull
+			IL_00ad: ret
 		} // end of method Receiver::__js_call__
 
 	} // end of class Receiver
@@ -871,7 +915,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 174 (0xae)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -880,23 +924,67 @@
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "value"
-			IL_0010: ldarg.2
-			IL_0011: ldc.i4.1
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0017: pop
-			IL_0018: ldarg.0
-			IL_0019: stloc.0
-			IL_001a: ldarg.1
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0025: ldstr "seenNewTarget"
-			IL_002a: ldloc.0
-			IL_002b: ldc.i4.1
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0031: pop
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_000b: isinst Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget::set_value(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "value"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldarg.0
+			IL_0056: stloc.0
+			IL_0057: ldarg.1
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0062: isinst Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget
+			IL_0067: dup
+			IL_0068: brfalse IL_0093
+
+			IL_006d: dup
+			IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0073: brfalse IL_0093
+
+			IL_0078: dup
+			IL_0079: ldstr "seenNewTarget"
+			IL_007e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0083: brfalse IL_0093
+
+			IL_0088: ldloc.0
+			IL_0089: callvirt instance void Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget::set_seenNewTarget(object)
+			IL_008e: br IL_00ac
+
+			IL_0093: pop
+			IL_0094: ldarg.1
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_009f: ldstr "seenNewTarget"
+			IL_00a4: ldloc.0
+			IL_00a5: ldc.i4.1
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_00ab: pop
+
+			IL_00ac: ldnull
+			IL_00ad: ret
 		} // end of method BoundTarget::__js_call__
 
 	} // end of class BoundTarget
@@ -1508,6 +1596,229 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L3C1_Receiver
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+			.field private object _seenNewTarget
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L3C1_Receiver::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L3C1_Receiver::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L3C1_Receiver::set_value
+
+			.method public hidebysig 
+				instance object get_seenNewTarget () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "seenNewTarget"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::_seenNewTarget
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::_seenNewTarget
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "seenNewTarget"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L3C1_Receiver::get_seenNewTarget
+
+			.method public hidebysig 
+				instance void set_seenNewTarget (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::_seenNewTarget
+				IL_0007: ldarg.0
+				IL_0008: ldstr "seenNewTarget"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L3C1_Receiver::set_seenNewTarget
+
+		} // end of class Ctor_L3C1_Receiver
+
+		.class nested public auto ansi beforefieldinit Ctor_L81C1_BoundTarget
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+			.field private object _seenNewTarget
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L81C1_BoundTarget::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L81C1_BoundTarget::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L81C1_BoundTarget::set_value
+
+			.method public hidebysig 
+				instance object get_seenNewTarget () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "seenNewTarget"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget::_seenNewTarget
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget::_seenNewTarget
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "seenNewTarget"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L81C1_BoundTarget::get_seenNewTarget
+
+			.method public hidebysig 
+				instance void set_seenNewTarget (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L81C1_BoundTarget::_seenNewTarget
+				IL_0007: ldarg.0
+				IL_0008: ldstr "seenNewTarget"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L81C1_BoundTarget::set_seenNewTarget
+
+		} // end of class Ctor_L81C1_BoundTarget
+
+
+	} // end of class ObjectLiterals
+
 
 	// Methods
 	.method public hidebysig static 
@@ -1520,7 +1831,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3189 (0xc75)
+		// Code size: 3060 (0xbf4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GeneratedConstruction_Semantics/Scope,
@@ -1531,10 +1842,10 @@
 			[5] class Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject,
 			[6] object,
 			[7] object,
-			[8] object,
+			[8] class Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[10] object,
-			[11] object,
+			[10] class Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver,
+			[11] class Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver,
 			[12] object,
 			[13] object,
 			[14] object,
@@ -1558,16 +1869,17 @@
 			[32] object,
 			[33] bool,
 			[34] object,
-			[35] object,
+			[35] class Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver,
 			[36] object,
-			[37] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[38] object,
-			[39] class [System.Runtime]System.Type,
-			[40] class Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject,
-			[41] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject,
-			[42] class Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject,
-			[43] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject,
-			[44] class [JavaScriptRuntime]JavaScriptRuntime.Array
+			[37] object,
+			[38] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[39] object,
+			[40] class [System.Runtime]System.Type,
+			[41] class Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject,
+			[42] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject,
+			[43] class Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject,
+			[44] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject,
+			[45] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1659,7 +1971,7 @@
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
 		IL_00c3: stloc.s 6
 		IL_00c5: volatile.
-		IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_00c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 		IL_00cc: brfalse IL_00e1
 
 		IL_00d1: ldloc.1
@@ -1670,7 +1982,7 @@
 		IL_00e1: ldloc.1
 		IL_00e2: ldstr "prototype"
 		IL_00e7: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:25"
-		IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_00ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_00f6: stloc.s 29
@@ -1681,7 +1993,7 @@
 		IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_010b: stloc.s 30
 		IL_010d: volatile.
-		IL_010f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_010f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 		IL_0114: brfalse IL_012a
 
 		IL_0119: ldloc.s 6
@@ -1692,12 +2004,12 @@
 		IL_012a: ldloc.s 6
 		IL_012c: ldstr "writable"
 		IL_0131: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:33"
-		IL_0136: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0136: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0140: stloc.s 29
 		IL_0142: volatile.
-		IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0144: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 		IL_0149: brfalse IL_015f
 
 		IL_014e: ldloc.s 6
@@ -1708,12 +2020,12 @@
 		IL_015f: ldloc.s 6
 		IL_0161: ldstr "enumerable"
 		IL_0166: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:35"
-		IL_016b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_016b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0175: stloc.s 31
 		IL_0177: volatile.
-		IL_0179: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0179: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 		IL_017e: brfalse IL_0194
 
 		IL_0183: ldloc.s 6
@@ -1724,7 +2036,7 @@
 		IL_0194: ldloc.s 6
 		IL_0196: ldstr "configurable"
 		IL_019b: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:37"
-		IL_01a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_01a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_01aa: stloc.s 32
@@ -1752,7 +2064,7 @@
 		IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_01d6: stloc.s 30
 		IL_01d8: volatile.
-		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 		IL_01df: brfalse IL_01f5
 
 		IL_01e4: ldloc.s 7
@@ -1763,7 +2075,7 @@
 		IL_01f5: ldloc.s 7
 		IL_01f7: ldstr "value"
 		IL_01fc: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:43"
-		IL_0201: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0201: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_020b: stloc.s 32
@@ -1775,7 +2087,7 @@
 		IL_0219: box [System.Runtime]System.Boolean
 		IL_021e: stloc.s 34
 		IL_0220: volatile.
-		IL_0222: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0222: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 		IL_0227: brfalse IL_023d
 
 		IL_022c: ldloc.s 7
@@ -1786,12 +2098,12 @@
 		IL_023d: ldloc.s 7
 		IL_023f: ldstr "writable"
 		IL_0244: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:47"
-		IL_0249: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0249: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0253: stloc.s 32
 		IL_0255: volatile.
-		IL_0257: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0257: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 		IL_025c: brfalse IL_0272
 
 		IL_0261: ldloc.s 7
@@ -1802,12 +2114,12 @@
 		IL_0272: ldloc.s 7
 		IL_0274: ldstr "enumerable"
 		IL_0279: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:49"
-		IL_027e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_027e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0288: stloc.s 31
 		IL_028a: volatile.
-		IL_028c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_028c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 		IL_0291: brfalse IL_02a7
 
 		IL_0296: ldloc.s 7
@@ -1818,7 +2130,7 @@
 		IL_02a7: ldloc.s 7
 		IL_02a9: ldstr "configurable"
 		IL_02ae: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:51"
-		IL_02b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_02b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 		IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_02bd: stloc.s 29
@@ -1847,878 +2159,839 @@
 		IL_02e2: stelem.ref
 		IL_02e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_02e8: pop
-		IL_02e9: ldloc.1
-		IL_02ea: dup
-		IL_02eb: ldc.r8 3
-		IL_02f4: box [System.Runtime]System.Double
-		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_02fe: stloc.s 8
-		IL_0300: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0305: stloc.s 30
-		IL_0307: volatile.
-		IL_0309: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_030e: brfalse IL_0324
+		IL_02e9: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::.ctor()
+		IL_02ee: stloc.s 35
+		IL_02f0: ldloc.1
+		IL_02f1: ldloc.s 35
+		IL_02f3: ldloc.1
+		IL_02f4: ldc.r8 3
+		IL_02fd: box [System.Runtime]System.Double
+		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0307: stloc.s 8
+		IL_0309: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_030e: stloc.s 30
+		IL_0310: ldloc.s 8
+		IL_0312: castclass Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver
+		IL_0317: callvirt instance object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::get_value()
+		IL_031c: stloc.s 29
+		IL_031e: ldloc.s 8
+		IL_0320: castclass Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver
+		IL_0325: callvirt instance object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::get_seenNewTarget()
+		IL_032a: stloc.s 31
+		IL_032c: ldloc.s 31
+		IL_032e: ldloc.1
+		IL_032f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0334: stloc.s 33
+		IL_0336: ldloc.s 33
+		IL_0338: box [System.Runtime]System.Boolean
+		IL_033d: stloc.s 34
+		IL_033f: ldloc.s 8
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0346: stloc.s 31
+		IL_0348: volatile.
+		IL_034a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_034f: brfalse IL_0364
 
-		IL_0313: ldloc.s 8
-		IL_0315: ldstr "value"
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_031f: br IL_033a
+		IL_0354: ldloc.1
+		IL_0355: ldstr "prototype"
+		IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_035f: br IL_0379
 
-		IL_0324: ldloc.s 8
-		IL_0326: ldstr "value"
-		IL_032b: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:62"
-		IL_0330: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0364: ldloc.1
+		IL_0365: ldstr "prototype"
+		IL_036a: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:68"
+		IL_036f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_033a: stloc.s 29
-		IL_033c: volatile.
-		IL_033e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0343: brfalse IL_0359
+		IL_0379: stloc.s 32
+		IL_037b: ldloc.s 31
+		IL_037d: ldloc.s 32
+		IL_037f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0384: stloc.s 33
+		IL_0386: ldloc.s 33
+		IL_0388: box [System.Runtime]System.Boolean
+		IL_038d: stloc.s 36
+		IL_038f: ldloc.s 8
+		IL_0391: ldloc.1
+		IL_0392: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0397: stloc.s 33
+		IL_0399: ldloc.s 33
+		IL_039b: box [System.Runtime]System.Boolean
+		IL_03a0: stloc.s 37
+		IL_03a2: ldloc.s 30
+		IL_03a4: ldc.i4.5
+		IL_03a5: newarr [System.Runtime]System.Object
+		IL_03aa: dup
+		IL_03ab: ldc.i4.0
+		IL_03ac: ldstr "direct"
+		IL_03b1: stelem.ref
+		IL_03b2: dup
+		IL_03b3: ldc.i4.1
+		IL_03b4: ldloc.s 29
+		IL_03b6: stelem.ref
+		IL_03b7: dup
+		IL_03b8: ldc.i4.2
+		IL_03b9: ldloc.s 34
+		IL_03bb: stelem.ref
+		IL_03bc: dup
+		IL_03bd: ldc.i4.3
+		IL_03be: ldloc.s 36
+		IL_03c0: stelem.ref
+		IL_03c1: dup
+		IL_03c2: ldc.i4.4
+		IL_03c3: ldloc.s 37
+		IL_03c5: stelem.ref
+		IL_03c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_03cb: pop
+		IL_03cc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03d1: dup
+		IL_03d2: ldstr "kind"
+		IL_03d7: ldstr "replacement"
+		IL_03dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_03e1: stloc.s 9
+		IL_03e3: ldloc.1
+		IL_03e4: ldstr "prototype"
+		IL_03e9: ldloc.s 9
+		IL_03eb: ldc.i4.1
+		IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_03f1: pop
+		IL_03f2: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::.ctor()
+		IL_03f7: stloc.s 35
+		IL_03f9: ldloc.1
+		IL_03fa: ldloc.s 35
+		IL_03fc: ldloc.1
+		IL_03fd: ldc.r8 5
+		IL_0406: box [System.Runtime]System.Double
+		IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0410: stloc.s 10
+		IL_0412: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0417: stloc.s 30
+		IL_0419: ldloc.s 10
+		IL_041b: castclass Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver
+		IL_0420: callvirt instance object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::get_value()
+		IL_0425: stloc.s 29
+		IL_0427: volatile.
+		IL_0429: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_042e: brfalse IL_0444
 
-		IL_0348: ldloc.s 8
-		IL_034a: ldstr "seenNewTarget"
-		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0354: br IL_036f
+		IL_0433: ldloc.s 10
+		IL_0435: ldstr "kind"
+		IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_043f: br IL_045a
 
-		IL_0359: ldloc.s 8
-		IL_035b: ldstr "seenNewTarget"
-		IL_0360: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:64"
-		IL_0365: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0444: ldloc.s 10
+		IL_0446: ldstr "kind"
+		IL_044b: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:92"
+		IL_0450: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_036f: stloc.s 31
-		IL_0371: ldloc.s 31
-		IL_0373: ldloc.1
-		IL_0374: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0379: stloc.s 33
-		IL_037b: ldloc.s 33
-		IL_037d: box [System.Runtime]System.Boolean
-		IL_0382: stloc.s 34
-		IL_0384: ldloc.s 8
-		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_038b: stloc.s 31
-		IL_038d: volatile.
-		IL_038f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0394: brfalse IL_03a9
+		IL_045a: stloc.s 32
+		IL_045c: ldloc.s 10
+		IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0463: stloc.s 31
+		IL_0465: ldloc.s 31
+		IL_0467: ldloc.s 9
+		IL_0469: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_046e: stloc.s 33
+		IL_0470: ldloc.s 33
+		IL_0472: box [System.Runtime]System.Boolean
+		IL_0477: stloc.s 37
+		IL_0479: ldloc.s 10
+		IL_047b: ldloc.1
+		IL_047c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0481: stloc.s 33
+		IL_0483: ldloc.s 33
+		IL_0485: box [System.Runtime]System.Boolean
+		IL_048a: stloc.s 36
+		IL_048c: ldloc.s 30
+		IL_048e: ldc.i4.5
+		IL_048f: newarr [System.Runtime]System.Object
+		IL_0494: dup
+		IL_0495: ldc.i4.0
+		IL_0496: ldstr "replacement"
+		IL_049b: stelem.ref
+		IL_049c: dup
+		IL_049d: ldc.i4.1
+		IL_049e: ldloc.s 29
+		IL_04a0: stelem.ref
+		IL_04a1: dup
+		IL_04a2: ldc.i4.2
+		IL_04a3: ldloc.s 32
+		IL_04a5: stelem.ref
+		IL_04a6: dup
+		IL_04a7: ldc.i4.3
+		IL_04a8: ldloc.s 37
+		IL_04aa: stelem.ref
+		IL_04ab: dup
+		IL_04ac: ldc.i4.4
+		IL_04ad: ldloc.s 36
+		IL_04af: stelem.ref
+		IL_04b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_04b5: pop
+		IL_04b6: ldloc.1
+		IL_04b7: ldstr "prototype"
+		IL_04bc: ldc.r8 7
+		IL_04c5: ldc.i4.1
+		IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_04cb: pop
+		IL_04cc: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::.ctor()
+		IL_04d1: stloc.s 35
+		IL_04d3: ldloc.1
+		IL_04d4: ldloc.s 35
+		IL_04d6: ldloc.1
+		IL_04d7: ldc.r8 6
+		IL_04e0: box [System.Runtime]System.Double
+		IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_04ea: stloc.s 11
+		IL_04ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04f1: stloc.s 30
+		IL_04f3: ldloc.s 11
+		IL_04f5: castclass Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver
+		IL_04fa: callvirt instance object Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver::get_value()
+		IL_04ff: stloc.s 32
+		IL_0501: ldloc.s 11
+		IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0508: stloc.s 29
+		IL_050a: ldstr "Object"
+		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0514: volatile.
+		IL_0516: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_051b: brfalse IL_052f
 
-		IL_0399: ldloc.1
-		IL_039a: ldstr "prototype"
-		IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03a4: br IL_03be
+		IL_0520: ldstr "prototype"
+		IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_052a: br IL_0543
 
-		IL_03a9: ldloc.1
-		IL_03aa: ldstr "prototype"
-		IL_03af: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:69"
-		IL_03b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_052f: ldstr "prototype"
+		IL_0534: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:117"
+		IL_0539: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03be: stloc.s 32
-		IL_03c0: ldloc.s 31
-		IL_03c2: ldloc.s 32
-		IL_03c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03c9: stloc.s 33
-		IL_03cb: ldloc.s 33
-		IL_03cd: box [System.Runtime]System.Boolean
-		IL_03d2: stloc.s 35
-		IL_03d4: ldloc.s 8
-		IL_03d6: ldloc.1
-		IL_03d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_03dc: stloc.s 33
-		IL_03de: ldloc.s 33
-		IL_03e0: box [System.Runtime]System.Boolean
-		IL_03e5: stloc.s 36
-		IL_03e7: ldloc.s 30
-		IL_03e9: ldc.i4.5
-		IL_03ea: newarr [System.Runtime]System.Object
-		IL_03ef: dup
-		IL_03f0: ldc.i4.0
-		IL_03f1: ldstr "direct"
-		IL_03f6: stelem.ref
-		IL_03f7: dup
-		IL_03f8: ldc.i4.1
-		IL_03f9: ldloc.s 29
-		IL_03fb: stelem.ref
-		IL_03fc: dup
-		IL_03fd: ldc.i4.2
-		IL_03fe: ldloc.s 34
-		IL_0400: stelem.ref
-		IL_0401: dup
-		IL_0402: ldc.i4.3
-		IL_0403: ldloc.s 35
-		IL_0405: stelem.ref
-		IL_0406: dup
-		IL_0407: ldc.i4.4
-		IL_0408: ldloc.s 36
-		IL_040a: stelem.ref
-		IL_040b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0410: pop
-		IL_0411: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0416: dup
-		IL_0417: ldstr "kind"
-		IL_041c: ldstr "replacement"
-		IL_0421: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0426: stloc.s 9
-		IL_0428: ldloc.1
-		IL_0429: ldstr "prototype"
-		IL_042e: ldloc.s 9
-		IL_0430: ldc.i4.1
-		IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0436: pop
-		IL_0437: ldloc.1
-		IL_0438: dup
-		IL_0439: ldc.r8 5
-		IL_0442: box [System.Runtime]System.Double
-		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_044c: stloc.s 10
-		IL_044e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0453: stloc.s 30
-		IL_0455: volatile.
-		IL_0457: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_045c: brfalse IL_0472
+		IL_0543: stloc.s 31
+		IL_0545: ldloc.s 29
+		IL_0547: ldloc.s 31
+		IL_0549: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_054e: stloc.s 33
+		IL_0550: ldloc.s 33
+		IL_0552: box [System.Runtime]System.Boolean
+		IL_0557: stloc.s 36
+		IL_0559: ldloc.s 30
+		IL_055b: ldstr "fallback"
+		IL_0560: ldloc.s 32
+		IL_0562: ldloc.s 36
+		IL_0564: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0569: pop
+		IL_056a: nop
+		IL_056b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0570: dup
+		IL_0571: ldstr "alternate"
+		IL_0576: ldc.i4.1
+		IL_0577: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_057c: stloc.s 38
+		IL_057e: ldloc.2
+		IL_057f: ldstr "prototype"
+		IL_0584: ldloc.s 38
+		IL_0586: ldc.i4.1
+		IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_058c: pop
+		IL_058d: ldloc.1
+		IL_058e: ldc.i4.1
+		IL_058f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0594: dup
+		IL_0595: ldc.r8 9
+		IL_059e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_05a3: ldloc.2
+		IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.Reflect::construct(object, object, object)
+		IL_05a9: stloc.s 12
+		IL_05ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05b0: stloc.s 30
+		IL_05b2: volatile.
+		IL_05b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_05b9: brfalse IL_05cf
 
-		IL_0461: ldloc.s 10
-		IL_0463: ldstr "value"
-		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_046d: br IL_0488
+		IL_05be: ldloc.s 12
+		IL_05c0: ldstr "value"
+		IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ca: br IL_05e5
 
-		IL_0472: ldloc.s 10
-		IL_0474: ldstr "value"
-		IL_0479: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:91"
-		IL_047e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_05cf: ldloc.s 12
+		IL_05d1: ldstr "value"
+		IL_05d6: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:136"
+		IL_05db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0488: stloc.s 29
-		IL_048a: volatile.
-		IL_048c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0491: brfalse IL_04a7
+		IL_05e5: stloc.s 32
+		IL_05e7: volatile.
+		IL_05e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_05ee: brfalse IL_0604
 
-		IL_0496: ldloc.s 10
-		IL_0498: ldstr "kind"
-		IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04a2: br IL_04bd
+		IL_05f3: ldloc.s 12
+		IL_05f5: ldstr "seenNewTarget"
+		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ff: br IL_061a
 
-		IL_04a7: ldloc.s 10
-		IL_04a9: ldstr "kind"
-		IL_04ae: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:93"
-		IL_04b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0604: ldloc.s 12
+		IL_0606: ldstr "seenNewTarget"
+		IL_060b: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:138"
+		IL_0610: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04bd: stloc.s 32
-		IL_04bf: ldloc.s 10
-		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_04c6: stloc.s 31
-		IL_04c8: ldloc.s 31
-		IL_04ca: ldloc.s 9
-		IL_04cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04d1: stloc.s 33
-		IL_04d3: ldloc.s 33
-		IL_04d5: box [System.Runtime]System.Boolean
-		IL_04da: stloc.s 36
-		IL_04dc: ldloc.s 10
-		IL_04de: ldloc.1
-		IL_04df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_04e4: stloc.s 33
-		IL_04e6: ldloc.s 33
-		IL_04e8: box [System.Runtime]System.Boolean
-		IL_04ed: stloc.s 35
-		IL_04ef: ldloc.s 30
-		IL_04f1: ldc.i4.5
-		IL_04f2: newarr [System.Runtime]System.Object
-		IL_04f7: dup
-		IL_04f8: ldc.i4.0
-		IL_04f9: ldstr "replacement"
-		IL_04fe: stelem.ref
-		IL_04ff: dup
-		IL_0500: ldc.i4.1
-		IL_0501: ldloc.s 29
-		IL_0503: stelem.ref
-		IL_0504: dup
-		IL_0505: ldc.i4.2
-		IL_0506: ldloc.s 32
-		IL_0508: stelem.ref
-		IL_0509: dup
-		IL_050a: ldc.i4.3
-		IL_050b: ldloc.s 36
-		IL_050d: stelem.ref
-		IL_050e: dup
-		IL_050f: ldc.i4.4
-		IL_0510: ldloc.s 35
-		IL_0512: stelem.ref
-		IL_0513: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0518: pop
-		IL_0519: ldloc.1
-		IL_051a: ldstr "prototype"
-		IL_051f: ldc.r8 7
-		IL_0528: ldc.i4.1
-		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_052e: pop
-		IL_052f: ldloc.1
-		IL_0530: dup
-		IL_0531: ldc.r8 6
-		IL_053a: box [System.Runtime]System.Double
-		IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0544: stloc.s 11
-		IL_0546: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_054b: stloc.s 30
-		IL_054d: volatile.
-		IL_054f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0554: brfalse IL_056a
+		IL_061a: stloc.s 31
+		IL_061c: ldloc.s 31
+		IL_061e: ldloc.2
+		IL_061f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0624: stloc.s 33
+		IL_0626: ldloc.s 33
+		IL_0628: box [System.Runtime]System.Boolean
+		IL_062d: stloc.s 36
+		IL_062f: volatile.
+		IL_0631: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0636: brfalse IL_064c
 
-		IL_0559: ldloc.s 11
-		IL_055b: ldstr "value"
-		IL_0560: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0565: br IL_0580
+		IL_063b: ldloc.s 12
+		IL_063d: ldstr "alternate"
+		IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0647: br IL_0662
 
-		IL_056a: ldloc.s 11
-		IL_056c: ldstr "value"
-		IL_0571: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:113"
-		IL_0576: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_064c: ldloc.s 12
+		IL_064e: ldstr "alternate"
+		IL_0653: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:142"
+		IL_0658: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0580: stloc.s 32
-		IL_0582: ldloc.s 11
-		IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0589: stloc.s 29
-		IL_058b: ldstr "Object"
-		IL_0590: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0595: volatile.
-		IL_0597: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_059c: brfalse IL_05b0
+		IL_0662: stloc.s 31
+		IL_0664: ldloc.s 12
+		IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_066b: stloc.s 29
+		IL_066d: volatile.
+		IL_066f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0674: brfalse IL_0689
 
-		IL_05a1: ldstr "prototype"
-		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ab: br IL_05c4
+		IL_0679: ldloc.2
+		IL_067a: ldstr "prototype"
+		IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0684: br IL_069e
 
-		IL_05b0: ldstr "prototype"
-		IL_05b5: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:118"
-		IL_05ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0689: ldloc.2
+		IL_068a: ldstr "prototype"
+		IL_068f: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:145"
+		IL_0694: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0699: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_05c4: stloc.s 31
-		IL_05c6: ldloc.s 29
-		IL_05c8: ldloc.s 31
-		IL_05ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05cf: stloc.s 33
-		IL_05d1: ldloc.s 33
-		IL_05d3: box [System.Runtime]System.Boolean
-		IL_05d8: stloc.s 35
-		IL_05da: ldloc.s 30
-		IL_05dc: ldstr "fallback"
-		IL_05e1: ldloc.s 32
-		IL_05e3: ldloc.s 35
-		IL_05e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_05ea: pop
-		IL_05eb: nop
-		IL_05ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_05f1: dup
-		IL_05f2: ldstr "alternate"
-		IL_05f7: ldc.i4.1
-		IL_05f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_05fd: stloc.s 37
-		IL_05ff: ldloc.2
-		IL_0600: ldstr "prototype"
-		IL_0605: ldloc.s 37
-		IL_0607: ldc.i4.1
-		IL_0608: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_060d: pop
-		IL_060e: ldloc.1
-		IL_060f: ldc.i4.1
-		IL_0610: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0615: dup
-		IL_0616: ldc.r8 9
-		IL_061f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0624: ldloc.2
-		IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.Reflect::construct(object, object, object)
-		IL_062a: stloc.s 12
-		IL_062c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0631: stloc.s 30
-		IL_0633: volatile.
-		IL_0635: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_063a: brfalse IL_0650
-
-		IL_063f: ldloc.s 12
-		IL_0641: ldstr "value"
-		IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_064b: br IL_0666
-
-		IL_0650: ldloc.s 12
-		IL_0652: ldstr "value"
-		IL_0657: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:137"
-		IL_065c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0666: stloc.s 32
-		IL_0668: volatile.
-		IL_066a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_066f: brfalse IL_0685
-
-		IL_0674: ldloc.s 12
-		IL_0676: ldstr "seenNewTarget"
-		IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0680: br IL_069b
-
-		IL_0685: ldloc.s 12
-		IL_0687: ldstr "seenNewTarget"
-		IL_068c: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:139"
-		IL_0691: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_069b: stloc.s 31
-		IL_069d: ldloc.s 31
-		IL_069f: ldloc.2
-		IL_06a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_06a5: stloc.s 33
-		IL_06a7: ldloc.s 33
-		IL_06a9: box [System.Runtime]System.Boolean
-		IL_06ae: stloc.s 35
-		IL_06b0: volatile.
-		IL_06b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_06b7: brfalse IL_06cd
-
-		IL_06bc: ldloc.s 12
+		IL_069e: stloc.s 39
+		IL_06a0: ldloc.s 29
+		IL_06a2: ldloc.s 39
+		IL_06a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06a9: stloc.s 33
+		IL_06ab: ldloc.s 33
+		IL_06ad: box [System.Runtime]System.Boolean
+		IL_06b2: stloc.s 37
+		IL_06b4: ldloc.s 30
+		IL_06b6: ldc.i4.5
+		IL_06b7: newarr [System.Runtime]System.Object
+		IL_06bc: dup
+		IL_06bd: ldc.i4.0
 		IL_06be: ldstr "alternate"
-		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06c8: br IL_06e3
+		IL_06c3: stelem.ref
+		IL_06c4: dup
+		IL_06c5: ldc.i4.1
+		IL_06c6: ldloc.s 32
+		IL_06c8: stelem.ref
+		IL_06c9: dup
+		IL_06ca: ldc.i4.2
+		IL_06cb: ldloc.s 36
+		IL_06cd: stelem.ref
+		IL_06ce: dup
+		IL_06cf: ldc.i4.3
+		IL_06d0: ldloc.s 31
+		IL_06d2: stelem.ref
+		IL_06d3: dup
+		IL_06d4: ldc.i4.4
+		IL_06d5: ldloc.s 37
+		IL_06d7: stelem.ref
+		IL_06d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_06dd: pop
+		IL_06de: nop
+		IL_06df: nop
+		IL_06e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06e5: stloc.s 30
+		IL_06e7: ldloc.3
+		IL_06e8: dup
+		IL_06e9: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_06ee: stloc.s 31
+		IL_06f0: volatile.
+		IL_06f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_06f7: brfalse IL_070d
 
-		IL_06cd: ldloc.s 12
-		IL_06cf: ldstr "alternate"
-		IL_06d4: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:143"
-		IL_06d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06fc: ldloc.s 31
+		IL_06fe: ldstr "kind"
+		IL_0703: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0708: br IL_0723
 
-		IL_06e3: stloc.s 31
-		IL_06e5: ldloc.s 12
-		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_06ec: stloc.s 29
-		IL_06ee: volatile.
-		IL_06f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_06f5: brfalse IL_070a
+		IL_070d: ldloc.s 31
+		IL_070f: ldstr "kind"
+		IL_0714: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:156"
+		IL_0719: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_071e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06fa: ldloc.2
-		IL_06fb: ldstr "prototype"
-		IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0705: br IL_071f
+		IL_0723: stloc.s 31
+		IL_0725: ldloc.s 4
+		IL_0727: dup
+		IL_0728: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_072d: stloc.s 32
+		IL_072f: volatile.
+		IL_0731: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0736: brfalse IL_074c
 
-		IL_070a: ldloc.2
-		IL_070b: ldstr "prototype"
-		IL_0710: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:146"
-		IL_0715: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_071a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_073b: ldloc.s 32
+		IL_073d: ldstr "kind"
+		IL_0742: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0747: br IL_0762
 
-		IL_071f: stloc.s 38
-		IL_0721: ldloc.s 29
-		IL_0723: ldloc.s 38
-		IL_0725: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_072a: stloc.s 33
-		IL_072c: ldloc.s 33
-		IL_072e: box [System.Runtime]System.Boolean
-		IL_0733: stloc.s 36
-		IL_0735: ldloc.s 30
-		IL_0737: ldc.i4.5
-		IL_0738: newarr [System.Runtime]System.Object
-		IL_073d: dup
-		IL_073e: ldc.i4.0
-		IL_073f: ldstr "alternate"
-		IL_0744: stelem.ref
-		IL_0745: dup
-		IL_0746: ldc.i4.1
-		IL_0747: ldloc.s 32
-		IL_0749: stelem.ref
-		IL_074a: dup
-		IL_074b: ldc.i4.2
-		IL_074c: ldloc.s 35
-		IL_074e: stelem.ref
-		IL_074f: dup
-		IL_0750: ldc.i4.3
-		IL_0751: ldloc.s 31
-		IL_0753: stelem.ref
-		IL_0754: dup
-		IL_0755: ldc.i4.4
-		IL_0756: ldloc.s 36
-		IL_0758: stelem.ref
-		IL_0759: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_075e: pop
-		IL_075f: nop
-		IL_0760: nop
-		IL_0761: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0766: stloc.s 30
-		IL_0768: ldloc.3
-		IL_0769: dup
-		IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_076f: stloc.s 31
-		IL_0771: volatile.
-		IL_0773: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0778: brfalse IL_078e
+		IL_074c: ldloc.s 32
+		IL_074e: ldstr "kind"
+		IL_0753: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:159"
+		IL_0758: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_077d: ldloc.s 31
-		IL_077f: ldstr "kind"
-		IL_0784: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0789: br IL_07a4
+		IL_0762: stloc.s 32
+		IL_0764: ldloc.s 30
+		IL_0766: ldstr "returns"
+		IL_076b: ldloc.s 31
+		IL_076d: ldloc.s 32
+		IL_076f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0774: pop
+		IL_0775: ldc.i4.1
+		IL_0776: newarr [System.Runtime]System.Object
+		IL_077b: dup
+		IL_077c: ldc.i4.0
+		IL_077d: ldloc.0
+		IL_077e: stelem.ref
+		IL_077f: stloc.s 28
+		IL_0781: ldtoken Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject
+		IL_0786: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_078b: ldtoken Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject
+		IL_0790: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0795: stloc.s 40
+		IL_0797: ldloc.s 28
+		IL_0799: newobj instance void Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject::.ctor(object[])
+		IL_079e: ldloc.s 40
+		IL_07a0: ldloc.s 28
+		IL_07a2: ldc.i4.0
+		IL_07a3: conv.r8
+		IL_07a4: ldc.i4.0
+		IL_07a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_07aa: castclass Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject
+		IL_07af: stloc.s 41
+		IL_07b1: ldc.i4.1
+		IL_07b2: newarr [System.Runtime]System.Object
+		IL_07b7: dup
+		IL_07b8: ldc.i4.0
+		IL_07b9: ldloc.0
+		IL_07ba: stelem.ref
+		IL_07bb: stloc.s 28
+		IL_07bd: ldloc.s 28
+		IL_07bf: ldc.i4.0
+		IL_07c0: ldelem.ref
+		IL_07c1: castclass Modules.Function_GeneratedConstruction_Semantics/Scope
+		IL_07c6: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
+		IL_07cb: ldc.i4.0
+		IL_07cc: conv.r8
+		IL_07cd: ldstr ""
+		IL_07d2: ldc.i4.0
+		IL_07d3: ldc.i4.1
+		IL_07d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07d9: stloc.s 42
+		IL_07db: ldloc.s 41
+		IL_07dd: ldloc.s 42
+		IL_07df: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_07e4: stloc.s 32
+		IL_07e6: ldloc.s 32
+		IL_07e8: stloc.s 13
+		IL_07ea: ldc.i4.1
+		IL_07eb: newarr [System.Runtime]System.Object
+		IL_07f0: dup
+		IL_07f1: ldc.i4.0
+		IL_07f2: ldloc.0
+		IL_07f3: stelem.ref
+		IL_07f4: stloc.s 28
+		IL_07f6: ldloc.s 28
+		IL_07f8: ldc.i4.0
+		IL_07f9: newarr [System.Runtime]System.Object
+		IL_07fe: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0803: ldloc.s 13
+		IL_0805: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_080a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_080f: newobj instance void Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject::.ctor(object[])
+		IL_0814: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0819: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_081e: dup
+		IL_081f: ldloc.s 13
+		IL_0821: ldstr "prototype"
+		IL_0826: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_082b: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0830: stloc.s 14
+		IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_083c: stloc.s 14
+		IL_083e: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_0843: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0848: stloc.s 30
+		IL_084a: volatile.
+		IL_084c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0851: brfalse IL_0867
 
-		IL_078e: ldloc.s 31
-		IL_0790: ldstr "kind"
-		IL_0795: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:157"
-		IL_079a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0856: ldloc.s 14
+		IL_0858: ldstr "replacement"
+		IL_085d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0862: br IL_087d
 
-		IL_07a4: stloc.s 31
-		IL_07a6: ldloc.s 4
-		IL_07a8: dup
-		IL_07a9: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_07ae: stloc.s 32
-		IL_07b0: volatile.
-		IL_07b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_07b7: brfalse IL_07cd
+		IL_0867: ldloc.s 14
+		IL_0869: ldstr "replacement"
+		IL_086e: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:178"
+		IL_0873: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0878: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07bc: ldloc.s 32
-		IL_07be: ldstr "kind"
-		IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07c8: br IL_07e3
+		IL_087d: stloc.s 32
+		IL_087f: volatile.
+		IL_0881: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0886: brfalse IL_089c
 
-		IL_07cd: ldloc.s 32
-		IL_07cf: ldstr "kind"
-		IL_07d4: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:160"
-		IL_07d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_07de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_088b: ldloc.s 14
+		IL_088d: ldstr "baseNewTarget"
+		IL_0892: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0897: br IL_08b2
 
-		IL_07e3: stloc.s 32
-		IL_07e5: ldloc.s 30
-		IL_07e7: ldstr "returns"
-		IL_07ec: ldloc.s 31
-		IL_07ee: ldloc.s 32
-		IL_07f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_07f5: pop
-		IL_07f6: ldc.i4.1
-		IL_07f7: newarr [System.Runtime]System.Object
-		IL_07fc: dup
-		IL_07fd: ldc.i4.0
-		IL_07fe: ldloc.0
-		IL_07ff: stelem.ref
-		IL_0800: stloc.s 28
-		IL_0802: ldtoken Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject
-		IL_0807: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_080c: ldtoken Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject
-		IL_0811: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0816: stloc.s 39
-		IL_0818: ldloc.s 28
-		IL_081a: newobj instance void Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject::.ctor(object[])
-		IL_081f: ldloc.s 39
-		IL_0821: ldloc.s 28
-		IL_0823: ldc.i4.0
-		IL_0824: conv.r8
-		IL_0825: ldc.i4.0
-		IL_0826: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_082b: castclass Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject
-		IL_0830: stloc.s 40
-		IL_0832: ldc.i4.1
-		IL_0833: newarr [System.Runtime]System.Object
-		IL_0838: dup
-		IL_0839: ldc.i4.0
-		IL_083a: ldloc.0
-		IL_083b: stelem.ref
-		IL_083c: stloc.s 28
-		IL_083e: ldloc.s 28
-		IL_0840: ldc.i4.0
-		IL_0841: ldelem.ref
-		IL_0842: castclass Modules.Function_GeneratedConstruction_Semantics/Scope
-		IL_0847: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
-		IL_084c: ldc.i4.0
-		IL_084d: conv.r8
-		IL_084e: ldstr ""
-		IL_0853: ldc.i4.0
-		IL_0854: ldc.i4.1
-		IL_0855: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_085a: stloc.s 41
-		IL_085c: ldloc.s 40
-		IL_085e: ldloc.s 41
-		IL_0860: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
-		IL_0865: stloc.s 32
-		IL_0867: ldloc.s 32
-		IL_0869: stloc.s 13
-		IL_086b: ldc.i4.1
-		IL_086c: newarr [System.Runtime]System.Object
-		IL_0871: dup
-		IL_0872: ldc.i4.0
-		IL_0873: ldloc.0
-		IL_0874: stelem.ref
-		IL_0875: stloc.s 28
-		IL_0877: ldloc.s 28
-		IL_0879: ldc.i4.0
-		IL_087a: newarr [System.Runtime]System.Object
-		IL_087f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0884: ldloc.s 13
-		IL_0886: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
-		IL_088b: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
-		IL_0890: newobj instance void Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject::.ctor(object[])
-		IL_0895: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
-		IL_089a: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_089f: dup
-		IL_08a0: ldloc.s 13
-		IL_08a2: ldstr "prototype"
-		IL_08a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_08ac: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_08b1: stloc.s 14
-		IL_08b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-		IL_08bd: stloc.s 14
-		IL_08bf: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
-		IL_08c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08c9: stloc.s 30
-		IL_08cb: volatile.
-		IL_08cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_08d2: brfalse IL_08e8
+		IL_089c: ldloc.s 14
+		IL_089e: ldstr "baseNewTarget"
+		IL_08a3: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:180"
+		IL_08a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_08ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_08d7: ldloc.s 14
-		IL_08d9: ldstr "replacement"
-		IL_08de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08e3: br IL_08fe
+		IL_08b2: stloc.s 31
+		IL_08b4: ldloc.s 31
+		IL_08b6: ldloc.s 13
+		IL_08b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_08bd: stloc.s 33
+		IL_08bf: ldloc.s 33
+		IL_08c1: box [System.Runtime]System.Boolean
+		IL_08c6: stloc.s 37
+		IL_08c8: ldloc.s 14
+		IL_08ca: ldloc.s 13
+		IL_08cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_08d1: stloc.s 33
+		IL_08d3: ldloc.s 33
+		IL_08d5: box [System.Runtime]System.Boolean
+		IL_08da: stloc.s 36
+		IL_08dc: ldloc.s 30
+		IL_08de: ldc.i4.4
+		IL_08df: newarr [System.Runtime]System.Object
+		IL_08e4: dup
+		IL_08e5: ldc.i4.0
+		IL_08e6: ldstr "derivedObject"
+		IL_08eb: stelem.ref
+		IL_08ec: dup
+		IL_08ed: ldc.i4.1
+		IL_08ee: ldloc.s 32
+		IL_08f0: stelem.ref
+		IL_08f1: dup
+		IL_08f2: ldc.i4.2
+		IL_08f3: ldloc.s 37
+		IL_08f5: stelem.ref
+		IL_08f6: dup
+		IL_08f7: ldc.i4.3
+		IL_08f8: ldloc.s 36
+		IL_08fa: stelem.ref
+		IL_08fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0900: pop
+		IL_0901: nop
+		IL_0902: ldloc.s 5
+		IL_0904: ldstr "bind"
+		IL_0909: ldc.i4.0
+		IL_090a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_090f: ldc.r8 11
+		IL_0918: box [System.Runtime]System.Double
+		IL_091d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0922: stloc.s 15
+		IL_0924: ldloc.s 15
+		IL_0926: dup
+		IL_0927: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_092c: stloc.s 16
+		IL_092e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0933: stloc.s 30
+		IL_0935: volatile.
+		IL_0937: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_093c: brfalse IL_0952
 
-		IL_08e8: ldloc.s 14
-		IL_08ea: ldstr "replacement"
-		IL_08ef: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:179"
-		IL_08f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_08f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0941: ldloc.s 16
+		IL_0943: ldstr "value"
+		IL_0948: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_094d: br IL_0968
 
-		IL_08fe: stloc.s 32
-		IL_0900: volatile.
-		IL_0902: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0907: brfalse IL_091d
+		IL_0952: ldloc.s 16
+		IL_0954: ldstr "value"
+		IL_0959: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:201"
+		IL_095e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0963: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_090c: ldloc.s 14
-		IL_090e: ldstr "baseNewTarget"
-		IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0918: br IL_0933
+		IL_0968: stloc.s 32
+		IL_096a: volatile.
+		IL_096c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0971: brfalse IL_0987
 
-		IL_091d: ldloc.s 14
-		IL_091f: ldstr "baseNewTarget"
-		IL_0924: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:181"
-		IL_0929: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_092e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0976: ldloc.s 16
+		IL_0978: ldstr "seenNewTarget"
+		IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0982: br IL_099d
 
-		IL_0933: stloc.s 31
-		IL_0935: ldloc.s 31
-		IL_0937: ldloc.s 13
-		IL_0939: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_093e: stloc.s 33
-		IL_0940: ldloc.s 33
-		IL_0942: box [System.Runtime]System.Boolean
-		IL_0947: stloc.s 36
-		IL_0949: ldloc.s 14
-		IL_094b: ldloc.s 13
-		IL_094d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0952: stloc.s 33
-		IL_0954: ldloc.s 33
-		IL_0956: box [System.Runtime]System.Boolean
-		IL_095b: stloc.s 35
-		IL_095d: ldloc.s 30
-		IL_095f: ldc.i4.4
-		IL_0960: newarr [System.Runtime]System.Object
-		IL_0965: dup
-		IL_0966: ldc.i4.0
-		IL_0967: ldstr "derivedObject"
-		IL_096c: stelem.ref
-		IL_096d: dup
-		IL_096e: ldc.i4.1
-		IL_096f: ldloc.s 32
-		IL_0971: stelem.ref
-		IL_0972: dup
-		IL_0973: ldc.i4.2
-		IL_0974: ldloc.s 36
-		IL_0976: stelem.ref
-		IL_0977: dup
-		IL_0978: ldc.i4.3
-		IL_0979: ldloc.s 35
-		IL_097b: stelem.ref
-		IL_097c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0981: pop
-		IL_0982: nop
-		IL_0983: ldloc.s 5
-		IL_0985: ldstr "bind"
-		IL_098a: ldc.i4.0
-		IL_098b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0990: ldc.r8 11
-		IL_0999: box [System.Runtime]System.Double
-		IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_09a3: stloc.s 15
-		IL_09a5: ldloc.s 15
-		IL_09a7: dup
-		IL_09a8: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_09ad: stloc.s 16
-		IL_09af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09b4: stloc.s 30
-		IL_09b6: volatile.
-		IL_09b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_09bd: brfalse IL_09d3
+		IL_0987: ldloc.s 16
+		IL_0989: ldstr "seenNewTarget"
+		IL_098e: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:203"
+		IL_0993: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_09c2: ldloc.s 16
-		IL_09c4: ldstr "value"
-		IL_09c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09ce: br IL_09e9
-
-		IL_09d3: ldloc.s 16
-		IL_09d5: ldstr "value"
-		IL_09da: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:202"
-		IL_09df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_09e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_09e9: stloc.s 32
-		IL_09eb: volatile.
-		IL_09ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_09f2: brfalse IL_0a08
-
-		IL_09f7: ldloc.s 16
-		IL_09f9: ldstr "seenNewTarget"
-		IL_09fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a03: br IL_0a1e
-
-		IL_0a08: ldloc.s 16
-		IL_0a0a: ldstr "seenNewTarget"
-		IL_0a0f: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:204"
-		IL_0a14: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0a19: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0a1e: stloc.s 31
-		IL_0a20: ldloc.s 31
-		IL_0a22: ldloc.s 5
-		IL_0a24: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0a29: stloc.s 33
-		IL_0a2b: ldloc.s 33
-		IL_0a2d: box [System.Runtime]System.Boolean
-		IL_0a32: stloc.s 35
-		IL_0a34: ldloc.s 16
-		IL_0a36: ldloc.s 5
-		IL_0a38: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0a3d: stloc.s 33
-		IL_0a3f: ldloc.s 33
-		IL_0a41: box [System.Runtime]System.Boolean
-		IL_0a46: stloc.s 36
-		IL_0a48: ldloc.s 16
-		IL_0a4a: ldloc.s 15
-		IL_0a4c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0a51: stloc.s 33
-		IL_0a53: ldloc.s 33
-		IL_0a55: box [System.Runtime]System.Boolean
-		IL_0a5a: stloc.s 34
-		IL_0a5c: ldloc.s 30
-		IL_0a5e: ldc.i4.5
-		IL_0a5f: newarr [System.Runtime]System.Object
-		IL_0a64: dup
-		IL_0a65: ldc.i4.0
-		IL_0a66: ldstr "bound"
-		IL_0a6b: stelem.ref
-		IL_0a6c: dup
-		IL_0a6d: ldc.i4.1
-		IL_0a6e: ldloc.s 32
-		IL_0a70: stelem.ref
-		IL_0a71: dup
-		IL_0a72: ldc.i4.2
-		IL_0a73: ldloc.s 35
-		IL_0a75: stelem.ref
-		IL_0a76: dup
-		IL_0a77: ldc.i4.3
-		IL_0a78: ldloc.s 36
-		IL_0a7a: stelem.ref
-		IL_0a7b: dup
-		IL_0a7c: ldc.i4.4
-		IL_0a7d: ldloc.s 34
-		IL_0a7f: stelem.ref
-		IL_0a80: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0a85: pop
-		IL_0a86: ldc.i4.1
-		IL_0a87: newarr [System.Runtime]System.Object
-		IL_0a8c: dup
-		IL_0a8d: ldc.i4.0
-		IL_0a8e: ldloc.0
-		IL_0a8f: stelem.ref
-		IL_0a90: stloc.s 28
-		IL_0a92: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject::.ctor()
-		IL_0a97: ldc.i4.0
-		IL_0a98: conv.r8
-		IL_0a99: ldstr ""
-		IL_0a9e: ldc.i4.0
-		IL_0a9f: ldc.i4.0
-		IL_0aa0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0aa5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject>(!!0)
-		IL_0aaa: stloc.s 42
-		IL_0aac: ldloc.s 42
-		IL_0aae: ldstr "arrow"
-		IL_0ab3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0ab8: stloc.s 17
-		IL_0aba: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0abf: stloc.s 37
-		IL_0ac1: ldc.i4.1
-		IL_0ac2: newarr [System.Runtime]System.Object
-		IL_0ac7: dup
-		IL_0ac8: ldc.i4.0
-		IL_0ac9: ldloc.0
-		IL_0aca: stelem.ref
-		IL_0acb: stloc.s 28
-		IL_0acd: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject::.ctor()
-		IL_0ad2: ldc.i4.0
-		IL_0ad3: conv.r8
-		IL_0ad4: ldstr ""
-		IL_0ad9: ldc.i4.0
-		IL_0ada: ldc.i4.1
-		IL_0adb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0ae0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject>(!!0)
-		IL_0ae5: stloc.s 43
-		IL_0ae7: ldloc.s 37
-		IL_0ae9: ldstr "method"
-		IL_0aee: ldloc.s 43
-		IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0af5: pop
-		IL_0af6: ldloc.s 37
-		IL_0af8: stloc.s 18
-		IL_0afa: ldc.i4.0
-		IL_0afb: box [System.Runtime]System.Boolean
-		IL_0b00: stloc.s 19
-		IL_0b02: ldc.i4.0
-		IL_0b03: box [System.Runtime]System.Boolean
-		IL_0b08: stloc.s 20
+		IL_099d: stloc.s 31
+		IL_099f: ldloc.s 31
+		IL_09a1: ldloc.s 5
+		IL_09a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_09a8: stloc.s 33
+		IL_09aa: ldloc.s 33
+		IL_09ac: box [System.Runtime]System.Boolean
+		IL_09b1: stloc.s 36
+		IL_09b3: ldloc.s 16
+		IL_09b5: ldloc.s 5
+		IL_09b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_09bc: stloc.s 33
+		IL_09be: ldloc.s 33
+		IL_09c0: box [System.Runtime]System.Boolean
+		IL_09c5: stloc.s 37
+		IL_09c7: ldloc.s 16
+		IL_09c9: ldloc.s 15
+		IL_09cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_09d0: stloc.s 33
+		IL_09d2: ldloc.s 33
+		IL_09d4: box [System.Runtime]System.Boolean
+		IL_09d9: stloc.s 34
+		IL_09db: ldloc.s 30
+		IL_09dd: ldc.i4.5
+		IL_09de: newarr [System.Runtime]System.Object
+		IL_09e3: dup
+		IL_09e4: ldc.i4.0
+		IL_09e5: ldstr "bound"
+		IL_09ea: stelem.ref
+		IL_09eb: dup
+		IL_09ec: ldc.i4.1
+		IL_09ed: ldloc.s 32
+		IL_09ef: stelem.ref
+		IL_09f0: dup
+		IL_09f1: ldc.i4.2
+		IL_09f2: ldloc.s 36
+		IL_09f4: stelem.ref
+		IL_09f5: dup
+		IL_09f6: ldc.i4.3
+		IL_09f7: ldloc.s 37
+		IL_09f9: stelem.ref
+		IL_09fa: dup
+		IL_09fb: ldc.i4.4
+		IL_09fc: ldloc.s 34
+		IL_09fe: stelem.ref
+		IL_09ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0a04: pop
+		IL_0a05: ldc.i4.1
+		IL_0a06: newarr [System.Runtime]System.Object
+		IL_0a0b: dup
+		IL_0a0c: ldc.i4.0
+		IL_0a0d: ldloc.0
+		IL_0a0e: stelem.ref
+		IL_0a0f: stloc.s 28
+		IL_0a11: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject::.ctor()
+		IL_0a16: ldc.i4.0
+		IL_0a17: conv.r8
+		IL_0a18: ldstr ""
+		IL_0a1d: ldc.i4.0
+		IL_0a1e: ldc.i4.0
+		IL_0a1f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a24: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject>(!!0)
+		IL_0a29: stloc.s 43
+		IL_0a2b: ldloc.s 43
+		IL_0a2d: ldstr "arrow"
+		IL_0a32: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0a37: stloc.s 17
+		IL_0a39: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0a3e: stloc.s 38
+		IL_0a40: ldc.i4.1
+		IL_0a41: newarr [System.Runtime]System.Object
+		IL_0a46: dup
+		IL_0a47: ldc.i4.0
+		IL_0a48: ldloc.0
+		IL_0a49: stelem.ref
+		IL_0a4a: stloc.s 28
+		IL_0a4c: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject::.ctor()
+		IL_0a51: ldc.i4.0
+		IL_0a52: conv.r8
+		IL_0a53: ldstr ""
+		IL_0a58: ldc.i4.0
+		IL_0a59: ldc.i4.1
+		IL_0a5a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a5f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject>(!!0)
+		IL_0a64: stloc.s 44
+		IL_0a66: ldloc.s 38
+		IL_0a68: ldstr "method"
+		IL_0a6d: ldloc.s 44
+		IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0a74: pop
+		IL_0a75: ldloc.s 38
+		IL_0a77: stloc.s 18
+		IL_0a79: ldc.i4.0
+		IL_0a7a: box [System.Runtime]System.Boolean
+		IL_0a7f: stloc.s 19
+		IL_0a81: ldc.i4.0
+		IL_0a82: box [System.Runtime]System.Boolean
+		IL_0a87: stloc.s 20
 		.try
 		{
-			IL_0b0a: nop
-			IL_0b0b: ldstr "Reflect"
-			IL_0b10: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b15: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b1a: ldc.i4.0
-			IL_0b1b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0b20: stloc.s 44
-			IL_0b22: ldstr "construct"
-			IL_0b27: ldloc.s 17
-			IL_0b29: ldloc.s 44
-			IL_0b2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0b30: pop
-			IL_0b31: leave IL_0b95
+			IL_0a89: nop
+			IL_0a8a: ldstr "Reflect"
+			IL_0a8f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a99: ldc.i4.0
+			IL_0a9a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0a9f: stloc.s 45
+			IL_0aa1: ldstr "construct"
+			IL_0aa6: ldloc.s 17
+			IL_0aa8: ldloc.s 45
+			IL_0aaa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0aaf: pop
+			IL_0ab0: leave IL_0b14
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0b36: stloc.s 21
-			IL_0b38: ldloc.s 21
-			IL_0b3a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0b3f: dup
-			IL_0b40: brtrue IL_0b56
+			IL_0ab5: stloc.s 21
+			IL_0ab7: ldloc.s 21
+			IL_0ab9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0abe: dup
+			IL_0abf: brtrue IL_0ad5
 
-			IL_0b45: pop
-			IL_0b46: ldloc.s 21
-			IL_0b48: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0b4d: dup
-			IL_0b4e: brtrue IL_0b62
+			IL_0ac4: pop
+			IL_0ac5: ldloc.s 21
+			IL_0ac7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0acc: dup
+			IL_0acd: brtrue IL_0ae1
 
-			IL_0b53: pop
-			IL_0b54: rethrow
+			IL_0ad2: pop
+			IL_0ad3: rethrow
 
-			IL_0b56: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0b5b: stloc.s 22
-			IL_0b5d: br IL_0b64
+			IL_0ad5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0ada: stloc.s 22
+			IL_0adc: br IL_0ae3
 
-			IL_0b62: stloc.s 22
+			IL_0ae1: stloc.s 22
 
-			IL_0b64: ldloc.s 22
-			IL_0b66: stloc.s 23
-			IL_0b68: ldloc.s 23
-			IL_0b6a: stloc.s 32
-			IL_0b6c: ldstr "TypeError"
-			IL_0b71: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b76: stloc.s 31
-			IL_0b78: ldloc.s 32
-			IL_0b7a: ldloc.s 31
-			IL_0b7c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0b81: stloc.s 33
-			IL_0b83: ldloc.s 33
-			IL_0b85: box [System.Runtime]System.Boolean
-			IL_0b8a: stloc.s 34
-			IL_0b8c: ldloc.s 34
-			IL_0b8e: stloc.s 19
-			IL_0b90: leave IL_0b95
+			IL_0ae3: ldloc.s 22
+			IL_0ae5: stloc.s 23
+			IL_0ae7: ldloc.s 23
+			IL_0ae9: stloc.s 32
+			IL_0aeb: ldstr "TypeError"
+			IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0af5: stloc.s 31
+			IL_0af7: ldloc.s 32
+			IL_0af9: ldloc.s 31
+			IL_0afb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0b00: stloc.s 33
+			IL_0b02: ldloc.s 33
+			IL_0b04: box [System.Runtime]System.Boolean
+			IL_0b09: stloc.s 34
+			IL_0b0b: ldloc.s 34
+			IL_0b0d: stloc.s 19
+			IL_0b0f: leave IL_0b14
 		} // end handler
 		.try
 		{
-			IL_0b95: nop
-			IL_0b96: ldstr "Reflect"
-			IL_0b9b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ba0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ba5: stloc.s 31
-			IL_0ba7: volatile.
-			IL_0ba9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_0bae: brfalse IL_0bc4
+			IL_0b14: nop
+			IL_0b15: ldstr "Reflect"
+			IL_0b1a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b1f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b24: stloc.s 31
+			IL_0b26: volatile.
+			IL_0b28: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0b2d: brfalse IL_0b43
 
-			IL_0bb3: ldloc.s 18
-			IL_0bb5: ldstr "method"
-			IL_0bba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bbf: br IL_0bda
+			IL_0b32: ldloc.s 18
+			IL_0b34: ldstr "method"
+			IL_0b39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b3e: br IL_0b59
 
-			IL_0bc4: ldloc.s 18
-			IL_0bc6: ldstr "method"
-			IL_0bcb: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:269"
-			IL_0bd0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_0bd5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0b43: ldloc.s 18
+			IL_0b45: ldstr "method"
+			IL_0b4a: ldstr "Function_GeneratedConstruction_Semantics:Modules.Function_GeneratedConstruction_Semantics:__js_module_init__:268"
+			IL_0b4f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0b54: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0bda: stloc.s 32
-			IL_0bdc: ldc.i4.0
-			IL_0bdd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0be2: stloc.s 44
-			IL_0be4: ldloc.s 31
-			IL_0be6: ldstr "construct"
-			IL_0beb: ldloc.s 32
-			IL_0bed: ldloc.s 44
-			IL_0bef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0bf4: pop
-			IL_0bf5: leave IL_0c59
+			IL_0b59: stloc.s 32
+			IL_0b5b: ldc.i4.0
+			IL_0b5c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0b61: stloc.s 45
+			IL_0b63: ldloc.s 31
+			IL_0b65: ldstr "construct"
+			IL_0b6a: ldloc.s 32
+			IL_0b6c: ldloc.s 45
+			IL_0b6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0b73: pop
+			IL_0b74: leave IL_0bd8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0bfa: stloc.s 24
-			IL_0bfc: ldloc.s 24
-			IL_0bfe: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0c03: dup
-			IL_0c04: brtrue IL_0c1a
+			IL_0b79: stloc.s 24
+			IL_0b7b: ldloc.s 24
+			IL_0b7d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0b82: dup
+			IL_0b83: brtrue IL_0b99
 
-			IL_0c09: pop
-			IL_0c0a: ldloc.s 24
-			IL_0c0c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0c11: dup
-			IL_0c12: brtrue IL_0c26
+			IL_0b88: pop
+			IL_0b89: ldloc.s 24
+			IL_0b8b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0b90: dup
+			IL_0b91: brtrue IL_0ba5
 
-			IL_0c17: pop
-			IL_0c18: rethrow
+			IL_0b96: pop
+			IL_0b97: rethrow
 
-			IL_0c1a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0c1f: stloc.s 25
-			IL_0c21: br IL_0c28
+			IL_0b99: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b9e: stloc.s 25
+			IL_0ba0: br IL_0ba7
 
-			IL_0c26: stloc.s 25
+			IL_0ba5: stloc.s 25
 
-			IL_0c28: ldloc.s 25
-			IL_0c2a: stloc.s 26
-			IL_0c2c: ldloc.s 26
-			IL_0c2e: stloc.s 32
-			IL_0c30: ldstr "TypeError"
-			IL_0c35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0c3a: stloc.s 31
-			IL_0c3c: ldloc.s 32
-			IL_0c3e: ldloc.s 31
-			IL_0c40: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0c45: stloc.s 33
-			IL_0c47: ldloc.s 33
-			IL_0c49: box [System.Runtime]System.Boolean
-			IL_0c4e: stloc.s 34
-			IL_0c50: ldloc.s 34
-			IL_0c52: stloc.s 20
-			IL_0c54: leave IL_0c59
+			IL_0ba7: ldloc.s 25
+			IL_0ba9: stloc.s 26
+			IL_0bab: ldloc.s 26
+			IL_0bad: stloc.s 32
+			IL_0baf: ldstr "TypeError"
+			IL_0bb4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0bb9: stloc.s 31
+			IL_0bbb: ldloc.s 32
+			IL_0bbd: ldloc.s 31
+			IL_0bbf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0bc4: stloc.s 33
+			IL_0bc6: ldloc.s 33
+			IL_0bc8: box [System.Runtime]System.Boolean
+			IL_0bcd: stloc.s 34
+			IL_0bcf: ldloc.s 34
+			IL_0bd1: stloc.s 20
+			IL_0bd3: leave IL_0bd8
 		} // end handler
 
-		IL_0c59: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0c5e: stloc.s 30
-		IL_0c60: ldloc.s 30
-		IL_0c62: ldstr "nonconstructors"
-		IL_0c67: ldloc.s 19
-		IL_0c69: ldloc.s 20
-		IL_0c6b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0c70: pop
-		IL_0c71: ldnull
-		IL_0c72: stloc.s 27
-		IL_0c74: ret
+		IL_0bd8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0bdd: stloc.s 30
+		IL_0bdf: ldloc.s 30
+		IL_0be1: ldstr "nonconstructors"
+		IL_0be6: ldloc.s 19
+		IL_0be8: ldloc.s 20
+		IL_0bea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0bef: pop
+		IL_0bf0: ldnull
+		IL_0bf1: stloc.s 27
+		IL_0bf3: ret
 	} // end of method Function_GeneratedConstruction_Semantics::__js_module_init__
 
 } // end of class Modules.Function_GeneratedConstruction_Semantics
@@ -2748,10 +3021,6 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_10
-	.field assembly static int32 __jroc_dynamicLookup_11
-	.field assembly static int32 __jroc_dynamicLookup_12
-	.field assembly static int32 __jroc_dynamicLookup_13
 	.field assembly static int32 __jroc_dynamicLookup_14
 	.field assembly static int32 __jroc_dynamicLookup_15
 	.field assembly static int32 __jroc_dynamicLookup_16

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
@@ -2166,7 +2166,7 @@
 		IL_02f3: ldloc.1
 		IL_02f4: ldc.r8 3
 		IL_02fd: box [System.Runtime]System.Double
-		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_0302: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver>(object, object, object, object)
 		IL_0307: stloc.s 8
 		IL_0309: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_030e: stloc.s 30
@@ -2262,7 +2262,7 @@
 		IL_03fc: ldloc.1
 		IL_03fd: ldc.r8 5
 		IL_0406: box [System.Runtime]System.Double
-		IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_040b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver>(object, object, object, object)
 		IL_0410: stloc.s 10
 		IL_0412: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0417: stloc.s 30
@@ -2341,7 +2341,7 @@
 		IL_04d6: ldloc.1
 		IL_04d7: ldc.r8 6
 		IL_04e0: box [System.Runtime]System.Double
-		IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_04e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_GeneratedConstruction_Semantics/ObjectLiterals/Ctor_L3C1_Receiver>(object, object, object, object)
 		IL_04ea: stloc.s 11
 		IL_04ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_04f1: stloc.s 30

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
@@ -217,20 +217,44 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Header size: 1
-				// Code size: 34 (0x22)
+				// Header size: 12
+				// Code size: 113 (0x71)
 				.maxstack 8
 
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-				IL_000b: ldstr "value"
-				IL_0010: ldc.r8 123
-				IL_0019: ldc.i4.1
-				IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_001f: pop
-				IL_0020: ldnull
-				IL_0021: ret
+				IL_000b: isinst Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor
+				IL_0010: dup
+				IL_0011: brfalse IL_0049
+
+				IL_0016: dup
+				IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+				IL_001c: brfalse IL_0049
+
+				IL_0021: dup
+				IL_0022: ldstr "value"
+				IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+				IL_002c: brfalse IL_0049
+
+				IL_0031: ldc.r8 123
+				IL_003a: box [System.Runtime]System.Double
+				IL_003f: callvirt instance void Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor::set_value(object)
+				IL_0044: br IL_006f
+
+				IL_0049: pop
+				IL_004a: ldarg.1
+				IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+				IL_0055: ldstr "value"
+				IL_005a: ldc.r8 123
+				IL_0063: box [System.Runtime]System.Double
+				IL_0068: ldc.i4.1
+				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_006e: pop
+
+				IL_006f: ldnull
+				IL_0070: ret
 			} // end of method FunctionExpression_Ctor::__js_call__
 
 		} // end of class FunctionExpression_Ctor
@@ -376,11 +400,12 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 74 (0x4a)
+				// Code size: 67 (0x43)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] object
+					[0] class Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor,
+					[1] object,
+					[2] class Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor
 				)
 
 				IL_0000: ldarg.0
@@ -389,28 +414,30 @@
 				IL_0003: castclass Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope
 				IL_0008: ldfld object Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope::Ctor
 				IL_000d: stloc.1
-				IL_000e: ldloc.1
-				IL_000f: dup
-				IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-				IL_0015: stloc.0
-				IL_0016: volatile.
-				IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-				IL_001d: brfalse IL_0032
+				IL_000e: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor::.ctor()
+				IL_0013: stloc.2
+				IL_0014: ldloc.1
+				IL_0015: ldloc.2
+				IL_0016: ldloc.1
+				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver0(object, object, object)
+				IL_001c: stloc.0
+				IL_001d: ldloc.0
+				IL_001e: isinst Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor
+				IL_0023: dup
+				IL_0024: brfalse IL_0034
 
-				IL_0022: ldloc.0
-				IL_0023: ldstr "value"
-				IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_002d: br IL_0047
+				IL_0029: callvirt instance object Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor::get_value()
+				IL_002e: stloc.1
+				IL_002f: br IL_0041
 
-				IL_0032: ldloc.0
-				IL_0033: ldstr "value"
-				IL_0038: ldstr "Function_NewExpression_CapturesOuterCtor:<TwoPhaseDummy_M6>:__js_call__:6"
-				IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0034: pop
+				IL_0035: ldloc.0
+				IL_0036: ldstr "value"
+				IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0040: stloc.1
 
-				IL_0047: stloc.1
-				IL_0048: ldloc.1
-				IL_0049: ret
+				IL_0041: ldloc.1
+				IL_0042: ret
 			} // end of method inner::__js_call__
 
 		} // end of class inner
@@ -666,6 +693,77 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L7C16_Ctor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L7C16_Ctor::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L7C16_Ctor::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L7C16_Ctor::set_value
+
+		} // end of class Ctor_L7C16_Ctor
+
+
+	} // end of class ObjectLiterals
+
 
 	// Methods
 	.method public hidebysig static 
@@ -746,12 +844,4 @@
 	} // end of method Program::Main
 
 } // end of class Program
-
-.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
-	extends [System.Runtime]System.Object
-{
-	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_7
-
-} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
@@ -419,7 +419,7 @@
 				IL_0014: ldloc.1
 				IL_0015: ldloc.2
 				IL_0016: ldloc.1
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver0(object, object, object)
+				IL_0017: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver0<class Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor>(object, object, object)
 				IL_001c: stloc.0
 				IL_001d: ldloc.0
 				IL_001e: isinst Modules.Function_NewExpression_CapturesOuterCtor/ObjectLiterals/Ctor_L7C16_Ctor

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ObjectCreate_ObjectPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ObjectCreate_ObjectPrototype.verified.txt
@@ -716,7 +716,7 @@
 		IL_00cc: ldloc.s 7
 		IL_00ce: ldloc.1
 		IL_00cf: ldstr "click"
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1<class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent>(object, object, object, object)
 		IL_00d9: stloc.2
 		IL_00da: ldloc.2
 		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ObjectCreate_ObjectPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ObjectCreate_ObjectPrototype.verified.txt
@@ -221,7 +221,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 56 (0x38)
+			// Code size: 178 (0xb2)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -230,23 +230,67 @@
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "type"
-			IL_0010: ldarg.2
-			IL_0011: ldc.i4.1
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0017: pop
-			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
-			IL_001d: stloc.0
-			IL_001e: ldarg.1
-			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0029: ldstr "timeStamp"
-			IL_002e: ldloc.0
-			IL_002f: ldc.i4.1
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0035: pop
-			IL_0036: ldnull
-			IL_0037: ret
+			IL_000b: isinst Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "type"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent::set_type(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "type"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Date::now()
+			IL_005a: stloc.0
+			IL_005b: ldarg.1
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0066: isinst Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent
+			IL_006b: dup
+			IL_006c: brfalse IL_0097
+
+			IL_0071: dup
+			IL_0072: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0077: brfalse IL_0097
+
+			IL_007c: dup
+			IL_007d: ldstr "timeStamp"
+			IL_0082: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0087: brfalse IL_0097
+
+			IL_008c: ldloc.0
+			IL_008d: callvirt instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent::set_timeStamp(object)
+			IL_0092: br IL_00b0
+
+			IL_0097: pop
+			IL_0098: ldarg.1
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_00a3: ldstr "timeStamp"
+			IL_00a8: ldloc.0
+			IL_00a9: ldc.i4.1
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_00af: pop
+
+			IL_00b0: ldnull
+			IL_00b1: ret
 		} // end of method MyEvent::__js_call__
 
 	} // end of class MyEvent
@@ -401,7 +445,7 @@
 			IL_0008: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_000d: stloc.2
 			IL_000e: volatile.
-			IL_0010: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0010: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_0015: brfalse IL_0033
 
 			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
@@ -414,7 +458,7 @@
 			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_003d: ldstr "type"
 			IL_0042: ldstr "Function_Prototype_ObjectCreate_ObjectPrototype:<TwoPhaseDummy_M5>:__js_call__:7"
-			IL_0047: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0047: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0051: stloc.1
@@ -454,6 +498,121 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L3C1_MyEvent
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _type
+			.field private object _timeStamp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L3C1_MyEvent::.ctor
+
+			.method public hidebysig 
+				instance object get_type () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "type"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent::_type
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent::_type
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "type"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L3C1_MyEvent::get_type
+
+			.method public hidebysig 
+				instance void set_type (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent::_type
+				IL_0007: ldarg.0
+				IL_0008: ldstr "type"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L3C1_MyEvent::set_type
+
+			.method public hidebysig 
+				instance object get_timeStamp () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "timeStamp"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent::_timeStamp
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent::_timeStamp
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "timeStamp"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L3C1_MyEvent::get_timeStamp
+
+			.method public hidebysig 
+				instance void set_timeStamp (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent::_timeStamp
+				IL_0007: ldarg.0
+				IL_0008: ldstr "timeStamp"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L3C1_MyEvent::set_timeStamp
+
+		} // end of class Ctor_L3C1_MyEvent
+
+
+	} // end of class ObjectLiterals
+
 
 	// Methods
 	.method public hidebysig static 
@@ -466,16 +625,17 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 264 (0x108)
+		// Code size: 273 (0x111)
 		.maxstack 12
 		.locals init (
 			[0] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/Scope,
 			[1] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject,
-			[2] object,
+			[2] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent,
 			[3] object[],
 			[4] object,
 			[5] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[7] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent
 		)
 
 		IL_0000: newobj instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/Scope::.ctor()
@@ -500,7 +660,7 @@
 		IL_0027: ldstr "Object"
 		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 		IL_0031: volatile.
-		IL_0033: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0033: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 		IL_0038: brfalse IL_004c
 
 		IL_003d: ldstr "prototype"
@@ -509,7 +669,7 @@
 
 		IL_004c: ldstr "prototype"
 		IL_0051: ldstr "Function_Prototype_ObjectCreate_ObjectPrototype:Modules.Function_Prototype_ObjectCreate_ObjectPrototype:__js_module_init__:11"
-		IL_0056: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0056: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0060: stloc.s 4
@@ -550,28 +710,31 @@
 		IL_00bd: ldc.i4.1
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
 		IL_00c3: pop
-		IL_00c4: ldloc.1
-		IL_00c5: dup
-		IL_00c6: ldstr "click"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_00d0: stloc.2
-		IL_00d1: ldloc.2
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d7: volatile.
-		IL_00d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_00de: brfalse IL_00f2
+		IL_00c4: newobj instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/ObjectLiterals/Ctor_L3C1_MyEvent::.ctor()
+		IL_00c9: stloc.s 7
+		IL_00cb: ldloc.1
+		IL_00cc: ldloc.s 7
+		IL_00ce: ldloc.1
+		IL_00cf: ldstr "click"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver1(object, object, object, object)
+		IL_00d9: stloc.2
+		IL_00da: ldloc.2
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e0: volatile.
+		IL_00e2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00e7: brfalse IL_00fb
 
-		IL_00e3: ldstr "dumpToConsole"
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00ed: br IL_0106
+		IL_00ec: ldstr "dumpToConsole"
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00f6: br IL_010f
 
-		IL_00f2: ldstr "dumpToConsole"
-		IL_00f7: ldstr "Function_Prototype_ObjectCreate_ObjectPrototype:Modules.Function_Prototype_ObjectCreate_ObjectPrototype:__js_module_init__:25"
-		IL_00fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_00fb: ldstr "dumpToConsole"
+		IL_0100: ldstr "Function_Prototype_ObjectCreate_ObjectPrototype:Modules.Function_Prototype_ObjectCreate_ObjectPrototype:__js_module_init__:26"
+		IL_0105: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0106: pop
-		IL_0107: ret
+		IL_010f: pop
+		IL_0110: ret
 	} // end of method Function_Prototype_ObjectCreate_ObjectPrototype::__js_module_init__
 
 } // end of class Modules.Function_Prototype_ObjectCreate_ObjectPrototype
@@ -601,9 +764,9 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_3
-	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -8497,7 +8497,7 @@
 			IL_04fc: ldloc.s 6
 			IL_04fe: ldarg.2
 			IL_04ff: box [System.Runtime]System.Double
-			IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_0504: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 			IL_0509: stloc.s 7
 			IL_050b: ldloc.1
 			IL_050c: ldc.r8 0.0
@@ -8527,7 +8527,7 @@
 			IL_0547: box [System.Runtime]System.Double
 			IL_054c: ldarg.2
 			IL_054d: box [System.Runtime]System.Double
-			IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_0552: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 			IL_0557: stloc.s 7
 			IL_0559: ldloc.1
 			IL_055a: ldc.r8 1
@@ -8552,7 +8552,7 @@
 			IL_058c: box [System.Runtime]System.Double
 			IL_0591: ldarg.2
 			IL_0592: box [System.Runtime]System.Double
-			IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_0597: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 			IL_059c: stloc.s 7
 			IL_059e: ldloc.1
 			IL_059f: ldc.r8 2
@@ -8582,7 +8582,7 @@
 			IL_05dd: ldloc.s 6
 			IL_05df: ldarg.2
 			IL_05e0: box [System.Runtime]System.Double
-			IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_05e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 			IL_05ea: stloc.s 7
 			IL_05ec: ldloc.1
 			IL_05ed: ldc.r8 3
@@ -8622,7 +8622,7 @@
 			IL_063f: ldloc.s 6
 			IL_0641: ldloc.s 5
 			IL_0643: ldloc.s 8
-			IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_0645: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 			IL_064a: stloc.s 7
 			IL_064c: ldloc.1
 			IL_064d: ldc.r8 4
@@ -8657,7 +8657,7 @@
 			IL_0694: ldarg.2
 			IL_0695: box [System.Runtime]System.Double
 			IL_069a: ldloc.s 5
-			IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_069c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 			IL_06a1: stloc.s 7
 			IL_06a3: ldloc.1
 			IL_06a4: ldc.r8 5
@@ -8687,7 +8687,7 @@
 			IL_06e2: ldarg.2
 			IL_06e3: box [System.Runtime]System.Double
 			IL_06e8: ldloc.s 5
-			IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_06ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 			IL_06ef: stloc.s 7
 			IL_06f1: ldloc.1
 			IL_06f2: ldc.r8 6
@@ -8722,7 +8722,7 @@
 			IL_0738: box [System.Runtime]System.Double
 			IL_073d: ldloc.s 5
 			IL_073f: ldloc.s 8
-			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_0741: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 			IL_0746: stloc.s 7
 			IL_0748: ldloc.1
 			IL_0749: ldc.r8 7
@@ -8747,7 +8747,7 @@
 			IL_078b: box [System.Runtime]System.Double
 			IL_0790: ldc.r8 0.0
 			IL_0799: box [System.Runtime]System.Double
-			IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_079e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 			IL_07a3: stloc.s 7
 			IL_07a5: ldloc.1
 			IL_07a6: ldc.r8 8
@@ -9171,7 +9171,7 @@
 				IL_0d07: box [System.Runtime]System.Double
 				IL_0d0c: ldc.r8 0.0
 				IL_0d15: box [System.Runtime]System.Double
-				IL_0d1a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+				IL_0d1a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
 				IL_0d1f: pop
 				IL_0d20: ldloc.0
 				IL_0d21: ldc.r8 1

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -1029,7 +1029,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 962 (0x3c2)
+			// Code size: 910 (0x38e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1055,342 +1055,338 @@
 				[20] object
 			)
 
-			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-			IL_0007: brfalse IL_001c
+			IL_0000: ldarg.2
+			IL_0001: isinst Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP
+			IL_0006: dup
+			IL_0007: brfalse IL_0018
 
-			IL_000c: ldarg.2
-			IL_000d: ldstr "V"
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0017: br IL_0031
+			IL_000c: callvirt instance object Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::get_V()
+			IL_0011: stloc.s 17
+			IL_0013: br IL_0026
 
-			IL_001c: ldarg.2
-			IL_001d: ldstr "V"
-			IL_0022: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M8>:__js_call__:3"
-			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0018: pop
+			IL_0019: ldarg.2
+			IL_001a: ldstr "V"
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0024: stloc.s 17
 
-			IL_0031: stloc.s 17
-			IL_0033: ldloc.s 17
-			IL_0035: ldc.r8 0.0
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0043: stloc.0
-			IL_0044: volatile.
-			IL_0046: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-			IL_004b: brfalse IL_0060
+			IL_0026: ldloc.s 17
+			IL_0028: ldc.r8 0.0
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0036: stloc.0
+			IL_0037: ldarg.3
+			IL_0038: isinst Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP
+			IL_003d: dup
+			IL_003e: brfalse IL_004f
 
+			IL_0043: callvirt instance object Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::get_V()
+			IL_0048: stloc.s 17
+			IL_004a: br IL_005d
+
+			IL_004f: pop
 			IL_0050: ldarg.3
 			IL_0051: ldstr "V"
 			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005b: br IL_0075
+			IL_005b: stloc.s 17
 
-			IL_0060: ldarg.3
-			IL_0061: ldstr "V"
-			IL_0066: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M8>:__js_call__:10"
-			IL_006b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_005d: ldloc.s 17
+			IL_005f: ldc.r8 0.0
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_006d: stloc.1
+			IL_006e: ldarg.2
+			IL_006f: isinst Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP
+			IL_0074: dup
+			IL_0075: brfalse IL_0086
 
-			IL_0075: stloc.s 17
-			IL_0077: ldloc.s 17
-			IL_0079: ldc.r8 0.0
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0087: stloc.1
-			IL_0088: volatile.
-			IL_008a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-			IL_008f: brfalse IL_00a4
+			IL_007a: callvirt instance object Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::get_V()
+			IL_007f: stloc.s 17
+			IL_0081: br IL_0094
 
-			IL_0094: ldarg.2
-			IL_0095: ldstr "V"
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009f: br IL_00b9
+			IL_0086: pop
+			IL_0087: ldarg.2
+			IL_0088: ldstr "V"
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0092: stloc.s 17
 
-			IL_00a4: ldarg.2
-			IL_00a5: ldstr "V"
-			IL_00aa: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M8>:__js_call__:17"
-			IL_00af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0094: ldloc.s 17
+			IL_0096: ldc.r8 1
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00a4: stloc.2
+			IL_00a5: ldarg.3
+			IL_00a6: isinst Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP
+			IL_00ab: dup
+			IL_00ac: brfalse IL_00bd
 
-			IL_00b9: stloc.s 17
-			IL_00bb: ldloc.s 17
-			IL_00bd: ldc.r8 1
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00cb: stloc.2
-			IL_00cc: volatile.
-			IL_00ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-			IL_00d3: brfalse IL_00e8
+			IL_00b1: callvirt instance object Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::get_V()
+			IL_00b6: stloc.s 17
+			IL_00b8: br IL_00cb
 
-			IL_00d8: ldarg.3
-			IL_00d9: ldstr "V"
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e3: br IL_00fd
+			IL_00bd: pop
+			IL_00be: ldarg.3
+			IL_00bf: ldstr "V"
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c9: stloc.s 17
 
-			IL_00e8: ldarg.3
-			IL_00e9: ldstr "V"
-			IL_00ee: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M8>:__js_call__:24"
-			IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00cb: ldloc.s 17
+			IL_00cd: ldc.r8 1
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00db: stloc.3
+			IL_00dc: ldloc.1
+			IL_00dd: stloc.s 17
+			IL_00df: ldloc.s 17
+			IL_00e1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00e6: ldloc.0
+			IL_00e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00ec: sub
+			IL_00ed: stloc.s 18
+			IL_00ef: ldloc.s 18
+			IL_00f1: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::abs(float64)
+			IL_00f6: stloc.s 4
+			IL_00f8: ldloc.3
+			IL_00f9: stloc.s 17
+			IL_00fb: ldloc.s 17
+			IL_00fd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0102: ldloc.2
+			IL_0103: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0108: sub
+			IL_0109: stloc.s 18
+			IL_010b: ldloc.s 18
+			IL_010d: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::abs(float64)
+			IL_0112: stloc.s 5
+			IL_0114: ldloc.0
+			IL_0115: stloc.s 6
+			IL_0117: ldloc.2
+			IL_0118: stloc.s 7
+			IL_011a: nop
+			IL_011b: nop
+			IL_011c: nop
+			IL_011d: nop
+			IL_011e: nop
+			IL_011f: nop
+			IL_0120: ldloc.1
+			IL_0121: stloc.s 17
+			IL_0123: ldloc.s 17
+			IL_0125: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_012a: ldloc.0
+			IL_012b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0130: clt
+			IL_0132: ldc.i4.0
+			IL_0133: ceq
+			IL_0135: brfalse IL_0155
 
-			IL_00fd: stloc.s 17
-			IL_00ff: ldloc.s 17
-			IL_0101: ldc.r8 1
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_010f: stloc.3
-			IL_0110: ldloc.1
-			IL_0111: stloc.s 17
-			IL_0113: ldloc.s 17
-			IL_0115: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_011a: ldloc.0
-			IL_011b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0120: sub
-			IL_0121: stloc.s 18
-			IL_0123: ldloc.s 18
-			IL_0125: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::abs(float64)
-			IL_012a: stloc.s 4
-			IL_012c: ldloc.3
-			IL_012d: stloc.s 17
-			IL_012f: ldloc.s 17
-			IL_0131: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0136: ldloc.2
-			IL_0137: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_013c: sub
-			IL_013d: stloc.s 18
-			IL_013f: ldloc.s 18
-			IL_0141: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::abs(float64)
-			IL_0146: stloc.s 5
-			IL_0148: ldloc.0
-			IL_0149: stloc.s 6
-			IL_014b: ldloc.2
-			IL_014c: stloc.s 7
-			IL_014e: nop
-			IL_014f: nop
-			IL_0150: nop
-			IL_0151: nop
-			IL_0152: nop
-			IL_0153: nop
-			IL_0154: ldloc.1
-			IL_0155: stloc.s 17
-			IL_0157: ldloc.s 17
-			IL_0159: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_015e: ldloc.0
-			IL_015f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0164: clt
-			IL_0166: ldc.i4.0
-			IL_0167: ceq
-			IL_0169: brfalse IL_0189
+			IL_013a: ldc.r8 1
+			IL_0143: stloc.s 8
+			IL_0145: ldc.r8 1
+			IL_014e: stloc.s 9
+			IL_0150: br IL_0175
 
-			IL_016e: ldc.r8 1
-			IL_0177: stloc.s 8
-			IL_0179: ldc.r8 1
-			IL_0182: stloc.s 9
-			IL_0184: br IL_01a9
+			IL_0155: ldc.r8 1
+			IL_015e: neg
+			IL_015f: stloc.s 18
+			IL_0161: ldloc.s 18
+			IL_0163: stloc.s 8
+			IL_0165: ldc.r8 1
+			IL_016e: neg
+			IL_016f: stloc.s 18
+			IL_0171: ldloc.s 18
+			IL_0173: stloc.s 9
 
-			IL_0189: ldc.r8 1
-			IL_0192: neg
-			IL_0193: stloc.s 18
-			IL_0195: ldloc.s 18
-			IL_0197: stloc.s 8
-			IL_0199: ldc.r8 1
-			IL_01a2: neg
-			IL_01a3: stloc.s 18
-			IL_01a5: ldloc.s 18
-			IL_01a7: stloc.s 9
+			IL_0175: ldloc.3
+			IL_0176: stloc.s 17
+			IL_0178: ldloc.s 17
+			IL_017a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_017f: ldloc.2
+			IL_0180: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0185: clt
+			IL_0187: ldc.i4.0
+			IL_0188: ceq
+			IL_018a: brfalse IL_01aa
 
-			IL_01a9: ldloc.3
-			IL_01aa: stloc.s 17
-			IL_01ac: ldloc.s 17
-			IL_01ae: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01b3: ldloc.2
-			IL_01b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01b9: clt
-			IL_01bb: ldc.i4.0
-			IL_01bc: ceq
-			IL_01be: brfalse IL_01de
+			IL_018f: ldc.r8 1
+			IL_0198: stloc.s 10
+			IL_019a: ldc.r8 1
+			IL_01a3: stloc.s 11
+			IL_01a5: br IL_01ca
 
-			IL_01c3: ldc.r8 1
-			IL_01cc: stloc.s 10
-			IL_01ce: ldc.r8 1
-			IL_01d7: stloc.s 11
-			IL_01d9: br IL_01fe
+			IL_01aa: ldc.r8 1
+			IL_01b3: neg
+			IL_01b4: stloc.s 18
+			IL_01b6: ldloc.s 18
+			IL_01b8: stloc.s 10
+			IL_01ba: ldc.r8 1
+			IL_01c3: neg
+			IL_01c4: stloc.s 18
+			IL_01c6: ldloc.s 18
+			IL_01c8: stloc.s 11
 
-			IL_01de: ldc.r8 1
-			IL_01e7: neg
-			IL_01e8: stloc.s 18
-			IL_01ea: ldloc.s 18
-			IL_01ec: stloc.s 10
-			IL_01ee: ldc.r8 1
-			IL_01f7: neg
+			IL_01ca: ldloc.s 4
+			IL_01cc: stloc.s 18
+			IL_01ce: ldloc.s 18
+			IL_01d0: ldloc.s 5
+			IL_01d2: clt
+			IL_01d4: ldc.i4.0
+			IL_01d5: ceq
+			IL_01d7: brfalse IL_0219
+
+			IL_01dc: ldc.r8 0.0
+			IL_01e5: stloc.s 8
+			IL_01e7: ldc.r8 0.0
+			IL_01f0: stloc.s 11
+			IL_01f2: ldloc.s 4
+			IL_01f4: stloc.s 12
+			IL_01f6: ldloc.s 4
 			IL_01f8: stloc.s 18
 			IL_01fa: ldloc.s 18
-			IL_01fc: stloc.s 11
+			IL_01fc: ldc.r8 2
+			IL_0205: div
+			IL_0206: stloc.s 18
+			IL_0208: ldloc.s 18
+			IL_020a: stloc.s 13
+			IL_020c: ldloc.s 5
+			IL_020e: stloc.s 14
+			IL_0210: ldloc.s 4
+			IL_0212: stloc.s 15
+			IL_0214: br IL_0251
 
-			IL_01fe: ldloc.s 4
-			IL_0200: stloc.s 18
-			IL_0202: ldloc.s 18
-			IL_0204: ldloc.s 5
-			IL_0206: clt
-			IL_0208: ldc.i4.0
-			IL_0209: ceq
-			IL_020b: brfalse IL_024d
+			IL_0219: ldc.r8 0.0
+			IL_0222: stloc.s 9
+			IL_0224: ldc.r8 0.0
+			IL_022d: stloc.s 10
+			IL_022f: ldloc.s 5
+			IL_0231: stloc.s 12
+			IL_0233: ldloc.s 5
+			IL_0235: stloc.s 18
+			IL_0237: ldloc.s 18
+			IL_0239: ldc.r8 2
+			IL_0242: div
+			IL_0243: stloc.s 18
+			IL_0245: ldloc.s 18
+			IL_0247: stloc.s 13
+			IL_0249: ldloc.s 4
+			IL_024b: stloc.s 14
+			IL_024d: ldloc.s 5
+			IL_024f: stloc.s 15
 
-			IL_0210: ldc.r8 0.0
-			IL_0219: stloc.s 8
-			IL_021b: ldc.r8 0.0
-			IL_0224: stloc.s 11
-			IL_0226: ldloc.s 4
-			IL_0228: stloc.s 12
-			IL_022a: ldloc.s 4
-			IL_022c: stloc.s 18
-			IL_022e: ldloc.s 18
-			IL_0230: ldc.r8 2
-			IL_0239: div
-			IL_023a: stloc.s 18
-			IL_023c: ldloc.s 18
-			IL_023e: stloc.s 13
-			IL_0240: ldloc.s 5
-			IL_0242: stloc.s 14
-			IL_0244: ldloc.s 4
-			IL_0246: stloc.s 15
-			IL_0248: br IL_0285
+			IL_0251: ldarg.0
+			IL_0252: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0257: volatile.
+			IL_0259: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_025e: brfalse IL_0272
 
-			IL_024d: ldc.r8 0.0
-			IL_0256: stloc.s 9
-			IL_0258: ldc.r8 0.0
-			IL_0261: stloc.s 10
-			IL_0263: ldloc.s 5
-			IL_0265: stloc.s 12
-			IL_0267: ldloc.s 5
-			IL_0269: stloc.s 18
-			IL_026b: ldloc.s 18
-			IL_026d: ldc.r8 2
-			IL_0276: div
-			IL_0277: stloc.s 18
-			IL_0279: ldloc.s 18
-			IL_027b: stloc.s 13
-			IL_027d: ldloc.s 4
-			IL_027f: stloc.s 14
-			IL_0281: ldloc.s 5
-			IL_0283: stloc.s 15
+			IL_0263: ldstr "LastPx"
+			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026d: br IL_0286
 
-			IL_0285: ldarg.0
-			IL_0286: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_028b: volatile.
-			IL_028d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-			IL_0292: brfalse IL_02a6
+			IL_0272: ldstr "LastPx"
+			IL_0277: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M8>:__js_call__:158"
+			IL_027c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0297: ldstr "LastPx"
-			IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a1: br IL_02ba
+			IL_0286: stloc.s 17
+			IL_0288: ldloc.s 17
+			IL_028a: ldloc.s 15
+			IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0291: stloc.s 19
+			IL_0293: ldloc.s 19
+			IL_0295: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(object)
+			IL_029a: stloc.s 18
+			IL_029c: ldloc.s 18
+			IL_029e: stloc.s 15
+			IL_02a0: ldarg.0
+			IL_02a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02a6: volatile.
+			IL_02a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_02ad: brfalse IL_02c1
 
-			IL_02a6: ldstr "LastPx"
-			IL_02ab: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M8>:__js_call__:162"
-			IL_02b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-			IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02b2: ldstr "LastPx"
+			IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02bc: br IL_02d5
 
-			IL_02ba: stloc.s 17
-			IL_02bc: ldloc.s 17
-			IL_02be: ldloc.s 15
-			IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_02c5: stloc.s 19
-			IL_02c7: ldloc.s 19
-			IL_02c9: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::round(object)
-			IL_02ce: stloc.s 18
-			IL_02d0: ldloc.s 18
-			IL_02d2: stloc.s 15
-			IL_02d4: ldarg.0
-			IL_02d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02da: volatile.
-			IL_02dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_02e1: brfalse IL_02f5
+			IL_02c1: ldstr "LastPx"
+			IL_02c6: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M8>:__js_call__:166"
+			IL_02cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02e6: ldstr "LastPx"
-			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f0: br IL_0309
+			IL_02d5: stloc.s 16
+			// loop start (head: IL_02d7)
+				IL_02d7: ldloc.s 16
+				IL_02d9: stloc.s 17
+				IL_02db: ldloc.s 17
+				IL_02dd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_02e2: ldloc.s 15
+				IL_02e4: clt
+				IL_02e6: brfalse IL_0374
 
-			IL_02f5: ldstr "LastPx"
-			IL_02fa: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M8>:__js_call__:170"
-			IL_02ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_02eb: ldloc.s 13
+				IL_02ed: ldloc.s 14
+				IL_02ef: add
+				IL_02f0: stloc.s 18
+				IL_02f2: ldloc.s 18
+				IL_02f4: stloc.s 13
+				IL_02f6: ldloc.s 13
+				IL_02f8: stloc.s 18
+				IL_02fa: ldloc.s 18
+				IL_02fc: ldloc.s 12
+				IL_02fe: clt
+				IL_0300: ldc.i4.0
+				IL_0301: ceq
+				IL_0303: brfalse IL_0331
 
-			IL_0309: stloc.s 16
-			// loop start (head: IL_030b)
-				IL_030b: ldloc.s 16
-				IL_030d: stloc.s 17
-				IL_030f: ldloc.s 17
-				IL_0311: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0316: ldloc.s 15
-				IL_0318: clt
-				IL_031a: brfalse IL_03a8
+				IL_0308: ldloc.s 13
+				IL_030a: ldloc.s 12
+				IL_030c: sub
+				IL_030d: stloc.s 18
+				IL_030f: ldloc.s 18
+				IL_0311: stloc.s 13
+				IL_0313: ldloc.s 6
+				IL_0315: ldloc.s 8
+				IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_031c: stloc.s 19
+				IL_031e: ldloc.s 19
+				IL_0320: stloc.s 6
+				IL_0322: ldloc.s 7
+				IL_0324: ldloc.s 10
+				IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_032b: stloc.s 19
+				IL_032d: ldloc.s 19
+				IL_032f: stloc.s 7
 
-				IL_031f: ldloc.s 13
-				IL_0321: ldloc.s 14
-				IL_0323: add
-				IL_0324: stloc.s 18
-				IL_0326: ldloc.s 18
-				IL_0328: stloc.s 13
-				IL_032a: ldloc.s 13
-				IL_032c: stloc.s 18
-				IL_032e: ldloc.s 18
-				IL_0330: ldloc.s 12
-				IL_0332: clt
-				IL_0334: ldc.i4.0
-				IL_0335: ceq
-				IL_0337: brfalse IL_0365
-
-				IL_033c: ldloc.s 13
-				IL_033e: ldloc.s 12
-				IL_0340: sub
-				IL_0341: stloc.s 18
-				IL_0343: ldloc.s 18
-				IL_0345: stloc.s 13
-				IL_0347: ldloc.s 6
-				IL_0349: ldloc.s 8
-				IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0350: stloc.s 19
-				IL_0352: ldloc.s 19
-				IL_0354: stloc.s 6
-				IL_0356: ldloc.s 7
-				IL_0358: ldloc.s 10
-				IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_035f: stloc.s 19
-				IL_0361: ldloc.s 19
-				IL_0363: stloc.s 7
-
-				IL_0365: ldloc.s 6
-				IL_0367: ldloc.s 9
-				IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_036e: stloc.s 19
-				IL_0370: ldloc.s 19
-				IL_0372: stloc.s 6
-				IL_0374: ldloc.s 7
-				IL_0376: ldloc.s 11
-				IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_037d: stloc.s 19
-				IL_037f: ldloc.s 19
-				IL_0381: stloc.s 7
-				IL_0383: ldloc.s 16
-				IL_0385: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_038a: ldc.r8 1
-				IL_0393: add
-				IL_0394: stloc.s 18
-				IL_0396: ldloc.s 18
-				IL_0398: box [System.Runtime]System.Double
-				IL_039d: stloc.s 20
-				IL_039f: ldloc.s 20
-				IL_03a1: stloc.s 16
-				IL_03a3: br IL_030b
+				IL_0331: ldloc.s 6
+				IL_0333: ldloc.s 9
+				IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_033a: stloc.s 19
+				IL_033c: ldloc.s 19
+				IL_033e: stloc.s 6
+				IL_0340: ldloc.s 7
+				IL_0342: ldloc.s 11
+				IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0349: stloc.s 19
+				IL_034b: ldloc.s 19
+				IL_034d: stloc.s 7
+				IL_034f: ldloc.s 16
+				IL_0351: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0356: ldc.r8 1
+				IL_035f: add
+				IL_0360: stloc.s 18
+				IL_0362: ldloc.s 18
+				IL_0364: box [System.Runtime]System.Double
+				IL_0369: stloc.s 20
+				IL_036b: ldloc.s 20
+				IL_036d: stloc.s 16
+				IL_036f: br IL_02d7
 			// end loop
 
-			IL_03a8: ldarg.0
-			IL_03a9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03ae: stloc.s 17
-			IL_03b0: ldloc.s 17
-			IL_03b2: ldstr "LastPx"
-			IL_03b7: ldloc.s 15
-			IL_03b9: ldc.i4.1
-			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_03bf: pop
-			IL_03c0: ldnull
-			IL_03c1: ret
+			IL_0374: ldarg.0
+			IL_0375: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_037a: stloc.s 17
+			IL_037c: ldloc.s 17
+			IL_037e: ldstr "LastPx"
+			IL_0383: ldloc.s 15
+			IL_0385: ldc.i4.1
+			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_038b: pop
+			IL_038c: ldnull
+			IL_038d: ret
 		} // end of method DrawLine::__js_call__
 
 	} // end of class DrawLine
@@ -2189,7 +2185,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 70 (0x46)
+			// Code size: 131 (0x83)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
@@ -2213,13 +2209,35 @@
 			IL_002c: ldarg.1
 			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0037: ldstr "V"
-			IL_003c: ldloc.0
-			IL_003d: ldc.i4.1
-			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0043: pop
-			IL_0044: ldnull
-			IL_0045: ret
+			IL_0037: isinst Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP
+			IL_003c: dup
+			IL_003d: brfalse IL_0068
+
+			IL_0042: dup
+			IL_0043: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0048: brfalse IL_0068
+
+			IL_004d: dup
+			IL_004e: ldstr "V"
+			IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0058: brfalse IL_0068
+
+			IL_005d: ldloc.0
+			IL_005e: callvirt instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::set_V(object)
+			IL_0063: br IL_0081
+
+			IL_0068: pop
+			IL_0069: ldarg.1
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0074: ldstr "V"
+			IL_0079: ldloc.0
+			IL_007a: ldc.i4.1
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0080: pop
+
+			IL_0081: ldnull
+			IL_0082: ret
 		} // end of method CreateP::__js_call__
 
 	} // end of class CreateP
@@ -5192,7 +5210,7 @@
 				IL_0064: ldarg.0
 				IL_0065: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 				IL_006a: volatile.
-				IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+				IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_0071: brfalse IL_0085
 
 				IL_0076: ldstr "Normal"
@@ -5201,7 +5219,7 @@
 
 				IL_0085: ldstr "Normal"
 				IL_008a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:24"
-				IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+				IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0099: stloc.s 6
@@ -5244,7 +5262,7 @@
 			IL_0107: ldarg.0
 			IL_0108: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_010d: volatile.
-			IL_010f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_010f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
 			IL_0114: brfalse IL_0128
 
 			IL_0119: ldstr "Line"
@@ -5253,7 +5271,7 @@
 
 			IL_0128: ldstr "Line"
 			IL_012d: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:46"
-			IL_0132: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_0132: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
 			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_013c: stloc.s 6
@@ -5300,7 +5318,7 @@
 			IL_01b9: ldarg.0
 			IL_01ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_01bf: volatile.
-			IL_01c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_01c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 			IL_01c6: brfalse IL_01da
 
 			IL_01cb: ldstr "Line"
@@ -5309,7 +5327,7 @@
 
 			IL_01da: ldstr "Line"
 			IL_01df: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:64"
-			IL_01e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_01e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01ee: stloc.s 8
@@ -5324,7 +5342,7 @@
 			IL_0208: ldarg.0
 			IL_0209: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_020e: volatile.
-			IL_0210: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_0210: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 			IL_0215: brfalse IL_0229
 
 			IL_021a: ldstr "Line"
@@ -5333,7 +5351,7 @@
 
 			IL_0229: ldstr "Line"
 			IL_022e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:72"
-			IL_0233: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_0233: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_023d: stloc.s 8
@@ -5380,7 +5398,7 @@
 			IL_02ba: ldarg.0
 			IL_02bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_02c0: volatile.
-			IL_02c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_02c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 			IL_02c7: brfalse IL_02db
 
 			IL_02cc: ldstr "Line"
@@ -5389,7 +5407,7 @@
 
 			IL_02db: ldstr "Line"
 			IL_02e0: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:90"
-			IL_02e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_02e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_02ef: stloc.s 6
@@ -5404,7 +5422,7 @@
 			IL_0309: ldarg.0
 			IL_030a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_030f: volatile.
-			IL_0311: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_0311: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 			IL_0316: brfalse IL_032a
 
 			IL_031b: ldstr "Line"
@@ -5413,7 +5431,7 @@
 
 			IL_032a: ldstr "Line"
 			IL_032f: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:98"
-			IL_0334: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_0334: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
 			IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_033e: stloc.s 6
@@ -5460,7 +5478,7 @@
 			IL_03bb: ldarg.0
 			IL_03bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_03c1: volatile.
-			IL_03c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_03c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 			IL_03c8: brfalse IL_03dc
 
 			IL_03cd: ldstr "Line"
@@ -5469,7 +5487,7 @@
 
 			IL_03dc: ldstr "Line"
 			IL_03e1: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:116"
-			IL_03e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_03e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
 			IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_03f0: stloc.s 8
@@ -5484,7 +5502,7 @@
 			IL_040a: ldarg.0
 			IL_040b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0410: volatile.
-			IL_0412: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_0412: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_0417: brfalse IL_042b
 
 			IL_041c: ldstr "Line"
@@ -5493,7 +5511,7 @@
 
 			IL_042b: ldstr "Line"
 			IL_0430: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:124"
-			IL_0435: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_0435: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
 			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_043f: stloc.s 8
@@ -5540,7 +5558,7 @@
 			IL_04bc: ldarg.0
 			IL_04bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_04c2: volatile.
-			IL_04c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_04c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
 			IL_04c9: brfalse IL_04dd
 
 			IL_04ce: ldstr "Line"
@@ -5549,7 +5567,7 @@
 
 			IL_04dd: ldstr "Line"
 			IL_04e2: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:142"
-			IL_04e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_04e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
 			IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_04f1: stloc.s 6
@@ -5578,7 +5596,7 @@
 			IL_0545: ldarg.0
 			IL_0546: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_054b: volatile.
-			IL_054d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_054d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
 			IL_0552: brfalse IL_0566
 
 			IL_0557: ldstr "Line"
@@ -5587,7 +5605,7 @@
 
 			IL_0566: ldstr "Line"
 			IL_056b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:160"
-			IL_0570: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_0570: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
 			IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_057a: stloc.s 6
@@ -5634,7 +5652,7 @@
 			IL_05f7: ldarg.0
 			IL_05f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_05fd: volatile.
-			IL_05ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_05ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 			IL_0604: brfalse IL_0618
 
 			IL_0609: ldstr "Line"
@@ -5643,7 +5661,7 @@
 
 			IL_0618: ldstr "Line"
 			IL_061d: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:178"
-			IL_0622: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_0622: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
 			IL_0627: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_062c: stloc.s 8
@@ -5658,7 +5676,7 @@
 			IL_0646: ldarg.0
 			IL_0647: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_064c: volatile.
-			IL_064e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_064e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
 			IL_0653: brfalse IL_0667
 
 			IL_0658: ldstr "Line"
@@ -5667,7 +5685,7 @@
 
 			IL_0667: ldstr "Line"
 			IL_066c: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:186"
-			IL_0671: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_0671: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
 			IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_067b: stloc.s 8
@@ -5714,7 +5732,7 @@
 			IL_06f8: ldarg.0
 			IL_06f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_06fe: volatile.
-			IL_0700: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_0700: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
 			IL_0705: brfalse IL_0719
 
 			IL_070a: ldstr "Line"
@@ -5723,7 +5741,7 @@
 
 			IL_0719: ldstr "Line"
 			IL_071e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:204"
-			IL_0723: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_0723: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
 			IL_0728: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_072d: stloc.s 6
@@ -5738,7 +5756,7 @@
 			IL_0747: ldarg.0
 			IL_0748: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_074d: volatile.
-			IL_074f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_074f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
 			IL_0754: brfalse IL_0768
 
 			IL_0759: ldstr "Line"
@@ -5747,7 +5765,7 @@
 
 			IL_0768: ldstr "Line"
 			IL_076d: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:212"
-			IL_0772: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_0772: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
 			IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_077c: stloc.s 6
@@ -5794,7 +5812,7 @@
 			IL_07f9: ldarg.0
 			IL_07fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_07ff: volatile.
-			IL_0801: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_0801: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
 			IL_0806: brfalse IL_081a
 
 			IL_080b: ldstr "Line"
@@ -5803,7 +5821,7 @@
 
 			IL_081a: ldstr "Line"
 			IL_081f: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:230"
-			IL_0824: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_0824: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
 			IL_0829: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_082e: stloc.s 8
@@ -5818,7 +5836,7 @@
 			IL_0848: ldarg.0
 			IL_0849: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_084e: volatile.
-			IL_0850: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_0850: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
 			IL_0855: brfalse IL_0869
 
 			IL_085a: ldstr "Line"
@@ -5827,7 +5845,7 @@
 
 			IL_0869: ldstr "Line"
 			IL_086e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:238"
-			IL_0873: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_0873: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
 			IL_0878: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_087d: stloc.s 8
@@ -5874,7 +5892,7 @@
 			IL_08fa: ldarg.0
 			IL_08fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0900: volatile.
-			IL_0902: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0902: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 			IL_0907: brfalse IL_091b
 
 			IL_090c: ldstr "Line"
@@ -5883,7 +5901,7 @@
 
 			IL_091b: ldstr "Line"
 			IL_0920: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:256"
-			IL_0925: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0925: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 			IL_092a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_092f: stloc.s 6
@@ -5912,7 +5930,7 @@
 			IL_0983: ldarg.0
 			IL_0984: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0989: volatile.
-			IL_098b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_098b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 			IL_0990: brfalse IL_09a4
 
 			IL_0995: ldstr "Line"
@@ -5921,7 +5939,7 @@
 
 			IL_09a4: ldstr "Line"
 			IL_09a9: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:274"
-			IL_09ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_09ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 			IL_09b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_09b8: stloc.s 6
@@ -5968,7 +5986,7 @@
 			IL_0a35: ldarg.0
 			IL_0a36: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0a3b: volatile.
-			IL_0a3d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0a3d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 			IL_0a42: brfalse IL_0a56
 
 			IL_0a47: ldstr "Line"
@@ -5977,7 +5995,7 @@
 
 			IL_0a56: ldstr "Line"
 			IL_0a5b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:292"
-			IL_0a60: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0a60: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0a6a: stloc.s 8
@@ -5992,7 +6010,7 @@
 			IL_0a84: ldarg.0
 			IL_0a85: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0a8a: volatile.
-			IL_0a8c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_0a8c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_0a91: brfalse IL_0aa5
 
 			IL_0a96: ldstr "Line"
@@ -6001,7 +6019,7 @@
 
 			IL_0aa5: ldstr "Line"
 			IL_0aaa: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:300"
-			IL_0aaf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_0aaf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_0ab4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0ab9: stloc.s 8
@@ -6048,7 +6066,7 @@
 			IL_0b36: ldarg.0
 			IL_0b37: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0b3c: volatile.
-			IL_0b3e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_0b3e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_0b43: brfalse IL_0b57
 
 			IL_0b48: ldstr "Line"
@@ -6057,7 +6075,7 @@
 
 			IL_0b57: ldstr "Line"
 			IL_0b5c: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:318"
-			IL_0b61: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_0b61: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_0b66: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0b6b: stloc.s 6
@@ -6072,7 +6090,7 @@
 			IL_0b85: ldarg.0
 			IL_0b86: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0b8b: volatile.
-			IL_0b8d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0b8d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0b92: brfalse IL_0ba6
 
 			IL_0b97: ldstr "Line"
@@ -6081,7 +6099,7 @@
 
 			IL_0ba6: ldstr "Line"
 			IL_0bab: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:326"
-			IL_0bb0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0bb0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0bb5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0bba: stloc.s 6
@@ -6128,7 +6146,7 @@
 			IL_0c37: ldarg.0
 			IL_0c38: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0c3d: volatile.
-			IL_0c3f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_0c3f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_0c44: brfalse IL_0c58
 
 			IL_0c49: ldstr "Line"
@@ -6137,7 +6155,7 @@
 
 			IL_0c58: ldstr "Line"
 			IL_0c5d: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:344"
-			IL_0c62: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_0c62: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_0c67: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0c6c: stloc.s 8
@@ -6152,7 +6170,7 @@
 			IL_0c86: ldarg.0
 			IL_0c87: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0c8c: volatile.
-			IL_0c8e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_0c8e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_0c93: brfalse IL_0ca7
 
 			IL_0c98: ldstr "Line"
@@ -6161,7 +6179,7 @@
 
 			IL_0ca7: ldstr "Line"
 			IL_0cac: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:352"
-			IL_0cb1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_0cb1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_0cb6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0cbb: stloc.s 8
@@ -6208,7 +6226,7 @@
 			IL_0d38: ldarg.0
 			IL_0d39: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0d3e: volatile.
-			IL_0d40: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0d40: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 			IL_0d45: brfalse IL_0d59
 
 			IL_0d4a: ldstr "Line"
@@ -6217,7 +6235,7 @@
 
 			IL_0d59: ldstr "Line"
 			IL_0d5e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:370"
-			IL_0d63: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0d63: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 			IL_0d68: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0d6d: stloc.s 6
@@ -6246,7 +6264,7 @@
 			IL_0dc1: ldarg.0
 			IL_0dc2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0dc7: volatile.
-			IL_0dc9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0dc9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 			IL_0dce: brfalse IL_0de2
 
 			IL_0dd3: ldstr "Line"
@@ -6255,7 +6273,7 @@
 
 			IL_0de2: ldstr "Line"
 			IL_0de7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:388"
-			IL_0dec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0dec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 			IL_0df1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0df6: stloc.s 6
@@ -6302,7 +6320,7 @@
 			IL_0e73: ldarg.0
 			IL_0e74: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0e79: volatile.
-			IL_0e7b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0e7b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 			IL_0e80: brfalse IL_0e94
 
 			IL_0e85: ldstr "Line"
@@ -6311,7 +6329,7 @@
 
 			IL_0e94: ldstr "Line"
 			IL_0e99: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:406"
-			IL_0e9e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0e9e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 			IL_0ea3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0ea8: stloc.s 8
@@ -6326,7 +6344,7 @@
 			IL_0ec2: ldarg.0
 			IL_0ec3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0ec8: volatile.
-			IL_0eca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0eca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 			IL_0ecf: brfalse IL_0ee3
 
 			IL_0ed4: ldstr "Line"
@@ -6335,7 +6353,7 @@
 
 			IL_0ee3: ldstr "Line"
 			IL_0ee8: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:414"
-			IL_0eed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0eed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 			IL_0ef2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0ef7: stloc.s 8
@@ -6382,7 +6400,7 @@
 			IL_0f74: ldarg.0
 			IL_0f75: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0f7a: volatile.
-			IL_0f7c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_0f7c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 			IL_0f81: brfalse IL_0f95
 
 			IL_0f86: ldstr "Line"
@@ -6391,7 +6409,7 @@
 
 			IL_0f95: ldstr "Line"
 			IL_0f9a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:432"
-			IL_0f9f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_0f9f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 			IL_0fa4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0fa9: stloc.s 6
@@ -6406,7 +6424,7 @@
 			IL_0fc3: ldarg.0
 			IL_0fc4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0fc9: volatile.
-			IL_0fcb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_0fcb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 			IL_0fd0: brfalse IL_0fe4
 
 			IL_0fd5: ldstr "Line"
@@ -6415,7 +6433,7 @@
 
 			IL_0fe4: ldstr "Line"
 			IL_0fe9: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:440"
-			IL_0fee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_0fee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 			IL_0ff3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0ff8: stloc.s 6
@@ -6462,7 +6480,7 @@
 			IL_1075: ldarg.0
 			IL_1076: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_107b: volatile.
-			IL_107d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_107d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_1082: brfalse IL_1096
 
 			IL_1087: ldstr "Line"
@@ -6471,7 +6489,7 @@
 
 			IL_1096: ldstr "Line"
 			IL_109b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:458"
-			IL_10a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_10a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_10a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_10aa: stloc.s 8
@@ -6486,7 +6504,7 @@
 			IL_10c4: ldarg.0
 			IL_10c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_10ca: volatile.
-			IL_10cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_10cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_10d1: brfalse IL_10e5
 
 			IL_10d6: ldstr "Line"
@@ -6495,7 +6513,7 @@
 
 			IL_10e5: ldstr "Line"
 			IL_10ea: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:466"
-			IL_10ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_10ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_10f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_10f9: stloc.s 8
@@ -6542,7 +6560,7 @@
 			IL_1176: ldarg.0
 			IL_1177: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_117c: volatile.
-			IL_117e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_117e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_1183: brfalse IL_1197
 
 			IL_1188: ldstr "Line"
@@ -6551,7 +6569,7 @@
 
 			IL_1197: ldstr "Line"
 			IL_119c: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:484"
-			IL_11a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_11a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_11a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_11ab: stloc.s 6
@@ -6580,7 +6598,7 @@
 			IL_11ff: ldarg.0
 			IL_1200: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_1205: volatile.
-			IL_1207: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_1207: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_120c: brfalse IL_1220
 
 			IL_1211: ldstr "Line"
@@ -6589,7 +6607,7 @@
 
 			IL_1220: ldstr "Line"
 			IL_1225: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:502"
-			IL_122a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_122a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_122f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1234: stloc.s 6
@@ -6636,7 +6654,7 @@
 			IL_12b1: ldarg.0
 			IL_12b2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_12b7: volatile.
-			IL_12b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_12b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_12be: brfalse IL_12d2
 
 			IL_12c3: ldstr "Line"
@@ -6645,7 +6663,7 @@
 
 			IL_12d2: ldstr "Line"
 			IL_12d7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:520"
-			IL_12dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_12dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_12e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_12e6: stloc.s 8
@@ -6660,7 +6678,7 @@
 			IL_1300: ldarg.0
 			IL_1301: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_1306: volatile.
-			IL_1308: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_1308: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_130d: brfalse IL_1321
 
 			IL_1312: ldstr "Line"
@@ -6669,7 +6687,7 @@
 
 			IL_1321: ldstr "Line"
 			IL_1326: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:528"
-			IL_132b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_132b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_1330: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1335: stloc.s 8
@@ -6716,7 +6734,7 @@
 			IL_13b2: ldarg.0
 			IL_13b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_13b8: volatile.
-			IL_13ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_13ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_13bf: brfalse IL_13d3
 
 			IL_13c4: ldstr "Line"
@@ -6725,7 +6743,7 @@
 
 			IL_13d3: ldstr "Line"
 			IL_13d8: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:546"
-			IL_13dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_13dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_13e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_13e7: stloc.s 6
@@ -6740,7 +6758,7 @@
 			IL_1401: ldarg.0
 			IL_1402: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_1407: volatile.
-			IL_1409: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_1409: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_140e: brfalse IL_1422
 
 			IL_1413: ldstr "Line"
@@ -6749,7 +6767,7 @@
 
 			IL_1422: ldstr "Line"
 			IL_1427: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:554"
-			IL_142c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_142c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_1431: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1436: stloc.s 6
@@ -6796,7 +6814,7 @@
 			IL_14b3: ldarg.0
 			IL_14b4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_14b9: volatile.
-			IL_14bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_14bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_14c0: brfalse IL_14d4
 
 			IL_14c5: ldstr "Line"
@@ -6805,7 +6823,7 @@
 
 			IL_14d4: ldstr "Line"
 			IL_14d9: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:572"
-			IL_14de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_14de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_14e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_14e8: stloc.s 8
@@ -6820,7 +6838,7 @@
 			IL_1502: ldarg.0
 			IL_1503: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_1508: volatile.
-			IL_150a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_150a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_150f: brfalse IL_1523
 
 			IL_1514: ldstr "Line"
@@ -6829,7 +6847,7 @@
 
 			IL_1523: ldstr "Line"
 			IL_1528: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:580"
-			IL_152d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_152d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_1532: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1537: stloc.s 8
@@ -6876,7 +6894,7 @@
 			IL_15b4: ldarg.0
 			IL_15b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_15ba: volatile.
-			IL_15bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_15bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_15c1: brfalse IL_15d5
 
 			IL_15c6: ldstr "Line"
@@ -6885,7 +6903,7 @@
 
 			IL_15d5: ldstr "Line"
 			IL_15da: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:598"
-			IL_15df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_15df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_15e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_15e9: stloc.s 6
@@ -6914,7 +6932,7 @@
 			IL_163d: ldarg.0
 			IL_163e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_1643: volatile.
-			IL_1645: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_1645: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_164a: brfalse IL_165e
 
 			IL_164f: ldstr "Line"
@@ -6923,7 +6941,7 @@
 
 			IL_165e: ldstr "Line"
 			IL_1663: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:616"
-			IL_1668: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_1668: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_166d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1672: stloc.s 6
@@ -6970,7 +6988,7 @@
 			IL_16ef: ldarg.0
 			IL_16f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_16f5: volatile.
-			IL_16f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_16f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_16fc: brfalse IL_1710
 
 			IL_1701: ldstr "Line"
@@ -6979,7 +6997,7 @@
 
 			IL_1710: ldstr "Line"
 			IL_1715: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:634"
-			IL_171a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_171a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_171f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1724: stloc.s 8
@@ -6994,7 +7012,7 @@
 			IL_173e: ldarg.0
 			IL_173f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_1744: volatile.
-			IL_1746: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_1746: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_174b: brfalse IL_175f
 
 			IL_1750: ldstr "Line"
@@ -7003,7 +7021,7 @@
 
 			IL_175f: ldstr "Line"
 			IL_1764: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:642"
-			IL_1769: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_1769: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_176e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1773: stloc.s 8
@@ -7050,7 +7068,7 @@
 			IL_17f0: ldarg.0
 			IL_17f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_17f6: volatile.
-			IL_17f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_17f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_17fd: brfalse IL_1811
 
 			IL_1802: ldstr "Line"
@@ -7059,7 +7077,7 @@
 
 			IL_1811: ldstr "Line"
 			IL_1816: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:660"
-			IL_181b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_181b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_1820: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1825: stloc.s 6
@@ -7074,7 +7092,7 @@
 			IL_183f: ldarg.0
 			IL_1840: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_1845: volatile.
-			IL_1847: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_1847: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_184c: brfalse IL_1860
 
 			IL_1851: ldstr "Line"
@@ -7083,7 +7101,7 @@
 
 			IL_1860: ldstr "Line"
 			IL_1865: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:668"
-			IL_186a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_186a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_186f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1874: stloc.s 6
@@ -7130,7 +7148,7 @@
 			IL_18f1: ldarg.0
 			IL_18f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_18f7: volatile.
-			IL_18f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_18f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_18fe: brfalse IL_1912
 
 			IL_1903: ldstr "Line"
@@ -7139,7 +7157,7 @@
 
 			IL_1912: ldstr "Line"
 			IL_1917: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:686"
-			IL_191c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_191c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_1921: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1926: stloc.s 8
@@ -7154,7 +7172,7 @@
 			IL_1940: ldarg.0
 			IL_1941: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_1946: volatile.
-			IL_1948: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_1948: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_194d: brfalse IL_1961
 
 			IL_1952: ldstr "Line"
@@ -7163,7 +7181,7 @@
 
 			IL_1961: ldstr "Line"
 			IL_1966: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:694"
-			IL_196b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_196b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_1970: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1975: stloc.s 8
@@ -7210,7 +7228,7 @@
 			IL_19f2: ldarg.0
 			IL_19f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_19f8: volatile.
-			IL_19fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_19fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_19ff: brfalse IL_1a13
 
 			IL_1a04: ldstr "Line"
@@ -7219,7 +7237,7 @@
 
 			IL_1a13: ldstr "Line"
 			IL_1a18: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:712"
-			IL_1a1d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_1a1d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_1a22: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_1a27: stloc.s 6
@@ -7486,7 +7504,7 @@
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
 			IL_0006: volatile.
-			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0008: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_000d: brfalse IL_0021
 
 			IL_0012: ldstr "LoopCount"
@@ -7495,14 +7513,14 @@
 
 			IL_0021: ldstr "LoopCount"
 			IL_0026: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:3"
-			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_002b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0035: stloc.2
 			IL_0036: ldarg.0
 			IL_0037: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
 			IL_003c: volatile.
-			IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_003e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0043: brfalse IL_0057
 
 			IL_0048: ldstr "LoopMax"
@@ -7511,7 +7529,7 @@
 
 			IL_0057: ldstr "LoopMax"
 			IL_005c: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:6"
-			IL_0061: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_0061: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_006b: stloc.3
@@ -7528,7 +7546,7 @@
 			IL_0081: ldarg.0
 			IL_0082: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
 			IL_0087: volatile.
-			IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+			IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_008e: brfalse IL_00a2
 
 			IL_0093: ldstr "LoopCount"
@@ -7537,7 +7555,7 @@
 
 			IL_00a2: ldstr "LoopCount"
 			IL_00a7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:18"
-			IL_00ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+			IL_00ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_00b6: stloc.3
@@ -7579,7 +7597,7 @@
 			IL_010e: ldc.r8 8
 			IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_011c: volatile.
-			IL_011e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+			IL_011e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 			IL_0123: brfalse IL_0137
 
 			IL_0128: ldstr "V"
@@ -7588,7 +7606,7 @@
 
 			IL_0137: ldstr "V"
 			IL_013c: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:42"
-			IL_0141: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+			IL_0141: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_014b: stloc.2
@@ -7605,7 +7623,7 @@
 			IL_016f: ldc.r8 8
 			IL_0178: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_017d: volatile.
-			IL_017f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+			IL_017f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 			IL_0184: brfalse IL_0198
 
 			IL_0189: ldstr "V"
@@ -7614,7 +7632,7 @@
 
 			IL_0198: ldstr "V"
 			IL_019d: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:50"
-			IL_01a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+			IL_01a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_01ac: stloc.2
@@ -7631,7 +7649,7 @@
 			IL_01d0: ldc.r8 8
 			IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_01de: volatile.
-			IL_01e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
+			IL_01e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 			IL_01e5: brfalse IL_01f9
 
 			IL_01ea: ldstr "V"
@@ -7640,7 +7658,7 @@
 
 			IL_01f9: ldstr "V"
 			IL_01fe: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:58"
-			IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
+			IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_020d: stloc.2
@@ -7746,7 +7764,7 @@
 			IL_0319: ldc.r8 8
 			IL_0322: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_0327: volatile.
-			IL_0329: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
+			IL_0329: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 			IL_032e: brfalse IL_0342
 
 			IL_0333: ldstr "V"
@@ -7755,7 +7773,7 @@
 
 			IL_0342: ldstr "V"
 			IL_0347: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:96"
-			IL_034c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
+			IL_034c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0356: stloc.2
@@ -7769,7 +7787,7 @@
 			IL_0372: ldc.r8 8
 			IL_037b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_0380: volatile.
-			IL_0382: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+			IL_0382: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 			IL_0387: brfalse IL_039b
 
 			IL_038c: ldstr "V"
@@ -7778,7 +7796,7 @@
 
 			IL_039b: ldstr "V"
 			IL_03a0: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:103"
-			IL_03a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+			IL_03a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 			IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_03af: stloc.s 9
@@ -7792,7 +7810,7 @@
 			IL_03ce: ldc.r8 8
 			IL_03d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_03dc: volatile.
-			IL_03de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
+			IL_03de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 			IL_03e3: brfalse IL_03f7
 
 			IL_03e8: ldstr "V"
@@ -7801,7 +7819,7 @@
 
 			IL_03f7: ldstr "V"
 			IL_03fc: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:110"
-			IL_0401: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
+			IL_0401: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_040b: stloc.s 10
@@ -7881,7 +7899,7 @@
 				IL_04d3: ldloc.1
 				IL_04d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 				IL_04d9: volatile.
-				IL_04db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+				IL_04db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 				IL_04e0: brfalse IL_04f4
 
 				IL_04e5: ldstr "V"
@@ -7890,7 +7908,7 @@
 
 				IL_04f4: ldstr "V"
 				IL_04f9: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:141"
-				IL_04fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+				IL_04fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 				IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 				IL_0508: stloc.2
@@ -8127,7 +8145,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 3849 (0xf09)
+			// Code size: 3958 (0xf76)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -8137,11 +8155,12 @@
 				[4] float64,
 				[5] object,
 				[6] object,
-				[7] object,
-				[8] float64,
-				[9] object[],
-				[10] object,
-				[11] object
+				[7] class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP,
+				[8] object,
+				[9] float64,
+				[10] object[],
+				[11] object,
+				[12] object
 			)
 
 			IL_0000: ldarg.0
@@ -8469,876 +8488,906 @@
 			IL_04e6: ldloc.s 4
 			IL_04e8: box [System.Runtime]System.Double
 			IL_04ed: stloc.s 6
-			IL_04ef: ldloc.3
-			IL_04f0: dup
-			IL_04f1: ldloc.s 5
-			IL_04f3: ldloc.s 6
-			IL_04f5: ldarg.2
-			IL_04f6: box [System.Runtime]System.Double
-			IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-			IL_0500: stloc.3
-			IL_0501: ldloc.1
-			IL_0502: ldc.r8 0.0
-			IL_050b: ldloc.3
-			IL_050c: ldc.i4.1
-			IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0512: pop
-			IL_0513: ldarg.0
-			IL_0514: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0519: stloc.3
-			IL_051a: ldarg.0
-			IL_051b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_0520: stloc.1
-			IL_0521: ldarg.2
-			IL_0522: neg
-			IL_0523: stloc.s 4
-			IL_0525: ldloc.s 4
-			IL_0527: box [System.Runtime]System.Double
-			IL_052c: stloc.s 6
-			IL_052e: ldloc.1
-			IL_052f: dup
-			IL_0530: ldloc.s 6
-			IL_0532: ldarg.2
-			IL_0533: box [System.Runtime]System.Double
-			IL_0538: ldarg.2
-			IL_0539: box [System.Runtime]System.Double
-			IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-			IL_0543: stloc.1
-			IL_0544: ldloc.3
-			IL_0545: ldc.r8 1
-			IL_054e: ldloc.1
-			IL_054f: ldc.i4.1
-			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0555: pop
-			IL_0556: ldarg.0
-			IL_0557: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_055c: stloc.1
-			IL_055d: ldarg.0
-			IL_055e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_0563: stloc.3
-			IL_0564: ldloc.3
-			IL_0565: dup
-			IL_0566: ldarg.2
-			IL_0567: box [System.Runtime]System.Double
-			IL_056c: ldarg.2
-			IL_056d: box [System.Runtime]System.Double
-			IL_0572: ldarg.2
-			IL_0573: box [System.Runtime]System.Double
-			IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-			IL_057d: stloc.3
-			IL_057e: ldloc.1
-			IL_057f: ldc.r8 2
-			IL_0588: ldloc.3
-			IL_0589: ldc.i4.1
-			IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_058f: pop
-			IL_0590: ldarg.0
-			IL_0591: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0596: stloc.3
-			IL_0597: ldarg.0
-			IL_0598: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_059d: stloc.1
-			IL_059e: ldarg.2
-			IL_059f: neg
-			IL_05a0: stloc.s 4
-			IL_05a2: ldloc.s 4
-			IL_05a4: box [System.Runtime]System.Double
-			IL_05a9: stloc.s 6
-			IL_05ab: ldloc.1
-			IL_05ac: dup
-			IL_05ad: ldarg.2
-			IL_05ae: box [System.Runtime]System.Double
-			IL_05b3: ldloc.s 6
-			IL_05b5: ldarg.2
-			IL_05b6: box [System.Runtime]System.Double
-			IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-			IL_05c0: stloc.1
-			IL_05c1: ldloc.3
-			IL_05c2: ldc.r8 3
-			IL_05cb: ldloc.1
-			IL_05cc: ldc.i4.1
-			IL_05cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_05d2: pop
-			IL_05d3: ldarg.0
-			IL_05d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_05d9: stloc.1
-			IL_05da: ldarg.0
-			IL_05db: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_05e0: stloc.3
-			IL_05e1: ldarg.2
-			IL_05e2: neg
-			IL_05e3: stloc.s 4
-			IL_05e5: ldloc.s 4
-			IL_05e7: box [System.Runtime]System.Double
-			IL_05ec: stloc.s 6
-			IL_05ee: ldarg.2
-			IL_05ef: neg
-			IL_05f0: stloc.s 4
-			IL_05f2: ldloc.s 4
-			IL_05f4: box [System.Runtime]System.Double
-			IL_05f9: stloc.s 5
-			IL_05fb: ldarg.2
-			IL_05fc: neg
-			IL_05fd: stloc.s 4
-			IL_05ff: ldloc.s 4
-			IL_0601: box [System.Runtime]System.Double
-			IL_0606: stloc.s 7
-			IL_0608: ldloc.3
-			IL_0609: dup
-			IL_060a: ldloc.s 6
-			IL_060c: ldloc.s 5
-			IL_060e: ldloc.s 7
-			IL_0610: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-			IL_0615: stloc.3
-			IL_0616: ldloc.1
-			IL_0617: ldc.r8 4
-			IL_0620: ldloc.3
-			IL_0621: ldc.i4.1
-			IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0627: pop
-			IL_0628: ldarg.0
-			IL_0629: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_062e: stloc.3
-			IL_062f: ldarg.0
-			IL_0630: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_0635: stloc.1
-			IL_0636: ldarg.2
-			IL_0637: neg
-			IL_0638: stloc.s 4
-			IL_063a: ldloc.s 4
-			IL_063c: box [System.Runtime]System.Double
-			IL_0641: stloc.s 7
-			IL_0643: ldarg.2
-			IL_0644: neg
-			IL_0645: stloc.s 4
-			IL_0647: ldloc.s 4
-			IL_0649: box [System.Runtime]System.Double
-			IL_064e: stloc.s 5
-			IL_0650: ldloc.1
-			IL_0651: dup
-			IL_0652: ldloc.s 7
-			IL_0654: ldarg.2
-			IL_0655: box [System.Runtime]System.Double
-			IL_065a: ldloc.s 5
-			IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-			IL_0661: stloc.1
-			IL_0662: ldloc.3
-			IL_0663: ldc.r8 5
-			IL_066c: ldloc.1
-			IL_066d: ldc.i4.1
-			IL_066e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0673: pop
-			IL_0674: ldarg.0
-			IL_0675: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_067a: stloc.1
-			IL_067b: ldarg.0
-			IL_067c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_0681: stloc.3
-			IL_0682: ldarg.2
-			IL_0683: neg
-			IL_0684: stloc.s 4
-			IL_0686: ldloc.s 4
-			IL_0688: box [System.Runtime]System.Double
-			IL_068d: stloc.s 5
-			IL_068f: ldloc.3
-			IL_0690: dup
-			IL_0691: ldarg.2
-			IL_0692: box [System.Runtime]System.Double
-			IL_0697: ldarg.2
-			IL_0698: box [System.Runtime]System.Double
-			IL_069d: ldloc.s 5
-			IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-			IL_06a4: stloc.3
-			IL_06a5: ldloc.1
-			IL_06a6: ldc.r8 6
-			IL_06af: ldloc.3
-			IL_06b0: ldc.i4.1
-			IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_06b6: pop
-			IL_06b7: ldarg.0
-			IL_06b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_06bd: stloc.3
-			IL_06be: ldarg.0
-			IL_06bf: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_06c4: stloc.1
-			IL_06c5: ldarg.2
-			IL_06c6: neg
-			IL_06c7: stloc.s 4
-			IL_06c9: ldloc.s 4
-			IL_06cb: box [System.Runtime]System.Double
-			IL_06d0: stloc.s 5
-			IL_06d2: ldarg.2
-			IL_06d3: neg
-			IL_06d4: stloc.s 4
-			IL_06d6: ldloc.s 4
-			IL_06d8: box [System.Runtime]System.Double
-			IL_06dd: stloc.s 7
-			IL_06df: ldloc.1
-			IL_06e0: dup
-			IL_06e1: ldarg.2
-			IL_06e2: box [System.Runtime]System.Double
-			IL_06e7: ldloc.s 5
-			IL_06e9: ldloc.s 7
-			IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-			IL_06f0: stloc.1
-			IL_06f1: ldloc.3
-			IL_06f2: ldc.r8 7
-			IL_06fb: ldloc.1
-			IL_06fc: ldc.i4.1
-			IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0702: pop
-			IL_0703: ldarg.0
-			IL_0704: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0709: stloc.1
-			IL_070a: ldarg.0
-			IL_070b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-			IL_0710: stloc.3
-			IL_0711: ldloc.3
-			IL_0712: dup
-			IL_0713: ldc.r8 0.0
-			IL_071c: box [System.Runtime]System.Double
-			IL_0721: ldc.r8 0.0
-			IL_072a: box [System.Runtime]System.Double
-			IL_072f: ldc.r8 0.0
+			IL_04ef: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+			IL_04f4: stloc.s 7
+			IL_04f6: ldloc.3
+			IL_04f7: ldloc.s 7
+			IL_04f9: ldloc.3
+			IL_04fa: ldloc.s 5
+			IL_04fc: ldloc.s 6
+			IL_04fe: ldarg.2
+			IL_04ff: box [System.Runtime]System.Double
+			IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_0509: stloc.s 7
+			IL_050b: ldloc.1
+			IL_050c: ldc.r8 0.0
+			IL_0515: ldloc.s 7
+			IL_0517: ldc.i4.1
+			IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_051d: pop
+			IL_051e: ldarg.0
+			IL_051f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0524: stloc.1
+			IL_0525: ldarg.0
+			IL_0526: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_052b: stloc.3
+			IL_052c: ldarg.2
+			IL_052d: neg
+			IL_052e: stloc.s 4
+			IL_0530: ldloc.s 4
+			IL_0532: box [System.Runtime]System.Double
+			IL_0537: stloc.s 6
+			IL_0539: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+			IL_053e: stloc.s 7
+			IL_0540: ldloc.3
+			IL_0541: ldloc.s 7
+			IL_0543: ldloc.3
+			IL_0544: ldloc.s 6
+			IL_0546: ldarg.2
+			IL_0547: box [System.Runtime]System.Double
+			IL_054c: ldarg.2
+			IL_054d: box [System.Runtime]System.Double
+			IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_0557: stloc.s 7
+			IL_0559: ldloc.1
+			IL_055a: ldc.r8 1
+			IL_0563: ldloc.s 7
+			IL_0565: ldc.i4.1
+			IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_056b: pop
+			IL_056c: ldarg.0
+			IL_056d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0572: stloc.1
+			IL_0573: ldarg.0
+			IL_0574: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_0579: stloc.3
+			IL_057a: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+			IL_057f: stloc.s 7
+			IL_0581: ldloc.3
+			IL_0582: ldloc.s 7
+			IL_0584: ldloc.3
+			IL_0585: ldarg.2
+			IL_0586: box [System.Runtime]System.Double
+			IL_058b: ldarg.2
+			IL_058c: box [System.Runtime]System.Double
+			IL_0591: ldarg.2
+			IL_0592: box [System.Runtime]System.Double
+			IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_059c: stloc.s 7
+			IL_059e: ldloc.1
+			IL_059f: ldc.r8 2
+			IL_05a8: ldloc.s 7
+			IL_05aa: ldc.i4.1
+			IL_05ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_05b0: pop
+			IL_05b1: ldarg.0
+			IL_05b2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_05b7: stloc.1
+			IL_05b8: ldarg.0
+			IL_05b9: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_05be: stloc.3
+			IL_05bf: ldarg.2
+			IL_05c0: neg
+			IL_05c1: stloc.s 4
+			IL_05c3: ldloc.s 4
+			IL_05c5: box [System.Runtime]System.Double
+			IL_05ca: stloc.s 6
+			IL_05cc: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+			IL_05d1: stloc.s 7
+			IL_05d3: ldloc.3
+			IL_05d4: ldloc.s 7
+			IL_05d6: ldloc.3
+			IL_05d7: ldarg.2
+			IL_05d8: box [System.Runtime]System.Double
+			IL_05dd: ldloc.s 6
+			IL_05df: ldarg.2
+			IL_05e0: box [System.Runtime]System.Double
+			IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_05ea: stloc.s 7
+			IL_05ec: ldloc.1
+			IL_05ed: ldc.r8 3
+			IL_05f6: ldloc.s 7
+			IL_05f8: ldc.i4.1
+			IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_05fe: pop
+			IL_05ff: ldarg.0
+			IL_0600: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0605: stloc.1
+			IL_0606: ldarg.0
+			IL_0607: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_060c: stloc.3
+			IL_060d: ldarg.2
+			IL_060e: neg
+			IL_060f: stloc.s 4
+			IL_0611: ldloc.s 4
+			IL_0613: box [System.Runtime]System.Double
+			IL_0618: stloc.s 6
+			IL_061a: ldarg.2
+			IL_061b: neg
+			IL_061c: stloc.s 4
+			IL_061e: ldloc.s 4
+			IL_0620: box [System.Runtime]System.Double
+			IL_0625: stloc.s 5
+			IL_0627: ldarg.2
+			IL_0628: neg
+			IL_0629: stloc.s 4
+			IL_062b: ldloc.s 4
+			IL_062d: box [System.Runtime]System.Double
+			IL_0632: stloc.s 8
+			IL_0634: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+			IL_0639: stloc.s 7
+			IL_063b: ldloc.3
+			IL_063c: ldloc.s 7
+			IL_063e: ldloc.3
+			IL_063f: ldloc.s 6
+			IL_0641: ldloc.s 5
+			IL_0643: ldloc.s 8
+			IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_064a: stloc.s 7
+			IL_064c: ldloc.1
+			IL_064d: ldc.r8 4
+			IL_0656: ldloc.s 7
+			IL_0658: ldc.i4.1
+			IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_065e: pop
+			IL_065f: ldarg.0
+			IL_0660: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0665: stloc.1
+			IL_0666: ldarg.0
+			IL_0667: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_066c: stloc.3
+			IL_066d: ldarg.2
+			IL_066e: neg
+			IL_066f: stloc.s 4
+			IL_0671: ldloc.s 4
+			IL_0673: box [System.Runtime]System.Double
+			IL_0678: stloc.s 8
+			IL_067a: ldarg.2
+			IL_067b: neg
+			IL_067c: stloc.s 4
+			IL_067e: ldloc.s 4
+			IL_0680: box [System.Runtime]System.Double
+			IL_0685: stloc.s 5
+			IL_0687: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+			IL_068c: stloc.s 7
+			IL_068e: ldloc.3
+			IL_068f: ldloc.s 7
+			IL_0691: ldloc.3
+			IL_0692: ldloc.s 8
+			IL_0694: ldarg.2
+			IL_0695: box [System.Runtime]System.Double
+			IL_069a: ldloc.s 5
+			IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_06a1: stloc.s 7
+			IL_06a3: ldloc.1
+			IL_06a4: ldc.r8 5
+			IL_06ad: ldloc.s 7
+			IL_06af: ldc.i4.1
+			IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_06b5: pop
+			IL_06b6: ldarg.0
+			IL_06b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_06bc: stloc.1
+			IL_06bd: ldarg.0
+			IL_06be: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_06c3: stloc.3
+			IL_06c4: ldarg.2
+			IL_06c5: neg
+			IL_06c6: stloc.s 4
+			IL_06c8: ldloc.s 4
+			IL_06ca: box [System.Runtime]System.Double
+			IL_06cf: stloc.s 5
+			IL_06d1: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+			IL_06d6: stloc.s 7
+			IL_06d8: ldloc.3
+			IL_06d9: ldloc.s 7
+			IL_06db: ldloc.3
+			IL_06dc: ldarg.2
+			IL_06dd: box [System.Runtime]System.Double
+			IL_06e2: ldarg.2
+			IL_06e3: box [System.Runtime]System.Double
+			IL_06e8: ldloc.s 5
+			IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_06ef: stloc.s 7
+			IL_06f1: ldloc.1
+			IL_06f2: ldc.r8 6
+			IL_06fb: ldloc.s 7
+			IL_06fd: ldc.i4.1
+			IL_06fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0703: pop
+			IL_0704: ldarg.0
+			IL_0705: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_070a: stloc.1
+			IL_070b: ldarg.0
+			IL_070c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_0711: stloc.3
+			IL_0712: ldarg.2
+			IL_0713: neg
+			IL_0714: stloc.s 4
+			IL_0716: ldloc.s 4
+			IL_0718: box [System.Runtime]System.Double
+			IL_071d: stloc.s 5
+			IL_071f: ldarg.2
+			IL_0720: neg
+			IL_0721: stloc.s 4
+			IL_0723: ldloc.s 4
+			IL_0725: box [System.Runtime]System.Double
+			IL_072a: stloc.s 8
+			IL_072c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+			IL_0731: stloc.s 7
+			IL_0733: ldloc.3
+			IL_0734: ldloc.s 7
+			IL_0736: ldloc.3
+			IL_0737: ldarg.2
 			IL_0738: box [System.Runtime]System.Double
-			IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-			IL_0742: stloc.3
-			IL_0743: ldloc.1
-			IL_0744: ldc.r8 8
-			IL_074d: ldloc.3
-			IL_074e: ldc.i4.1
-			IL_074f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0754: pop
-			IL_0755: ldarg.0
-			IL_0756: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_075b: stloc.3
-			IL_075c: ldc.i4.6
-			IL_075d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0762: dup
-			IL_0763: ldc.i4.3
-			IL_0764: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0769: dup
-			IL_076a: ldc.r8 0.0
-			IL_0773: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0778: dup
-			IL_0779: ldc.r8 1
-			IL_0782: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0787: dup
-			IL_0788: ldc.r8 2
-			IL_0791: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0796: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_079b: dup
-			IL_079c: ldc.i4.3
-			IL_079d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_07a2: dup
-			IL_07a3: ldc.r8 3
-			IL_07ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_07b1: dup
-			IL_07b2: ldc.r8 2
-			IL_07bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_07c0: dup
-			IL_07c1: ldc.r8 6
-			IL_07ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_07cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_07d4: dup
-			IL_07d5: ldc.i4.3
-			IL_07d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_073d: ldloc.s 5
+			IL_073f: ldloc.s 8
+			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_0746: stloc.s 7
+			IL_0748: ldloc.1
+			IL_0749: ldc.r8 7
+			IL_0752: ldloc.s 7
+			IL_0754: ldc.i4.1
+			IL_0755: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_075a: pop
+			IL_075b: ldarg.0
+			IL_075c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0761: stloc.1
+			IL_0762: ldarg.0
+			IL_0763: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+			IL_0768: stloc.3
+			IL_0769: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+			IL_076e: stloc.s 7
+			IL_0770: ldloc.3
+			IL_0771: ldloc.s 7
+			IL_0773: ldloc.3
+			IL_0774: ldc.r8 0.0
+			IL_077d: box [System.Runtime]System.Double
+			IL_0782: ldc.r8 0.0
+			IL_078b: box [System.Runtime]System.Double
+			IL_0790: ldc.r8 0.0
+			IL_0799: box [System.Runtime]System.Double
+			IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+			IL_07a3: stloc.s 7
+			IL_07a5: ldloc.1
+			IL_07a6: ldc.r8 8
+			IL_07af: ldloc.s 7
+			IL_07b1: ldc.i4.1
+			IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_07b7: pop
+			IL_07b8: ldarg.0
+			IL_07b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07be: stloc.1
+			IL_07bf: ldc.i4.6
+			IL_07c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_07c5: dup
+			IL_07c6: ldc.i4.3
+			IL_07c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_07cc: dup
+			IL_07cd: ldc.r8 0.0
+			IL_07d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 			IL_07db: dup
-			IL_07dc: ldc.r8 7
+			IL_07dc: ldc.r8 1
 			IL_07e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 			IL_07ea: dup
-			IL_07eb: ldc.r8 6
+			IL_07eb: ldc.r8 2
 			IL_07f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_07f9: dup
-			IL_07fa: ldc.r8 5
-			IL_0803: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0808: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_080d: dup
-			IL_080e: ldc.i4.3
-			IL_080f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_07f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_07fe: dup
+			IL_07ff: ldc.i4.3
+			IL_0800: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0805: dup
+			IL_0806: ldc.r8 3
+			IL_080f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 			IL_0814: dup
-			IL_0815: ldc.r8 4
+			IL_0815: ldc.r8 2
 			IL_081e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 			IL_0823: dup
-			IL_0824: ldc.r8 5
+			IL_0824: ldc.r8 6
 			IL_082d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0832: dup
-			IL_0833: ldc.r8 1
-			IL_083c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_0841: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0846: dup
-			IL_0847: ldc.i4.3
-			IL_0848: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0832: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0837: dup
+			IL_0838: ldc.i4.3
+			IL_0839: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_083e: dup
+			IL_083f: ldc.r8 7
+			IL_0848: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 			IL_084d: dup
-			IL_084e: ldc.r8 4
+			IL_084e: ldc.r8 6
 			IL_0857: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 			IL_085c: dup
-			IL_085d: ldc.r8 0.0
+			IL_085d: ldc.r8 5
 			IL_0866: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_086b: dup
-			IL_086c: ldc.r8 3
-			IL_0875: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_087a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_087f: dup
-			IL_0880: ldc.i4.3
-			IL_0881: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_086b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0870: dup
+			IL_0871: ldc.i4.3
+			IL_0872: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0877: dup
+			IL_0878: ldc.r8 4
+			IL_0881: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 			IL_0886: dup
-			IL_0887: ldc.r8 1
+			IL_0887: ldc.r8 5
 			IL_0890: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 			IL_0895: dup
-			IL_0896: ldc.r8 5
+			IL_0896: ldc.r8 1
 			IL_089f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_08a4: dup
-			IL_08a5: ldc.r8 6
-			IL_08ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_08b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_08b8: stloc.2
-			IL_08b9: ldloc.3
-			IL_08ba: ldstr "Edge"
-			IL_08bf: ldloc.2
-			IL_08c0: ldc.i4.1
-			IL_08c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_08c6: pop
-			IL_08c7: ldarg.0
-			IL_08c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_08cd: stloc.3
-			IL_08ce: ldc.i4.0
-			IL_08cf: newarr [System.Runtime]System.Object
-			IL_08d4: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
-			IL_08d9: stloc.1
-			IL_08da: ldloc.3
-			IL_08db: ldstr "Normal"
-			IL_08e0: ldloc.1
-			IL_08e1: ldc.i4.1
-			IL_08e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_08e7: pop
-			IL_08e8: ldc.r8 0.0
-			IL_08f1: stloc.0
-			// loop start (head: IL_08f2)
-				IL_08f2: ldloc.0
-				IL_08f3: stloc.s 4
-				IL_08f5: ldarg.0
-				IL_08f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_08fb: volatile.
-				IL_08fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-				IL_0902: brfalse IL_0916
+			IL_08a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_08a9: dup
+			IL_08aa: ldc.i4.3
+			IL_08ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_08b0: dup
+			IL_08b1: ldc.r8 4
+			IL_08ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_08bf: dup
+			IL_08c0: ldc.r8 0.0
+			IL_08c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_08ce: dup
+			IL_08cf: ldc.r8 3
+			IL_08d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_08dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_08e2: dup
+			IL_08e3: ldc.i4.3
+			IL_08e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_08e9: dup
+			IL_08ea: ldc.r8 1
+			IL_08f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_08f8: dup
+			IL_08f9: ldc.r8 5
+			IL_0902: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0907: dup
+			IL_0908: ldc.r8 6
+			IL_0911: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_0916: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_091b: stloc.2
+			IL_091c: ldloc.1
+			IL_091d: ldstr "Edge"
+			IL_0922: ldloc.2
+			IL_0923: ldc.i4.1
+			IL_0924: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0929: pop
+			IL_092a: ldarg.0
+			IL_092b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0930: stloc.1
+			IL_0931: ldc.i4.0
+			IL_0932: newarr [System.Runtime]System.Object
+			IL_0937: call class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::Construct(object[])
+			IL_093c: stloc.3
+			IL_093d: ldloc.1
+			IL_093e: ldstr "Normal"
+			IL_0943: ldloc.3
+			IL_0944: ldc.i4.1
+			IL_0945: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_094a: pop
+			IL_094b: ldc.r8 0.0
+			IL_0954: stloc.0
+			// loop start (head: IL_0955)
+				IL_0955: ldloc.0
+				IL_0956: stloc.s 4
+				IL_0958: ldarg.0
+				IL_0959: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_095e: volatile.
+				IL_0960: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+				IL_0965: brfalse IL_0979
 
-				IL_0907: ldstr "Edge"
-				IL_090c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0911: br IL_092a
+				IL_096a: ldstr "Edge"
+				IL_096f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0974: br IL_098d
 
-				IL_0916: ldstr "Edge"
-				IL_091b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:280"
-				IL_0920: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-				IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0979: ldstr "Edge"
+				IL_097e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:289"
+				IL_0983: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+				IL_0988: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_092a: stloc.1
-				IL_092b: ldloc.1
-				IL_092c: ldstr "length"
-				IL_0931: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0936: stloc.s 8
-				IL_0938: ldloc.s 4
-				IL_093a: ldloc.s 8
-				IL_093c: clt
-				IL_093e: brfalse IL_0b70
+				IL_098d: stloc.3
+				IL_098e: ldloc.3
+				IL_098f: ldstr "length"
+				IL_0994: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0999: stloc.s 9
+				IL_099b: ldloc.s 4
+				IL_099d: ldloc.s 9
+				IL_099f: clt
+				IL_09a1: brfalse IL_0bd3
 
-				IL_0943: ldarg.0
-				IL_0944: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0949: volatile.
-				IL_094b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-				IL_0950: brfalse IL_0964
+				IL_09a6: ldarg.0
+				IL_09a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_09ac: volatile.
+				IL_09ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
+				IL_09b3: brfalse IL_09c7
 
-				IL_0955: ldstr "Normal"
-				IL_095a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_095f: br IL_0978
+				IL_09b8: ldstr "Normal"
+				IL_09bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_09c2: br IL_09db
 
-				IL_0964: ldstr "Normal"
-				IL_0969: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:288"
-				IL_096e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-				IL_0973: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_09c7: ldstr "Normal"
+				IL_09cc: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:297"
+				IL_09d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
+				IL_09d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0978: stloc.1
-				IL_0979: ldarg.0
-				IL_097a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcNormal
-				IL_097f: ldc.i4.1
-				IL_0980: newarr [System.Runtime]System.Object
-				IL_0985: dup
-				IL_0986: ldc.i4.0
-				IL_0987: ldarg.0
-				IL_0988: stelem.ref
-				IL_0989: stloc.s 9
-				IL_098b: ldarg.0
-				IL_098c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0991: ldarg.0
-				IL_0992: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0997: volatile.
-				IL_0999: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-				IL_099e: brfalse IL_09b2
+				IL_09db: stloc.3
+				IL_09dc: ldarg.0
+				IL_09dd: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcNormal
+				IL_09e2: ldc.i4.1
+				IL_09e3: newarr [System.Runtime]System.Object
+				IL_09e8: dup
+				IL_09e9: ldc.i4.0
+				IL_09ea: ldarg.0
+				IL_09eb: stelem.ref
+				IL_09ec: stloc.s 10
+				IL_09ee: ldarg.0
+				IL_09ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_09f4: ldarg.0
+				IL_09f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_09fa: volatile.
+				IL_09fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+				IL_0a01: brfalse IL_0a15
 
-				IL_09a3: ldstr "Edge"
-				IL_09a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_09ad: br IL_09c6
+				IL_0a06: ldstr "Edge"
+				IL_0a0b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0a10: br IL_0a29
 
-				IL_09b2: ldstr "Edge"
-				IL_09b7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:294"
-				IL_09bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-				IL_09c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0a15: ldstr "Edge"
+				IL_0a1a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:303"
+				IL_0a1f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+				IL_0a24: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_09c6: stloc.3
-				IL_09c7: ldloc.3
-				IL_09c8: ldloc.0
-				IL_09c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_09ce: stloc.3
-				IL_09cf: ldloc.3
-				IL_09d0: ldc.r8 0.0
-				IL_09d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_09de: stloc.3
-				IL_09df: ldloc.3
-				IL_09e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_09e5: stloc.3
-				IL_09e6: volatile.
-				IL_09e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-				IL_09ed: brfalse IL_0a02
+				IL_0a29: stloc.1
+				IL_0a2a: ldloc.1
+				IL_0a2b: ldloc.0
+				IL_0a2c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0a31: stloc.1
+				IL_0a32: ldloc.1
+				IL_0a33: ldc.r8 0.0
+				IL_0a3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0a41: stloc.1
+				IL_0a42: ldloc.1
+				IL_0a43: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0a48: stloc.1
+				IL_0a49: volatile.
+				IL_0a4b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+				IL_0a50: brfalse IL_0a65
 
-				IL_09f2: ldloc.3
-				IL_09f3: ldstr "V"
-				IL_09f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_09fd: br IL_0a17
+				IL_0a55: ldloc.1
+				IL_0a56: ldstr "V"
+				IL_0a5b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0a60: br IL_0a7a
 
-				IL_0a02: ldloc.3
-				IL_0a03: ldstr "V"
-				IL_0a08: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:300"
-				IL_0a0d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-				IL_0a12: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0a65: ldloc.1
+				IL_0a66: ldstr "V"
+				IL_0a6b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:309"
+				IL_0a70: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+				IL_0a75: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0a17: stloc.3
-				IL_0a18: ldarg.0
-				IL_0a19: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0a1e: ldarg.0
-				IL_0a1f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0a24: volatile.
-				IL_0a26: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-				IL_0a2b: brfalse IL_0a3f
+				IL_0a7a: stloc.1
+				IL_0a7b: ldarg.0
+				IL_0a7c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0a81: ldarg.0
+				IL_0a82: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0a87: volatile.
+				IL_0a89: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
+				IL_0a8e: brfalse IL_0aa2
 
-				IL_0a30: ldstr "Edge"
-				IL_0a35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0a3a: br IL_0a53
+				IL_0a93: ldstr "Edge"
+				IL_0a98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0a9d: br IL_0ab6
 
-				IL_0a3f: ldstr "Edge"
-				IL_0a44: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:304"
-				IL_0a49: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-				IL_0a4e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0aa2: ldstr "Edge"
+				IL_0aa7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:313"
+				IL_0aac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
+				IL_0ab1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0a53: stloc.s 10
-				IL_0a55: ldloc.s 10
-				IL_0a57: ldloc.0
-				IL_0a58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0a5d: stloc.s 10
-				IL_0a5f: ldloc.s 10
-				IL_0a61: ldc.r8 1
-				IL_0a6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0a6f: stloc.s 10
-				IL_0a71: ldloc.s 10
-				IL_0a73: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0a78: stloc.s 10
-				IL_0a7a: volatile.
-				IL_0a7c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-				IL_0a81: brfalse IL_0a97
+				IL_0ab6: stloc.s 11
+				IL_0ab8: ldloc.s 11
+				IL_0aba: ldloc.0
+				IL_0abb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0ac0: stloc.s 11
+				IL_0ac2: ldloc.s 11
+				IL_0ac4: ldc.r8 1
+				IL_0acd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0ad2: stloc.s 11
+				IL_0ad4: ldloc.s 11
+				IL_0ad6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0adb: stloc.s 11
+				IL_0add: volatile.
+				IL_0adf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
+				IL_0ae4: brfalse IL_0afa
 
-				IL_0a86: ldloc.s 10
-				IL_0a88: ldstr "V"
-				IL_0a8d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0a92: br IL_0aad
+				IL_0ae9: ldloc.s 11
+				IL_0aeb: ldstr "V"
+				IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0af5: br IL_0b10
 
-				IL_0a97: ldloc.s 10
-				IL_0a99: ldstr "V"
-				IL_0a9e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:310"
-				IL_0aa3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-				IL_0aa8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0afa: ldloc.s 11
+				IL_0afc: ldstr "V"
+				IL_0b01: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:319"
+				IL_0b06: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
+				IL_0b0b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0aad: stloc.s 10
-				IL_0aaf: ldarg.0
-				IL_0ab0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0ab5: ldarg.0
-				IL_0ab6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0abb: volatile.
-				IL_0abd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-				IL_0ac2: brfalse IL_0ad6
+				IL_0b10: stloc.s 11
+				IL_0b12: ldarg.0
+				IL_0b13: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b18: ldarg.0
+				IL_0b19: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b1e: volatile.
+				IL_0b20: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+				IL_0b25: brfalse IL_0b39
 
-				IL_0ac7: ldstr "Edge"
-				IL_0acc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0ad1: br IL_0aea
+				IL_0b2a: ldstr "Edge"
+				IL_0b2f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b34: br IL_0b4d
 
-				IL_0ad6: ldstr "Edge"
-				IL_0adb: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:314"
-				IL_0ae0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-				IL_0ae5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0b39: ldstr "Edge"
+				IL_0b3e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:323"
+				IL_0b43: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+				IL_0b48: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0aea: stloc.s 11
-				IL_0aec: ldloc.s 11
-				IL_0aee: ldloc.0
-				IL_0aef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0af4: stloc.s 11
-				IL_0af6: ldloc.s 11
-				IL_0af8: ldc.r8 2
-				IL_0b01: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0b06: stloc.s 11
-				IL_0b08: ldloc.s 11
-				IL_0b0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0b0f: stloc.s 11
-				IL_0b11: volatile.
-				IL_0b13: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-				IL_0b18: brfalse IL_0b2e
+				IL_0b4d: stloc.s 12
+				IL_0b4f: ldloc.s 12
+				IL_0b51: ldloc.0
+				IL_0b52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b57: stloc.s 12
+				IL_0b59: ldloc.s 12
+				IL_0b5b: ldc.r8 2
+				IL_0b64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b69: stloc.s 12
+				IL_0b6b: ldloc.s 12
+				IL_0b6d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0b72: stloc.s 12
+				IL_0b74: volatile.
+				IL_0b76: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+				IL_0b7b: brfalse IL_0b91
 
-				IL_0b1d: ldloc.s 11
-				IL_0b1f: ldstr "V"
-				IL_0b24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b29: br IL_0b44
+				IL_0b80: ldloc.s 12
+				IL_0b82: ldstr "V"
+				IL_0b87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b8c: br IL_0ba7
 
-				IL_0b2e: ldloc.s 11
-				IL_0b30: ldstr "V"
-				IL_0b35: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:320"
-				IL_0b3a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-				IL_0b3f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0b91: ldloc.s 12
+				IL_0b93: ldstr "V"
+				IL_0b98: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:329"
+				IL_0b9d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+				IL_0ba2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0b44: stloc.s 11
-				IL_0b46: ldloc.s 9
-				IL_0b48: ldloc.3
-				IL_0b49: ldloc.s 10
-				IL_0b4b: ldloc.s 11
-				IL_0b4d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_0b52: stloc.s 11
-				IL_0b54: ldloc.1
-				IL_0b55: ldloc.0
-				IL_0b56: ldloc.s 11
-				IL_0b58: ldc.i4.1
-				IL_0b59: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-				IL_0b5e: pop
-				IL_0b5f: ldloc.0
-				IL_0b60: ldc.r8 1
-				IL_0b69: add
-				IL_0b6a: stloc.0
-				IL_0b6b: br IL_08f2
+				IL_0ba7: stloc.s 12
+				IL_0ba9: ldloc.s 10
+				IL_0bab: ldloc.1
+				IL_0bac: ldloc.s 11
+				IL_0bae: ldloc.s 12
+				IL_0bb0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_0bb5: stloc.s 12
+				IL_0bb7: ldloc.3
+				IL_0bb8: ldloc.0
+				IL_0bb9: ldloc.s 12
+				IL_0bbb: ldc.i4.1
+				IL_0bbc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+				IL_0bc1: pop
+				IL_0bc2: ldloc.0
+				IL_0bc3: ldc.r8 1
+				IL_0bcc: add
+				IL_0bcd: stloc.0
+				IL_0bce: br IL_0955
 			// end loop
 
-			IL_0b70: ldarg.0
-			IL_0b71: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b76: stloc.s 11
-			IL_0b78: ldc.i4.s 12
-			IL_0b7a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0b7f: dup
-			IL_0b80: ldc.i4.0
-			IL_0b81: box [System.Runtime]System.Boolean
-			IL_0b86: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0b8b: dup
-			IL_0b8c: ldc.i4.0
-			IL_0b8d: box [System.Runtime]System.Boolean
-			IL_0b92: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0b97: dup
-			IL_0b98: ldc.i4.0
-			IL_0b99: box [System.Runtime]System.Boolean
-			IL_0b9e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ba3: dup
-			IL_0ba4: ldc.i4.0
-			IL_0ba5: box [System.Runtime]System.Boolean
-			IL_0baa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0baf: dup
-			IL_0bb0: ldc.i4.0
-			IL_0bb1: box [System.Runtime]System.Boolean
-			IL_0bb6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bbb: dup
-			IL_0bbc: ldc.i4.0
-			IL_0bbd: box [System.Runtime]System.Boolean
-			IL_0bc2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bc7: dup
-			IL_0bc8: ldc.i4.0
-			IL_0bc9: box [System.Runtime]System.Boolean
-			IL_0bce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bd3: dup
-			IL_0bd4: ldc.i4.0
-			IL_0bd5: box [System.Runtime]System.Boolean
-			IL_0bda: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bdf: dup
-			IL_0be0: ldc.i4.0
-			IL_0be1: box [System.Runtime]System.Boolean
-			IL_0be6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0beb: dup
-			IL_0bec: ldc.i4.0
-			IL_0bed: box [System.Runtime]System.Boolean
-			IL_0bf2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0bf7: dup
-			IL_0bf8: ldc.i4.0
-			IL_0bf9: box [System.Runtime]System.Boolean
-			IL_0bfe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c03: dup
-			IL_0c04: ldc.i4.0
-			IL_0c05: box [System.Runtime]System.Boolean
-			IL_0c0a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c0f: stloc.2
-			IL_0c10: ldloc.s 11
-			IL_0c12: ldstr "Line"
-			IL_0c17: ldloc.2
-			IL_0c18: ldc.i4.1
-			IL_0c19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0c1e: pop
-			IL_0c1f: ldarg.0
-			IL_0c20: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c25: stloc.s 11
-			IL_0c27: ldc.r8 9
-			IL_0c30: ldc.r8 2
-			IL_0c39: mul
-			IL_0c3a: ldarg.2
-			IL_0c3b: mul
-			IL_0c3c: stloc.s 8
-			IL_0c3e: ldloc.s 11
-			IL_0c40: ldstr "NumPx"
-			IL_0c45: ldloc.s 8
-			IL_0c47: ldc.i4.1
-			IL_0c48: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0c4d: pop
-			IL_0c4e: ldc.r8 0.0
-			IL_0c57: stloc.0
-			// loop start (head: IL_0c58)
-				IL_0c58: ldloc.0
-				IL_0c59: stloc.s 8
-				IL_0c5b: ldarg.0
-				IL_0c5c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0c61: ldstr "NumPx"
-				IL_0c66: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0c6b: stloc.s 4
-				IL_0c6d: ldloc.s 8
-				IL_0c6f: ldloc.s 4
-				IL_0c71: clt
-				IL_0c73: brfalse IL_0cc4
+			IL_0bd3: ldarg.0
+			IL_0bd4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0bd9: stloc.s 12
+			IL_0bdb: ldc.i4.s 12
+			IL_0bdd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0be2: dup
+			IL_0be3: ldc.i4.0
+			IL_0be4: box [System.Runtime]System.Boolean
+			IL_0be9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0bee: dup
+			IL_0bef: ldc.i4.0
+			IL_0bf0: box [System.Runtime]System.Boolean
+			IL_0bf5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0bfa: dup
+			IL_0bfb: ldc.i4.0
+			IL_0bfc: box [System.Runtime]System.Boolean
+			IL_0c01: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c06: dup
+			IL_0c07: ldc.i4.0
+			IL_0c08: box [System.Runtime]System.Boolean
+			IL_0c0d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c12: dup
+			IL_0c13: ldc.i4.0
+			IL_0c14: box [System.Runtime]System.Boolean
+			IL_0c19: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c1e: dup
+			IL_0c1f: ldc.i4.0
+			IL_0c20: box [System.Runtime]System.Boolean
+			IL_0c25: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c2a: dup
+			IL_0c2b: ldc.i4.0
+			IL_0c2c: box [System.Runtime]System.Boolean
+			IL_0c31: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c36: dup
+			IL_0c37: ldc.i4.0
+			IL_0c38: box [System.Runtime]System.Boolean
+			IL_0c3d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c42: dup
+			IL_0c43: ldc.i4.0
+			IL_0c44: box [System.Runtime]System.Boolean
+			IL_0c49: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c4e: dup
+			IL_0c4f: ldc.i4.0
+			IL_0c50: box [System.Runtime]System.Boolean
+			IL_0c55: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c5a: dup
+			IL_0c5b: ldc.i4.0
+			IL_0c5c: box [System.Runtime]System.Boolean
+			IL_0c61: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c66: dup
+			IL_0c67: ldc.i4.0
+			IL_0c68: box [System.Runtime]System.Boolean
+			IL_0c6d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c72: stloc.2
+			IL_0c73: ldloc.s 12
+			IL_0c75: ldstr "Line"
+			IL_0c7a: ldloc.2
+			IL_0c7b: ldc.i4.1
+			IL_0c7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0c81: pop
+			IL_0c82: ldarg.0
+			IL_0c83: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c88: stloc.s 12
+			IL_0c8a: ldc.r8 9
+			IL_0c93: ldc.r8 2
+			IL_0c9c: mul
+			IL_0c9d: ldarg.2
+			IL_0c9e: mul
+			IL_0c9f: stloc.s 9
+			IL_0ca1: ldloc.s 12
+			IL_0ca3: ldstr "NumPx"
+			IL_0ca8: ldloc.s 9
+			IL_0caa: ldc.i4.1
+			IL_0cab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0cb0: pop
+			IL_0cb1: ldc.r8 0.0
+			IL_0cba: stloc.0
+			// loop start (head: IL_0cbb)
+				IL_0cbb: ldloc.0
+				IL_0cbc: stloc.s 9
+				IL_0cbe: ldarg.0
+				IL_0cbf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0cc4: ldstr "NumPx"
+				IL_0cc9: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0cce: stloc.s 4
+				IL_0cd0: ldloc.s 9
+				IL_0cd2: ldloc.s 4
+				IL_0cd4: clt
+				IL_0cd6: brfalse IL_0d31
 
-				IL_0c78: ldarg.0
-				IL_0c79: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-				IL_0c7e: stloc.s 11
-				IL_0c80: ldloc.s 11
-				IL_0c82: dup
-				IL_0c83: ldc.r8 0.0
-				IL_0c8c: box [System.Runtime]System.Double
-				IL_0c91: ldc.r8 0.0
-				IL_0c9a: box [System.Runtime]System.Double
-				IL_0c9f: ldc.r8 0.0
-				IL_0ca8: box [System.Runtime]System.Double
-				IL_0cad: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct3(object, object, object, object, object)
-				IL_0cb2: pop
-				IL_0cb3: ldloc.0
-				IL_0cb4: ldc.r8 1
-				IL_0cbd: add
-				IL_0cbe: stloc.0
-				IL_0cbf: br IL_0c58
+				IL_0cdb: ldarg.0
+				IL_0cdc: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+				IL_0ce1: stloc.s 12
+				IL_0ce3: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+				IL_0ce8: stloc.s 7
+				IL_0cea: ldloc.s 12
+				IL_0cec: ldloc.s 7
+				IL_0cee: ldloc.s 12
+				IL_0cf0: ldc.r8 0.0
+				IL_0cf9: box [System.Runtime]System.Double
+				IL_0cfe: ldc.r8 0.0
+				IL_0d07: box [System.Runtime]System.Double
+				IL_0d0c: ldc.r8 0.0
+				IL_0d15: box [System.Runtime]System.Double
+				IL_0d1a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3(object, object, object, object, object, object)
+				IL_0d1f: pop
+				IL_0d20: ldloc.0
+				IL_0d21: ldc.r8 1
+				IL_0d2a: add
+				IL_0d2b: stloc.0
+				IL_0d2c: br IL_0cbb
 			// end loop
 
-			IL_0cc4: ldarg.0
-			IL_0cc5: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
-			IL_0cca: ldc.i4.1
-			IL_0ccb: newarr [System.Runtime]System.Object
-			IL_0cd0: dup
-			IL_0cd1: ldc.i4.0
-			IL_0cd2: ldarg.0
-			IL_0cd3: stelem.ref
-			IL_0cd4: stloc.s 9
-			IL_0cd6: ldarg.0
-			IL_0cd7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0cdc: stloc.s 11
-			IL_0cde: ldarg.0
-			IL_0cdf: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0ce4: volatile.
-			IL_0ce6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
-			IL_0ceb: brfalse IL_0cff
+			IL_0d31: ldarg.0
+			IL_0d32: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
+			IL_0d37: ldc.i4.1
+			IL_0d38: newarr [System.Runtime]System.Object
+			IL_0d3d: dup
+			IL_0d3e: ldc.i4.0
+			IL_0d3f: ldarg.0
+			IL_0d40: stelem.ref
+			IL_0d41: stloc.s 10
+			IL_0d43: ldarg.0
+			IL_0d44: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0d49: stloc.s 12
+			IL_0d4b: ldarg.0
+			IL_0d4c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0d51: volatile.
+			IL_0d53: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+			IL_0d58: brfalse IL_0d6c
 
-			IL_0cf0: ldstr "V"
-			IL_0cf5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cfa: br IL_0d13
+			IL_0d5d: ldstr "V"
+			IL_0d62: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d67: br IL_0d80
 
-			IL_0cff: ldstr "V"
-			IL_0d04: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:386"
-			IL_0d09: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
-			IL_0d0e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0d6c: ldstr "V"
+			IL_0d71: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:396"
+			IL_0d76: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+			IL_0d7b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0d13: stloc.1
-			IL_0d14: ldloc.1
-			IL_0d15: ldc.r8 0.0
-			IL_0d1e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0d23: stloc.1
-			IL_0d24: ldarg.0
-			IL_0d25: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0d2a: volatile.
-			IL_0d2c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
-			IL_0d31: brfalse IL_0d45
+			IL_0d80: stloc.3
+			IL_0d81: ldloc.3
+			IL_0d82: ldc.r8 0.0
+			IL_0d8b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d90: stloc.3
+			IL_0d91: ldarg.0
+			IL_0d92: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0d97: volatile.
+			IL_0d99: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+			IL_0d9e: brfalse IL_0db2
 
-			IL_0d36: ldstr "V"
-			IL_0d3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d40: br IL_0d59
+			IL_0da3: ldstr "V"
+			IL_0da8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dad: br IL_0dc6
 
-			IL_0d45: ldstr "V"
-			IL_0d4a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:391"
-			IL_0d4f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
-			IL_0d54: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0db2: ldstr "V"
+			IL_0db7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:401"
+			IL_0dbc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+			IL_0dc1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0d59: stloc.s 10
-			IL_0d5b: ldloc.s 10
-			IL_0d5d: ldc.r8 1
-			IL_0d66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0d6b: stloc.s 10
-			IL_0d6d: ldarg.0
-			IL_0d6e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0d73: volatile.
-			IL_0d75: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
-			IL_0d7a: brfalse IL_0d8e
+			IL_0dc6: stloc.s 11
+			IL_0dc8: ldloc.s 11
+			IL_0dca: ldc.r8 1
+			IL_0dd3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0dd8: stloc.s 11
+			IL_0dda: ldarg.0
+			IL_0ddb: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0de0: volatile.
+			IL_0de2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+			IL_0de7: brfalse IL_0dfb
 
-			IL_0d7f: ldstr "V"
-			IL_0d84: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d89: br IL_0da2
+			IL_0dec: ldstr "V"
+			IL_0df1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0df6: br IL_0e0f
 
-			IL_0d8e: ldstr "V"
-			IL_0d93: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:396"
-			IL_0d98: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
-			IL_0d9d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0dfb: ldstr "V"
+			IL_0e00: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:406"
+			IL_0e05: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+			IL_0e0a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0da2: stloc.3
-			IL_0da3: ldloc.3
-			IL_0da4: ldc.r8 2
-			IL_0dad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0db2: stloc.3
-			IL_0db3: ldloc.s 9
-			IL_0db5: ldloc.s 11
-			IL_0db7: ldloc.1
-			IL_0db8: ldloc.s 10
-			IL_0dba: ldloc.3
-			IL_0dbb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0dc0: stloc.3
-			IL_0dc1: ldarg.0
-			IL_0dc2: ldloc.3
-			IL_0dc3: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0dc8: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0dcd: ldarg.0
-			IL_0dce: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
-			IL_0dd3: ldc.i4.1
-			IL_0dd4: newarr [System.Runtime]System.Object
-			IL_0dd9: dup
-			IL_0dda: ldc.i4.0
-			IL_0ddb: ldarg.0
-			IL_0ddc: stelem.ref
-			IL_0ddd: stloc.s 9
-			IL_0ddf: ldarg.0
-			IL_0de0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0de5: stloc.3
-			IL_0de6: ldarg.0
-			IL_0de7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0dec: stloc.s 10
-			IL_0dee: ldloc.s 9
-			IL_0df0: ldloc.3
-			IL_0df1: ldloc.s 10
-			IL_0df3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0df8: stloc.s 10
-			IL_0dfa: ldarg.0
-			IL_0dfb: ldloc.s 10
-			IL_0dfd: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0e02: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0e07: ldc.r8 0.0
-			IL_0e10: stloc.0
-			// loop start (head: IL_0e11)
-				IL_0e11: ldloc.0
-				IL_0e12: stloc.s 4
-				IL_0e14: ldloc.s 4
-				IL_0e16: ldc.r8 9
-				IL_0e1f: clt
-				IL_0e21: brfalse IL_0ebd
+			IL_0e0f: stloc.1
+			IL_0e10: ldloc.1
+			IL_0e11: ldc.r8 2
+			IL_0e1a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e1f: stloc.1
+			IL_0e20: ldloc.s 10
+			IL_0e22: ldloc.s 12
+			IL_0e24: ldloc.3
+			IL_0e25: ldloc.s 11
+			IL_0e27: ldloc.1
+			IL_0e28: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
+			IL_0e2d: stloc.1
+			IL_0e2e: ldarg.0
+			IL_0e2f: ldloc.1
+			IL_0e30: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e35: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e3a: ldarg.0
+			IL_0e3b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
+			IL_0e40: ldc.i4.1
+			IL_0e41: newarr [System.Runtime]System.Object
+			IL_0e46: dup
+			IL_0e47: ldc.i4.0
+			IL_0e48: ldarg.0
+			IL_0e49: stelem.ref
+			IL_0e4a: stloc.s 10
+			IL_0e4c: ldarg.0
+			IL_0e4d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e52: stloc.1
+			IL_0e53: ldarg.0
+			IL_0e54: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0e59: stloc.s 11
+			IL_0e5b: ldloc.s 10
+			IL_0e5d: ldloc.1
+			IL_0e5e: ldloc.s 11
+			IL_0e60: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0e65: stloc.s 11
+			IL_0e67: ldarg.0
+			IL_0e68: ldloc.s 11
+			IL_0e6a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e6f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0e74: ldc.r8 0.0
+			IL_0e7d: stloc.0
+			// loop start (head: IL_0e7e)
+				IL_0e7e: ldloc.0
+				IL_0e7f: stloc.s 4
+				IL_0e81: ldloc.s 4
+				IL_0e83: ldc.r8 9
+				IL_0e8c: clt
+				IL_0e8e: brfalse IL_0f2a
 
-				IL_0e26: ldarg.0
-				IL_0e27: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0e2c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_0e31: ldloc.0
-				IL_0e32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0e37: stloc.s 10
-				IL_0e39: ldarg.0
-				IL_0e3a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
-				IL_0e3f: ldc.i4.1
-				IL_0e40: newarr [System.Runtime]System.Object
-				IL_0e45: dup
-				IL_0e46: ldc.i4.0
-				IL_0e47: ldarg.0
-				IL_0e48: stelem.ref
-				IL_0e49: stloc.s 9
-				IL_0e4b: ldarg.0
-				IL_0e4c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-				IL_0e51: stloc.3
-				IL_0e52: ldarg.0
-				IL_0e53: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0e58: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_0e5d: ldloc.0
-				IL_0e5e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0e63: volatile.
-				IL_0e65: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
-				IL_0e6a: brfalse IL_0e7e
+				IL_0e93: ldarg.0
+				IL_0e94: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0e99: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0e9e: ldloc.0
+				IL_0e9f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0ea4: stloc.s 11
+				IL_0ea6: ldarg.0
+				IL_0ea7: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
+				IL_0eac: ldc.i4.1
+				IL_0ead: newarr [System.Runtime]System.Object
+				IL_0eb2: dup
+				IL_0eb3: ldc.i4.0
+				IL_0eb4: ldarg.0
+				IL_0eb5: stelem.ref
+				IL_0eb6: stloc.s 10
+				IL_0eb8: ldarg.0
+				IL_0eb9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+				IL_0ebe: stloc.1
+				IL_0ebf: ldarg.0
+				IL_0ec0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0ec5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0eca: ldloc.0
+				IL_0ecb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0ed0: volatile.
+				IL_0ed2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+				IL_0ed7: brfalse IL_0eeb
 
-				IL_0e6f: ldstr "V"
-				IL_0e74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0e79: br IL_0e92
+				IL_0edc: ldstr "V"
+				IL_0ee1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0ee6: br IL_0eff
 
-				IL_0e7e: ldstr "V"
-				IL_0e83: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:426"
-				IL_0e88: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
-				IL_0e8d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0eeb: ldstr "V"
+				IL_0ef0: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:436"
+				IL_0ef5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+				IL_0efa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0e92: stloc.1
-				IL_0e93: ldloc.s 9
-				IL_0e95: ldloc.3
-				IL_0e96: ldloc.1
-				IL_0e97: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0e9c: stloc.1
-				IL_0e9d: ldloc.s 10
-				IL_0e9f: ldstr "V"
-				IL_0ea4: ldloc.1
-				IL_0ea5: ldc.i4.1
-				IL_0ea6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0eab: pop
-				IL_0eac: ldloc.0
-				IL_0ead: ldc.r8 1
-				IL_0eb6: add
-				IL_0eb7: stloc.0
-				IL_0eb8: br IL_0e11
+				IL_0eff: stloc.3
+				IL_0f00: ldloc.s 10
+				IL_0f02: ldloc.1
+				IL_0f03: ldloc.3
+				IL_0f04: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0f09: stloc.3
+				IL_0f0a: ldloc.s 11
+				IL_0f0c: ldstr "V"
+				IL_0f11: ldloc.3
+				IL_0f12: ldc.i4.1
+				IL_0f13: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0f18: pop
+				IL_0f19: ldloc.0
+				IL_0f1a: ldc.r8 1
+				IL_0f23: add
+				IL_0f24: stloc.0
+				IL_0f25: br IL_0e7e
 			// end loop
 
-			IL_0ebd: ldarg.0
-			IL_0ebe: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
-			IL_0ec3: stloc.1
-			IL_0ec4: ldloc.1
-			IL_0ec5: ldc.i4.1
-			IL_0ec6: newarr [System.Runtime]System.Object
-			IL_0ecb: dup
-			IL_0ecc: ldc.i4.0
-			IL_0ecd: ldarg.0
-			IL_0ece: stelem.ref
-			IL_0ecf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0ed4: pop
-			IL_0ed5: ldarg.0
-			IL_0ed6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0edb: stloc.1
-			IL_0edc: ldloc.1
-			IL_0edd: ldstr "Init"
-			IL_0ee2: ldc.i4.1
-			IL_0ee3: box [System.Runtime]System.Boolean
-			IL_0ee8: ldc.i4.1
-			IL_0ee9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0eee: pop
-			IL_0eef: ldarg.0
-			IL_0ef0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
-			IL_0ef5: stloc.1
-			IL_0ef6: ldloc.1
-			IL_0ef7: ldc.i4.1
-			IL_0ef8: newarr [System.Runtime]System.Object
-			IL_0efd: dup
-			IL_0efe: ldc.i4.0
-			IL_0eff: ldarg.0
-			IL_0f00: stelem.ref
-			IL_0f01: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0f06: pop
-			IL_0f07: ldnull
-			IL_0f08: ret
+			IL_0f2a: ldarg.0
+			IL_0f2b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
+			IL_0f30: stloc.3
+			IL_0f31: ldloc.3
+			IL_0f32: ldc.i4.1
+			IL_0f33: newarr [System.Runtime]System.Object
+			IL_0f38: dup
+			IL_0f39: ldc.i4.0
+			IL_0f3a: ldarg.0
+			IL_0f3b: stelem.ref
+			IL_0f3c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0f41: pop
+			IL_0f42: ldarg.0
+			IL_0f43: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0f48: stloc.3
+			IL_0f49: ldloc.3
+			IL_0f4a: ldstr "Init"
+			IL_0f4f: ldc.i4.1
+			IL_0f50: box [System.Runtime]System.Boolean
+			IL_0f55: ldc.i4.1
+			IL_0f56: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0f5b: pop
+			IL_0f5c: ldarg.0
+			IL_0f5d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
+			IL_0f62: stloc.3
+			IL_0f63: ldloc.3
+			IL_0f64: ldc.i4.1
+			IL_0f65: newarr [System.Runtime]System.Object
+			IL_0f6a: dup
+			IL_0f6b: ldc.i4.0
+			IL_0f6c: ldarg.0
+			IL_0f6d: stelem.ref
+			IL_0f6e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0f73: pop
+			IL_0f74: ldnull
+			IL_0f75: ret
 		} // end of method Init::__js_call__
 
 	} // end of class Init
@@ -9579,6 +9628,77 @@
 		} // end of method Scope::.ctor
 
 	} // end of class Scope
+
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L97C1_CreateP
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _V
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L97C1_CreateP::.ctor
+
+			.method public hidebysig 
+				instance object get_V () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "V"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::_V
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::_V
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "V"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L97C1_CreateP::get_V
+
+			.method public hidebysig 
+				instance void set_V (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::_V
+				IL_0007: ldarg.0
+				IL_0008: ldstr "V"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L97C1_CreateP::set_V
+
+		} // end of class Ctor_L97C1_CreateP
+
+
+	} // end of class ObjectLiterals
 
 
 	// Methods
@@ -10150,7 +10270,6 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_36
 	.field assembly static int32 __jroc_dynamicLookup_37
 	.field assembly static int32 __jroc_dynamicLookup_38
 	.field assembly static int32 __jroc_dynamicLookup_39
@@ -10224,9 +10343,6 @@
 	.field assembly static int32 __jroc_dynamicLookup_107
 	.field assembly static int32 __jroc_dynamicLookup_108
 	.field assembly static int32 __jroc_dynamicLookup_109
-	.field assembly static int32 __jroc_dynamicLookup_110
-	.field assembly static int32 __jroc_dynamicLookup_111
-	.field assembly static int32 __jroc_dynamicLookup_112
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/LIRInstructionInfoTests.cs
+++ b/tests/Jroc.Tests/LIRInstructionInfoTests.cs
@@ -91,6 +91,74 @@ public sealed class LIRInstructionInfoTests
     }
 
     [Fact]
+    public void ConstructorInferredReads_KeepInstanceSensitiveCallEffects()
+    {
+        var parser = new JavaScriptParser();
+        var program = parser.ParseJavaScript(
+            "const literal = {}; function C(value) { this.value = value; }",
+            "inferred-effects.js");
+        var literalDeclaration = Assert.IsType<VariableDeclaration>(
+            program.Body[0]);
+        var literalDeclarator = Assert.Single(literalDeclaration.Declarations);
+        var literal = Assert.IsType<ObjectExpression>(literalDeclarator.Init);
+        var constructor = Assert.IsType<FunctionDeclaration>(program.Body[1]);
+        var globalScope = new Scope(
+            "global",
+            ScopeKind.Global,
+            parent: null,
+            program);
+        var literalBinding = new BindingInfo(
+            "literal",
+            BindingKind.Const,
+            globalScope,
+            literalDeclarator);
+        var constructorBinding = new BindingInfo(
+            "C",
+            BindingKind.Function,
+            globalScope,
+            constructor);
+        var constructorScope = new Scope(
+            "C",
+            ScopeKind.Function,
+            globalScope,
+            constructor);
+        var literalShape = new ObjectLiteralShapeInfo(
+            literal,
+            literalBinding,
+            []);
+        var constructorShape = new ConstructorShapeInfo(
+            constructor,
+            constructorScope,
+            constructorBinding,
+            []);
+
+        var literalMetadata = LIRInstructionInfo.GetMetadata(
+            new LIRGetInferredMember(
+                literalShape,
+                "value",
+                new TempVariable(0),
+                new TempVariable(1)));
+        var constructorMetadata = LIRInstructionInfo.GetMetadata(
+            new LIRGetInferredMember(
+                constructorShape,
+                "value",
+                new TempVariable(0),
+                new TempVariable(1)));
+
+        AssertEffects(
+            literalMetadata,
+            LIRInstructionEffects.ReadsHeap
+                | LIRInstructionEffects.MayThrow);
+        AssertEffects(
+            constructorMetadata,
+            LIRInstructionEffects.EmitsInternalControlFlow
+                | LIRInstructionEffects.Calls
+                | LIRInstructionEffects.MayThrow
+                | LIRInstructionEffects.ReadsHeap
+                | LIRInstructionEffects.WritesHeap);
+    }
+
+    [Fact]
     public void TdzCheckedScopeLoad_IsMayThrowAndOrderingSensitive()
     {
         var parser = new JavaScriptParser();

--- a/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
+++ b/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
@@ -766,7 +766,7 @@
 		IL_00db: ldloc.1
 		IL_00dc: ldloc.s 7
 		IL_00de: ldloc.1
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver0(object, object, object)
+		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver0<class Modules.Require_StringDecoder_MemoryStreamStyle/ObjectLiterals/Ctor_L5C1_MemoryWritableStream>(object, object, object)
 		IL_00e4: stloc.2
 		IL_00e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00ea: stloc.s 8

--- a/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
+++ b/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
@@ -213,21 +213,44 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 31 (0x1f)
+			// Header size: 12
+			// Code size: 97 (0x61)
 			.maxstack 8
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "decodeStrings"
-			IL_0010: ldc.i4.1
-			IL_0011: box [System.Runtime]System.Boolean
-			IL_0016: ldc.i4.1
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_001c: pop
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_000b: isinst Modules.Require_StringDecoder_MemoryStreamStyle/ObjectLiterals/Ctor_L5C1_MemoryWritableStream
+			IL_0010: dup
+			IL_0011: brfalse IL_0041
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_0041
+
+			IL_0021: dup
+			IL_0022: ldstr "decodeStrings"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_0041
+
+			IL_0031: ldc.i4.1
+			IL_0032: box [System.Runtime]System.Boolean
+			IL_0037: callvirt instance void Modules.Require_StringDecoder_MemoryStreamStyle/ObjectLiterals/Ctor_L5C1_MemoryWritableStream::set_decodeStrings(object)
+			IL_003c: br IL_005f
+
+			IL_0041: pop
+			IL_0042: ldarg.1
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_004d: ldstr "decodeStrings"
+			IL_0052: ldc.i4.1
+			IL_0053: box [System.Runtime]System.Boolean
+			IL_0058: ldc.i4.1
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_005e: pop
+
+			IL_005f: ldnull
+			IL_0060: ret
 		} // end of method MemoryWritableStream::__js_call__
 
 	} // end of class MemoryWritableStream
@@ -416,7 +439,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.2
@@ -431,7 +454,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "decodeStrings"
 			IL_0036: ldstr "Require_StringDecoder_MemoryStreamStyle:<TwoPhaseDummy_M5>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.2
@@ -481,7 +504,7 @@
 			IL_009b: ldloc.1
 			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00a1: volatile.
-			IL_00a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_00a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_00a8: brfalse IL_00bd
 
 			IL_00ad: ldstr "write"
@@ -492,14 +515,14 @@
 			IL_00bd: ldstr "write"
 			IL_00c2: ldarg.3
 			IL_00c3: ldstr "Require_StringDecoder_MemoryStreamStyle:<TwoPhaseDummy_M5>:__js_call__:30"
-			IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
 			IL_00d2: stloc.2
 			IL_00d3: ldloc.1
 			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_00d9: volatile.
-			IL_00db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_00db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_00e0: brfalse IL_00f4
 
 			IL_00e5: ldstr "end"
@@ -508,7 +531,7 @@
 
 			IL_00f4: ldstr "end"
 			IL_00f9: ldstr "Require_StringDecoder_MemoryStreamStyle:<TwoPhaseDummy_M5>:__js_call__:32"
-			IL_00fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_00fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 			IL_0108: stloc.s 6
@@ -556,6 +579,77 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L5C1_MemoryWritableStream
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _decodeStrings
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L5C1_MemoryWritableStream::.ctor
+
+			.method public hidebysig 
+				instance object get_decodeStrings () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "decodeStrings"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Require_StringDecoder_MemoryStreamStyle/ObjectLiterals/Ctor_L5C1_MemoryWritableStream::_decodeStrings
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Require_StringDecoder_MemoryStreamStyle/ObjectLiterals/Ctor_L5C1_MemoryWritableStream::_decodeStrings
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "decodeStrings"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L5C1_MemoryWritableStream::get_decodeStrings
+
+			.method public hidebysig 
+				instance void set_decodeStrings (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Require_StringDecoder_MemoryStreamStyle/ObjectLiterals/Ctor_L5C1_MemoryWritableStream::_decodeStrings
+				IL_0007: ldarg.0
+				IL_0008: ldstr "decodeStrings"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L5C1_MemoryWritableStream::set_decodeStrings
+
+		} // end of class Ctor_L5C1_MemoryWritableStream
+
+
+	} // end of class ObjectLiterals
+
 
 	// Methods
 	.method public hidebysig static 
@@ -568,20 +662,21 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 356 (0x164)
+		// Code size: 365 (0x16d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_StringDecoder_MemoryStreamStyle/Scope,
 			[1] class Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject,
-			[2] object,
+			[2] class Modules.Require_StringDecoder_MemoryStreamStyle/ObjectLiterals/Ctor_L5C1_MemoryWritableStream,
 			[3] object[],
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStringDecoderModule,
 			[5] object,
 			[6] class Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[8] bool,
-			[9] object,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
+			[7] class Modules.Require_StringDecoder_MemoryStreamStyle/ObjectLiterals/Ctor_L5C1_MemoryWritableStream,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[9] bool,
+			[10] object,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
 		)
 
 		IL_0000: newobj instance void Modules.Require_StringDecoder_MemoryStreamStyle/Scope::.ctor()
@@ -626,7 +721,7 @@
 		IL_0063: stfld object Modules.Require_StringDecoder_MemoryStreamStyle/Scope::StringDecoder
 		IL_0068: nop
 		IL_0069: volatile.
-		IL_006b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_006b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 		IL_0070: brfalse IL_0085
 
 		IL_0075: ldloc.1
@@ -637,7 +732,7 @@
 		IL_0085: ldloc.1
 		IL_0086: ldstr "prototype"
 		IL_008b: ldstr "Require_StringDecoder_MemoryStreamStyle:Modules.Require_StringDecoder_MemoryStreamStyle:__js_module_init__:15"
-		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0090: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_009a: stloc.s 5
@@ -666,50 +761,53 @@
 		IL_00cd: ldc.i4.1
 		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
 		IL_00d3: pop
-		IL_00d4: ldloc.1
-		IL_00d5: dup
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_00db: stloc.2
-		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e1: stloc.s 7
-		IL_00e3: ldloc.2
-		IL_00e4: ldloc.1
-		IL_00e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_00d4: newobj instance void Modules.Require_StringDecoder_MemoryStreamStyle/ObjectLiterals/Ctor_L5C1_MemoryWritableStream::.ctor()
+		IL_00d9: stloc.s 7
+		IL_00db: ldloc.1
+		IL_00dc: ldloc.s 7
+		IL_00de: ldloc.1
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver0(object, object, object)
+		IL_00e4: stloc.2
+		IL_00e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00ea: stloc.s 8
-		IL_00ec: ldloc.s 8
-		IL_00ee: box [System.Runtime]System.Boolean
+		IL_00ec: ldloc.2
+		IL_00ed: ldloc.1
+		IL_00ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
 		IL_00f3: stloc.s 9
-		IL_00f5: ldloc.s 7
-		IL_00f7: ldloc.s 9
-		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fe: pop
-		IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0104: stloc.s 7
-		IL_0106: ldloc.2
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010c: ldc.i4.3
-		IL_010d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0112: dup
-		IL_0113: ldc.r8 226
-		IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0121: dup
-		IL_0122: ldc.r8 130
-		IL_012b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0130: dup
-		IL_0131: ldc.r8 172
-		IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-		IL_0144: stloc.s 10
-		IL_0146: ldstr "decode"
-		IL_014b: ldloc.s 10
-		IL_014d: ldstr "utf8"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0157: stloc.s 5
-		IL_0159: ldloc.s 7
-		IL_015b: ldloc.s 5
-		IL_015d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0162: pop
-		IL_0163: ret
+		IL_00f5: ldloc.s 9
+		IL_00f7: box [System.Runtime]System.Boolean
+		IL_00fc: stloc.s 10
+		IL_00fe: ldloc.s 8
+		IL_0100: ldloc.s 10
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0107: pop
+		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010d: stloc.s 8
+		IL_010f: ldloc.2
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0115: ldc.i4.3
+		IL_0116: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_011b: dup
+		IL_011c: ldc.r8 226
+		IL_0125: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_012a: dup
+		IL_012b: ldc.r8 130
+		IL_0134: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0139: dup
+		IL_013a: ldc.r8 172
+		IL_0143: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0148: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+		IL_014d: stloc.s 11
+		IL_014f: ldstr "decode"
+		IL_0154: ldloc.s 11
+		IL_0156: ldstr "utf8"
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0160: stloc.s 5
+		IL_0162: ldloc.s 8
+		IL_0164: ldloc.s 5
+		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_016b: pop
+		IL_016c: ret
 	} // end of method Require_StringDecoder_MemoryStreamStyle::__js_module_init__
 
 } // end of class Modules.Require_StringDecoder_MemoryStreamStyle
@@ -739,10 +837,10 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_4
 	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
@@ -220,20 +220,42 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 26 (0x1a)
+			// Header size: 12
+			// Code size: 87 (0x57)
 			.maxstack 8
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "name"
-			IL_0010: ldarg.2
-			IL_0011: ldc.i4.1
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0017: pop
-			IL_0018: ldnull
-			IL_0019: ret
+			IL_000b: isinst Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L6C1_Animal
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "name"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L6C1_Animal::set_name(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "name"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method Animal::__js_call__
 
 	} // end of class Animal
@@ -388,7 +410,7 @@
 			)
 
 			IL_0000: volatile.
-			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_0002: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0007: brfalse IL_0026
 
 			IL_000c: ldarg.1
@@ -403,7 +425,7 @@
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "name"
 			IL_0036: ldstr "Require_Util_Inherits_Basic:<TwoPhaseDummy_M5>:__js_call__:3"
-			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0045: stloc.0
@@ -572,28 +594,72 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 50 (0x32)
+			// Header size: 12
+			// Code size: 172 (0xac)
 			.maxstack 8
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "name"
-			IL_0010: ldarg.2
-			IL_0011: ldc.i4.1
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0017: pop
-			IL_0018: ldarg.1
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_0023: ldstr "breed"
-			IL_0028: ldarg.3
-			IL_0029: ldc.i4.1
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_002f: pop
-			IL_0030: ldnull
-			IL_0031: ret
+			IL_000b: isinst Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "name"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::set_name(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "name"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldarg.1
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0060: isinst Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog
+			IL_0065: dup
+			IL_0066: brfalse IL_0091
+
+			IL_006b: dup
+			IL_006c: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_0071: brfalse IL_0091
+
+			IL_0076: dup
+			IL_0077: ldstr "breed"
+			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_0081: brfalse IL_0091
+
+			IL_0086: ldarg.3
+			IL_0087: callvirt instance void Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::set_breed(object)
+			IL_008c: br IL_00aa
+
+			IL_0091: pop
+			IL_0092: ldarg.1
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_009d: ldstr "breed"
+			IL_00a2: ldarg.3
+			IL_00a3: ldc.i4.1
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_00a9: pop
+
+			IL_00aa: ldnull
+			IL_00ab: ret
 		} // end of method Dog::__js_call__
 
 	} // end of class Dog
@@ -626,6 +692,185 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L6C1_Animal
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _name
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L6C1_Animal::.ctor
+
+			.method public hidebysig 
+				instance object get_name () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "name"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L6C1_Animal::_name
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L6C1_Animal::_name
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "name"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L6C1_Animal::get_name
+
+			.method public hidebysig 
+				instance void set_name (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L6C1_Animal::_name
+				IL_0007: ldarg.0
+				IL_0008: ldstr "name"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L6C1_Animal::set_name
+
+		} // end of class Ctor_L6C1_Animal
+
+		.class nested public auto ansi beforefieldinit Ctor_L15C1_Dog
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _name
+			.field private object _breed
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L15C1_Dog::.ctor
+
+			.method public hidebysig 
+				instance object get_name () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "name"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::_name
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::_name
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "name"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L15C1_Dog::get_name
+
+			.method public hidebysig 
+				instance void set_name (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::_name
+				IL_0007: ldarg.0
+				IL_0008: ldstr "name"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L15C1_Dog::set_name
+
+			.method public hidebysig 
+				instance object get_breed () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "breed"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::_breed
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::_breed
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "breed"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L15C1_Dog::get_breed
+
+			.method public hidebysig 
+				instance void set_breed (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::_breed
+				IL_0007: ldarg.0
+				IL_0008: ldstr "breed"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L15C1_Dog::set_breed
+
+		} // end of class Ctor_L15C1_Dog
+
+
+	} // end of class ObjectLiterals
+
 
 	// Methods
 	.method public hidebysig static 
@@ -638,20 +883,21 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 466 (0x1d2)
+		// Code size: 397 (0x18d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Inherits_Basic/Scope,
 			[1] class Modules.Require_Util_Inherits_Basic/Animal/FunctionObject,
 			[2] class Modules.Require_Util_Inherits_Basic/Dog/FunctionObject,
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
-			[4] object,
+			[4] class Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog,
 			[5] object[],
 			[6] object,
 			[7] class Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] bool,
-			[10] object
+			[10] object,
+			[11] class Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog
 		)
 
 		IL_0000: newobj instance void Modules.Require_Util_Inherits_Basic/Scope::.ctor()
@@ -693,7 +939,7 @@
 		IL_0052: stloc.3
 		IL_0053: nop
 		IL_0054: volatile.
-		IL_0056: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0056: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 		IL_005b: brfalse IL_0070
 
 		IL_0060: ldloc.1
@@ -704,7 +950,7 @@
 		IL_0070: ldloc.1
 		IL_0071: ldstr "prototype"
 		IL_0076: ldstr "Require_Util_Inherits_Basic:Modules.Require_Util_Inherits_Basic:__js_module_init__:17"
-		IL_007b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_007b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
 		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0085: stloc.s 6
@@ -745,7 +991,7 @@
 		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00e0: stloc.s 8
 		IL_00e2: volatile.
-		IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 		IL_00e9: brfalse IL_00fe
 
 		IL_00ee: ldloc.2
@@ -756,7 +1002,7 @@
 		IL_00fe: ldloc.2
 		IL_00ff: ldstr "super_"
 		IL_0104: ldstr "Require_Util_Inherits_Basic:Modules.Require_Util_Inherits_Basic:__js_module_init__:32"
-		IL_0109: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0109: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
 		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0113: stloc.s 6
@@ -771,57 +1017,36 @@
 		IL_012a: ldloc.s 10
 		IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0131: pop
-		IL_0132: ldloc.2
-		IL_0133: dup
-		IL_0134: ldstr "Buddy"
-		IL_0139: ldstr "Golden Retriever"
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_0143: stloc.s 4
-		IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014a: stloc.s 8
-		IL_014c: volatile.
-		IL_014e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0153: brfalse IL_0169
-
-		IL_0158: ldloc.s 4
-		IL_015a: ldstr "name"
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0164: br IL_017f
-
-		IL_0169: ldloc.s 4
-		IL_016b: ldstr "name"
-		IL_0170: ldstr "Require_Util_Inherits_Basic:Modules.Require_Util_Inherits_Basic:__js_module_init__:44"
-		IL_0175: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_017f: stloc.s 6
-		IL_0181: ldloc.s 8
-		IL_0183: ldloc.s 6
-		IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018a: pop
-		IL_018b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0190: stloc.s 8
-		IL_0192: volatile.
-		IL_0194: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0199: brfalse IL_01af
-
-		IL_019e: ldloc.s 4
-		IL_01a0: ldstr "breed"
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01aa: br IL_01c5
-
-		IL_01af: ldloc.s 4
-		IL_01b1: ldstr "breed"
-		IL_01b6: ldstr "Require_Util_Inherits_Basic:Modules.Require_Util_Inherits_Basic:__js_module_init__:49"
-		IL_01bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_01c5: stloc.s 6
-		IL_01c7: ldloc.s 8
-		IL_01c9: ldloc.s 6
-		IL_01cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d0: pop
-		IL_01d1: ret
+		IL_0132: newobj instance void Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::.ctor()
+		IL_0137: stloc.s 11
+		IL_0139: ldloc.2
+		IL_013a: ldloc.s 11
+		IL_013c: ldloc.2
+		IL_013d: ldstr "Buddy"
+		IL_0142: ldstr "Golden Retriever"
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2(object, object, object, object, object)
+		IL_014c: stloc.s 4
+		IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0153: stloc.s 8
+		IL_0155: ldloc.s 4
+		IL_0157: castclass Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog
+		IL_015c: callvirt instance object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::get_name()
+		IL_0161: stloc.s 6
+		IL_0163: ldloc.s 8
+		IL_0165: ldloc.s 6
+		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_016c: pop
+		IL_016d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0172: stloc.s 8
+		IL_0174: ldloc.s 4
+		IL_0176: castclass Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog
+		IL_017b: callvirt instance object Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog::get_breed()
+		IL_0180: stloc.s 6
+		IL_0182: ldloc.s 8
+		IL_0184: ldloc.s 6
+		IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_018b: pop
+		IL_018c: ret
 	} // end of method Require_Util_Inherits_Basic::__js_module_init__
 
 } // end of class Modules.Require_Util_Inherits_Basic
@@ -851,11 +1076,9 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_3
-	.field assembly static int32 __jroc_dynamicLookup_4
-	.field assembly static int32 __jroc_dynamicLookup_5
 	.field assembly static int32 __jroc_dynamicLookup_6
 	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
@@ -1024,7 +1024,7 @@
 		IL_013c: ldloc.2
 		IL_013d: ldstr "Buddy"
 		IL_0142: ldstr "Golden Retriever"
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2(object, object, object, object, object)
+		IL_0147: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2<class Modules.Require_Util_Inherits_Basic/ObjectLiterals/Ctor_L15C1_Dog>(object, object, object, object, object)
 		IL_014c: stloc.s 4
 		IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0153: stloc.s 8

--- a/tests/Jroc.Tests/ObjectLiteralTypeGenerationGroundworkTests.cs
+++ b/tests/Jroc.Tests/ObjectLiteralTypeGenerationGroundworkTests.cs
@@ -195,6 +195,62 @@ public sealed class ObjectLiteralTypeGenerationGroundworkTests
     }
 
     [Fact]
+    public void GeneratedAssembly_DeclaresConstructorShapeTypeWithMirroredAccessors()
+    {
+        var entryPath = Path.Combine(
+            Path.GetTempPath(),
+            "Jroc.Tests",
+            "ConstructorShapeTypeGeneration",
+            Guid.NewGuid().ToString("N"),
+            "entry.js");
+
+        var artifact = JrocInMemoryCompiler.Compile(
+            new JrocInMemoryCompileRequest(entryPath)
+            {
+                SourceText = """
+                    function GraphNode(x, y) {
+                        this.x = x;
+                        this.y = y;
+                        this.pos = { x: x, y: y };
+                    }
+                    var node = new GraphNode(1, 2);
+                    console.log(node.pos.x);
+                    """
+            });
+
+        using var loadedAssembly =
+            JrocInMemoryAssemblyLoader.Load(artifact);
+        var moduleType = loadedAssembly.Assembly.GetType(
+            "Modules.entry",
+            throwOnError: true)!;
+        var container = moduleType.GetNestedType(
+            "ObjectLiterals",
+            BindingFlags.Public | BindingFlags.NonPublic)!;
+        var shapeType = Assert.Single(
+            container.GetNestedTypes(
+                BindingFlags.Public | BindingFlags.NonPublic),
+            type => type.Name.StartsWith(
+                "Ctor_",
+                StringComparison.Ordinal));
+
+        Assert.Equal(typeof(JsObject), shapeType.BaseType);
+        Assert.Equal(
+            new[] { "_x", "_y", "_pos" },
+            shapeType.GetFields(
+                    BindingFlags.Instance | BindingFlags.NonPublic)
+                .Select(static field => field.Name));
+        foreach (var member in new[] { "x", "y", "pos" })
+        {
+            Assert.NotNull(shapeType.GetMethod(
+                $"get_{member}",
+                BindingFlags.Instance | BindingFlags.Public));
+            Assert.NotNull(shapeType.GetMethod(
+                $"set_{member}",
+                BindingFlags.Instance | BindingFlags.Public));
+        }
+    }
+
+    [Fact]
     public void JsObjectSubclass_PreservesDictionaryDescriptorEnumerationAndJsonBehavior()
     {
         var obj = new SpecializedJsObjectForTest

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
@@ -578,20 +578,42 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Header size: 1
-			// Code size: 26 (0x1a)
+			// Header size: 12
+			// Code size: 87 (0x57)
 			.maxstack 8
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
-			IL_000b: ldstr "value"
-			IL_0010: ldarg.2
-			IL_0011: ldc.i4.1
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0017: pop
-			IL_0018: ldnull
-			IL_0019: ret
+			IL_000b: isinst Modules.Proxy_ApplyAndConstructTraps_WithFallback/ObjectLiterals/Ctor_L19C1_Box
+			IL_0010: dup
+			IL_0011: brfalse IL_003c
+
+			IL_0016: dup
+			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Function::IsCurrentGeneratedConstructionReceiver(object)
+			IL_001c: brfalse IL_003c
+
+			IL_0021: dup
+			IL_0022: ldstr "value"
+			IL_0027: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CanUseSpecializedDataPropertySetter(object, string)
+			IL_002c: brfalse IL_003c
+
+			IL_0031: ldarg.2
+			IL_0032: callvirt instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/ObjectLiterals/Ctor_L19C1_Box::set_value(object)
+			IL_0037: br IL_0055
+
+			IL_003c: pop
+			IL_003d: ldarg.1
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_0048: ldstr "value"
+			IL_004d: ldarg.2
+			IL_004e: ldc.i4.1
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0054: pop
+
+			IL_0055: ldnull
+			IL_0056: ret
 		} // end of method Box::__js_call__
 
 	} // end of class Box
@@ -825,6 +847,77 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit ObjectLiterals
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Ctor_L19C1_Box
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsObject
+		{
+			// Fields
+			.field private object _value
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::.ctor()
+				IL_0006: ret
+			} // end of method Ctor_L19C1_Box::.ctor
+
+			.method public hidebysig 
+				instance object get_value () cil managed 
+			{
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldstr "value"
+				IL_0006: ldarg.0
+				IL_0007: ldfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/ObjectLiterals/Ctor_L19C1_Box::_value
+				IL_000c: call instance bool [JavaScriptRuntime]JavaScriptRuntime.JsObject::IsSpecializedDataPropertyCurrent(string, object)
+				IL_0011: brfalse IL_001d
+
+				IL_0016: ldarg.0
+				IL_0017: ldfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/ObjectLiterals/Ctor_L19C1_Box::_value
+				IL_001c: ret
+
+				IL_001d: ldarg.0
+				IL_001e: ldstr "value"
+				IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0028: ret
+			} // end of method Ctor_L19C1_Box::get_value
+
+			.method public hidebysig 
+				instance void set_value (
+					object ''
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: stfld object Modules.Proxy_ApplyAndConstructTraps_WithFallback/ObjectLiterals/Ctor_L19C1_Box::_value
+				IL_0007: ldarg.0
+				IL_0008: ldstr "value"
+				IL_000d: ldarg.1
+				IL_000e: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0013: ret
+			} // end of method Ctor_L19C1_Box::set_value
+
+		} // end of class Ctor_L19C1_Box
+
+
+	} // end of class ObjectLiterals
+
 
 	// Methods
 	.method public hidebysig static 
@@ -1013,7 +1106,7 @@
 		IL_018b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0190: stloc.s 12
 		IL_0192: volatile.
-		IL_0194: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0194: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 		IL_0199: brfalse IL_01af
 
 		IL_019e: ldloc.s 4
@@ -1024,7 +1117,7 @@
 		IL_01af: ldloc.s 4
 		IL_01b1: ldstr "value"
 		IL_01b6: ldstr "Proxy_ApplyAndConstructTraps_WithFallback:Modules.Proxy_ApplyAndConstructTraps_WithFallback:__js_module_init__:53"
-		IL_01bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_01bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_01c5: stloc.s 13
@@ -1035,7 +1128,7 @@
 		IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_01d6: stloc.s 12
 		IL_01d8: volatile.
-		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 		IL_01df: brfalse IL_01f5
 
 		IL_01e4: ldloc.s 4
@@ -1046,7 +1139,7 @@
 		IL_01f5: ldloc.s 4
 		IL_01f7: ldstr "sameNewTarget"
 		IL_01fc: ldstr "Proxy_ApplyAndConstructTraps_WithFallback:Modules.Proxy_ApplyAndConstructTraps_WithFallback:__js_module_init__:58"
-		IL_0201: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0201: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_020b: stloc.s 13
@@ -1091,7 +1184,7 @@
 		IL_0290: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0295: stloc.s 12
 		IL_0297: volatile.
-		IL_0299: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0299: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 		IL_029e: brfalse IL_02b4
 
 		IL_02a3: ldloc.s 7
@@ -1102,7 +1195,7 @@
 		IL_02b4: ldloc.s 7
 		IL_02b6: ldstr "value"
 		IL_02bb: ldstr "Proxy_ApplyAndConstructTraps_WithFallback:Modules.Proxy_ApplyAndConstructTraps_WithFallback:__js_module_init__:85"
-		IL_02c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
 		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_02ca: stloc.s 13
@@ -1116,7 +1209,7 @@
 		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
 		IL_02e4: stloc.s 13
 		IL_02e6: volatile.
-		IL_02e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 		IL_02ed: brfalse IL_0302
 
 		IL_02f2: ldloc.2
@@ -1127,7 +1220,7 @@
 		IL_0302: ldloc.2
 		IL_0303: ldstr "prototype"
 		IL_0308: ldstr "Proxy_ApplyAndConstructTraps_WithFallback:Modules.Proxy_ApplyAndConstructTraps_WithFallback:__js_module_init__:91"
-		IL_030d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_030d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 		IL_0317: stloc.s 17
@@ -1172,10 +1265,10 @@
 	extends [System.Runtime]System.Object
 {
 	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_7
 	.field assembly static int32 __jroc_dynamicLookup_8
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
+	.field assembly static int32 __jroc_dynamicLookup_11
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/RuntimeStaticStateAuditTests.cs
+++ b/tests/Jroc.Tests/RuntimeStaticStateAuditTests.cs
@@ -29,6 +29,7 @@ public sealed class RuntimeStaticStateAuditTests
         new("JavaScriptRuntime.DynamicLookupInlineCache._nextRecentSite", "thread-local cache-site lookup state"),
         new("JavaScriptRuntime.DynamicLookupInlineCache._previousSite", "thread-local cache-site lookup state"),
         new("JavaScriptRuntime.DynamicLookupInlineCache._recentSites", "thread-local cache-site lookup state"),
+        new("JavaScriptRuntime.Function._generatedConstructionReceivers", "thread-local invocation state"),
         new("JavaScriptRuntime.Node.AsyncContextRuntime._activeContextRuntimeCount", "process-wide fast-path activity count"),
         new("JavaScriptRuntime.Node.AsyncContextRuntime._enabledHookCount", "process-wide fast-path activity count"),
         new("JavaScriptRuntime.Node.FsCommon._nextFileDescriptor", "process-wide resource identity allocator"),

--- a/tests/Jroc.Tests/SymbolTable/ConstructorShapeAnalysisTests.cs
+++ b/tests/Jroc.Tests/SymbolTable/ConstructorShapeAnalysisTests.cs
@@ -1,0 +1,120 @@
+using Acornima.Ast;
+using Jroc.Services;
+using Jroc.SymbolTables;
+using Xunit;
+
+namespace Jroc.Tests;
+
+public sealed class ConstructorShapeAnalysisTests
+{
+    private static SymbolTable Build(string source)
+    {
+        var parser = new JavaScriptParser();
+        var module = new ModuleDefinition
+        {
+            Ast = parser.ParseJavaScript(source, "test.js"),
+            Path = "test.js",
+            Name = "test",
+            ModuleId = "test"
+        };
+        new SymbolTableBuilder().Build(module);
+        return module.SymbolTable!;
+    }
+
+    [Fact]
+    public void GraphNodePrefix_IsEligibleAndPropagatesToNewBinding()
+    {
+        var symbols = Build(
+            """
+            function GraphNode(x, y, wall) {
+                this.x = x;
+                this.y = y;
+                this.wall = wall;
+                this.pos = { x: x, y: y };
+            }
+            var node = new GraphNode(1, 2, false);
+            console.log(node.pos);
+            """);
+
+        var constructor = symbols.GetBindingInfo("GraphNode")!;
+        var node = symbols.GetBindingInfo("node")!;
+        Assert.NotNull(constructor.ConstructorShape);
+        Assert.True(
+            constructor.ConstructorShape!.IsEligible,
+            constructor.ConstructorShape.DisqualifyReason);
+        Assert.Equal(
+            new[] { "x", "y", "wall", "pos" },
+            constructor.ConstructorShape.Members.Select(
+                static member => member.Name));
+        Assert.Same(constructor.ConstructorShape, node.ConstructedShape);
+    }
+
+    [Theory]
+    [InlineData(
+        "function C(v) { if (v) this.x = v; }",
+        "conditionally")]
+    [InlineData(
+        "function C(k, v) { this[k] = v; }",
+        "computed")]
+    [InlineData(
+        "function C(v) { this.x = v; delete this.x; }",
+        "delete")]
+    [InlineData(
+        "function C(v) { this.x = v; Object.defineProperty(this, 'x', { value: v }); }",
+        "defineProperty")]
+    [InlineData(
+        "function C(v) { consume(this); this.x = v; }",
+        "after the unconditional")]
+    [InlineData(
+        "function C(v) { this.x = v; var later = () => { this.y = v; }; }",
+        "outside the top-level")]
+    [InlineData(
+        "function C(v) { this.x = v; return {}; }",
+        "return value")]
+    public void UnsupportedConstructor_IsDisqualified(
+        string source,
+        string reason)
+    {
+        var shape = Build(source).GetBindingInfo("C")!.ConstructorShape;
+        Assert.NotNull(shape);
+        Assert.False(shape!.IsEligible);
+        Assert.Contains(
+            reason,
+            shape.DisqualifyReason,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ParameterPropertyUse_RecordsGuardedShapeCandidate()
+    {
+        var symbols = Build(
+            """
+            function GraphNode(pos) {
+                this.pos = pos;
+            }
+            function read(obj) {
+                return obj.pos;
+            }
+            read(new GraphNode("x"));
+            """);
+        var readScope = Enumerate(symbols.Root)
+            .Single(scope => scope.Name == "read");
+        var candidate = Assert.Single(
+            readScope.Bindings["obj"].ConstructorShapeCandidates);
+        Assert.Same(
+            symbols.GetBindingInfo("GraphNode")!.ConstructorShape,
+            candidate);
+    }
+
+    private static IEnumerable<Scope> Enumerate(Scope scope)
+    {
+        yield return scope;
+        foreach (var child in scope.Children)
+        {
+            foreach (var descendant in Enumerate(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- infer conservative layouts for eligible ES5 constructor functions
- generate typed `JsObject` subclasses and specialized `new` allocation
- emit direct and `isinst`-guarded member access with complete dynamic fallback
- preserve constructor, descriptor, prototype `[[Set]]`, mutation, enumeration, custom-receiver, and strict-mode semantics
- extend the Kraken A* IL guardrail and document measured Phase 5 impact

## Performance

Sequential same-host BenchmarkDotNet comparison against Phase 4 commit
`71bf78438` on Intel Xeon 6975P-C, Ubuntu 24.04, .NET 10.0.11,
BenchmarkDotNet 0.15.8, 3 launches x 3 measured iterations (`N = 9`):

| Variant | Mean | Median | Allocated |
| --- | ---: | ---: | ---: |
| Phase 4 | 4.889 s | 4.900 s | 56,893,608 B |
| Phase 5 | 3.063 s | 2.946 s | 56,971,416 B |

Phase 5 is 37.3% faster by mean and 39.9% faster by median. Allocation changed
by +77,808 bytes (+0.14%).

Exact `findGraphNode` IL:

- 193 bytes
- 2 guarded constructor field reads
- 0 dynamic-cache property reads
- 2 cached arity-1 `findGraphNode` calls

## Validation

- 3,676 passed / 1 skipped in `Jroc.Tests`
- 1,059 generator tests passed
- 393 passed / 1 skipped relevant Object, Reflect, Proxy, and Function test262 cases
- warning-free Release build
- Kraken guardrail parser tests and exact IL guardrail passed
- independent code review completed

Closes #1965.
Part of #1958.
