### PR TITLE
feat(hosting): implement Phase 4 iterable and built-in projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- compiler/runtime/hosting/docs: implement Phase 4 iterable and built-in
+  generated facades for #1917 and issues #1943, #1944, #1945, #1946, and
+  #1947. Generator and custom iterator values now project through
+  `IEnumerable<T>`/`IAsyncEnumerable<T>` with JavaScript `return()` cleanup,
+  cancellation, contextual failures, root-disposal integration, and preserved
+  single-use/independent-iterator behavior. Generated contracts now cover Date,
+  RegExp, Error subclasses, opaque Symbols, Map/Set/weak collections,
+  ArrayBuffer/SharedArrayBuffer, DataView, and every currently supported typed
+  array while preserving identity, ordered iteration, backing-store sharing,
+  offsets, mutation, and BCL/generated-only public signatures. Async iterator
+  thenables, runtime-thread disposal, async-generator await rejection routing,
+  inherited class iterables, nested control-flow return inference, collection
+  alias identity, shared-buffer slicing, and mutated constructor helpers retain
+  their JavaScript semantics at the facade boundary. Callable collection
+  aliases now share generated-handle identity, primitive async iterator results
+  are rejected, and concurrent enumerator/root disposal awaits one in-flight
+  iterator close operation.
 - compiler/runtime/hosting/docs: implement Phase 3 rich generated export
   facades for #1917 and issues #1938, #1939, #1940, #1941, and #1942.
   Generated public contracts now avoid runtime types in bases, generic

--- a/docs/runtime/DotNetLibraryHosting.md
+++ b/docs/runtime/DotNetLibraryHosting.md
@@ -35,6 +35,14 @@ Exports, generated constructor contracts, and generated object/instance/array
 handles marshal work to that script thread. Runtime proxy types remain an
 implementation detail of the generated facade.
 
+Generator and custom iterable exports use runtime-owned adapters behind
+`IEnumerable<T>`/`IAsyncEnumerable<T>`. Enumerator disposal is marshalled back
+to JavaScript `return()` before root shutdown, so generator `finally` blocks
+run on early break, cancellation, and import disposal. Built-in, collection,
+and binary facade contracts use the same identity cache and thread-affine
+dispatch as ordinary generated handles; no runtime implementation type appears
+in their public signatures.
+
 ### Hosted `child_process.fork()`
 
 Hosted runtimes can launch compiled child processes, but unlike standalone `Engine.Execute(...)` they require an explicit launchable assembly path whenever hosted code may call `child_process.fork()`. Set `JsModuleLoadOptions.CompiledAssemblyPath` when calling `JsEngine.LoadModule(...)`; hosted `fork()` does not infer a launch target automatically, even if the assembly was loaded from a physical file.

--- a/docs/sdk/Index.md
+++ b/docs/sdk/Index.md
@@ -10,6 +10,9 @@ This page is the **canonical user documentation** for SDK consumers. The older d
 - **Library hosting**: import compiled JavaScript assemblies through generated
   `Run`/`Import` facades and call `module.exports` from C#.
 - **Generated script facades**: run an assembly or published script directly through assembly-named static types without referencing runtime APIs from C#.
+- **BCL iterable and built-in projections**: consume generators with
+  `foreach`/`await foreach`, and use generated contracts for Date, RegExp,
+  Error, Symbol, collections, buffers, DataView, and supported typed arrays.
 - **In-memory compile-and-run**: use `Jroc.Core` to produce PE/PDB bytes and optionally load them into a collectible context without writing generated assemblies to disk.
 - A dedicated **script thread** per hosted runtime instance.
 - Optional **debug symbols**: emit Portable PDB (`.pdb`) data for stepping and better stack traces against the original `.js` / `.mjs` source path, including rewritten `import` / `export` module code.

--- a/docs/sdk/api/GeneratedFacades.md
+++ b/docs/sdk/api/GeneratedFacades.md
@@ -151,3 +151,116 @@ Object contracts also expose `GetDynamicProperty`, `SetDynamicProperty`, and
 `HasDynamicProperty` as a BCL-only fallback for computed or otherwise unknown
 properties. These lookups are lazy, so aliases and cycles preserve identity
 without recursively materializing an object graph.
+
+## Iterables and generators
+
+Synchronous generator results and values with `Symbol.iterator` project as
+`IEnumerable<object>`. Async generators and `Symbol.asyncIterator` values
+project as `IAsyncEnumerable<object>`. Generated object contracts implement the
+same BCL interfaces when the exported object literal declares the corresponding
+well-known-symbol method. Exported class instances and constructed handles also
+implement those interfaces when the method is declared or inherited from a
+statically known base class.
+
+```csharp
+foreach (var value in exports.Values())
+{
+    Console.WriteLine(value);
+}
+
+await foreach (var value in exports.AsyncValues())
+{
+    Console.WriteLine(value);
+}
+```
+
+Each enumeration obtains a JavaScript iterator on the owning script thread.
+Reusable iterables can produce independent enumerators; generator objects retain
+their JavaScript single-use behavior. Disposing an enumerator before completion
+invokes the iterator's `return()` method, including generator `finally`
+cleanup. Async cancellation performs the same close operation before reporting
+`OperationCanceledException`. Disposing the root import closes active
+enumerators before shutting down the runtime. Iteration failures retain the
+module, member, and JavaScript error/stack context.
+
+Async iterator `next()` and `return()` results use JavaScript
+`Promise.resolve` assimilation, so Promise values and custom thenables have the
+same behavior. Root disposal requested from a callback already running on the
+script thread starts asynchronous iterator cleanup without blocking that
+thread, then completes shutdown after cleanup settles. Concurrent enumerator
+and root disposal share one cleanup operation, so an in-flight `return()` is
+never abandoned. A fulfilled `next()` value must still be an iterator-result
+object; primitive results fail through the contextual exception path.
+
+The hosting projection intentionally does not add a bidirectional
+`next(value)` API. Use JavaScript code to drive that protocol when a generator
+depends on values sent by its consumer.
+
+## Built-in value contracts
+
+Generated contracts preserve identity, mutation, and import lifetime for these
+exported built-ins:
+
+- `IDate`: time value mutation and string/ISO operations, including invalid
+  dates.
+- `IRegExp`: `Source`, `Flags`, mutable `LastIndex`, `Exec`, and `Test`.
+  `Exec` returns the generated array contract.
+- `IError`: mutable `Name`, `Message`, and `Cause`, plus `Stack`; the same
+  contract represents supported Error subclasses.
+- `ISymbol`: opaque `Description`, registry key, well-known name, and display
+  string. Symbol values cannot be forged or converted to ordinary strings.
+- `IDateConstructor`, `IRegExpConstructor`, `IErrorConstructor`, and
+  `ISymbolConstructor` when those intrinsic constructor values are exported.
+
+Constructor helper methods are looked up on the exported JavaScript constructor
+at call time. Replacing properties such as `Date.now`, `Date.parse`, `Date.UTC`,
+or `RegExp.escape` is therefore visible to generated-facade callers.
+
+The same projection is used for direct/default exports, named properties,
+nested objects, aliases, and function return values. Invalid date ISO
+conversion, invalid regular-expression construction, and unsupported
+operations fail explicitly through the contextual hosting exception path.
+
+## Collections
+
+`IMap` and `ISet` expose size, lookup/mutation, and ordered BCL enumeration.
+Map enumeration yields generated `IMapEntry` handles rather than converting to
+`Dictionary`, so JavaScript key equality and object identity remain intact.
+`IWeakMap` and `IWeakSet` expose only `get`/`has`/`set`/`add`/`delete` operations;
+they deliberately do not implement enumeration or expose storage.
+
+Object keys and values remain runtime-owned handles. Passing a handle back into
+the same import unwraps the original JavaScript object; crossing import
+instances is rejected. Object values reached through `Map.Get`, `WeakMap.Get`,
+entry/key/value iteration, or a direct generated object export share the
+runtime's canonical generated handle whenever their projection contracts are
+compatible. Callable keys and values use the same rule rather than switching to
+a separate dynamic callable wrapper.
+
+## Binary values
+
+`IArrayBuffer` represents both `ArrayBuffer` and the currently supported
+`SharedArrayBuffer`; `IsShared` distinguishes them. It exposes byte length,
+maximum length/resizability, copying `Slice`, and supported resize behavior.
+`IDataView` preserves its buffer, byte offset/length, endianness, and all
+currently implemented numeric accessors. `ITypedArray` preserves its concrete
+`Kind`, buffer, offset, byte/element lengths, bytes per element, indexed reads,
+ordered iteration, and mutation.
+
+The supported typed-array kinds are `Int8Array`, `Uint8Array`,
+`Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`,
+`Float32Array`, and `Float64Array`. Multiple projected views continue to share
+the JavaScript backing store, so mutations are immediately visible across
+views. Host indexes outside the current typed-array view fail with
+`ArgumentOutOfRangeException`; invalid `DataView` access uses the contextual
+JavaScript exception path.
+
+Slicing a `SharedArrayBuffer` produces another shared buffer with copied,
+independent contents; it does not silently downgrade the result to an ordinary
+`ArrayBuffer`.
+
+JROC does not currently implement ArrayBuffer detachment, BigInt typed arrays,
+typed-array `slice`/`subarray`, or growable `SharedArrayBuffer`. Generated
+contracts do not claim those operations. Fixed buffers reject `Resize`
+explicitly, and `SharedArrayBuffer` is exposed only for the runtime behavior
+JROC currently executes.

--- a/docs/sdk/api/TypeMapping.md
+++ b/docs/sdk/api/TypeMapping.md
@@ -10,7 +10,7 @@ This is the practical mapping you will see when hosting compiled JS from C#.
 | `string` | `string` |
 | `boolean` | `bool` |
 | `undefined` | `null` |
-| `null` | `JavaScriptRuntime.JsNull.Null` (runtime sentinel) |
+| `null` | An opaque dynamic proxy when projected as `object`; `null` when a more specific generated reference contract permits no value |
 
 ## Objects / functions
 
@@ -23,6 +23,11 @@ Typed hosting:
 - If your contract return type is `object`, runtime references remain behind a
   dynamic proxy or `JsCallable`; raw generated/runtime object types are not
   exposed.
+- Generator and custom iterable results use `IEnumerable<object>`; async
+  generator and async iterable results use `IAsyncEnumerable<object>`.
+- Date, RegExp, Error, Symbol, Map/Set/weak collections, ArrayBuffer,
+  SharedArrayBuffer, DataView, and supported typed arrays use generated
+  `IDisposable` contracts. Their nested values use the same projection rules.
 
 Dynamic hosting:
 

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementTry.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementTry.cs
@@ -25,20 +25,22 @@ public sealed partial class HIRToLIRLowerer
         var yieldCountFinally = _isGenerator && tryStmt.FinallyBody != null ? CountYieldExpressionsInStatement(tryStmt.FinallyBody) : 0;
         var yieldCount = yieldCountTry + yieldCountCatch + yieldCountFinally;
 
+        // Generator suspension via 'yield' cannot occur within CLR EH regions (try/finally), because
+        // our yield lowering suspends via 'ret'. CLR requires protected regions to exit via 'leave'.
+        // When yields appear within a try/catch/finally in a generator, lower it as an explicit
+        // state-machine routing (similar to async-with-await try/finally lowering). This must take
+        // precedence for async generators so generator.return() is routed through finally even when
+        // the same protected region also contains await expressions.
+        if (_isGenerator && (hasCatch || hasFinally) && yieldCount > 0)
+        {
+            return TryLowerGeneratorTryWithYield(tryStmt);
+        }
+
         // Async try/finally (and try/catch/finally) cannot use IL exception regions when awaits occur
         // within the protected region, because awaits suspend MoveNext via 'ret'.
         if (_isAsync && hasFinally && awaitCount > 0)
         {
             return TryLowerAsyncTryWithFinallyWithAwait(tryStmt);
-        }
-
-        // Generator suspension via 'yield' cannot occur within CLR EH regions (try/finally), because
-        // our yield lowering suspends via 'ret'. CLR requires protected regions to exit via 'leave'.
-        // When yields appear within a try/catch/finally in a generator, lower it as an explicit
-        // state-machine routing (similar to async-with-await try/finally lowering).
-        if (_isGenerator && (hasCatch || hasFinally) && yieldCount > 0)
-        {
-            return TryLowerGeneratorTryWithYield(tryStmt);
         }
         if (_isAsync && hasCatch && !hasFinally && awaitCount > 0)
         {
@@ -408,6 +410,35 @@ public sealed partial class HIRToLIRLowerer
         var catchEntryLabel = hasCatch ? CreateLabel() : -1;
         var finallyEntryLabel = hasFinally ? CreateLabel() : -1;
         var finallyExitLabel = hasFinally ? CreateLabel() : -1;
+        var completionDispatchLabel = hasFinally ? finallyExitLabel : CreateLabel();
+
+        var asyncInfo = _isAsync ? _methodBodyIR.AsyncInfo : null;
+        var tryRejectStateId = -1;
+        var tryRejectLabel = -1;
+        var catchRejectStateId = -1;
+        var catchRejectLabel = -1;
+        var finallyRejectStateId = -1;
+        var finallyRejectLabel = -1;
+        if (asyncInfo != null)
+        {
+            tryRejectStateId = asyncInfo.AllocateResumeStateId();
+            tryRejectLabel = CreateLabel();
+            asyncInfo.RegisterResumeLabel(tryRejectStateId, tryRejectLabel);
+
+            if (hasCatch)
+            {
+                catchRejectStateId = asyncInfo.AllocateResumeStateId();
+                catchRejectLabel = CreateLabel();
+                asyncInfo.RegisterResumeLabel(catchRejectStateId, catchRejectLabel);
+            }
+
+            if (hasFinally)
+            {
+                finallyRejectStateId = asyncInfo.AllocateResumeStateId();
+                finallyRejectLabel = CreateLabel();
+                asyncInfo.RegisterResumeLabel(finallyRejectStateId, finallyRejectLabel);
+            }
+        }
 
         // Reset pending completion fields on entry.
         {
@@ -440,13 +471,40 @@ public sealed partial class HIRToLIRLowerer
         try
         {
             // --- Try block ---
-            if (!TryLowerStatement(tryStmt.TryBlock))
+            if (asyncInfo != null)
             {
-                return false;
+                _asyncTryCatchStack.Push(new AsyncTryCatchContext(
+                    tryRejectStateId,
+                    tryRejectLabel,
+                    pendingExceptionField));
+            }
+            try
+            {
+                if (!TryLowerStatement(tryStmt.TryBlock))
+                {
+                    return false;
+                }
+            }
+            finally
+            {
+                if (asyncInfo != null)
+                {
+                    _asyncTryCatchStack.Pop();
+                }
             }
 
             // Normal completion flows into finally (if present) or directly after try.
             _methodBodyIR.Instructions.Add(new LIRBranch(hasFinally ? finallyEntryLabel : afterTryLabel));
+
+            if (asyncInfo != null)
+            {
+                EmitGeneratorAsyncRejectionRoute(
+                    tryRejectLabel,
+                    scopeName,
+                    hasPendingExceptionField,
+                    hasPendingReturnField,
+                    hasCatch ? catchEntryLabel : finallyEntryLabel);
+            }
 
             // --- Catch block ---
             if (hasCatch)
@@ -480,12 +538,39 @@ public sealed partial class HIRToLIRLowerer
                     return false;
                 }
 
-                if (tryStmt.CatchBody != null && !TryLowerStatement(tryStmt.CatchBody))
+                if (asyncInfo != null)
                 {
-                    return false;
+                    _asyncTryCatchStack.Push(new AsyncTryCatchContext(
+                        catchRejectStateId,
+                        catchRejectLabel,
+                        pendingExceptionField));
+                }
+                try
+                {
+                    if (tryStmt.CatchBody != null && !TryLowerStatement(tryStmt.CatchBody))
+                    {
+                        return false;
+                    }
+                }
+                finally
+                {
+                    if (asyncInfo != null)
+                    {
+                        _asyncTryCatchStack.Pop();
+                    }
                 }
 
                 _methodBodyIR.Instructions.Add(new LIRBranch(hasFinally ? finallyEntryLabel : afterTryLabel));
+
+                if (asyncInfo != null)
+                {
+                    EmitGeneratorAsyncRejectionRoute(
+                        catchRejectLabel,
+                        scopeName,
+                        hasPendingExceptionField,
+                        hasPendingReturnField,
+                        hasFinally ? finallyEntryLabel : completionDispatchLabel);
+                }
 
                 // Restore the context state to 'try' for subsequent lowering.
                 _generatorTryCatchFinallyStack.Pop();
@@ -500,15 +585,46 @@ public sealed partial class HIRToLIRLowerer
                 _generatorTryCatchFinallyStack.Pop();
                 _generatorTryCatchFinallyStack.Push(ctx with { IsInFinally = true });
 
-                EmitProcessExitGuard();
-                if (tryStmt.FinallyBody != null && !TryLowerStatement(tryStmt.FinallyBody))
+                if (asyncInfo != null)
                 {
-                    return false;
+                    _asyncTryCatchStack.Push(new AsyncTryCatchContext(
+                        finallyRejectStateId,
+                        finallyRejectLabel,
+                        pendingExceptionField));
+                }
+                try
+                {
+                    EmitProcessExitGuard();
+                    if (tryStmt.FinallyBody != null && !TryLowerStatement(tryStmt.FinallyBody))
+                    {
+                        return false;
+                    }
+                }
+                finally
+                {
+                    if (asyncInfo != null)
+                    {
+                        _asyncTryCatchStack.Pop();
+                    }
                 }
                 _methodBodyIR.Instructions.Add(new LIRBranch(finallyExitLabel));
 
+                if (asyncInfo != null)
+                {
+                    EmitGeneratorAsyncRejectionRoute(
+                        finallyRejectLabel,
+                        scopeName,
+                        hasPendingExceptionField,
+                        hasPendingReturnField,
+                        finallyExitLabel);
+                }
+
                 // --- After finally: dispatch based on completion ---
                 _methodBodyIR.Instructions.Add(new LIRLabel(finallyExitLabel));
+            }
+            else
+            {
+                _methodBodyIR.Instructions.Add(new LIRLabel(completionDispatchLabel));
             }
 
             // If we are nested within another generator try/catch/finally routing context, propagate
@@ -585,6 +701,30 @@ public sealed partial class HIRToLIRLowerer
                 _generatorTryCatchFinallyStack.Pop();
             }
         }
+    }
+
+    private void EmitGeneratorAsyncRejectionRoute(
+        int rejectionLabel,
+        string scopeName,
+        string hasPendingExceptionField,
+        string hasPendingReturnField,
+        int targetLabel)
+    {
+        _methodBodyIR.Instructions.Add(new LIRLabel(rejectionLabel));
+
+        var trueTemp = CreateTempVariable();
+        _methodBodyIR.Instructions.Add(new LIRConstBoolean(true, trueTemp));
+        DefineTempStorage(trueTemp, new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool)));
+        _methodBodyIR.Instructions.Add(
+            new LIRStoreScopeFieldByName(scopeName, hasPendingExceptionField, trueTemp));
+
+        var falseTemp = CreateTempVariable();
+        _methodBodyIR.Instructions.Add(new LIRConstBoolean(false, falseTemp));
+        DefineTempStorage(falseTemp, new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool)));
+        _methodBodyIR.Instructions.Add(
+            new LIRStoreScopeFieldByName(scopeName, hasPendingReturnField, falseTemp));
+
+        _methodBodyIR.Instructions.Add(new LIRBranch(targetLabel));
     }
 
     private void EmitProcessExitGuard()

--- a/src/Compiler/Services/AssemblyGenerator.cs
+++ b/src/Compiler/Services/AssemblyGenerator.cs
@@ -104,6 +104,7 @@ namespace Jroc.Services
                     default,
                     default,
                     default,
+                    default,
                     default);
 
             // Phase 0: compute callable counts across all modules so we can assign stable

--- a/src/Compiler/Services/Contracts/GeneratedContractMetadataEmitter.cs
+++ b/src/Compiler/Services/Contracts/GeneratedContractMetadataEmitter.cs
@@ -11,7 +11,8 @@ internal sealed record GeneratedContractMetadataReferences(
     MethodDefinitionHandle JsExportValueAttributeCtor,
     MethodDefinitionHandle JsObjectContractAttributeCtor,
     MethodDefinitionHandle JsArrayContractAttributeCtor,
-    MethodDefinitionHandle JsCallableContractAttributeCtor);
+    MethodDefinitionHandle JsCallableContractAttributeCtor,
+    MethodDefinitionHandle JsBuiltinContractAttributeCtor);
 
 internal sealed class GeneratedContractMetadataEmitter
 {
@@ -42,6 +43,7 @@ internal sealed class GeneratedContractMetadataEmitter
         var jsObjectContractCtor = EmitAttributeType("JsObjectContractAttribute", hasStringArgument: false);
         var jsArrayContractCtor = EmitAttributeType("JsArrayContractAttribute", hasStringArgument: false);
         var jsCallableContractCtor = EmitAttributeType("JsCallableContractAttribute", hasStringArgument: false);
+        var jsBuiltinContractCtor = EmitAttributeType("JsBuiltinContractAttribute", hasStringArgument: true);
 
         return new GeneratedContractMetadataReferences(
             jsModuleCtor,
@@ -49,7 +51,8 @@ internal sealed class GeneratedContractMetadataEmitter
             jsExportValueCtor,
             jsObjectContractCtor,
             jsArrayContractCtor,
-            jsCallableContractCtor);
+            jsCallableContractCtor,
+            jsBuiltinContractCtor);
     }
 
     private MethodDefinitionHandle EmitAttributeType(string typeName, bool hasStringArgument)

--- a/src/Compiler/Services/Contracts/ModuleExportsContractEmitter.cs
+++ b/src/Compiler/Services/Contracts/ModuleExportsContractEmitter.cs
@@ -29,6 +29,22 @@ internal sealed class ModuleExportsContractEmitter
     private const string FallbackCallableContractKey = "\0callable";
     private const string FallbackConstructorContractKey = "\0constructor";
     private const string ConstructorContractKeyPrefix = "\0constructor:";
+    private const string DateContractKey = "\0builtin:Date";
+    private const string DateConstructorContractKey = "\0builtin:DateConstructor";
+    private const string RegExpContractKey = "\0builtin:RegExp";
+    private const string RegExpConstructorContractKey = "\0builtin:RegExpConstructor";
+    private const string ErrorContractKey = "\0builtin:Error";
+    private const string ErrorConstructorContractKey = "\0builtin:ErrorConstructor";
+    private const string SymbolContractKey = "\0builtin:Symbol";
+    private const string SymbolConstructorContractKey = "\0builtin:SymbolConstructor";
+    private const string MapEntryContractKey = "\0builtin:MapEntry";
+    private const string MapContractKey = "\0builtin:Map";
+    private const string SetContractKey = "\0builtin:Set";
+    private const string WeakMapContractKey = "\0builtin:WeakMap";
+    private const string WeakSetContractKey = "\0builtin:WeakSet";
+    private const string ArrayBufferContractKey = "\0builtin:ArrayBuffer";
+    private const string DataViewContractKey = "\0builtin:DataView";
+    private const string TypedArrayContractKey = "\0builtin:TypedArray";
 
     private readonly MetadataBuilder _metadata;
     private readonly BaseClassLibraryReferences _bcl;
@@ -218,6 +234,110 @@ internal sealed class ModuleExportsContractEmitter
                 nestedTypes,
                 instanceInterfacesByClassName[FallbackObjectContractKey]);
         }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.Symbol))
+        {
+            instanceInterfacesByClassName[SymbolContractKey] = EmitSymbolInterface(
+                facadeType,
+                nestedTypes);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.ArrayBuffer))
+        {
+            instanceInterfacesByClassName[ArrayBufferContractKey] = EmitArrayBufferInterface(
+                facadeType,
+                nestedTypes);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.Map))
+        {
+            instanceInterfacesByClassName[MapEntryContractKey] = EmitMapEntryInterface(
+                facadeType,
+                nestedTypes);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.Date))
+        {
+            instanceInterfacesByClassName[DateContractKey] = EmitDateInterface(
+                facadeType,
+                nestedTypes);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.RegExp))
+        {
+            instanceInterfacesByClassName[RegExpContractKey] = EmitRegExpInterface(
+                facadeType,
+                nestedTypes,
+                instanceInterfacesByClassName[FallbackArrayContractKey]);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.Error))
+        {
+            instanceInterfacesByClassName[ErrorContractKey] = EmitErrorInterface(
+                facadeType,
+                nestedTypes);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.Map))
+        {
+            instanceInterfacesByClassName[MapContractKey] = EmitMapInterface(
+                facadeType,
+                nestedTypes,
+                instanceInterfacesByClassName[MapEntryContractKey]);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.Set))
+        {
+            instanceInterfacesByClassName[SetContractKey] = EmitSetInterface(
+                facadeType,
+                nestedTypes);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.WeakMap))
+        {
+            instanceInterfacesByClassName[WeakMapContractKey] = EmitWeakMapInterface(
+                facadeType,
+                nestedTypes);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.WeakSet))
+        {
+            instanceInterfacesByClassName[WeakSetContractKey] = EmitWeakSetInterface(
+                facadeType,
+                nestedTypes);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.DataView))
+        {
+            instanceInterfacesByClassName[DataViewContractKey] = EmitDataViewInterface(
+                facadeType,
+                nestedTypes,
+                instanceInterfacesByClassName[ArrayBufferContractKey]);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.TypedArray))
+        {
+            instanceInterfacesByClassName[TypedArrayContractKey] = EmitTypedArrayInterface(
+                facadeType,
+                nestedTypes,
+                instanceInterfacesByClassName[ArrayBufferContractKey]);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.DateConstructor))
+        {
+            instanceInterfacesByClassName[DateConstructorContractKey] = EmitDateConstructorInterface(
+                facadeType,
+                nestedTypes,
+                instanceInterfacesByClassName[DateContractKey]);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.RegExpConstructor))
+        {
+            instanceInterfacesByClassName[RegExpConstructorContractKey] = EmitRegExpConstructorInterface(
+                facadeType,
+                nestedTypes,
+                instanceInterfacesByClassName[RegExpContractKey]);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.ErrorConstructor))
+        {
+            instanceInterfacesByClassName[ErrorConstructorContractKey] = EmitErrorConstructorInterface(
+                facadeType,
+                nestedTypes,
+                instanceInterfacesByClassName[ErrorContractKey]);
+        }
+        if (fallbackRequirements.HasFlag(FallbackContractKind.SymbolConstructor))
+        {
+            instanceInterfacesByClassName[SymbolConstructorContractKey] = EmitSymbolConstructorInterface(
+                facadeType,
+                nestedTypes,
+                instanceInterfacesByClassName[SymbolContractKey]);
+        }
 
         // Emit class instance and constructor contracts first so function inference can reference them.
         var classContracts = BuildClassContractDefinitions(module, exportShape, topLevel);
@@ -334,15 +454,17 @@ internal sealed class ModuleExportsContractEmitter
             }
             else
             {
-                valueType = TypeOrHandle.FromClr(
-                    MapClrType(
-                        InferClrTypeFromExpression(
-                            directValueNode,
-                            topLevel,
-                            classFields: null,
-                            instanceInterfacesByClassName,
-                            ensureClassInstanceInterface: null)
-                        .ClrType ?? typeof(object)));
+                var inferredDirectType = InferClrTypeFromExpression(
+                    directValueNode,
+                    topLevel,
+                    classFields: null,
+                    instanceInterfacesByClassName,
+                    ensureClassInstanceInterface: null);
+                valueType = inferredDirectType.Handle.HasValue
+                    || inferredDirectType.OpenGenericTypeRef.HasValue
+                    ? inferredDirectType
+                    : TypeOrHandle.FromClr(
+                        MapClrType(inferredDirectType.ClrType ?? typeof(object)));
             }
             var valueProperty = EmitReadOnlyProperty(
                 exportsTypeBuilder,
@@ -499,9 +621,19 @@ internal sealed class ModuleExportsContractEmitter
             }
 
             // Default: exported value projected as a read-only property.
-            // Prefer stable binding type from symbol table when available (e.g. const x = complexExpr).
+            // Prefer generated/BCL projection shapes over broad stable runtime CLR types.
+            var inferredType = InferClrTypeFromExpression(
+                valueNode,
+                memberTopLevel,
+                classFields: null,
+                instanceInterfacesByClassName,
+                ensureClassInstanceInterface: null);
             TypeOrHandle clrType;
-            if (member.StableClrType != null)
+            if (inferredType.Handle.HasValue || inferredType.OpenGenericTypeRef.HasValue)
+            {
+                clrType = inferredType;
+            }
+            else if (member.StableClrType != null)
             {
                 clrType = TypeOrHandle.FromClr(MapClrType(member.StableClrType));
             }
@@ -515,12 +647,7 @@ internal sealed class ModuleExportsContractEmitter
             }
             else
             {
-                clrType = InferClrTypeFromExpression(
-                    valueNode,
-                    memberTopLevel,
-                    classFields: null,
-                    instanceInterfacesByClassName,
-                    ensureClassInstanceInterface: null);
+                clrType = inferredType;
             }
             var propHandle = EmitProperty(
                 exportsTypeBuilder,
@@ -612,6 +739,564 @@ internal sealed class ModuleExportsContractEmitter
         nestedTypes.Add(typeDef, facadeType);
         _metadata.AddInterfaceImplementation(typeDef, _typeRefs.GetOrAdd(typeof(IDisposable)));
         return typeDef;
+    }
+
+    private TypeDefinitionHandle EmitDateInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IDate");
+        EmitInterfaceMethod(typeBuilder, Method("GetTime", typeof(double)), "getTime");
+        EmitInterfaceMethod(typeBuilder, Method("SetTime", typeof(double), ("value", typeof(object))), "setTime");
+        EmitInterfaceMethod(typeBuilder, Method("ToISOString", typeof(string)), "toISOString");
+        EmitInterfaceMethod(typeBuilder, Method("ToUtcString", typeof(string)), "toUTCString");
+        EmitInterfaceMethod(typeBuilder, Method("ToDisplayString", typeof(string)), "toString");
+        return CompleteBuiltinInterface(typeBuilder, facadeType, nestedTypes, "Date");
+    }
+
+    private TypeDefinitionHandle EmitDateConstructorInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes,
+        TypeDefinitionHandle dateContract)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IDateConstructor");
+        EmitInterfaceMethod(
+            typeBuilder,
+            new ContractMethod(
+                "Construct",
+                ["arguments"],
+                [TypeOrHandle.FromClr(typeof(object[]))],
+                TypeOrHandle.FromHandle(dateContract),
+                IsParamArray: true));
+        EmitInterfaceMethod(typeBuilder, Method("Now", typeof(double)), "now");
+        EmitInterfaceMethod(typeBuilder, Method("Parse", typeof(double), ("input", typeof(string))), "parse");
+        EmitInterfaceMethod(
+            typeBuilder,
+            new ContractMethod(
+                "Utc",
+                ["arguments"],
+                [TypeOrHandle.FromClr(typeof(object[]))],
+                TypeOrHandle.FromClr(typeof(double)),
+                IsParamArray: true),
+            "UTC");
+        return CompleteBuiltinInterface(typeBuilder, facadeType, nestedTypes, "DateConstructor");
+    }
+
+    private TypeDefinitionHandle EmitRegExpInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes,
+        TypeDefinitionHandle arrayContract)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IRegExp");
+        var firstProperty = EmitReadOnlyProperty(
+            typeBuilder,
+            "Source",
+            TypeOrHandle.FromClr(typeof(string)),
+            "source");
+        EmitReadOnlyProperty(typeBuilder, "Flags", TypeOrHandle.FromClr(typeof(string)), "flags");
+        EmitProperty(
+            typeBuilder,
+            "LastIndex",
+            TypeOrHandle.FromClr(typeof(double)),
+            canWrite: true,
+            exportName: "lastIndex");
+        EmitInterfaceMethod(
+            typeBuilder,
+            new ContractMethod(
+                "Exec",
+                ["input"],
+                [TypeOrHandle.FromClr(typeof(object))],
+                TypeOrHandle.FromHandle(arrayContract)),
+            "exec");
+        EmitInterfaceMethod(typeBuilder, Method("Test", typeof(bool), ("input", typeof(object))), "test");
+        EmitInterfaceMethod(typeBuilder, Method("ToDisplayString", typeof(string)), "toString");
+        return CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "RegExp",
+            firstProperty);
+    }
+
+    private TypeDefinitionHandle EmitRegExpConstructorInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes,
+        TypeDefinitionHandle regExpContract)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IRegExpConstructor");
+        EmitInterfaceMethod(
+            typeBuilder,
+            new ContractMethod(
+                "Construct",
+                ["arguments"],
+                [TypeOrHandle.FromClr(typeof(object[]))],
+                TypeOrHandle.FromHandle(regExpContract),
+                IsParamArray: true));
+        EmitInterfaceMethod(typeBuilder, Method("Escape", typeof(string), ("input", typeof(object))), "escape");
+        return CompleteBuiltinInterface(typeBuilder, facadeType, nestedTypes, "RegExpConstructor");
+    }
+
+    private TypeDefinitionHandle EmitErrorInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IError");
+        var firstProperty = EmitProperty(
+            typeBuilder,
+            "Name",
+            TypeOrHandle.FromClr(typeof(string)),
+            canWrite: true,
+            exportName: "name");
+        EmitProperty(
+            typeBuilder,
+            "Message",
+            TypeOrHandle.FromClr(typeof(string)),
+            canWrite: true,
+            exportName: "message");
+        EmitProperty(
+            typeBuilder,
+            "Cause",
+            TypeOrHandle.FromClr(typeof(object)),
+            canWrite: true,
+            exportName: "cause");
+        EmitReadOnlyProperty(
+            typeBuilder,
+            "Stack",
+            TypeOrHandle.FromClr(typeof(string)),
+            "stack");
+        return CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "Error",
+            firstProperty);
+    }
+
+    private TypeDefinitionHandle EmitErrorConstructorInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes,
+        TypeDefinitionHandle errorContract)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IErrorConstructor");
+        EmitInterfaceMethod(
+            typeBuilder,
+            new ContractMethod(
+                "Construct",
+                ["arguments"],
+                [TypeOrHandle.FromClr(typeof(object[]))],
+                TypeOrHandle.FromHandle(errorContract),
+                IsParamArray: true));
+        return CompleteBuiltinInterface(typeBuilder, facadeType, nestedTypes, "ErrorConstructor");
+    }
+
+    private TypeDefinitionHandle EmitSymbolInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "ISymbol");
+        var firstProperty = EmitReadOnlyProperty(
+            typeBuilder,
+            "Description",
+            TypeOrHandle.FromClr(typeof(string)),
+            "description");
+        EmitReadOnlyProperty(typeBuilder, "RegistryKey", TypeOrHandle.FromClr(typeof(string)));
+        EmitReadOnlyProperty(typeBuilder, "WellKnownName", TypeOrHandle.FromClr(typeof(string)));
+        EmitInterfaceMethod(typeBuilder, Method("ToDisplayString", typeof(string)), "toString");
+        return CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "Symbol",
+            firstProperty);
+    }
+
+    private TypeDefinitionHandle EmitSymbolConstructorInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes,
+        TypeDefinitionHandle symbolContract)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "ISymbolConstructor");
+        EmitInterfaceMethod(
+            typeBuilder,
+            new ContractMethod(
+                "Create",
+                ["description"],
+                [TypeOrHandle.FromClr(typeof(object))],
+                TypeOrHandle.FromHandle(symbolContract)));
+        EmitInterfaceMethod(
+            typeBuilder,
+            new ContractMethod(
+                "For",
+                ["key"],
+                [TypeOrHandle.FromClr(typeof(object))],
+                TypeOrHandle.FromHandle(symbolContract)),
+            "for");
+        EmitInterfaceMethod(
+            typeBuilder,
+            new ContractMethod(
+                "KeyFor",
+                ["symbol"],
+                [TypeOrHandle.FromHandle(symbolContract)],
+                TypeOrHandle.FromClr(typeof(string))),
+            "keyFor");
+        var firstProperty = EmitReadOnlyProperty(
+            typeBuilder,
+            "Iterator",
+            TypeOrHandle.FromHandle(symbolContract),
+            "iterator");
+        EmitReadOnlyProperty(
+            typeBuilder,
+            "AsyncIterator",
+            TypeOrHandle.FromHandle(symbolContract),
+            "asyncIterator");
+        return CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "SymbolConstructor",
+            firstProperty);
+    }
+
+    private TypeDefinitionHandle EmitMapEntryInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IMapEntry");
+        var firstProperty = EmitReadOnlyProperty(
+            typeBuilder,
+            "Key",
+            TypeOrHandle.FromClr(typeof(object)));
+        EmitReadOnlyProperty(typeBuilder, "Value", TypeOrHandle.FromClr(typeof(object)));
+        return CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "MapEntry",
+            firstProperty);
+    }
+
+    private TypeDefinitionHandle EmitMapInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes,
+        TypeDefinitionHandle mapEntryContract)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IMap");
+        var firstProperty = EmitReadOnlyProperty(
+            typeBuilder,
+            "Count",
+            TypeOrHandle.FromClr(typeof(double)),
+            "size");
+        EmitInterfaceMethod(typeBuilder, Method("Get", typeof(object), ("key", typeof(object))), "get");
+        EmitInterfaceMethod(typeBuilder, Method("Has", typeof(bool), ("key", typeof(object))), "has");
+        EmitInterfaceMethod(
+            typeBuilder,
+            Method("Set", typeof(void), ("key", typeof(object)), ("value", typeof(object))),
+            "set");
+        EmitInterfaceMethod(typeBuilder, Method("Delete", typeof(bool), ("key", typeof(object))), "delete");
+        EmitInterfaceMethod(typeBuilder, Method("Clear", typeof(void)), "clear");
+        EmitInterfaceMethod(
+            typeBuilder,
+            GenericMethod("Keys", typeof(IEnumerable<>), typeof(object)),
+            "keys");
+        EmitInterfaceMethod(
+            typeBuilder,
+            GenericMethod("Values", typeof(IEnumerable<>), typeof(object)),
+            "values");
+        EmitInterfaceMethod(
+            typeBuilder,
+            GenericMethod("Entries", typeof(IEnumerable<>), mapEntryContract),
+            "entries");
+        var typeDef = CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "Map",
+            firstProperty);
+        AddGenericInterfaceImplementation(typeDef, typeof(IEnumerable<>), mapEntryContract);
+        return typeDef;
+    }
+
+    private TypeDefinitionHandle EmitSetInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "ISet");
+        var firstProperty = EmitReadOnlyProperty(
+            typeBuilder,
+            "Count",
+            TypeOrHandle.FromClr(typeof(double)),
+            "size");
+        EmitInterfaceMethod(typeBuilder, Method("Has", typeof(bool), ("value", typeof(object))), "has");
+        EmitInterfaceMethod(typeBuilder, Method("Add", typeof(void), ("value", typeof(object))), "add");
+        EmitInterfaceMethod(typeBuilder, Method("Delete", typeof(bool), ("value", typeof(object))), "delete");
+        EmitInterfaceMethod(typeBuilder, Method("Clear", typeof(void)), "clear");
+        EmitInterfaceMethod(
+            typeBuilder,
+            GenericMethod("Values", typeof(IEnumerable<>), typeof(object)),
+            "values");
+        var typeDef = CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "Set",
+            firstProperty);
+        AddGenericInterfaceImplementation(typeDef, typeof(IEnumerable<>), typeof(object));
+        return typeDef;
+    }
+
+    private TypeDefinitionHandle EmitWeakMapInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IWeakMap");
+        EmitInterfaceMethod(typeBuilder, Method("Get", typeof(object), ("key", typeof(object))), "get");
+        EmitInterfaceMethod(typeBuilder, Method("Has", typeof(bool), ("key", typeof(object))), "has");
+        EmitInterfaceMethod(
+            typeBuilder,
+            Method("Set", typeof(void), ("key", typeof(object)), ("value", typeof(object))),
+            "set");
+        EmitInterfaceMethod(typeBuilder, Method("Delete", typeof(bool), ("key", typeof(object))), "delete");
+        return CompleteBuiltinInterface(typeBuilder, facadeType, nestedTypes, "WeakMap");
+    }
+
+    private TypeDefinitionHandle EmitWeakSetInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IWeakSet");
+        EmitInterfaceMethod(typeBuilder, Method("Has", typeof(bool), ("value", typeof(object))), "has");
+        EmitInterfaceMethod(typeBuilder, Method("Add", typeof(void), ("value", typeof(object))), "add");
+        EmitInterfaceMethod(typeBuilder, Method("Delete", typeof(bool), ("value", typeof(object))), "delete");
+        return CompleteBuiltinInterface(typeBuilder, facadeType, nestedTypes, "WeakSet");
+    }
+
+    private TypeDefinitionHandle EmitArrayBufferInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes)
+    {
+        var selfContract = MetadataTokens.TypeDefinitionHandle(
+            _metadata.GetRowCount(TableIndex.TypeDef) + 1);
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IArrayBuffer");
+        var firstProperty = EmitReadOnlyProperty(
+            typeBuilder,
+            "ByteLength",
+            TypeOrHandle.FromClr(typeof(double)),
+            "byteLength");
+        EmitReadOnlyProperty(
+            typeBuilder,
+            "MaxByteLength",
+            TypeOrHandle.FromClr(typeof(double)),
+            "maxByteLength");
+        EmitReadOnlyProperty(
+            typeBuilder,
+            "Resizable",
+            TypeOrHandle.FromClr(typeof(bool)),
+            "resizable");
+        EmitReadOnlyProperty(
+            typeBuilder,
+            "IsShared",
+            TypeOrHandle.FromClr(typeof(bool)));
+        EmitInterfaceMethod(
+            typeBuilder,
+            new ContractMethod(
+                "Slice",
+                ["arguments"],
+                [TypeOrHandle.FromClr(typeof(object[]))],
+                TypeOrHandle.FromHandle(selfContract),
+                IsParamArray: true),
+            "slice");
+        EmitInterfaceMethod(typeBuilder, Method("Resize", typeof(void), ("newLength", typeof(object))), "resize");
+        return CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "ArrayBuffer",
+            firstProperty);
+    }
+
+    private TypeDefinitionHandle EmitDataViewInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes,
+        TypeDefinitionHandle arrayBufferContract)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "IDataView");
+        var firstProperty = EmitReadOnlyProperty(
+            typeBuilder,
+            "Buffer",
+            TypeOrHandle.FromHandle(arrayBufferContract),
+            "buffer");
+        EmitReadOnlyProperty(typeBuilder, "ByteOffset", TypeOrHandle.FromClr(typeof(double)), "byteOffset");
+        EmitReadOnlyProperty(typeBuilder, "ByteLength", TypeOrHandle.FromClr(typeof(double)), "byteLength");
+        EmitInterfaceMethod(typeBuilder, Method("GetInt8", typeof(double), ("byteOffset", typeof(object))), "getInt8");
+        EmitInterfaceMethod(typeBuilder, Method("GetUint8", typeof(double), ("byteOffset", typeof(object))), "getUint8");
+        EmitDataViewEndianGetter(typeBuilder, "GetInt16", "getInt16");
+        EmitDataViewEndianGetter(typeBuilder, "GetUint16", "getUint16");
+        EmitDataViewEndianGetter(typeBuilder, "GetInt32", "getInt32");
+        EmitDataViewEndianGetter(typeBuilder, "GetUint32", "getUint32");
+        EmitDataViewEndianGetter(typeBuilder, "GetFloat32", "getFloat32");
+        EmitDataViewEndianGetter(typeBuilder, "GetFloat64", "getFloat64");
+        EmitInterfaceMethod(
+            typeBuilder,
+            Method("SetInt8", typeof(void), ("byteOffset", typeof(object)), ("value", typeof(object))),
+            "setInt8");
+        EmitInterfaceMethod(
+            typeBuilder,
+            Method("SetUint8", typeof(void), ("byteOffset", typeof(object)), ("value", typeof(object))),
+            "setUint8");
+        EmitDataViewEndianSetter(typeBuilder, "SetInt16", "setInt16");
+        EmitDataViewEndianSetter(typeBuilder, "SetUint16", "setUint16");
+        EmitDataViewEndianSetter(typeBuilder, "SetInt32", "setInt32");
+        EmitDataViewEndianSetter(typeBuilder, "SetUint32", "setUint32");
+        EmitDataViewEndianSetter(typeBuilder, "SetFloat32", "setFloat32");
+        EmitDataViewEndianSetter(typeBuilder, "SetFloat64", "setFloat64");
+        return CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "DataView",
+            firstProperty);
+    }
+
+    private TypeDefinitionHandle EmitTypedArrayInterface(
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes,
+        TypeDefinitionHandle arrayBufferContract)
+    {
+        var typeBuilder = new TypeBuilder(_metadata, string.Empty, "ITypedArray");
+        var firstProperty = EmitReadOnlyProperty(
+            typeBuilder,
+            "Buffer",
+            TypeOrHandle.FromHandle(arrayBufferContract),
+            "buffer");
+        EmitReadOnlyProperty(typeBuilder, "ByteOffset", TypeOrHandle.FromClr(typeof(double)), "byteOffset");
+        EmitReadOnlyProperty(typeBuilder, "ByteLength", TypeOrHandle.FromClr(typeof(double)), "byteLength");
+        EmitReadOnlyProperty(typeBuilder, "Length", TypeOrHandle.FromClr(typeof(double)), "length");
+        EmitReadOnlyProperty(
+            typeBuilder,
+            "BytesPerElement",
+            TypeOrHandle.FromClr(typeof(double)),
+            "BYTES_PER_ELEMENT");
+        EmitReadOnlyProperty(typeBuilder, "Kind", TypeOrHandle.FromClr(typeof(string)));
+        EmitInterfaceMethod(typeBuilder, Method("Get", typeof(double), ("index", typeof(double))));
+        EmitInterfaceMethod(
+            typeBuilder,
+            Method("Set", typeof(void), ("index", typeof(double)), ("value", typeof(object))));
+
+        var typeDef = CompleteBuiltinInterface(
+            typeBuilder,
+            facadeType,
+            nestedTypes,
+            "TypedArray",
+            firstProperty);
+        AddGenericInterfaceImplementation(typeDef, typeof(IEnumerable<>), typeof(object));
+        return typeDef;
+    }
+
+    private void EmitDataViewEndianGetter(TypeBuilder typeBuilder, string methodName, string exportName)
+        => EmitInterfaceMethod(
+            typeBuilder,
+            Method(
+                methodName,
+                typeof(double),
+                ("byteOffset", typeof(object)),
+                ("littleEndian", typeof(bool))),
+            exportName);
+
+    private void EmitDataViewEndianSetter(TypeBuilder typeBuilder, string methodName, string exportName)
+        => EmitInterfaceMethod(
+            typeBuilder,
+            Method(
+                methodName,
+                typeof(void),
+                ("byteOffset", typeof(object)),
+                ("value", typeof(object)),
+                ("littleEndian", typeof(bool))),
+            exportName);
+
+    private TypeDefinitionHandle CompleteBuiltinInterface(
+        TypeBuilder typeBuilder,
+        TypeDefinitionHandle facadeType,
+        NestedTypeRelationshipRegistry nestedTypes,
+        string kind,
+        PropertyDefinitionHandle firstProperty = default)
+    {
+        var typeDef = typeBuilder.AddTypeDefinition(
+            TypeAttributes.NestedPublic | TypeAttributes.Interface | TypeAttributes.Abstract,
+            default);
+        nestedTypes.Add(typeDef, facadeType);
+        if (!firstProperty.IsNil)
+        {
+            _metadata.AddPropertyMap(typeDef, firstProperty);
+        }
+
+        _metadata.AddInterfaceImplementation(typeDef, _typeRefs.GetOrAdd(typeof(IDisposable)));
+        AddBuiltinMarkerAttribute(typeDef, kind);
+        return typeDef;
+    }
+
+    private static ContractMethod Method(
+        string name,
+        Type returnType,
+        params (string Name, Type Type)[] parameters)
+        => new(
+            name,
+            parameters.Select(parameter => parameter.Name).ToArray(),
+            parameters.Select(parameter => TypeOrHandle.FromClr(parameter.Type)).ToArray(),
+            TypeOrHandle.FromClr(returnType));
+
+    private ContractMethod GenericMethod(
+        string name,
+        Type openGenericReturnType,
+        Type genericArgument)
+        => new(
+            name,
+            Array.Empty<string>(),
+            Array.Empty<TypeOrHandle>(),
+            TypeOrHandle.FromGenericInstantiation(
+                _typeRefs.GetOrAdd(openGenericReturnType),
+                genericArgument));
+
+    private ContractMethod GenericMethod(
+        string name,
+        Type openGenericReturnType,
+        EntityHandle genericArgument)
+        => new(
+            name,
+            Array.Empty<string>(),
+            Array.Empty<TypeOrHandle>(),
+            TypeOrHandle.FromGenericInstantiation(
+                _typeRefs.GetOrAdd(openGenericReturnType),
+                genericArgument));
+
+    private void AddGenericInterfaceImplementation(
+        TypeDefinitionHandle typeDef,
+        Type openGenericInterface,
+        Type genericArgument)
+        => _metadata.AddInterfaceImplementation(
+            typeDef,
+            CreateGenericTypeSpecification(openGenericInterface, TypeOrHandle.FromClr(genericArgument)));
+
+    private void AddGenericInterfaceImplementation(
+        TypeDefinitionHandle typeDef,
+        Type openGenericInterface,
+        EntityHandle genericArgument)
+        => _metadata.AddInterfaceImplementation(
+            typeDef,
+            CreateGenericTypeSpecification(openGenericInterface, TypeOrHandle.FromHandle(genericArgument)));
+
+    private TypeSpecificationHandle CreateGenericTypeSpecification(
+        Type openGenericType,
+        TypeOrHandle genericArgument)
+    {
+        var blob = new BlobBuilder();
+        var instantiation = new BlobEncoder(blob)
+            .TypeSpecificationSignature()
+            .GenericInstantiation(
+                _typeRefs.GetOrAdd(openGenericType),
+                genericArgumentCount: 1,
+                isValueType: false);
+        EncodeParamType(instantiation.AddArgument(), genericArgument);
+        return _metadata.AddTypeSpecification(_metadata.GetOrAddBlob(blob));
     }
 
     private void EmitDynamicObjectHelpers(TypeBuilder typeBuilder)
@@ -885,9 +1570,34 @@ internal sealed class ModuleExportsContractEmitter
         }
 
         _metadata.AddInterfaceImplementation(typeDef, _typeRefs.GetOrAdd(typeof(IDisposable)));
-        if (members is ObjectExpression)
+        if (members is ObjectExpression objectExpression)
         {
             AddGeneratedMarkerAttribute(typeDef, _generatedMetadata.JsObjectContractAttributeCtor);
+            if (IsSyncIterableObject(objectExpression, topLevelIndex))
+            {
+                AddGenericInterfaceImplementation(typeDef, typeof(IEnumerable<>), typeof(object));
+            }
+            if (IsAsyncIterableObject(objectExpression, topLevelIndex))
+            {
+                AddGenericInterfaceImplementation(typeDef, typeof(IAsyncEnumerable<>), typeof(object));
+            }
+        }
+        else if (members is Node classContractNode)
+        {
+            if (HasClassWellKnownSymbolMethod(
+                    classContractNode,
+                    topLevelIndex,
+                    "iterator"))
+            {
+                AddGenericInterfaceImplementation(typeDef, typeof(IEnumerable<>), typeof(object));
+            }
+            if (HasClassWellKnownSymbolMethod(
+                    classContractNode,
+                    topLevelIndex,
+                    "asyncIterator"))
+            {
+                AddGenericInterfaceImplementation(typeDef, typeof(IAsyncEnumerable<>), typeof(object));
+            }
         }
 
         return typeDef;
@@ -1121,7 +1831,22 @@ internal sealed class ModuleExportsContractEmitter
         Object = 1,
         Array = 2,
         Callable = 4,
-        Constructor = 8
+        Constructor = 8,
+        Date = 16,
+        DateConstructor = 32,
+        RegExp = 64,
+        RegExpConstructor = 128,
+        Error = 256,
+        ErrorConstructor = 512,
+        Symbol = 1024,
+        SymbolConstructor = 2048,
+        Map = 4096,
+        Set = 8192,
+        WeakMap = 16384,
+        WeakSet = 32768,
+        ArrayBuffer = 65536,
+        DataView = 131072,
+        TypedArray = 262144
     }
 
     private sealed record ClassContractDefinition(
@@ -1277,6 +2002,7 @@ internal sealed class ModuleExportsContractEmitter
                 ? topLevel
                 : BuildTopLevelDeclarationIndex(member.SourceModule.Ast);
             var valueNode = GetValueNode(member.SourceNode);
+            requirements |= GetExpressionFallbackRequirement(valueNode, memberTopLevel);
             if (TryResolveExportAsFunction(valueNode, memberTopLevel, out var function, out _))
             {
                 requirements |= GetFunctionFallbackRequirements(function, memberTopLevel);
@@ -1288,6 +2014,7 @@ internal sealed class ModuleExportsContractEmitter
         }
 
         var directValueNode = GetValueNode(exportShape.DirectValueSourceNode);
+        requirements |= GetExpressionFallbackRequirement(directValueNode, topLevel);
         if (TryResolveExportAsFunction(directValueNode, topLevel, out var directFunction, out _))
         {
             requirements |= GetFunctionFallbackRequirements(directFunction, topLevel);
@@ -1301,6 +2028,38 @@ internal sealed class ModuleExportsContractEmitter
         {
             requirements |= FallbackContractKind.Object;
         }
+        if (requirements.HasFlag(FallbackContractKind.RegExp))
+        {
+            requirements |= FallbackContractKind.Array;
+        }
+        if (requirements.HasFlag(FallbackContractKind.DateConstructor))
+        {
+            requirements |= FallbackContractKind.Date;
+        }
+        if (requirements.HasFlag(FallbackContractKind.RegExpConstructor))
+        {
+            requirements |= FallbackContractKind.RegExp | FallbackContractKind.Array;
+        }
+        if (requirements.HasFlag(FallbackContractKind.ErrorConstructor))
+        {
+            requirements |= FallbackContractKind.Error;
+        }
+        if (requirements.HasFlag(FallbackContractKind.SymbolConstructor))
+        {
+            requirements |= FallbackContractKind.Symbol;
+        }
+        if (requirements.HasFlag(FallbackContractKind.DataView)
+            || requirements.HasFlag(FallbackContractKind.TypedArray))
+        {
+            requirements |= FallbackContractKind.ArrayBuffer;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Map)
+            || requirements.HasFlag(FallbackContractKind.Set)
+            || requirements.HasFlag(FallbackContractKind.WeakMap)
+            || requirements.HasFlag(FallbackContractKind.WeakSet))
+        {
+            requirements |= FallbackContractKind.Object;
+        }
 
         return requirements;
     }
@@ -1308,18 +2067,28 @@ internal sealed class ModuleExportsContractEmitter
     private static FallbackContractKind GetObjectFallbackRequirements(
         ObjectExpression objectExpression,
         TopLevelIndex topLevel)
+        => GetObjectFallbackRequirements(
+            objectExpression,
+            topLevel,
+            new HashSet<Node>(ReferenceEqualityComparer.Instance));
+
+    private static FallbackContractKind GetObjectFallbackRequirements(
+        ObjectExpression objectExpression,
+        TopLevelIndex topLevel,
+        HashSet<Node> visited)
     {
+        if (!visited.Add(objectExpression))
+        {
+            return FallbackContractKind.None;
+        }
+
         var requirements = FallbackContractKind.None;
         foreach (var property in objectExpression.Properties.OfType<Property>())
         {
-            requirements |= property.Value switch
-            {
-                FunctionExpression or ArrowFunctionExpression =>
-                    GetFunctionFallbackRequirements(property.Value, topLevel),
-                ObjectExpression childObject =>
-                    GetObjectFallbackRequirements(childObject, topLevel),
-                _ => FallbackContractKind.None
-            };
+            requirements |= GetExpressionFallbackRequirement(
+                property.Value,
+                topLevel,
+                visited);
         }
 
         return requirements;
@@ -1328,10 +2097,24 @@ internal sealed class ModuleExportsContractEmitter
     private static FallbackContractKind GetFunctionFallbackRequirements(
         Node functionNode,
         TopLevelIndex topLevel)
+        => GetFunctionFallbackRequirements(
+            functionNode,
+            topLevel,
+            new HashSet<Node>(ReferenceEqualityComparer.Instance));
+
+    private static FallbackContractKind GetFunctionFallbackRequirements(
+        Node functionNode,
+        TopLevelIndex topLevel,
+        HashSet<Node> visited)
     {
+        if (!visited.Add(functionNode))
+        {
+            return FallbackContractKind.None;
+        }
+
         if (functionNode is ArrowFunctionExpression { Body: Expression expressionBody })
         {
-            return GetExpressionFallbackRequirement(expressionBody, topLevel);
+            return GetExpressionFallbackRequirement(expressionBody, topLevel, visited);
         }
 
         if (GetFunctionBody(functionNode) is not BlockStatement block)
@@ -1340,11 +2123,12 @@ internal sealed class ModuleExportsContractEmitter
         }
 
         var requirements = FallbackContractKind.None;
-        foreach (var returnStatement in block.Body.OfType<ReturnStatement>())
+        foreach (var returnStatement in GetFunctionReturnStatements(functionNode))
         {
             requirements |= GetExpressionFallbackRequirement(
                 returnStatement.Argument,
-                topLevel);
+                topLevel,
+                visited);
         }
 
         return requirements;
@@ -1353,17 +2137,75 @@ internal sealed class ModuleExportsContractEmitter
     private static FallbackContractKind GetExpressionFallbackRequirement(
         Node? expression,
         TopLevelIndex topLevel)
+        => GetExpressionFallbackRequirement(
+            expression,
+            topLevel,
+            new HashSet<Node>(ReferenceEqualityComparer.Instance));
+
+    private static FallbackContractKind GetExpressionFallbackRequirement(
+        Node? expression,
+        TopLevelIndex topLevel,
+        HashSet<Node> visited)
     {
         switch (expression)
         {
             case FunctionExpression or ArrowFunctionExpression:
-                return FallbackContractKind.Callable;
-            case ObjectExpression:
-                return FallbackContractKind.Object;
+                return FallbackContractKind.Callable
+                       | GetFunctionFallbackRequirements(expression, topLevel, visited);
+            case ObjectExpression objectExpression:
+                var objectKind = IsAsyncIterableObject(objectExpression, topLevel)
+                                 || IsSyncIterableObject(objectExpression, topLevel)
+                    ? FallbackContractKind.None
+                    : FallbackContractKind.Object;
+                return objectKind
+                       | GetObjectFallbackRequirements(objectExpression, topLevel, visited);
+        }
+
+        if (expression == null || !visited.Add(expression))
+        {
+            return FallbackContractKind.None;
+        }
+
+        switch (expression)
+        {
             case ArrayExpression:
                 return FallbackContractKind.Array;
             case ClassExpression:
                 return FallbackContractKind.Constructor | FallbackContractKind.Object;
+            case NewExpression { Callee: Identifier constructor }
+                when IsUnshadowedBuiltinName(constructor.Name, topLevel)
+                     && GetBuiltinInstanceRequirement(constructor.Name) != FallbackContractKind.None:
+                return GetBuiltinInstanceRequirement(constructor.Name);
+            case CallExpression { Callee: Identifier { Name: "RegExp" } }
+                when IsUnshadowedBuiltinName("RegExp", topLevel):
+                return FallbackContractKind.RegExp;
+            case CallExpression { Callee: Identifier error }
+                when IsErrorConstructorName(error.Name)
+                     && IsUnshadowedBuiltinName(error.Name, topLevel):
+                return FallbackContractKind.Error;
+            case CallExpression { Callee: Identifier { Name: "Symbol" } }
+                when IsUnshadowedBuiltinName("Symbol", topLevel):
+            case CallExpression
+            {
+                Callee: MemberExpression
+                {
+                    Object: Identifier { Name: "Symbol" },
+                    Property: Identifier { Name: "for" }
+                }
+            } when IsUnshadowedBuiltinName("Symbol", topLevel):
+            case MemberExpression
+            {
+                Object: Identifier { Name: "Symbol" },
+                Property: Identifier
+            } when IsUnshadowedBuiltinName("Symbol", topLevel):
+                return FallbackContractKind.Symbol;
+            case CallExpression { Callee: Identifier functionName }
+                when topLevel.Functions.TryGetValue(functionName.Name, out var function):
+                if (IsAsyncGeneratorFunction(function) || IsGeneratorFunction(function))
+                {
+                    return FallbackContractKind.None;
+                }
+                return GetFunctionFallbackRequirements(function, topLevel, visited);
             case CallExpression
             {
                 Callee: MemberExpression
@@ -1377,13 +2219,98 @@ internal sealed class ModuleExportsContractEmitter
                 return FallbackContractKind.Callable;
             case Identifier identifier when topLevel.Classes.ContainsKey(identifier.Name):
                 return FallbackContractKind.None;
-            case Identifier identifier
-                when topLevel.VariableInitializers.TryGetValue(identifier.Name, out var initializer):
-                return GetExpressionFallbackRequirement(initializer, topLevel);
+            case Identifier identifier:
+                if (topLevel.VariableInitializers.TryGetValue(identifier.Name, out var initializer))
+                {
+                    return GetExpressionFallbackRequirement(initializer, topLevel, visited);
+                }
+                var constructorRequirement = GetBuiltinConstructorRequirement(identifier.Name);
+                if (constructorRequirement != FallbackContractKind.None)
+                {
+                    return constructorRequirement;
+                }
+                return FallbackContractKind.None;
             default:
                 return FallbackContractKind.None;
         }
     }
+
+    private static FallbackContractKind GetBuiltinInstanceRequirement(string name)
+    {
+        if (string.Equals(name, "Date", StringComparison.Ordinal))
+        {
+            return FallbackContractKind.Date;
+        }
+        if (string.Equals(name, "RegExp", StringComparison.Ordinal))
+        {
+            return FallbackContractKind.RegExp;
+        }
+        if (IsErrorConstructorName(name))
+        {
+            return FallbackContractKind.Error;
+        }
+
+        return name switch
+        {
+            "Map" => FallbackContractKind.Map,
+            "Set" => FallbackContractKind.Set,
+            "WeakMap" => FallbackContractKind.WeakMap,
+            "WeakSet" => FallbackContractKind.WeakSet,
+            "ArrayBuffer" or "SharedArrayBuffer" => FallbackContractKind.ArrayBuffer,
+            "DataView" => FallbackContractKind.DataView,
+            _ when IsTypedArrayConstructorName(name) => FallbackContractKind.TypedArray,
+            _ => FallbackContractKind.None
+        };
+    }
+
+    private static FallbackContractKind GetBuiltinConstructorRequirement(string name)
+    {
+        if (string.Equals(name, "Date", StringComparison.Ordinal))
+        {
+            return FallbackContractKind.DateConstructor;
+        }
+        if (string.Equals(name, "RegExp", StringComparison.Ordinal))
+        {
+            return FallbackContractKind.RegExpConstructor;
+        }
+        if (IsErrorConstructorName(name))
+        {
+            return FallbackContractKind.ErrorConstructor;
+        }
+        if (string.Equals(name, "Symbol", StringComparison.Ordinal))
+        {
+            return FallbackContractKind.SymbolConstructor;
+        }
+
+        return FallbackContractKind.None;
+    }
+
+    private static bool IsErrorConstructorName(string name)
+        => name is "Error"
+            or "EvalError"
+            or "RangeError"
+            or "ReferenceError"
+            or "SyntaxError"
+            or "TypeError"
+            or "URIError"
+            or "AggregateError"
+            or "SuppressedError";
+
+    private static bool IsTypedArrayConstructorName(string name)
+        => name is "Int8Array"
+            or "Uint8Array"
+            or "Uint8ClampedArray"
+            or "Int16Array"
+            or "Uint16Array"
+            or "Int32Array"
+            or "Uint32Array"
+            or "Float32Array"
+            or "Float64Array";
+
+    private static bool IsUnshadowedBuiltinName(string name, TopLevelIndex topLevel)
+        => !topLevel.Functions.ContainsKey(name)
+           && !topLevel.Classes.ContainsKey(name)
+           && !topLevel.VariableInitializers.ContainsKey(name);
 
     private static bool TryGetPropertyName(Expression key, out string name)
     {
@@ -1400,6 +2327,64 @@ internal sealed class ModuleExportsContractEmitter
                 return false;
         }
     }
+
+    private static bool IsSyncIterableObject(
+        ObjectExpression objectExpression,
+        TopLevelIndex? topLevel)
+        => (topLevel == null || IsUnshadowedBuiltinName("Symbol", topLevel.Value))
+           && HasWellKnownSymbolMethod(objectExpression, "iterator");
+
+    private static bool IsAsyncIterableObject(
+        ObjectExpression objectExpression,
+        TopLevelIndex? topLevel)
+        => (topLevel == null || IsUnshadowedBuiltinName("Symbol", topLevel.Value))
+           && HasWellKnownSymbolMethod(objectExpression, "asyncIterator");
+
+    private static bool HasWellKnownSymbolMethod(
+        ObjectExpression objectExpression,
+        string symbolName)
+        => objectExpression.Properties.OfType<Property>().Any(property =>
+            property.Key is MemberExpression
+            {
+                Object: Identifier { Name: "Symbol" },
+                Property: Identifier symbol
+            }
+            && string.Equals(symbol.Name, symbolName, StringComparison.Ordinal)
+            && property.Value is FunctionExpression or ArrowFunctionExpression);
+
+    private static bool HasClassWellKnownSymbolMethod(
+        Node classNode,
+        TopLevelIndex? topLevel,
+        string symbolName)
+        => (topLevel == null || IsUnshadowedBuiltinName("Symbol", topLevel.Value))
+           && GetClassHierarchyBodies(classNode, topLevel).Any(body =>
+               body.Body
+                   .OfType<Acornima.Ast.MethodDefinition>()
+                   .Any(method =>
+                       !method.Static
+                       && method.Value is FunctionExpression
+                       && method.Key is MemberExpression
+                       {
+                           Object: Identifier { Name: "Symbol" },
+                           Property: Identifier symbol
+                       }
+                       && string.Equals(symbol.Name, symbolName, StringComparison.Ordinal)));
+
+    private static bool IsGeneratorFunction(Node functionNode)
+        => functionNode switch
+        {
+            FunctionDeclaration function => function.Generator && !function.Async,
+            FunctionExpression function => function.Generator && !function.Async,
+            _ => false
+        };
+
+    private static bool IsAsyncGeneratorFunction(Node functionNode)
+        => functionNode switch
+        {
+            FunctionDeclaration function => function.Generator && function.Async,
+            FunctionExpression function => function.Generator && function.Async,
+            _ => false
+        };
 
     private static bool TryGetClassBody(object? classNode, out ClassBody body)
     {
@@ -1697,6 +2682,66 @@ internal sealed class ModuleExportsContractEmitter
         {
             count++;
         }
+        if (requirements.HasFlag(FallbackContractKind.Date))
+        {
+            count += 5;
+        }
+        if (requirements.HasFlag(FallbackContractKind.DateConstructor))
+        {
+            count += 4;
+        }
+        if (requirements.HasFlag(FallbackContractKind.RegExp))
+        {
+            count += 7;
+        }
+        if (requirements.HasFlag(FallbackContractKind.RegExpConstructor))
+        {
+            count += 2;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Error))
+        {
+            count += 7;
+        }
+        if (requirements.HasFlag(FallbackContractKind.ErrorConstructor))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Symbol))
+        {
+            count += 4;
+        }
+        if (requirements.HasFlag(FallbackContractKind.SymbolConstructor))
+        {
+            count += 5;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Map))
+        {
+            count += 11;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Set))
+        {
+            count += 6;
+        }
+        if (requirements.HasFlag(FallbackContractKind.WeakMap))
+        {
+            count += 4;
+        }
+        if (requirements.HasFlag(FallbackContractKind.WeakSet))
+        {
+            count += 3;
+        }
+        if (requirements.HasFlag(FallbackContractKind.ArrayBuffer))
+        {
+            count += 6;
+        }
+        if (requirements.HasFlag(FallbackContractKind.DataView))
+        {
+            count += 19;
+        }
+        if (requirements.HasFlag(FallbackContractKind.TypedArray))
+        {
+            count += 8;
+        }
         return count;
     }
 
@@ -1716,6 +2761,66 @@ internal sealed class ModuleExportsContractEmitter
             count++;
         }
         if (requirements.HasFlag(FallbackContractKind.Constructor))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Date))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.DateConstructor))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.RegExp))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.RegExpConstructor))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Error))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.ErrorConstructor))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Symbol))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.SymbolConstructor))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Map))
+        {
+            count += 2;
+        }
+        if (requirements.HasFlag(FallbackContractKind.Set))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.WeakMap))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.WeakSet))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.ArrayBuffer))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.DataView))
+        {
+            count++;
+        }
+        if (requirements.HasFlag(FallbackContractKind.TypedArray))
         {
             count++;
         }
@@ -2072,6 +3177,20 @@ internal sealed class ModuleExportsContractEmitter
 
     private TypeOrHandle WrapReturnTypeForAsyncFunction(Node functionNode, TypeOrHandle baseReturnType)
     {
+        if (IsAsyncGeneratorFunction(functionNode))
+        {
+            return TypeOrHandle.FromGenericInstantiation(
+                _typeRefs.GetOrAdd(typeof(IAsyncEnumerable<>)),
+                typeof(object));
+        }
+
+        if (IsGeneratorFunction(functionNode))
+        {
+            return TypeOrHandle.FromGenericInstantiation(
+                _typeRefs.GetOrAdd(typeof(IEnumerable<>)),
+                typeof(object));
+        }
+
         var isAsync = functionNode switch
         {
             FunctionDeclaration fd => fd.Async,
@@ -2118,7 +3237,7 @@ internal sealed class ModuleExportsContractEmitter
         };
     }
 
-    private static TypeOrHandle InferReturnTypeFromFunction(
+    private TypeOrHandle InferReturnTypeFromFunction(
         Node functionNode,
         TopLevelIndex? topLevelIndex,
         Dictionary<string, Type>? classFields,
@@ -2131,38 +3250,82 @@ internal sealed class ModuleExportsContractEmitter
             return InferClrTypeFromExpression(exprBody, topLevelIndex, classFields, instanceInterfacesByClassName, ensureClassInstanceInterface);
         }
 
-        // Block body: look for a single return statement.
-        if (GetFunctionBody(functionNode) is BlockStatement block)
+        // Block body: infer all returns in this callable while excluding nested
+        // functions and classes, whose returns belong to different contracts.
+        if (GetFunctionBody(functionNode) is BlockStatement)
         {
-            ReturnStatement? onlyReturn = null;
-            var returnCount = 0;
-
-            foreach (var stmt in block.Body)
-            {
-                if (stmt is ReturnStatement rs)
-                {
-                    returnCount++;
-                    onlyReturn ??= rs;
-                }
-            }
-
-            if (returnCount == 0)
+            var returns = GetFunctionReturnStatements(functionNode);
+            if (returns.Count == 0)
             {
                 return TypeOrHandle.FromClr(typeof(void));
             }
 
-            if (returnCount == 1 && onlyReturn != null)
+            TypeOrHandle? commonReturn = null;
+            foreach (var returnStatement in returns)
             {
-                if (onlyReturn.Argument is Expression arg)
+                var returnType = returnStatement.Argument is Expression argument
+                    ? InferClrTypeFromExpression(
+                        argument,
+                        topLevelIndex,
+                        classFields,
+                        instanceInterfacesByClassName,
+                        ensureClassInstanceInterface)
+                    : TypeOrHandle.FromClr(typeof(void));
+                if (commonReturn == null)
                 {
-                    return InferClrTypeFromExpression(arg, topLevelIndex, classFields, instanceInterfacesByClassName, ensureClassInstanceInterface);
+                    commonReturn = returnType;
                 }
-
-                return TypeOrHandle.FromClr(typeof(void));
+                else if (commonReturn.Value != returnType)
+                {
+                    return TypeOrHandle.FromClr(typeof(object));
+                }
             }
+
+            return commonReturn ?? TypeOrHandle.FromClr(typeof(void));
         }
 
         return TypeOrHandle.FromClr(typeof(object));
+    }
+
+    private static IReadOnlyList<ReturnStatement> GetFunctionReturnStatements(
+        Node functionNode)
+    {
+        if (GetFunctionBody(functionNode) is not BlockStatement body)
+        {
+            return Array.Empty<ReturnStatement>();
+        }
+
+        var returns = new List<ReturnStatement>();
+        foreach (var child in body.ChildNodes)
+        {
+            CollectFunctionReturns(child, returns);
+        }
+        return returns;
+    }
+
+    private static void CollectFunctionReturns(
+        Node node,
+        List<ReturnStatement> returns)
+    {
+        if (node is FunctionDeclaration
+            or FunctionExpression
+            or ArrowFunctionExpression
+            or ClassDeclaration
+            or ClassExpression)
+        {
+            return;
+        }
+
+        if (node is ReturnStatement returnStatement)
+        {
+            returns.Add(returnStatement);
+            return;
+        }
+
+        foreach (var child in node.ChildNodes)
+        {
+            CollectFunctionReturns(child, returns);
+        }
     }
 
     private static Node? GetFunctionBody(Node functionNode)
@@ -2176,7 +3339,7 @@ internal sealed class ModuleExportsContractEmitter
         };
     }
 
-    private static TypeOrHandle InferClrTypeFromExpression(
+    private TypeOrHandle InferClrTypeFromExpression(
         Node? expr,
         TopLevelIndex? topLevelIndex,
         Dictionary<string, Type>? classFields,
@@ -2194,6 +3357,18 @@ internal sealed class ModuleExportsContractEmitter
                     return TypeOrHandle.FromHandle(callableContract);
                 }
                 return TypeOrHandle.FromClr(typeof(object));
+
+            case ObjectExpression objectExpression
+                when IsAsyncIterableObject(objectExpression, topLevelIndex):
+                return TypeOrHandle.FromGenericInstantiation(
+                    _typeRefs.GetOrAdd(typeof(IAsyncEnumerable<>)),
+                    typeof(object));
+
+            case ObjectExpression objectExpression
+                when IsSyncIterableObject(objectExpression, topLevelIndex):
+                return TypeOrHandle.FromGenericInstantiation(
+                    _typeRefs.GetOrAdd(typeof(IEnumerable<>)),
+                    typeof(object));
 
             case ObjectExpression:
                 if (TryGetProjectionInterface(
@@ -2222,6 +3397,67 @@ internal sealed class ModuleExportsContractEmitter
                         out var constructorContract))
                 {
                     return TypeOrHandle.FromHandle(constructorContract);
+                }
+                return TypeOrHandle.FromClr(typeof(object));
+
+            case NewExpression { Callee: Identifier constructor }
+                when topLevelIndex == null
+                     || IsUnshadowedBuiltinName(constructor.Name, topLevelIndex.Value):
+                if (TryGetBuiltinProjectionInterface(
+                        constructor.Name,
+                        isConstructorValue: false,
+                        instanceInterfacesByClassName,
+                        out var builtinInstance))
+                {
+                    return TypeOrHandle.FromHandle(builtinInstance);
+                }
+                return TypeOrHandle.FromClr(typeof(object));
+
+            case CallExpression { Callee: Identifier { Name: "RegExp" } }
+                when topLevelIndex == null
+                     || IsUnshadowedBuiltinName("RegExp", topLevelIndex.Value):
+                return GetProjectionOrObject(instanceInterfacesByClassName, RegExpContractKey);
+
+            case CallExpression { Callee: Identifier error }
+                when IsErrorConstructorName(error.Name)
+                     && (topLevelIndex == null
+                         || IsUnshadowedBuiltinName(error.Name, topLevelIndex.Value)):
+                return GetProjectionOrObject(instanceInterfacesByClassName, ErrorContractKey);
+
+            case CallExpression { Callee: Identifier { Name: "Symbol" } }
+                when topLevelIndex == null
+                     || IsUnshadowedBuiltinName("Symbol", topLevelIndex.Value):
+            case CallExpression
+            {
+                Callee: MemberExpression
+                {
+                    Object: Identifier { Name: "Symbol" },
+                    Property: Identifier { Name: "for" }
+                }
+            } when topLevelIndex == null
+                   || IsUnshadowedBuiltinName("Symbol", topLevelIndex.Value):
+            case MemberExpression
+            {
+                Object: Identifier { Name: "Symbol" },
+                Property: Identifier
+            } when topLevelIndex == null
+                   || IsUnshadowedBuiltinName("Symbol", topLevelIndex.Value):
+                return GetProjectionOrObject(instanceInterfacesByClassName, SymbolContractKey);
+
+            case CallExpression { Callee: Identifier functionName }
+                when topLevelIndex != null
+                     && topLevelIndex.Value.Functions.TryGetValue(functionName.Name, out var calledFunction):
+                if (IsAsyncGeneratorFunction(calledFunction))
+                {
+                    return TypeOrHandle.FromGenericInstantiation(
+                        _typeRefs.GetOrAdd(typeof(IAsyncEnumerable<>)),
+                        typeof(object));
+                }
+                if (IsGeneratorFunction(calledFunction))
+                {
+                    return TypeOrHandle.FromGenericInstantiation(
+                        _typeRefs.GetOrAdd(typeof(IEnumerable<>)),
+                        typeof(object));
                 }
                 return TypeOrHandle.FromClr(typeof(object));
 
@@ -2301,16 +3537,30 @@ internal sealed class ModuleExportsContractEmitter
                 }
                 return TypeOrHandle.FromClr(typeof(object));
 
-            case Identifier id when topLevelIndex != null:
-                if (topLevelIndex.Value.VariableInitializers.TryGetValue(id.Name, out var init))
+            case Identifier id:
+                if (topLevelIndex != null
+                    && topLevelIndex.Value.VariableInitializers.TryGetValue(id.Name, out var initializer))
                 {
-                    return InferClrTypeFromExpression(init, topLevelIndex, classFields, instanceInterfacesByClassName, ensureClassInstanceInterface);
+                    return InferClrTypeFromExpression(
+                        initializer,
+                        topLevelIndex,
+                        classFields,
+                        instanceInterfacesByClassName,
+                        ensureClassInstanceInterface);
+                }
+                if (TryGetBuiltinProjectionInterface(
+                        id.Name,
+                        isConstructorValue: true,
+                        instanceInterfacesByClassName,
+                        out var builtinConstructor))
+                {
+                    return TypeOrHandle.FromHandle(builtinConstructor);
                 }
                 return TypeOrHandle.FromClr(typeof(object));
 
             case NewExpression ne when ne.Callee is Identifier ctorId && instanceInterfacesByClassName != null:
-                // new Counter(...) => ICounter (handle) if we have a known instance contract.
-                if (instanceInterfacesByClassName.TryGetValue(ctorId.Name, out var instanceHandle) && !instanceHandle.IsNil)
+                if (instanceInterfacesByClassName.TryGetValue(ctorId.Name, out var instanceHandle)
+                    && !instanceHandle.IsNil)
                 {
                     return TypeOrHandle.FromHandle(instanceHandle);
                 }
@@ -2342,6 +3592,53 @@ internal sealed class ModuleExportsContractEmitter
 
         handle = default;
         return false;
+    }
+
+    private static TypeOrHandle GetProjectionOrObject(
+        Dictionary<string, TypeDefinitionHandle>? interfaces,
+        string key)
+        => TryGetProjectionInterface(interfaces, key, out var handle)
+            ? TypeOrHandle.FromHandle(handle)
+            : TypeOrHandle.FromClr(typeof(object));
+
+    private static bool TryGetBuiltinProjectionInterface(
+        string name,
+        bool isConstructorValue,
+        Dictionary<string, TypeDefinitionHandle>? interfaces,
+        out TypeDefinitionHandle handle)
+    {
+        handle = default;
+        string? key;
+        if (isConstructorValue)
+        {
+            key = name switch
+            {
+                "Date" => DateConstructorContractKey,
+                "RegExp" => RegExpConstructorContractKey,
+                "Symbol" => SymbolConstructorContractKey,
+                _ when IsErrorConstructorName(name) => ErrorConstructorContractKey,
+                _ => null
+            };
+        }
+        else
+        {
+            key = name switch
+            {
+                "Date" => DateContractKey,
+                "RegExp" => RegExpContractKey,
+                _ when IsErrorConstructorName(name) => ErrorContractKey,
+                "Map" => MapContractKey,
+                "Set" => SetContractKey,
+                "WeakMap" => WeakMapContractKey,
+                "WeakSet" => WeakSetContractKey,
+                "ArrayBuffer" or "SharedArrayBuffer" => ArrayBufferContractKey,
+                "DataView" => DataViewContractKey,
+                _ when IsTypedArrayConstructorName(name) => TypedArrayContractKey,
+                _ => null
+            };
+        }
+
+        return key != null && TryGetProjectionInterface(interfaces, key, out handle);
     }
 
     private static Type MapClrType(Type type)
@@ -2622,6 +3919,16 @@ internal sealed class ModuleExportsContractEmitter
             typeDefinition,
             constructor,
             CreateParameterlessAttributeValue());
+    }
+
+    private void AddBuiltinMarkerAttribute(
+        TypeDefinitionHandle typeDefinition,
+        string kind)
+    {
+        _metadata.AddCustomAttribute(
+            typeDefinition,
+            _generatedMetadata.JsBuiltinContractAttributeCtor,
+            CreateSingleStringCustomAttributeValue(kind));
     }
 
     private BlobHandle CreateParameterlessAttributeValue()

--- a/src/Compiler/Utilities/Ecma335/TypeReferenceRegistry.cs
+++ b/src/Compiler/Utilities/Ecma335/TypeReferenceRegistry.cs
@@ -24,7 +24,6 @@ namespace Jroc.Utilities.Ecma335
             ["System.Collections.Generic.List`1"] = "System.Collections",
             ["System.Collections.Generic.IList`1"] = "System.Collections",
             ["System.Collections.Generic.ICollection`1"] = "System.Collections",
-            ["System.Collections.Generic.IEnumerable`1"] = "System.Collections",
         };
 
         public TypeReferenceRegistry(MetadataBuilder metadataBuilder)

--- a/src/JavaScriptRuntime/ArrayBuffer.cs
+++ b/src/JavaScriptRuntime/ArrayBuffer.cs
@@ -193,7 +193,7 @@ namespace JavaScriptRuntime
             return true;
         }
 
-        private static int CoerceRelativeIndex(object? value, int defaultValue, int length)
+        protected static int CoerceRelativeIndex(object? value, int defaultValue, int length)
         {
             if (value is null || value is JsNull)
             {

--- a/src/JavaScriptRuntime/Hosting/ExportMemberResolver.cs
+++ b/src/JavaScriptRuntime/Hosting/ExportMemberResolver.cs
@@ -32,12 +32,11 @@ internal static class ExportMemberResolver
 
         foreach (var candidate in GetNameCandidates(contractName))
         {
-            if (exports is IDictionary<string, object?>
-                && JavaScriptRuntime.ObjectRuntime.HasPropertyIn(candidate, exports))
+            if (JavaScriptRuntime.ObjectRuntime.HasPropertyIn(candidate, exports))
             {
                 // Read through the runtime property path so accessor properties
-                // and inherited class members are evaluated instead of
-                // returning a raw backing slot.
+                // inherited members, and mutations on callable constructor
+                // objects are observed instead of returning a raw CLR slot.
                 value = JavaScriptRuntime.ObjectRuntime.GetProperty(exports, candidate);
                 return true;
             }

--- a/src/JavaScriptRuntime/Hosting/GeneratedContractMetadata.cs
+++ b/src/JavaScriptRuntime/Hosting/GeneratedContractMetadata.cs
@@ -48,6 +48,31 @@ internal static class GeneratedContractMetadata
     internal static bool IsCallableContract(Type? contractType)
         => HasGeneratedAttribute(contractType, "JsCallableContractAttribute");
 
+    internal static string? GetBuiltinContractKind(Type? contractType)
+        => contractType == null
+            ? null
+            : GetStringConstructorArgument(contractType, "JsBuiltinContractAttribute");
+
+    internal static Type? GetSiblingObjectContract(Type? contractType)
+        => GetSiblingGeneratedHandleContract(contractType, "IObject");
+
+    internal static Type? GetSiblingCallableContract(Type? contractType)
+        => GetSiblingGeneratedHandleContract(contractType, "ICallable");
+
+    private static Type? GetSiblingGeneratedHandleContract(
+        Type? contractType,
+        string name)
+    {
+        var siblingContract = contractType?.DeclaringType?.GetNestedType(
+            name,
+            BindingFlags.Public | BindingFlags.NonPublic);
+        return IsGeneratedContractType(siblingContract)
+               && siblingContract!.IsInterface
+               && typeof(IDisposable).IsAssignableFrom(siblingContract)
+            ? siblingContract
+            : null;
+    }
+
     private static string? GetStringConstructorArgument(MemberInfo member, string attributeName)
         => member
             .GetCustomAttributesData()

--- a/src/JavaScriptRuntime/Hosting/JsHandleProxy.cs
+++ b/src/JavaScriptRuntime/Hosting/JsHandleProxy.cs
@@ -2,6 +2,11 @@ using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using JsArrayBuffer = JavaScriptRuntime.SharedArrayBuffer;
+using JsCallableOperations = JavaScriptRuntime.CallableOperations;
+using JsObjectRuntime = JavaScriptRuntime.ObjectRuntime;
+using JsSymbol = JavaScriptRuntime.Symbol;
+using JsTypedArray = JavaScriptRuntime.TypedArrayBase;
 
 namespace Jroc.Runtime;
 
@@ -9,15 +14,21 @@ internal class JsHandleProxy : DispatchProxy
 {
     private JsRuntimeInstance? _runtime;
     private object? _target;
+    private Type? _contractType;
     private int _disposed;
 
-    internal void Initialize(JsRuntimeInstance runtime, object? target)
+    internal void Initialize(
+        JsRuntimeInstance runtime,
+        object? target,
+        Type contractType)
     {
         ArgumentNullException.ThrowIfNull(runtime);
         ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(contractType);
 
         _runtime = runtime;
         _target = target;
+        _contractType = contractType;
     }
 
     internal object UnwrapTarget()
@@ -61,10 +72,23 @@ internal class JsHandleProxy : DispatchProxy
 
         var runtime = _runtime ?? throw new ObjectDisposedException(nameof(JsHandleProxy));
         var target = _target ?? throw new ObjectDisposedException(nameof(JsHandleProxy));
+        var contractType = _contractType
+            ?? throw new ObjectDisposedException(nameof(JsHandleProxy));
 
         if (targetMethod.DeclaringType == typeof(object))
         {
             return HandleObjectMethod(targetMethod, args);
+        }
+
+        if (TryInvokeEnumerableMember(
+                runtime,
+                target,
+                contractType,
+                targetMethod,
+                args,
+                out var enumerableResult))
+        {
+            return enumerableResult;
         }
 
         if (targetMethod.IsSpecialName)
@@ -76,6 +100,16 @@ internal class JsHandleProxy : DispatchProxy
                 {
                     return runtime.Invoke(() =>
                     {
+                        if (TryGetGeneratedBuiltinProperty(
+                                runtime,
+                                target,
+                                contractType,
+                                targetMethod,
+                                out var builtinValue))
+                        {
+                            return builtinValue;
+                        }
+
                         var value = ExportMemberResolver.GetExportMember(target, name);
                         return JsReturnConverter.ConvertReturn(
                             runtime,
@@ -98,11 +132,24 @@ internal class JsHandleProxy : DispatchProxy
                 var name = GetContractMemberName(targetMethod, targetMethod.Name.Substring(4));
                 try
                 {
-                    runtime.Invoke(() => ExportMemberResolver.SetExportMember(
-                        runtime,
-                        target,
-                        name,
-                        args is { Length: > 0 } ? args[0] : null));
+                    runtime.Invoke(() =>
+                    {
+                        if (TrySetGeneratedBuiltinProperty(
+                                runtime,
+                                target,
+                                contractType,
+                                targetMethod,
+                                args is { Length: > 0 } ? args[0] : null))
+                        {
+                            return;
+                        }
+
+                        ExportMemberResolver.SetExportMember(
+                            runtime,
+                            target,
+                            name,
+                            args is { Length: > 0 } ? args[0] : null);
+                    });
                     return null;
                 }
                 catch (Exception ex)
@@ -147,6 +194,17 @@ internal class JsHandleProxy : DispatchProxy
                     out var helperResult))
                 {
                     return helperResult;
+                }
+
+                if (TryInvokeGeneratedBuiltinHelper(
+                    runtime,
+                    target,
+                    contractType,
+                    targetMethod,
+                    args ?? Array.Empty<object?>(),
+                    out var builtinResult))
+                {
+                    return builtinResult;
                 }
 
                 var result = ExportMemberResolver.InvokeInstanceMethod(
@@ -195,6 +253,284 @@ internal class JsHandleProxy : DispatchProxy
             targetMethod.Name,
             targetMethod.DeclaringType);
         return true;
+    }
+
+    private static bool TryInvokeEnumerableMember(
+        JsRuntimeInstance runtime,
+        object target,
+        Type contractType,
+        MethodInfo targetMethod,
+        object?[]? args,
+        out object? result)
+    {
+        result = null;
+        var declaringType = targetMethod.DeclaringType;
+        if (declaringType == null)
+        {
+            return false;
+        }
+
+        var isAsync = declaringType.IsGenericType
+            && declaringType.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>)
+            && targetMethod.Name == nameof(IAsyncEnumerable<object>.GetAsyncEnumerator);
+        var isGenericSync = declaringType.IsGenericType
+            && declaringType.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+            && targetMethod.Name == nameof(IEnumerable<object>.GetEnumerator);
+        var isNonGenericSync = declaringType == typeof(System.Collections.IEnumerable)
+            && targetMethod.Name == nameof(System.Collections.IEnumerable.GetEnumerator);
+        if (!isAsync && !isGenericSync && !isNonGenericSync)
+        {
+            return false;
+        }
+
+        var enumerableInterface = contractType
+            .GetInterfaces()
+            .Append(contractType)
+            .FirstOrDefault(type =>
+                type.IsGenericType
+                && type.GetGenericTypeDefinition()
+                    == (isAsync ? typeof(IAsyncEnumerable<>) : typeof(IEnumerable<>)));
+        if (enumerableInterface == null)
+        {
+            return false;
+        }
+
+        var elementType = enumerableInterface.GetGenericArguments()[0];
+        var adapter = runtime.GetOrCreateIterableAdapter(
+            target,
+            elementType,
+            isAsync,
+            targetMethod.Name,
+            contractType);
+        result = targetMethod.Invoke(adapter, args);
+        return true;
+    }
+
+    private static bool TryGetGeneratedBuiltinProperty(
+        JsRuntimeInstance runtime,
+        object target,
+        Type contractType,
+        MethodInfo targetMethod,
+        out object? result)
+    {
+        result = null;
+        var kind = GeneratedContractMetadata.GetBuiltinContractKind(contractType);
+        var propertyName = targetMethod.Name.Substring(4);
+        switch (kind, propertyName)
+        {
+            case ("Error", "Name"):
+            case ("Error", "Message"):
+            case ("Error", "Cause"):
+            case ("Error", "Stack"):
+                var errorPropertyName = char.ToLowerInvariant(propertyName[0]) + propertyName[1..];
+                result = JsReturnConverter.ConvertReturn(
+                    runtime,
+                    JsObjectRuntime.GetProperty(target, errorPropertyName),
+                    targetMethod.ReturnType,
+                    errorPropertyName,
+                    contractType);
+                return true;
+            case ("Symbol", "Description"):
+                result = target is JsSymbol describedSymbol
+                    ? describedSymbol.Description
+                    : throw new InvalidCastException("The generated Symbol contract target is not a Symbol.");
+                return true;
+            case ("Symbol", "RegistryKey"):
+                result = target is JsSymbol symbol
+                    ? JsSymbol.keyFor(symbol)
+                    : throw new InvalidCastException("The generated Symbol contract target is not a Symbol.");
+                return true;
+            case ("Symbol", "WellKnownName"):
+                result = GetWellKnownSymbolName(target);
+                return true;
+            case ("ArrayBuffer", "IsShared"):
+                result = target is JsArrayBuffer;
+                return true;
+            case ("TypedArray", "Kind"):
+                result = target is JsTypedArray
+                    ? target.GetType().Name
+                    : throw new InvalidCastException("The generated typed-array contract target is not a typed array.");
+                return true;
+            case ("MapEntry", "Key"):
+                result = JsReturnConverter.ConvertReturn(
+                    runtime,
+                    JsObjectRuntime.GetItem(target, 0d),
+                    targetMethod.ReturnType,
+                    propertyName,
+                    contractType);
+                return true;
+            case ("MapEntry", "Value"):
+                result = JsReturnConverter.ConvertReturn(
+                    runtime,
+                    JsObjectRuntime.GetItem(target, 1d),
+                    targetMethod.ReturnType,
+                    propertyName,
+                    contractType);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TrySetGeneratedBuiltinProperty(
+        JsRuntimeInstance runtime,
+        object target,
+        Type contractType,
+        MethodInfo targetMethod,
+        object? value)
+    {
+        var kind = GeneratedContractMetadata.GetBuiltinContractKind(contractType);
+        var propertyName = targetMethod.Name.Substring(4);
+        if (kind != "Error"
+            || propertyName is not ("Name" or "Message" or "Cause"))
+        {
+            return false;
+        }
+
+        var errorPropertyName = char.ToLowerInvariant(propertyName[0]) + propertyName[1..];
+        JsObjectRuntime.SetItem(
+            target,
+            errorPropertyName,
+            runtime.NormalizeHostValue(value));
+        return true;
+    }
+
+    private static bool TryInvokeGeneratedBuiltinHelper(
+        JsRuntimeInstance runtime,
+        object target,
+        Type contractType,
+        MethodInfo targetMethod,
+        object?[] args,
+        out object? result)
+    {
+        result = null;
+        var kind = GeneratedContractMetadata.GetBuiltinContractKind(contractType);
+        if (kind == "SymbolConstructor" && targetMethod.Name == "Create")
+        {
+            result = JsReturnConverter.ConvertReturn(
+                runtime,
+                ExportMemberResolver.InvokeJsCallable(
+                    runtime,
+                    target,
+                    args,
+                    receiver: null),
+                targetMethod.ReturnType,
+                targetMethod.Name,
+                contractType);
+            return true;
+        }
+
+        if (kind == "Symbol" && targetMethod.Name == "ToDisplayString")
+        {
+            result = target is JsSymbol symbol
+                ? symbol.ToString()
+                : throw new InvalidCastException(
+                    "The generated Symbol contract target is not a Symbol.");
+            return true;
+        }
+
+        if (kind == "TypedArray")
+        {
+            switch (targetMethod.Name)
+            {
+                case "Get":
+                    RequireArgumentCount(targetMethod, args, 1);
+                    var getIndex = GetTypedArrayIndex(target, args[0]);
+                    result = JsReturnConverter.ConvertReturn(
+                        runtime,
+                        JsObjectRuntime.GetItem(target, getIndex),
+                        targetMethod.ReturnType,
+                        targetMethod.Name,
+                        contractType);
+                    return true;
+                case "Set":
+                    RequireArgumentCount(targetMethod, args, 2);
+                    var setIndex = GetTypedArrayIndex(target, args[0]);
+                    JsObjectRuntime.SetItem(
+                        target,
+                        setIndex,
+                        runtime.NormalizeHostValue(args[1]));
+                    return true;
+            }
+        }
+
+        if (kind == "ArrayBuffer"
+            && target is JavaScriptRuntime.ArrayBuffer arrayBuffer)
+        {
+            if (targetMethod.Name == "Slice")
+            {
+                var sliceArguments = UnpackParamsArray(targetMethod, args);
+                var slice = target is JavaScriptRuntime.SharedArrayBuffer sharedBuffer
+                    ? sharedBuffer.slice(
+                        sliceArguments.ElementAtOrDefault(0),
+                        sliceArguments.ElementAtOrDefault(1))
+                    : arrayBuffer.slice(
+                        sliceArguments.ElementAtOrDefault(0),
+                        sliceArguments.ElementAtOrDefault(1));
+                result = JsReturnConverter.ConvertReturn(
+                    runtime,
+                    slice,
+                    targetMethod.ReturnType,
+                    "slice",
+                    contractType);
+                return true;
+            }
+
+            if (targetMethod.Name == "Resize")
+            {
+                _ = arrayBuffer.resize(args.ElementAtOrDefault(0));
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string? GetWellKnownSymbolName(object target)
+    {
+        if (target is not JsSymbol symbol)
+        {
+            throw new InvalidCastException(
+                "The generated Symbol contract target is not a Symbol.");
+        }
+
+        foreach (var name in new[]
+                 {
+                     "iterator", "asyncIterator", "hasInstance", "isConcatSpreadable",
+                     "match", "matchAll", "replace", "search", "species", "split",
+                     "toPrimitive", "toStringTag", "unscopables", "dispose", "asyncDispose"
+                 })
+        {
+            if (ReferenceEquals(symbol, JsSymbol.GetWellKnown(name)))
+            {
+                return name;
+            }
+        }
+
+        return null;
+    }
+
+    private static double GetTypedArrayIndex(object target, object? value)
+    {
+        if (target is not JsTypedArray typedArray)
+        {
+            throw new InvalidCastException(
+                "The generated typed-array contract target is not a typed array.");
+        }
+
+        var index = ToArrayIndex(value);
+        if (!double.IsFinite(index)
+            || index < 0
+            || index != Math.Truncate(index)
+            || index >= typedArray.length)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                value,
+                "Typed-array host indexes must identify an existing element.");
+        }
+
+        return index;
     }
 
     private static bool TryInvokeGeneratedObjectHelper(
@@ -351,6 +687,7 @@ internal class JsHandleProxy : DispatchProxy
 
         Interlocked.Exchange(ref _runtime, null);
         Interlocked.Exchange(ref _target, null);
+        Interlocked.Exchange(ref _contractType, null);
     }
 
     private object? HandleObjectMethod(MethodInfo targetMethod, object?[]? args)
@@ -369,15 +706,21 @@ internal class JsConstructorProxy : DispatchProxy
 {
     private JsRuntimeInstance? _runtime;
     private object? _constructor;
+    private Type? _contractType;
     private int _disposed;
 
-    internal void Initialize(JsRuntimeInstance runtime, object? constructor)
+    internal void Initialize(
+        JsRuntimeInstance runtime,
+        object? constructor,
+        Type contractType)
     {
         ArgumentNullException.ThrowIfNull(runtime);
         ArgumentNullException.ThrowIfNull(constructor);
+        ArgumentNullException.ThrowIfNull(contractType);
 
         _runtime = runtime;
         _constructor = constructor;
+        _contractType = contractType;
     }
 
     internal object UnwrapConstructor()
@@ -421,6 +764,8 @@ internal class JsConstructorProxy : DispatchProxy
 
         var runtime = _runtime ?? throw new ObjectDisposedException(nameof(JsConstructorProxy));
         var constructor = _constructor ?? throw new ObjectDisposedException(nameof(JsConstructorProxy));
+        var contractType = _contractType
+            ?? throw new ObjectDisposedException(nameof(JsConstructorProxy));
 
         if (targetMethod.DeclaringType == typeof(object))
         {
@@ -511,6 +856,7 @@ internal class JsConstructorProxy : DispatchProxy
 
         Interlocked.Exchange(ref _runtime, null);
         Interlocked.Exchange(ref _constructor, null);
+        Interlocked.Exchange(ref _contractType, null);
     }
 
     private static string GetContractMemberName(MethodInfo targetMethod, string fallback)

--- a/src/JavaScriptRuntime/Hosting/JsIterableAdapters.cs
+++ b/src/JavaScriptRuntime/Hosting/JsIterableAdapters.cs
@@ -96,8 +96,10 @@ internal sealed class JsEnumerator<T> : IEnumerator<T>, IRuntimeDisposalParticip
     private readonly IJavaScriptIterator _iterator;
     private readonly string? _memberName;
     private readonly Type? _contractType;
+    private readonly object _disposeGate = new();
+    private Task? _disposeTask;
     private bool _completed;
-    private bool _disposed;
+    private volatile bool _disposed;
     private bool _hasCurrent;
     private T? _current;
 
@@ -168,13 +170,26 @@ internal sealed class JsEnumerator<T> : IEnumerator<T>, IRuntimeDisposalParticip
         => throw new NotSupportedException("JavaScript iterators cannot be reset.");
 
     public void Dispose()
-        => DisposeCore(forRuntimeShutdown: false);
+        => GetOrStartDisposeTask(forRuntimeShutdown: false).GetAwaiter().GetResult();
 
     Task IRuntimeDisposalParticipant.DisposeForRuntimeShutdownAsync()
+        => GetOrStartDisposeTask(forRuntimeShutdown: true);
+
+    // Host disposal and runtime-shutdown disposal can race from different threads;
+    // both paths share one cleanup so iterator return() runs exactly once.
+    private Task GetOrStartDisposeTask(bool forRuntimeShutdown)
+    {
+        lock (_disposeGate)
+        {
+            return _disposeTask ??= RunDisposeCore(forRuntimeShutdown);
+        }
+    }
+
+    private Task RunDisposeCore(bool forRuntimeShutdown)
     {
         try
         {
-            DisposeCore(forRuntimeShutdown: true);
+            DisposeCore(forRuntimeShutdown);
             return Task.CompletedTask;
         }
         catch (Exception exception)
@@ -185,11 +200,6 @@ internal sealed class JsEnumerator<T> : IEnumerator<T>, IRuntimeDisposalParticip
 
     private void DisposeCore(bool forRuntimeShutdown)
     {
-        if (_disposed)
-        {
-            return;
-        }
-
         _disposed = true;
         _hasCurrent = false;
         try
@@ -202,7 +212,18 @@ internal sealed class JsEnumerator<T> : IEnumerator<T>, IRuntimeDisposalParticip
                 }
                 else
                 {
-                    _runtime.Invoke(_iterator.Return);
+                    try
+                    {
+                        _runtime.Invoke(_iterator.Return);
+                    }
+                    catch (ObjectDisposedException)
+                        when (!_runtime.IsShutdown)
+                    {
+                        // Runtime shutdown was signaled after this enumerator won the
+                        // cleanup race; the script thread is still draining disposal
+                        // work, so route return() through the disposal queue.
+                        _runtime.InvokeDuringDisposal(_iterator.Return);
+                    }
                 }
             }
         }

--- a/src/JavaScriptRuntime/Hosting/JsIterableAdapters.cs
+++ b/src/JavaScriptRuntime/Hosting/JsIterableAdapters.cs
@@ -1,0 +1,447 @@
+using System.Collections;
+using System.Reflection;
+using JavaScriptRuntime;
+
+namespace Jroc.Runtime;
+
+internal static class JsIterableAdapterFactory
+{
+    private static readonly MethodInfo CreateEnumerableOpenGeneric = typeof(JsIterableAdapterFactory)
+        .GetMethod(nameof(CreateEnumerableCore), BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    private static readonly MethodInfo CreateAsyncEnumerableOpenGeneric = typeof(JsIterableAdapterFactory)
+        .GetMethod(nameof(CreateAsyncEnumerableCore), BindingFlags.Static | BindingFlags.NonPublic)!;
+
+    internal static object CreateEnumerable(
+        JsRuntimeInstance runtime,
+        object target,
+        Type elementType,
+        string? memberName,
+        Type? contractType)
+        => CreateEnumerableOpenGeneric
+            .MakeGenericMethod(elementType)
+            .Invoke(null, [runtime, target, memberName, contractType])!;
+
+    internal static object CreateAsyncEnumerable(
+        JsRuntimeInstance runtime,
+        object target,
+        Type elementType,
+        string? memberName,
+        Type? contractType)
+        => CreateAsyncEnumerableOpenGeneric
+            .MakeGenericMethod(elementType)
+            .Invoke(null, [runtime, target, memberName, contractType])!;
+
+    private static IEnumerable<T> CreateEnumerableCore<T>(
+        JsRuntimeInstance runtime,
+        object target,
+        string? memberName,
+        Type? contractType)
+        => new JsEnumerable<T>(runtime, target, memberName, contractType);
+
+    private static IAsyncEnumerable<T> CreateAsyncEnumerableCore<T>(
+        JsRuntimeInstance runtime,
+        object target,
+        string? memberName,
+        Type? contractType)
+        => new JsAsyncEnumerable<T>(runtime, target, memberName, contractType);
+}
+
+internal sealed class JsEnumerable<T> : IEnumerable<T>
+{
+    private readonly JsRuntimeInstance _runtime;
+    private readonly object _target;
+    private readonly string? _memberName;
+    private readonly Type? _contractType;
+
+    internal JsEnumerable(
+        JsRuntimeInstance runtime,
+        object target,
+        string? memberName,
+        Type? contractType)
+    {
+        _runtime = runtime;
+        _target = target;
+        _memberName = memberName;
+        _contractType = contractType;
+    }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        try
+        {
+            var iterator = _runtime.Invoke(() => ObjectRuntime.GetIterator(_target));
+            return new JsEnumerator<T>(
+                _runtime,
+                iterator,
+                _memberName,
+                _contractType);
+        }
+        catch (Exception exception)
+        {
+            throw JsHostingExceptionTranslator.TranslateProxyCall(
+                exception,
+                _runtime,
+                _memberName ?? "GetEnumerator",
+                _contractType);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+internal sealed class JsEnumerator<T> : IEnumerator<T>, IRuntimeDisposalParticipant
+{
+    private readonly JsRuntimeInstance _runtime;
+    private readonly IJavaScriptIterator _iterator;
+    private readonly string? _memberName;
+    private readonly Type? _contractType;
+    private bool _completed;
+    private bool _disposed;
+    private bool _hasCurrent;
+    private T? _current;
+
+    internal JsEnumerator(
+        JsRuntimeInstance runtime,
+        IJavaScriptIterator iterator,
+        string? memberName,
+        Type? contractType)
+    {
+        _runtime = runtime;
+        _iterator = iterator;
+        _memberName = memberName;
+        _contractType = contractType;
+        _runtime.RegisterRuntimeDisposalParticipant(this);
+    }
+
+    public T Current
+        => _hasCurrent
+            ? _current!
+            : throw new InvalidOperationException("The JavaScript iterator is not positioned on a value.");
+
+    object? IEnumerator.Current => Current;
+
+    public bool MoveNext()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        try
+        {
+            var result = _runtime.Invoke(() =>
+            {
+                var step = _iterator.Next();
+                if (step.done)
+                {
+                    return (HasValue: false, Value: default(T));
+                }
+
+                var converted = JsReturnConverter.ConvertReturn(
+                    _runtime,
+                    step.value,
+                    typeof(T),
+                    _memberName,
+                    _contractType);
+                return (HasValue: true, Value: (T?)converted);
+            });
+
+            _hasCurrent = result.HasValue;
+            _current = result.Value;
+            if (!result.HasValue)
+            {
+                Complete();
+            }
+
+            return result.HasValue;
+        }
+        catch (Exception exception)
+        {
+            Complete();
+            throw JsHostingExceptionTranslator.TranslateProxyCall(
+                exception,
+                _runtime,
+                _memberName ?? "MoveNext",
+                _contractType);
+        }
+    }
+
+    public void Reset()
+        => throw new NotSupportedException("JavaScript iterators cannot be reset.");
+
+    public void Dispose()
+        => DisposeCore(forRuntimeShutdown: false);
+
+    Task IRuntimeDisposalParticipant.DisposeForRuntimeShutdownAsync()
+    {
+        try
+        {
+            DisposeCore(forRuntimeShutdown: true);
+            return Task.CompletedTask;
+        }
+        catch (Exception exception)
+        {
+            return Task.FromException(exception);
+        }
+    }
+
+    private void DisposeCore(bool forRuntimeShutdown)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _hasCurrent = false;
+        try
+        {
+            if (!_completed && _iterator.HasReturn)
+            {
+                if (forRuntimeShutdown)
+                {
+                    _runtime.InvokeDuringDisposal(_iterator.Return);
+                }
+                else
+                {
+                    _runtime.Invoke(_iterator.Return);
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            throw JsHostingExceptionTranslator.TranslateProxyCall(
+                exception,
+                _runtime,
+                _memberName ?? "Dispose",
+                _contractType);
+        }
+        finally
+        {
+            Complete();
+        }
+    }
+
+    private void Complete()
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        _completed = true;
+        _runtime.UnregisterRuntimeDisposalParticipant(this);
+    }
+}
+
+internal sealed class JsAsyncEnumerable<T> : IAsyncEnumerable<T>
+{
+    private readonly JsRuntimeInstance _runtime;
+    private readonly object _target;
+    private readonly string? _memberName;
+    private readonly Type? _contractType;
+
+    internal JsAsyncEnumerable(
+        JsRuntimeInstance runtime,
+        object target,
+        string? memberName,
+        Type? contractType)
+    {
+        _runtime = runtime;
+        _target = target;
+        _memberName = memberName;
+        _contractType = contractType;
+    }
+
+    public IAsyncEnumerator<T> GetAsyncEnumerator(
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var iterator = _runtime.Invoke(() => ObjectRuntime.GetAsyncIterator(_target));
+            return new JsAsyncEnumerator<T>(
+                _runtime,
+                iterator,
+                cancellationToken,
+                _memberName,
+                _contractType);
+        }
+        catch (Exception exception)
+        {
+            throw JsHostingExceptionTranslator.TranslateProxyCall(
+                exception,
+                _runtime,
+                _memberName ?? "GetAsyncEnumerator",
+                _contractType);
+        }
+    }
+}
+
+internal sealed class JsAsyncEnumerator<T> :
+    IAsyncEnumerator<T>,
+    IRuntimeDisposalParticipant
+{
+    private readonly JsRuntimeInstance _runtime;
+    private readonly IJavaScriptAsyncIterator _iterator;
+    private readonly CancellationToken _cancellationToken;
+    private readonly string? _memberName;
+    private readonly Type? _contractType;
+    private readonly object _disposeGate = new();
+    private Task? _disposeTask;
+    private bool _completed;
+    private bool _disposed;
+    private T? _current;
+
+    internal JsAsyncEnumerator(
+        JsRuntimeInstance runtime,
+        IJavaScriptAsyncIterator iterator,
+        CancellationToken cancellationToken,
+        string? memberName,
+        Type? contractType)
+    {
+        _runtime = runtime;
+        _iterator = iterator;
+        _cancellationToken = cancellationToken;
+        _memberName = memberName;
+        _contractType = contractType;
+        _runtime.RegisterRuntimeDisposalParticipant(this);
+    }
+
+    public T Current => _current!;
+
+    public async ValueTask<bool> MoveNextAsync()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        try
+        {
+            _cancellationToken.ThrowIfCancellationRequested();
+            var nextPromise = _runtime.Invoke(
+                () => (Promise)Promise.resolve(_iterator.Next())!);
+            var result = await JsPromiseTaskInterop.ToRawTask(
+                    _runtime,
+                    nextPromise,
+                    _memberName,
+                    _contractType)
+                .WaitAsync(_cancellationToken)
+                .ConfigureAwait(false);
+
+            _cancellationToken.ThrowIfCancellationRequested();
+            var step = _runtime.Invoke(() => ReadIteratorResult(result));
+            if (step.Done)
+            {
+                _current = default;
+                Complete();
+                return false;
+            }
+
+            _current = (T?)_runtime.Invoke(() => JsReturnConverter.ConvertReturn(
+                _runtime,
+                step.Value,
+                typeof(T),
+                _memberName,
+                _contractType));
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            await GetOrStartDisposeTask(forRuntimeShutdown: false).ConfigureAwait(false);
+            throw;
+        }
+        catch (Exception exception)
+        {
+            Complete();
+            throw JsHostingExceptionTranslator.TranslateProxyCall(
+                exception,
+                _runtime,
+                _memberName ?? "MoveNextAsync",
+                _contractType);
+        }
+    }
+
+    public ValueTask DisposeAsync()
+        => new(GetOrStartDisposeTask(forRuntimeShutdown: false));
+
+    Task IRuntimeDisposalParticipant.DisposeForRuntimeShutdownAsync()
+        => GetOrStartDisposeTask(forRuntimeShutdown: true);
+
+    private Task GetOrStartDisposeTask(bool forRuntimeShutdown)
+    {
+        lock (_disposeGate)
+        {
+            return _disposeTask ??= DisposeCoreAsync(forRuntimeShutdown);
+        }
+    }
+
+    private async Task DisposeCoreAsync(bool forRuntimeShutdown)
+    {
+        _disposed = true;
+        try
+        {
+            if (!_completed && _iterator.HasReturn)
+            {
+                object? InvokeReturn()
+                    => _iterator is AsyncGeneratorObject generator
+                        ? ExportMemberResolver.InvokeInstanceMethod(
+                            _runtime,
+                            generator,
+                            "return",
+                            [null])
+                        : _iterator.Return();
+
+                var returnPromise = forRuntimeShutdown
+                    ? _runtime.InvokeDuringDisposal(
+                        () => (Promise)Promise.resolve(InvokeReturn())!)
+                    : _runtime.Invoke(
+                        () => (Promise)Promise.resolve(InvokeReturn())!);
+                _ = await JsPromiseTaskInterop.ToRawTask(
+                        _runtime,
+                        returnPromise,
+                        _memberName,
+                        _contractType,
+                        forRuntimeShutdown)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (Exception exception)
+        {
+            throw JsHostingExceptionTranslator.TranslateProxyCall(
+                exception,
+                _runtime,
+                _memberName ?? "DisposeAsync",
+                _contractType);
+        }
+        finally
+        {
+            Complete();
+        }
+    }
+
+    private (bool Done, object? Value) ReadIteratorResult(object? result)
+    {
+        if (result is IIteratorResult iteratorResult)
+        {
+            return (iteratorResult.done, iteratorResult.value);
+        }
+
+        if (result == null
+            || result is JsNull
+            || TypeUtilities.IsPrimitive(result))
+        {
+            throw new TypeError("Async iterator next() did not return an object.");
+        }
+
+        return (
+            TypeUtilities.ToBoolean(ObjectRuntime.GetProperty(result, "done")),
+            ObjectRuntime.GetProperty(result, "value"));
+    }
+
+    private void Complete()
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        _completed = true;
+        _runtime.UnregisterRuntimeDisposalParticipant(this);
+    }
+}

--- a/src/JavaScriptRuntime/Hosting/JsPromiseTaskInterop.cs
+++ b/src/JavaScriptRuntime/Hosting/JsPromiseTaskInterop.cs
@@ -99,6 +99,64 @@ internal static class JsPromiseTaskInterop
         return completion.Task;
     }
 
+    internal static Task<object?> ToRawTask(
+        JsRuntimeInstance runtime,
+        Promise promise,
+        string? memberName = null,
+        Type? contractType = null,
+        bool duringRuntimeDisposal = false)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        ArgumentNullException.ThrowIfNull(promise);
+
+        var completion = new RuntimeTaskCompletion<object?>(
+            runtime,
+            unregisterOnCompletion: !duringRuntimeDisposal);
+        if (!duringRuntimeDisposal
+            && !runtime.TryRegisterRuntimeDependentOperation(completion))
+        {
+            return completion.Task;
+        }
+
+        try
+        {
+            object? Attach()
+            {
+                promise.then(
+                    onFulfilled: new Func<object[]?, object?, object?>((_, value) =>
+                    {
+                        completion.TrySetResult(value);
+                        return null;
+                    }),
+                    onRejected: new Func<object[]?, object?, object?>((_, reason) =>
+                    {
+                        completion.TrySetException(ToException(
+                            runtime,
+                            reason,
+                            memberName,
+                            contractType));
+                        return null;
+                    }));
+                return null;
+            }
+
+            if (duringRuntimeDisposal)
+            {
+                runtime.InvokeDuringDisposal(Attach);
+            }
+            else
+            {
+                runtime.Invoke(Attach);
+            }
+        }
+        catch (Exception exception)
+        {
+            completion.TrySetException(exception);
+        }
+
+        return completion.Task;
+    }
+
     private static Exception ToException(
         JsRuntimeInstance runtime,
         object? reason,
@@ -145,19 +203,23 @@ internal static class JsPromiseTaskInterop
     private sealed class RuntimeTaskCompletion<T> : IRuntimeDependentOperation
     {
         private readonly JsRuntimeInstance _runtime;
+        private readonly bool _unregisterOnCompletion;
         private readonly TaskCompletionSource<T> _completion =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        internal RuntimeTaskCompletion(JsRuntimeInstance runtime)
+        internal RuntimeTaskCompletion(
+            JsRuntimeInstance runtime,
+            bool unregisterOnCompletion = true)
         {
             _runtime = runtime;
+            _unregisterOnCompletion = unregisterOnCompletion;
         }
 
         internal Task<T> Task => _completion.Task;
 
         internal void TrySetResult(T result)
         {
-            if (_completion.TrySetResult(result))
+            if (_completion.TrySetResult(result) && _unregisterOnCompletion)
             {
                 _runtime.UnregisterRuntimeDependentOperation(this);
             }
@@ -165,7 +227,7 @@ internal static class JsPromiseTaskInterop
 
         internal void TrySetException(Exception exception)
         {
-            if (_completion.TrySetException(exception))
+            if (_completion.TrySetException(exception) && _unregisterOnCompletion)
             {
                 _runtime.UnregisterRuntimeDependentOperation(this);
             }

--- a/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
+++ b/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
@@ -116,15 +116,15 @@ internal static class JsReturnConverter
         {
             if (!TypeUtilities.IsPrimitive(value))
             {
-                if (runtime.TryGetExistingHandleProxy(value, out var existingHandle))
-                {
-                    return existingHandle;
-                }
-
                 var canonicalContract =
                     JavaScriptRuntime.CallableOperations.IsCallable(value)
                         ? GeneratedContractMetadata.GetSiblingCallableContract(contractType)
                         : GeneratedContractMetadata.GetSiblingObjectContract(contractType);
+                if (runtime.TryGetExistingHandleProxy(value, canonicalContract, out var existingHandle))
+                {
+                    return existingHandle;
+                }
+
                 if (canonicalContract != null)
                 {
                     return runtime.GetOrCreateHandleProxy(canonicalContract, value);

--- a/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
+++ b/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
@@ -37,6 +37,14 @@ internal static class JsReturnConverter
             memberName = null;
             contractType = null;
         }
+        // Preserve Phase 2's opaque object projection for a direct JavaScript
+        // null export. More specific generated contracts (for example
+        // RegExp.exec()'s array result) should surface JavaScript null as CLR
+        // null rather than manufacturing a handle for the null sentinel.
+        if (value is JsNull && returnType != typeof(object))
+        {
+            value = null;
+        }
 
         if (returnType == typeof(Task))
         {
@@ -78,6 +86,22 @@ internal static class JsReturnConverter
             return null;
         }
 
+        if (TryGetEnumerableElementType(returnType, out var elementType, out var isAsync))
+        {
+            if (value == null)
+            {
+                throw new InvalidCastException(
+                    $"JavaScript value for '{memberName ?? "<iteration>"}' is null and cannot be projected as '{returnType.FullName}'.");
+            }
+
+            return runtime.GetOrCreateIterableAdapter(
+                value,
+                elementType,
+                isAsync,
+                memberName,
+                contractType);
+        }
+
         if (value == null)
         {
             return returnType.IsValueType ? Activator.CreateInstance(returnType) : null;
@@ -88,22 +112,38 @@ internal static class JsReturnConverter
             return runtime.GetOrCreateConstructorProxy(returnType, value);
         }
 
+        if (returnType == typeof(object))
+        {
+            if (!TypeUtilities.IsPrimitive(value))
+            {
+                if (runtime.TryGetExistingHandleProxy(value, out var existingHandle))
+                {
+                    return existingHandle;
+                }
+
+                var canonicalContract =
+                    JavaScriptRuntime.CallableOperations.IsCallable(value)
+                        ? GeneratedContractMetadata.GetSiblingCallableContract(contractType)
+                        : GeneratedContractMetadata.GetSiblingObjectContract(contractType);
+                if (canonicalContract != null)
+                {
+                    return runtime.GetOrCreateHandleProxy(canonicalContract, value);
+                }
+            }
+
+            // An object-typed host contract erases whether the value is a JS reference.
+            // Keep runtime objects behind the dynamic hosting boundary instead of leaking them.
+            return JsDynamicValueProxy.Wrap(runtime, value);
+        }
+
         if (JavaScriptRuntime.CallableOperations.IsCallable(value))
         {
             var callable = runtime.GetOrCreateCallableWrapper(value);
-            if (returnType == typeof(object)
-                || returnType == typeof(JsCallable)
+            if (returnType == typeof(JsCallable)
                 || returnType.IsInstanceOfType(callable))
             {
                 return callable;
             }
-        }
-
-        if (returnType == typeof(object))
-        {
-            // An object-typed host contract erases whether the value is a JS reference.
-            // Keep runtime objects behind the dynamic hosting boundary instead of leaking them.
-            return JsDynamicValueProxy.Wrap(runtime, value);
         }
 
         if (returnType.IsInstanceOfType(value))
@@ -163,6 +203,33 @@ internal static class JsReturnConverter
         => GeneratedContractMetadata.IsGeneratedContractType(returnType)
            && returnType.IsInterface
            && typeof(IDisposable).IsAssignableFrom(returnType);
+
+    private static bool TryGetEnumerableElementType(
+        Type returnType,
+        out Type elementType,
+        out bool isAsync)
+    {
+        if (returnType.IsGenericType)
+        {
+            var definition = returnType.GetGenericTypeDefinition();
+            if (definition == typeof(IEnumerable<>))
+            {
+                elementType = returnType.GetGenericArguments()[0];
+                isAsync = false;
+                return true;
+            }
+            if (definition == typeof(IAsyncEnumerable<>))
+            {
+                elementType = returnType.GetGenericArguments()[0];
+                isAsync = true;
+                return true;
+            }
+        }
+
+        elementType = null!;
+        isAsync = false;
+        return false;
+    }
 
     private sealed record ResultConversionMethods(
         MethodInfo PromiseToTask,

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -28,6 +28,9 @@ internal sealed class JsRuntimeInstance : IDisposable
     private readonly BlockingCollection<IWorkItem> _queue = new();
     private readonly ConcurrentDictionary<IWorkItem, byte> _pendingWorkItems = new();
     private readonly ConcurrentDictionary<IRuntimeDependentOperation, byte> _runtimeDependentOperations = new();
+    // Active iterators must close before runtime shutdown so iterator return(), generator
+    // finally blocks, and async cleanup can run. Registration and completion occur on host
+    // and continuation threads while root disposal may race from another thread.
     private readonly ConcurrentDictionary<IRuntimeDisposalParticipant, byte> _runtimeDisposalParticipants = new();
 
     // Dedicated thread that owns the engine, synchronization context, and event loop.

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -219,11 +219,19 @@ internal sealed class JsRuntimeInstance : IDisposable
         Exception? enumerationCleanupFailure = null;
         try
         {
-            enumerationCleanup.GetAwaiter().GetResult();
+            // Bound the wait like the thread join below: a JavaScript finally block
+            // awaiting a never-settling promise must not hang host Dispose forever.
+            if (!enumerationCleanup.Wait(DisposeJoinTimeout))
+            {
+                enumerationCleanupFailure = new TimeoutException(
+                    "Timed out waiting for JavaScript iterator cleanup during disposal.");
+            }
         }
-        catch (Exception exception)
+        catch (AggregateException exception)
         {
-            enumerationCleanupFailure = exception;
+            enumerationCleanupFailure = exception.InnerExceptions.Count == 1
+                ? exception.InnerException
+                : exception;
         }
 
         FinishShutdown();
@@ -290,14 +298,33 @@ internal sealed class JsRuntimeInstance : IDisposable
             });
     }
 
-    internal bool TryGetExistingHandleProxy(object target, out object proxy)
+    internal bool TryGetExistingHandleProxy(
+        object target,
+        Type? preferredContract,
+        out object proxy)
     {
         ArgumentNullException.ThrowIfNull(target);
-        if (_handleProxies.TryGetValue(target, out var proxies)
-            && proxies.Values.FirstOrDefault() is { } existing)
+        if (_handleProxies.TryGetValue(target, out var proxies))
         {
-            proxy = existing;
-            return true;
+            // Selection must be deterministic so repeated object-typed reads of the
+            // same JS value keep returning a reference-identical proxy even after
+            // additional contract projections are cached for the target.
+            if (preferredContract != null
+                && proxies.TryGetValue(preferredContract, out var preferred))
+            {
+                proxy = preferred;
+                return true;
+            }
+
+            var existing = proxies
+                .OrderBy(pair => pair.Key.FullName, StringComparer.Ordinal)
+                .Select(pair => pair.Value)
+                .FirstOrDefault();
+            if (existing != null)
+            {
+                proxy = existing;
+                return true;
+            }
         }
 
         proxy = null!;
@@ -422,6 +449,15 @@ internal sealed class JsRuntimeInstance : IDisposable
         {
             FailWorkItem(item);
             throw CreateDisposedException();
+        }
+
+        // The script thread fails pending items before disposing the queue and only
+        // then completes _terminated; an item enqueued inside that window would
+        // otherwise never execute, so fail it once termination is observed.
+        _ = Task.WhenAny(completion.Task, _terminated.Task).GetAwaiter().GetResult();
+        if (!completion.Task.IsCompleted)
+        {
+            FailWorkItem(item);
         }
 
         return completion.Task.GetAwaiter().GetResult();

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using JavaScriptRuntime;
 using JavaScriptRuntime.Modules.CommonJS;
 using JavaScriptRuntime.Node;
@@ -27,6 +28,7 @@ internal sealed class JsRuntimeInstance : IDisposable
     private readonly BlockingCollection<IWorkItem> _queue = new();
     private readonly ConcurrentDictionary<IWorkItem, byte> _pendingWorkItems = new();
     private readonly ConcurrentDictionary<IRuntimeDependentOperation, byte> _runtimeDependentOperations = new();
+    private readonly ConcurrentDictionary<IRuntimeDisposalParticipant, byte> _runtimeDisposalParticipants = new();
 
     // Dedicated thread that owns the engine, synchronization context, and event loop.
     private readonly Thread _thread;
@@ -52,6 +54,7 @@ internal sealed class JsRuntimeInstance : IDisposable
     private readonly ConditionalWeakTable<object, ConcurrentDictionary<Type, object>> _handleProxies = new();
     private readonly ConditionalWeakTable<object, ConcurrentDictionary<Type, object>> _constructorProxies = new();
     private readonly ConditionalWeakTable<object, JsDynamicValueProxy> _dynamicValueProxies = new();
+    private readonly ConditionalWeakTable<object, ConcurrentDictionary<IterableAdapterKey, object>> _iterableAdapters = new();
 
     public JsRuntimeInstance(Assembly compiledAssembly, string moduleId, JsModuleLoadOptions? options = null)
     {
@@ -191,26 +194,39 @@ internal sealed class JsRuntimeInstance : IDisposable
             return;
         }
 
-        FailPendingOperations();
+        var enumerationCleanupTasks = new List<Task>();
+        foreach (var participant in _runtimeDisposalParticipants.Keys)
+        {
+            if (!_runtimeDisposalParticipants.TryRemove(participant, out _))
+            {
+                continue;
+            }
 
-        _agent?.RequestShutdown();
+            enumerationCleanupTasks.Add(participant.DisposeForRuntimeShutdownAsync());
+        }
 
-        // Stop accepting work. Agent shutdown cancellation wakes the consumer.
+        var enumerationCleanup = Task.WhenAll(enumerationCleanupTasks);
+        if (IsRuntimeThread && !enumerationCleanup.IsCompleted)
+        {
+            _ = FinishRuntimeThreadDisposalAsync(enumerationCleanup);
+            GC.SuppressFinalize(this);
+            return;
+        }
+
+        Exception? enumerationCleanupFailure = null;
         try
         {
-            _queue.CompleteAdding();
+            enumerationCleanup.GetAwaiter().GetResult();
         }
-        catch (ObjectDisposedException)
+        catch (Exception exception)
         {
-            // If the runtime thread already terminated, it may have disposed the queue.
-        }
-        catch (InvalidOperationException)
-        {
-            // Already marked complete.
+            enumerationCleanupFailure = exception;
         }
 
+        FinishShutdown();
+
         // Avoid self-join if Dispose is called from within the script thread.
-        if (Thread.CurrentThread.ManagedThreadId != _thread.ManagedThreadId)
+        if (!IsRuntimeThread)
         {
             if (!_thread.Join(DisposeJoinTimeout))
             {
@@ -224,9 +240,16 @@ internal sealed class JsRuntimeInstance : IDisposable
         // This type intentionally has no finalizer (it would be unsafe to block/join on the finalizer thread).
         // Ensure we don't ever pay finalization costs if one is added later.
         GC.SuppressFinalize(this);
+
+        if (enumerationCleanupFailure != null)
+        {
+            ExceptionDispatchInfo.Capture(enumerationCleanupFailure).Throw();
+        }
     }
 
     internal bool IsShutdown => _terminated.Task.IsCompleted;
+    internal bool IsRuntimeThread
+        => Thread.CurrentThread.ManagedThreadId == _thread.ManagedThreadId;
 
     internal int PendingWorkItemCount => _pendingWorkItems.Count;
 
@@ -259,9 +282,23 @@ internal sealed class JsRuntimeInstance : IDisposable
             .GetOrAdd(interfaceType, type =>
             {
                 var proxy = JsProxyFactory.CreateProxy(type, typeof(JsHandleProxy));
-                ((JsHandleProxy)proxy).Initialize(this, target);
+                ((JsHandleProxy)proxy).Initialize(this, target, type);
                 return proxy;
             });
+    }
+
+    internal bool TryGetExistingHandleProxy(object target, out object proxy)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        if (_handleProxies.TryGetValue(target, out var proxies)
+            && proxies.Values.FirstOrDefault() is { } existing)
+        {
+            proxy = existing;
+            return true;
+        }
+
+        proxy = null!;
+        return false;
     }
 
     internal object GetOrCreateConstructorProxy(Type interfaceType, object constructor)
@@ -274,7 +311,7 @@ internal sealed class JsRuntimeInstance : IDisposable
             .GetOrAdd(interfaceType, type =>
             {
                 var proxy = JsProxyFactory.CreateProxy(type, typeof(JsConstructorProxy));
-                ((JsConstructorProxy)proxy).Initialize(this, constructor);
+                ((JsConstructorProxy)proxy).Initialize(this, constructor, type);
                 return proxy;
             });
     }
@@ -286,6 +323,113 @@ internal sealed class JsRuntimeInstance : IDisposable
             target,
             value => new JsDynamicValueProxy(this, value));
     }
+
+    internal object GetOrCreateIterableAdapter(
+        object target,
+        Type elementType,
+        bool isAsync,
+        string? memberName,
+        Type? contractType)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(elementType);
+
+        var key = new IterableAdapterKey(
+            elementType,
+            isAsync,
+            memberName,
+            contractType);
+        return _iterableAdapters
+            .GetOrCreateValue(target)
+            .GetOrAdd(
+                key,
+                _ => isAsync
+                    ? JsIterableAdapterFactory.CreateAsyncEnumerable(
+                        this,
+                        target,
+                        elementType,
+                        memberName,
+                        contractType)
+                    : JsIterableAdapterFactory.CreateEnumerable(
+                        this,
+                        target,
+                        elementType,
+                        memberName,
+                        contractType));
+    }
+
+    internal void RegisterRuntimeDisposalParticipant(
+        IRuntimeDisposalParticipant participant)
+    {
+        ArgumentNullException.ThrowIfNull(participant);
+        if (Volatile.Read(ref _disposeSignaled) != 0)
+        {
+            throw CreateDisposedException();
+        }
+
+        if (!_runtimeDisposalParticipants.TryAdd(participant, 0))
+        {
+            throw new InvalidOperationException(
+                "The runtime disposal participant is already registered.");
+        }
+
+        if (Volatile.Read(ref _disposeSignaled) != 0
+            && _runtimeDisposalParticipants.TryRemove(participant, out _))
+        {
+            var cleanup = participant.DisposeForRuntimeShutdownAsync();
+            if (!IsRuntimeThread || cleanup.IsCompleted)
+            {
+                cleanup.GetAwaiter().GetResult();
+            }
+            throw CreateDisposedException();
+        }
+    }
+
+    internal void UnregisterRuntimeDisposalParticipant(
+        IRuntimeDisposalParticipant participant)
+        => _runtimeDisposalParticipants.TryRemove(participant, out _);
+
+    internal TResult InvokeDuringDisposal<TResult>(Func<TResult> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        if (_terminated.Task.IsCompleted)
+        {
+            throw CreateDisposedException();
+        }
+
+        if (Thread.CurrentThread.ManagedThreadId == _thread.ManagedThreadId)
+        {
+            return func();
+        }
+
+        var completion = new TaskCompletionSource<TResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var item = new WorkItem<TResult>(func, completion);
+        if (!_pendingWorkItems.TryAdd(item, 0))
+        {
+            throw new InvalidOperationException("Failed to register disposal work.");
+        }
+
+        try
+        {
+            _queue.Add(item);
+        }
+        catch (Exception exception)
+            when (exception is ObjectDisposedException or InvalidOperationException)
+        {
+            FailWorkItem(item);
+            throw CreateDisposedException();
+        }
+
+        return completion.Task.GetAwaiter().GetResult();
+    }
+
+    internal void InvokeDuringDisposal(Action action)
+        => InvokeDuringDisposal(() =>
+        {
+            action();
+            return (object?)null;
+        });
 
     internal HostedMethodFunctionObject GetOrCreateHostMethodAdapter(
         object target,
@@ -682,6 +826,44 @@ internal sealed class JsRuntimeInstance : IDisposable
     private static ObjectDisposedException CreateDisposedException()
         => new(nameof(JsRuntimeInstance));
 
+    private async Task FinishRuntimeThreadDisposalAsync(Task enumerationCleanup)
+    {
+        try
+        {
+            await enumerationCleanup.ConfigureAwait(false);
+        }
+        catch
+        {
+            // Disposal is already in progress and cannot synchronously report an
+            // asynchronous cleanup failure back through a runtime-thread callback.
+        }
+        finally
+        {
+            FinishShutdown();
+        }
+    }
+
+    private void FinishShutdown()
+    {
+        FailPendingOperations();
+        _agent?.RequestShutdown();
+
+        try
+        {
+            _queue.CompleteAdding();
+        }
+        catch (Exception exception)
+            when (exception is ObjectDisposedException or InvalidOperationException)
+        {
+        }
+    }
+
+    private readonly record struct IterableAdapterKey(
+        Type ElementType,
+        bool IsAsync,
+        string? MemberName,
+        Type? ContractType);
+
     private static string NormalizeLocalModuleSpecifier(string moduleId)
     {
         var trimmed = moduleId.Trim();
@@ -786,4 +968,9 @@ internal sealed class JsRuntimeInstance : IDisposable
 internal interface IRuntimeDependentOperation
 {
     void OnRuntimeDisposed(ObjectDisposedException exception);
+}
+
+internal interface IRuntimeDisposalParticipant
+{
+    Task DisposeForRuntimeShutdownAsync();
 }

--- a/src/JavaScriptRuntime/SharedArrayBuffer.cs
+++ b/src/JavaScriptRuntime/SharedArrayBuffer.cs
@@ -46,6 +46,32 @@ namespace JavaScriptRuntime
             return new SharedArrayBuffer(_backingStore);
         }
 
+        public new SharedArrayBuffer slice(object? start)
+            => slice(start, null);
+
+        public new SharedArrayBuffer slice(object? start, object? end)
+        {
+            var bytes = RawBytes;
+            var startIndex = CoerceRelativeIndex(start, 0, bytes.Length);
+            var endIndex = CoerceRelativeIndex(end, bytes.Length, bytes.Length);
+            if (endIndex < startIndex)
+            {
+                endIndex = startIndex;
+            }
+
+            var result = new SharedArrayBuffer(endIndex - startIndex);
+            if (endIndex > startIndex)
+            {
+                System.Buffer.BlockCopy(
+                    bytes,
+                    startIndex,
+                    result.RawBytes,
+                    0,
+                    endIndex - startIndex);
+            }
+            return result;
+        }
+
         private static RuntimeSharedArrayBufferBackingStore CreateBackingStore(object? length)
         {
             var byteLength = CoerceByteLength(length);

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Compile_Scripts_Test262Bootstrap
 	extends [System.Runtime]System.Object
 {
@@ -157,6 +177,26 @@
 				} // end of method IObject::HasDynamicProperty
 
 			} // end of class IObject
+
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
 
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
@@ -674,7 +714,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 683 (0x2ab)
@@ -1284,7 +1324,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 156 (0x9c)
@@ -1536,7 +1576,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 233 (0xe9)
@@ -1571,7 +1611,7 @@
 
 			IL_0038: ldstr "isAbsolute"
 			IL_003d: ldarg.2
-			IL_003e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M28>:__js_call__:11"
+			IL_003e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M30>:__js_call__:11"
 			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1600,7 +1640,7 @@
 			IL_0089: br IL_00a2
 
 			IL_008e: ldstr "cwd"
-			IL_0093: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M28>:__js_call__:21"
+			IL_0093: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M30>:__js_call__:21"
 			IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
 			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -1944,7 +1984,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 109 (0x6d)
@@ -2536,7 +2576,7 @@
 
 			IL_0044: ldarg.1
 			IL_0045: ldstr "length"
-			IL_004a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M32>:__js_call__:9"
+			IL_004a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:9"
 			IL_004f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2939,7 +2979,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 277 (0x115)
@@ -3286,7 +3326,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 2195 (0x893)
@@ -3371,7 +3411,7 @@
 
 			IL_0094: ldarg.2
 			IL_0095: ldstr "upstream"
-			IL_009a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:27"
+			IL_009a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:27"
 			IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3401,7 +3441,7 @@
 
 			IL_00e8: ldarg.2
 			IL_00e9: ldstr "upstream"
-			IL_00ee: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:34"
+			IL_00ee: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:34"
 			IL_00f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3465,7 +3505,7 @@
 
 			IL_0188: ldarg.2
 			IL_0189: ldstr "upstream"
-			IL_018e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:57"
+			IL_018e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:57"
 			IL_0193: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3481,7 +3521,7 @@
 
 			IL_01bc: ldloc.s 12
 			IL_01be: ldstr "owner"
-			IL_01c3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:59"
+			IL_01c3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:59"
 			IL_01c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3513,7 +3553,7 @@
 
 			IL_0215: ldarg.2
 			IL_0216: ldstr "upstream"
-			IL_021b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:67"
+			IL_021b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:67"
 			IL_0220: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3529,7 +3569,7 @@
 
 			IL_0249: ldloc.s 9
 			IL_024b: ldstr "repo"
-			IL_0250: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:69"
+			IL_0250: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:69"
 			IL_0255: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3561,7 +3601,7 @@
 
 			IL_02a2: ldarg.2
 			IL_02a3: ldstr "upstream"
-			IL_02a8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:77"
+			IL_02a8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:77"
 			IL_02ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3577,7 +3617,7 @@
 
 			IL_02d6: ldloc.s 12
 			IL_02d8: ldstr "cloneUrl"
-			IL_02dd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:79"
+			IL_02dd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:79"
 			IL_02e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3609,7 +3649,7 @@
 
 			IL_032f: ldarg.2
 			IL_0330: ldstr "upstream"
-			IL_0335: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:87"
+			IL_0335: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:87"
 			IL_033a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 			IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3625,7 +3665,7 @@
 
 			IL_0363: ldloc.s 9
 			IL_0365: ldstr "commit"
-			IL_036a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:89"
+			IL_036a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:89"
 			IL_036f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3657,7 +3697,7 @@
 
 			IL_03bc: ldarg.2
 			IL_03bd: ldstr "upstream"
-			IL_03c2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:97"
+			IL_03c2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:97"
 			IL_03c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3673,7 +3713,7 @@
 
 			IL_03f0: ldloc.s 12
 			IL_03f2: ldstr "packageVersion"
-			IL_03f7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:99"
+			IL_03f7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:99"
 			IL_03fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 			IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3705,7 +3745,7 @@
 
 			IL_0449: ldarg.2
 			IL_044a: ldstr "localOverrideEnvVar"
-			IL_044f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:107"
+			IL_044f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:107"
 			IL_0454: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 			IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3737,7 +3777,7 @@
 
 			IL_04a1: ldarg.2
 			IL_04a2: ldstr "managedRoot"
-			IL_04a7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:115"
+			IL_04a7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:115"
 			IL_04ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3769,7 +3809,7 @@
 
 			IL_04f9: ldarg.2
 			IL_04fa: ldstr "lineEndings"
-			IL_04ff: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:123"
+			IL_04ff: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:123"
 			IL_0504: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3801,7 +3841,7 @@
 
 			IL_0551: ldarg.2
 			IL_0552: ldstr "updateStrategy"
-			IL_0557: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:131"
+			IL_0557: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:131"
 			IL_055c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3833,7 +3873,7 @@
 
 			IL_05a9: ldarg.2
 			IL_05aa: ldstr "includeFiles"
-			IL_05af: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:139"
+			IL_05af: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:139"
 			IL_05b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3865,7 +3905,7 @@
 
 			IL_0601: ldarg.2
 			IL_0602: ldstr "includeDirectories"
-			IL_0607: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:147"
+			IL_0607: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:147"
 			IL_060c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3897,7 +3937,7 @@
 
 			IL_0659: ldarg.2
 			IL_065a: ldstr "requiredFiles"
-			IL_065f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:155"
+			IL_065f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:155"
 			IL_0664: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3929,7 +3969,7 @@
 
 			IL_06b1: ldarg.2
 			IL_06b2: ldstr "requiredDirectories"
-			IL_06b7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:163"
+			IL_06b7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:163"
 			IL_06bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3961,7 +4001,7 @@
 
 			IL_0709: ldarg.2
 			IL_070a: ldstr "defaultHarnessFiles"
-			IL_070f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:171"
+			IL_070f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:171"
 			IL_0714: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3993,7 +4033,7 @@
 
 			IL_0761: ldarg.2
 			IL_0762: ldstr "excludedFromMvp"
-			IL_0767: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:179"
+			IL_0767: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:179"
 			IL_076c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4024,7 +4064,7 @@
 
 			IL_07b4: ldarg.2
 			IL_07b5: ldstr "attributionFiles"
-			IL_07ba: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:186"
+			IL_07ba: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:186"
 			IL_07bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4050,7 +4090,7 @@
 
 			IL_0809: ldarg.2
 			IL_080a: ldstr "upstream"
-			IL_080f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:195"
+			IL_080f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:195"
 			IL_0814: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_0819: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4066,7 +4106,7 @@
 
 			IL_083d: ldloc.s 9
 			IL_083f: ldstr "commit"
-			IL_0844: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M34>:__js_call__:197"
+			IL_0844: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:197"
 			IL_0849: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4246,7 +4286,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 105 (0x69)
@@ -4459,7 +4499,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 291 (0x123)
@@ -4484,7 +4524,7 @@
 
 			IL_0022: ldstr "dirname"
 			IL_0027: ldarg.2
-			IL_0028: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:3"
+			IL_0028: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M38>:__js_call__:3"
 			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -4503,7 +4543,7 @@
 
 			IL_005b: ldarg.3
 			IL_005c: ldstr "managedRoot"
-			IL_0061: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:9"
+			IL_0061: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M38>:__js_call__:9"
 			IL_0066: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4519,7 +4559,7 @@
 
 			IL_008d: ldarg.3
 			IL_008e: ldstr "upstream"
-			IL_0093: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:12"
+			IL_0093: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M38>:__js_call__:12"
 			IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4535,7 +4575,7 @@
 
 			IL_00bf: ldloc.3
 			IL_00c0: ldstr "commit"
-			IL_00c5: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:14"
+			IL_00c5: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M38>:__js_call__:14"
 			IL_00ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4731,7 +4771,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 273 (0x111)
@@ -4785,7 +4825,7 @@
 
 			IL_0063: ldarg.2
 			IL_0064: ldstr "managedRoot"
-			IL_0069: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M37>:__js_call__:8"
+			IL_0069: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:8"
 			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4805,7 +4845,7 @@
 
 			IL_009d: ldarg.2
 			IL_009e: ldstr "upstream"
-			IL_00a3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M37>:__js_call__:12"
+			IL_00a3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:12"
 			IL_00a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4821,7 +4861,7 @@
 
 			IL_00d1: ldloc.s 4
 			IL_00d3: ldstr "commit"
-			IL_00d8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M37>:__js_call__:14"
+			IL_00d8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:14"
 			IL_00dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5021,7 +5061,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 431 (0x1af)
@@ -5050,7 +5090,7 @@
 
 			IL_001c: ldarg.2
 			IL_001d: ldstr "root"
-			IL_0022: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M38>:__js_call__:3"
+			IL_0022: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M40>:__js_call__:3"
 			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5072,7 +5112,7 @@
 			IL_005f: br IL_0078
 
 			IL_0064: ldstr "env"
-			IL_0069: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M38>:__js_call__:9"
+			IL_0069: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M40>:__js_call__:9"
 			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5088,7 +5128,7 @@
 
 			IL_0096: ldarg.3
 			IL_0097: ldstr "localOverrideEnvVar"
-			IL_009c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M38>:__js_call__:12"
+			IL_009c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M40>:__js_call__:12"
 			IL_00a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5139,7 +5179,7 @@
 
 			IL_0114: ldarg.2
 			IL_0115: ldstr "root"
-			IL_011a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M38>:__js_call__:39"
+			IL_011a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M40>:__js_call__:39"
 			IL_011f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5165,7 +5205,7 @@
 
 			IL_015e: ldarg.3
 			IL_015f: ldstr "localOverrideEnvVar"
-			IL_0164: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M38>:__js_call__:48"
+			IL_0164: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M40>:__js_call__:48"
 			IL_0169: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5370,7 +5410,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 2154 (0x86a)
@@ -5430,7 +5470,7 @@
 
 			IL_004d: ldarg.2
 			IL_004e: ldstr "upstream"
-			IL_0053: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:17"
+			IL_0053: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:17"
 			IL_0058: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5446,7 +5486,7 @@
 
 			IL_0081: ldloc.s 4
 			IL_0083: ldstr "cloneUrl"
-			IL_0088: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:19"
+			IL_0088: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:19"
 			IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5469,7 +5509,7 @@
 
 			IL_00cc: ldarg.2
 			IL_00cd: ldstr "upstream"
-			IL_00d2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:25"
+			IL_00d2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:25"
 			IL_00d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5485,7 +5525,7 @@
 
 			IL_0100: ldloc.s 4
 			IL_0102: ldstr "commit"
-			IL_0107: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:27"
+			IL_0107: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:27"
 			IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5508,7 +5548,7 @@
 
 			IL_014b: ldarg.2
 			IL_014c: ldstr "upstream"
-			IL_0151: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:33"
+			IL_0151: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:33"
 			IL_0156: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5524,7 +5564,7 @@
 
 			IL_017f: ldloc.s 4
 			IL_0181: ldstr "packageVersion"
-			IL_0186: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:35"
+			IL_0186: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:35"
 			IL_018b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5556,7 +5596,7 @@
 
 			IL_01dc: ldarg.2
 			IL_01dd: ldstr "managedRoot"
-			IL_01e2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:43"
+			IL_01e2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:43"
 			IL_01e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5603,7 +5643,7 @@
 
 			IL_0264: ldarg.2
 			IL_0265: ldstr "localOverrideEnvVar"
-			IL_026a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:57"
+			IL_026a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:57"
 			IL_026f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
 			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5626,7 +5666,7 @@
 
 			IL_02ae: ldarg.2
 			IL_02af: ldstr "lineEndings"
-			IL_02b4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:63"
+			IL_02b4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:63"
 			IL_02b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
 			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5649,7 +5689,7 @@
 
 			IL_02f8: ldarg.2
 			IL_02f9: ldstr "updateStrategy"
-			IL_02fe: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:69"
+			IL_02fe: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:69"
 			IL_0303: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
 			IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5672,7 +5712,7 @@
 
 			IL_0342: ldarg.2
 			IL_0343: ldstr "includeFiles"
-			IL_0348: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:75"
+			IL_0348: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:75"
 			IL_034d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
 			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5690,7 +5730,7 @@
 
 			IL_0380: ldstr "join"
 			IL_0385: ldstr ", "
-			IL_038a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:78"
+			IL_038a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:78"
 			IL_038f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
 			IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -5713,7 +5753,7 @@
 
 			IL_03ce: ldarg.2
 			IL_03cf: ldstr "includeDirectories"
-			IL_03d4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:84"
+			IL_03d4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:84"
 			IL_03d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
 			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5731,7 +5771,7 @@
 
 			IL_040c: ldstr "join"
 			IL_0411: ldstr ", "
-			IL_0416: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:87"
+			IL_0416: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:87"
 			IL_041b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
 			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -5754,7 +5794,7 @@
 
 			IL_045a: ldarg.2
 			IL_045b: ldstr "requiredFiles"
-			IL_0460: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:93"
+			IL_0460: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:93"
 			IL_0465: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
 			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5772,7 +5812,7 @@
 
 			IL_0498: ldstr "join"
 			IL_049d: ldstr ", "
-			IL_04a2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:96"
+			IL_04a2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:96"
 			IL_04a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
 			IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -5795,7 +5835,7 @@
 
 			IL_04e6: ldarg.2
 			IL_04e7: ldstr "requiredDirectories"
-			IL_04ec: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:102"
+			IL_04ec: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:102"
 			IL_04f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
 			IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5813,7 +5853,7 @@
 
 			IL_0524: ldstr "join"
 			IL_0529: ldstr ", "
-			IL_052e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:105"
+			IL_052e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:105"
 			IL_0533: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
 			IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -5836,7 +5876,7 @@
 
 			IL_0572: ldarg.2
 			IL_0573: ldstr "defaultHarnessFiles"
-			IL_0578: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:111"
+			IL_0578: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:111"
 			IL_057d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
 			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5854,7 +5894,7 @@
 
 			IL_05b0: ldstr "join"
 			IL_05b5: ldstr ", "
-			IL_05ba: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:114"
+			IL_05ba: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:114"
 			IL_05bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
 			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -5877,7 +5917,7 @@
 
 			IL_05fe: ldarg.2
 			IL_05ff: ldstr "excludedFromMvp"
-			IL_0604: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:120"
+			IL_0604: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:120"
 			IL_0609: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
 			IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5895,7 +5935,7 @@
 
 			IL_063c: ldstr "join"
 			IL_0641: ldstr "; "
-			IL_0646: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:123"
+			IL_0646: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:123"
 			IL_064b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
 			IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -5918,7 +5958,7 @@
 
 			IL_068a: ldarg.2
 			IL_068b: ldstr "attributionFiles"
-			IL_0690: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:129"
+			IL_0690: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:129"
 			IL_0695: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
 			IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5936,7 +5976,7 @@
 
 			IL_06c8: ldstr "join"
 			IL_06cd: ldstr ", "
-			IL_06d2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:132"
+			IL_06d2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:132"
 			IL_06d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
 			IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -6016,7 +6056,7 @@
 
 			IL_07aa: ldarg.3
 			IL_07ab: ldstr "source"
-			IL_07b0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:145"
+			IL_07b0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:145"
 			IL_07b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
 			IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6052,7 +6092,7 @@
 
 			IL_080f: ldarg.3
 			IL_0810: ldstr "rootPath"
-			IL_0815: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:155"
+			IL_0815: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:155"
 			IL_081a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
 			IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6230,7 +6270,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 83 (0x53)
@@ -6445,7 +6485,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 175 (0xaf)
@@ -6728,7 +6768,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 1014 (0x3f6)
@@ -6821,7 +6861,7 @@
 
 			IL_00c5: ldloc.0
 			IL_00c6: ldstr "error"
-			IL_00cb: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M42>:__js_call__:17"
+			IL_00cb: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:17"
 			IL_00d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
 			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6843,7 +6883,7 @@
 
 			IL_0108: ldloc.0
 			IL_0109: ldstr "error"
-			IL_010e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M42>:__js_call__:22"
+			IL_010e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:22"
 			IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
 			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6871,7 +6911,7 @@
 
 			IL_014f: ldloc.0
 			IL_0150: ldstr "status"
-			IL_0155: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M42>:__js_call__:28"
+			IL_0155: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:28"
 			IL_015a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
 			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6895,7 +6935,7 @@
 
 			IL_01a0: ldloc.0
 			IL_01a1: ldstr "stderr"
-			IL_01a6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M42>:__js_call__:35"
+			IL_01a6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:35"
 			IL_01ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
 			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6942,7 +6982,7 @@
 
 			IL_0226: ldloc.0
 			IL_0227: ldstr "stdout"
-			IL_022c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M42>:__js_call__:49"
+			IL_022c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:49"
 			IL_0231: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
 			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7021,7 +7061,7 @@
 
 			IL_0303: ldstr "join"
 			IL_0308: ldstr " "
-			IL_030d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M42>:__js_call__:74"
+			IL_030d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:74"
 			IL_0312: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
 			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -7088,7 +7128,7 @@
 
 			IL_03c6: ldloc.0
 			IL_03c7: ldstr "stdout"
-			IL_03cc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M42>:__js_call__:98"
+			IL_03cc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:98"
 			IL_03d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
 			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7330,7 +7370,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 483 (0x1e3)
@@ -7365,7 +7405,7 @@
 
 			IL_0023: ldarg.2
 			IL_0024: ldstr "includeFiles"
-			IL_0029: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M43>:__js_call__:6"
+			IL_0029: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:6"
 			IL_002e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
 			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7457,7 +7497,7 @@
 
 			IL_00f0: ldarg.2
 			IL_00f1: ldstr "includeDirectories"
-			IL_00f6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M43>:__js_call__:51"
+			IL_00f6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:51"
 			IL_00fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
 			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7910,7 +7950,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 2351 (0x92f)
@@ -7969,7 +8009,7 @@
 
 			IL_002a: ldarg.3
 			IL_002b: ldstr "requiredFiles"
-			IL_0030: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:9"
+			IL_0030: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:9"
 			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
 			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8038,7 +8078,7 @@
 
 					IL_00d7: ldstr "split"
 					IL_00dc: ldstr "/"
-					IL_00e1: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:35"
+					IL_00e1: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:35"
 					IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
 					IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -8130,7 +8170,7 @@
 					IL_01df: br IL_01f8
 
 					IL_01e4: ldstr "isFile"
-					IL_01e9: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:50"
+					IL_01e9: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:50"
 					IL_01ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
 					IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -8198,7 +8238,7 @@
 
 			IL_027f: ldarg.3
 			IL_0280: ldstr "requiredDirectories"
-			IL_0285: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:84"
+			IL_0285: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:84"
 			IL_028a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
 			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8267,7 +8307,7 @@
 
 					IL_0331: ldstr "split"
 					IL_0336: ldstr "/"
-					IL_033b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:110"
+					IL_033b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:110"
 					IL_0340: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
 					IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -8359,7 +8399,7 @@
 					IL_0439: br IL_0452
 
 					IL_043e: ldstr "isDirectory"
-					IL_0443: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:125"
+					IL_0443: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:125"
 					IL_0448: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
 					IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -8626,7 +8666,7 @@
 
 			IL_06f5: ldloc.s 14
 			IL_06f7: ldstr "version"
-			IL_06fc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:228"
+			IL_06fc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:228"
 			IL_0701: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
 			IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8642,7 +8682,7 @@
 
 			IL_0729: ldarg.3
 			IL_072a: ldstr "upstream"
-			IL_072f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:231"
+			IL_072f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:231"
 			IL_0734: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
 			IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8658,7 +8698,7 @@
 
 			IL_075d: ldloc.s 30
 			IL_075f: ldstr "packageVersion"
-			IL_0764: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:233"
+			IL_0764: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:233"
 			IL_0769: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
 			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8694,7 +8734,7 @@
 
 			IL_07c2: ldarg.3
 			IL_07c3: ldstr "upstream"
-			IL_07c8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:248"
+			IL_07c8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:248"
 			IL_07cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
 			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8710,7 +8750,7 @@
 
 			IL_07f6: ldloc.s 30
 			IL_07f8: ldstr "packageVersion"
-			IL_07fd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:250"
+			IL_07fd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:250"
 			IL_0802: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
 			IL_0807: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8741,7 +8781,7 @@
 
 			IL_085c: ldloc.s 14
 			IL_085e: ldstr "version"
-			IL_0863: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:258"
+			IL_0863: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:258"
 			IL_0868: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
 			IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8770,7 +8810,7 @@
 
 			IL_08ae: ldloc.s 14
 			IL_08b0: ldstr "version"
-			IL_08b5: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M44>:__js_call__:267"
+			IL_08b5: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:267"
 			IL_08ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
 			IL_08bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9033,7 +9073,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 1316 (0x524)
@@ -9084,7 +9124,7 @@
 
 			IL_0049: ldloc.0
 			IL_004a: ldstr "ok"
-			IL_004f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:13"
+			IL_004f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:13"
 			IL_0054: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
 			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9239,7 +9279,7 @@
 
 			IL_01d2: ldarg.3
 			IL_01d3: ldstr "upstream"
-			IL_01d8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:67"
+			IL_01d8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:67"
 			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9255,7 +9295,7 @@
 
 			IL_0206: ldloc.s 7
 			IL_0208: ldstr "cloneUrl"
-			IL_020d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:69"
+			IL_020d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:69"
 			IL_0212: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
 			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9380,7 +9420,7 @@
 
 			IL_0350: ldarg.3
 			IL_0351: ldstr "upstream"
-			IL_0356: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:105"
+			IL_0356: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:105"
 			IL_035b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
 			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9396,7 +9436,7 @@
 
 			IL_0384: ldloc.s 7
 			IL_0386: ldstr "commit"
-			IL_038b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:107"
+			IL_038b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:107"
 			IL_0390: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
 			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9478,7 +9518,7 @@
 
 			IL_0467: ldloc.1
 			IL_0468: ldstr "ok"
-			IL_046d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:129"
+			IL_046d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:129"
 			IL_0472: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
 			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9502,7 +9542,7 @@
 
 			IL_04ab: ldloc.1
 			IL_04ac: ldstr "message"
-			IL_04b1: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:135"
+			IL_04b1: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:135"
 			IL_04b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
 			IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9745,7 +9785,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 635 (0x27b)
@@ -9802,7 +9842,7 @@
 
 			IL_0057: ldloc.0
 			IL_0058: ldstr "rootPath"
-			IL_005d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:14"
+			IL_005d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:14"
 			IL_0062: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
 			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9823,7 +9863,7 @@
 
 			IL_0094: ldloc.1
 			IL_0095: ldstr "ok"
-			IL_009a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:20"
+			IL_009a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:20"
 			IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
 			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9847,7 +9887,7 @@
 
 			IL_00da: ldloc.0
 			IL_00db: ldstr "rootPath"
-			IL_00e0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:26"
+			IL_00e0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:26"
 			IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
 			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9871,7 +9911,7 @@
 
 			IL_012c: ldloc.1
 			IL_012d: ldstr "message"
-			IL_0132: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:32"
+			IL_0132: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:32"
 			IL_0137: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
 			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9908,7 +9948,7 @@
 
 			IL_018e: ldloc.0
 			IL_018f: ldstr "source"
-			IL_0194: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:41"
+			IL_0194: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:41"
 			IL_0199: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
 			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9924,7 +9964,7 @@
 
 			IL_01c1: ldloc.0
 			IL_01c2: ldstr "rootPath"
-			IL_01c7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:43"
+			IL_01c7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:43"
 			IL_01cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
 			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -9971,7 +10011,7 @@
 
 			IL_0240: ldarg.s args
 			IL_0242: ldstr "force"
-			IL_0247: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:57"
+			IL_0247: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:57"
 			IL_024c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
 			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10178,7 +10218,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 707 (0x2c3)
@@ -10217,7 +10257,7 @@
 
 			IL_0030: ldarg.2
 			IL_0031: ldstr "rootPath"
-			IL_0036: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:8"
+			IL_0036: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:8"
 			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10240,7 +10280,7 @@
 
 			IL_006e: ldarg.2
 			IL_006f: ldstr "reused"
-			IL_0074: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:17"
+			IL_0074: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:17"
 			IL_0079: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_156
 			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10273,7 +10313,7 @@
 
 			IL_00c8: ldarg.2
 			IL_00c9: ldstr "source"
-			IL_00ce: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:33"
+			IL_00ce: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:33"
 			IL_00d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_157
 			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10305,7 +10345,7 @@
 
 			IL_0124: ldarg.2
 			IL_0125: ldstr "rootPath"
-			IL_012a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:41"
+			IL_012a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:41"
 			IL_012f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_158
 			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10332,7 +10372,7 @@
 
 			IL_0179: ldarg.3
 			IL_017a: ldstr "upstream"
-			IL_017f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:48"
+			IL_017f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:48"
 			IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
 			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10348,7 +10388,7 @@
 
 			IL_01ad: ldloc.s 4
 			IL_01af: ldstr "commit"
-			IL_01b4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:50"
+			IL_01b4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:50"
 			IL_01b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
 			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10371,7 +10411,7 @@
 
 			IL_01f8: ldarg.3
 			IL_01f9: ldstr "upstream"
-			IL_01fe: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:56"
+			IL_01fe: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:56"
 			IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
 			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10387,7 +10427,7 @@
 
 			IL_022c: ldloc.s 4
 			IL_022e: ldstr "packageVersion"
-			IL_0233: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:58"
+			IL_0233: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:58"
 			IL_0238: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
 			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10618,7 +10658,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 26 00 00 02
+				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
 			// Code size: 700 (0x2bc)
@@ -10660,7 +10700,7 @@
 			IL_0034: br IL_004d
 
 			IL_0039: ldstr "argv"
-			IL_003e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:6"
+			IL_003e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:6"
 			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10715,7 +10755,7 @@
 
 			IL_00e2: ldloc.0
 			IL_00e3: ldstr "help"
-			IL_00e8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:15"
+			IL_00e8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:15"
 			IL_00ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
 			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10762,7 +10802,7 @@
 
 			IL_0155: ldloc.0
 			IL_0156: ldstr "pin"
-			IL_015b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:30"
+			IL_015b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:30"
 			IL_0160: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
 			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10829,7 +10869,7 @@
 
 			IL_01f7: ldloc.0
 			IL_01f8: ldstr "describe"
-			IL_01fd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:55"
+			IL_01fd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:55"
 			IL_0202: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
 			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -10895,7 +10935,7 @@
 
 			IL_0294: ldloc.0
 			IL_0295: ldstr "printRoot"
-			IL_029a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:77"
+			IL_029a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:77"
 			IL_029f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
 			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Compile_Scripts_Test262MetadataParser
 	extends [System.Runtime]System.Object
 {
@@ -189,6 +209,26 @@
 					} // end of method IObject::HasDynamicProperty
 
 				} // end of class IObject
+
+				.class interface nested public auto ansi abstract ICallable
+					implements [System.Runtime]System.IDisposable
+				{
+					.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+						01 00 00 00
+					)
+					// Methods
+					.method public hidebysig newslot abstract virtual 
+						instance object Invoke (
+							object[] arguments
+						) cil managed 
+					{
+						.param [1]
+							.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+								01 00 00 00
+							)
+					} // end of method ICallable::Invoke
+
+				} // end of class ICallable
 
 				.class interface nested public auto ansi abstract IExports
 					implements [System.Runtime]System.IDisposable
@@ -730,7 +770,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 2c 00 00 02
+				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
 			// Header size: 12
 			// Code size: 100 (0x64)
@@ -957,7 +997,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 2c 00 00 02
+				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
 			// Header size: 12
 			// Code size: 218 (0xda)
@@ -1000,7 +1040,7 @@
 
 			IL_0043: ldarg.2
 			IL_0044: ldstr "phase"
-			IL_0049: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M22>:__js_call__:14"
+			IL_0049: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:14"
 			IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1037,7 +1077,7 @@
 
 			IL_00a6: ldarg.2
 			IL_00a7: ldstr "type"
-			IL_00ac: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M22>:__js_call__:23"
+			IL_00ac: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:23"
 			IL_00b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
 			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1223,7 +1263,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 2c 00 00 02
+				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
 			// Header size: 12
 			// Code size: 313 (0x139)
@@ -1266,7 +1306,7 @@
 
 			IL_0043: ldarg.2
 			IL_0044: ldstr "code"
-			IL_0049: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M23>:__js_call__:14"
+			IL_0049: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M25>:__js_call__:14"
 			IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1303,7 +1343,7 @@
 
 			IL_00a6: ldarg.2
 			IL_00a7: ldstr "source"
-			IL_00ac: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M23>:__js_call__:23"
+			IL_00ac: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M25>:__js_call__:23"
 			IL_00b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1340,7 +1380,7 @@
 
 			IL_0105: ldarg.2
 			IL_0106: ldstr "reason"
-			IL_010b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M23>:__js_call__:32"
+			IL_010b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M25>:__js_call__:32"
 			IL_0110: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1514,7 +1554,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 2c 00 00 02
+				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
 			// Header size: 12
 			// Code size: 7157 (0x1bf5)
@@ -1571,7 +1611,7 @@
 
 			IL_0066: ldarg.3
 			IL_0067: ldstr "filePath"
-			IL_006c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:16"
+			IL_006c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:16"
 			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1610,7 +1650,7 @@
 
 			IL_00cb: ldarg.3
 			IL_00cc: ldstr "fileName"
-			IL_00d1: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:27"
+			IL_00d1: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:27"
 			IL_00d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1649,7 +1689,7 @@
 
 			IL_0130: ldarg.3
 			IL_0131: ldstr "hasFrontmatter"
-			IL_0136: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:38"
+			IL_0136: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:38"
 			IL_013b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1688,7 +1728,7 @@
 
 			IL_0195: ldarg.3
 			IL_0196: ldstr "unknownKeys"
-			IL_019b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:49"
+			IL_019b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:49"
 			IL_01a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1704,7 +1744,7 @@
 
 			IL_01c7: ldloc.2
 			IL_01c8: ldstr "length"
-			IL_01cd: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:51"
+			IL_01cd: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:51"
 			IL_01d2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1743,7 +1783,7 @@
 
 			IL_022c: ldarg.3
 			IL_022d: ldstr "unknownKeys"
-			IL_0232: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:62"
+			IL_0232: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:62"
 			IL_0237: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1786,7 +1826,7 @@
 
 			IL_02a1: ldarg.3
 			IL_02a2: ldstr "description"
-			IL_02a7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:75"
+			IL_02a7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:75"
 			IL_02ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1825,7 +1865,7 @@
 
 			IL_0306: ldarg.3
 			IL_0307: ldstr "info"
-			IL_030c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:86"
+			IL_030c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:86"
 			IL_0311: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1864,7 +1904,7 @@
 
 			IL_036b: ldarg.3
 			IL_036c: ldstr "esid"
-			IL_0371: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:97"
+			IL_0371: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:97"
 			IL_0376: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1903,7 +1943,7 @@
 
 			IL_03d0: ldarg.3
 			IL_03d1: ldstr "es5id"
-			IL_03d6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:108"
+			IL_03d6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:108"
 			IL_03db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1942,7 +1982,7 @@
 
 			IL_0435: ldarg.3
 			IL_0436: ldstr "includes"
-			IL_043b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:119"
+			IL_043b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:119"
 			IL_0440: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1958,7 +1998,7 @@
 
 			IL_0467: ldloc.2
 			IL_0468: ldstr "length"
-			IL_046d: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:121"
+			IL_046d: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:121"
 			IL_0472: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1997,7 +2037,7 @@
 
 			IL_04cc: ldarg.3
 			IL_04cd: ldstr "includes"
-			IL_04d2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:132"
+			IL_04d2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:132"
 			IL_04d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2040,7 +2080,7 @@
 
 			IL_0541: ldarg.3
 			IL_0542: ldstr "includes"
-			IL_0547: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:145"
+			IL_0547: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:145"
 			IL_054c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2083,7 +2123,7 @@
 
 			IL_05b6: ldarg.3
 			IL_05b7: ldstr "flags"
-			IL_05bc: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:158"
+			IL_05bc: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:158"
 			IL_05c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2099,7 +2139,7 @@
 
 			IL_05e8: ldloc.2
 			IL_05e9: ldstr "length"
-			IL_05ee: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:160"
+			IL_05ee: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:160"
 			IL_05f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2138,7 +2178,7 @@
 
 			IL_064d: ldarg.3
 			IL_064e: ldstr "flags"
-			IL_0653: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:171"
+			IL_0653: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:171"
 			IL_0658: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2181,7 +2221,7 @@
 
 			IL_06c2: ldarg.3
 			IL_06c3: ldstr "flags"
-			IL_06c8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:184"
+			IL_06c8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:184"
 			IL_06cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2224,7 +2264,7 @@
 
 			IL_0737: ldarg.3
 			IL_0738: ldstr "flags"
-			IL_073d: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:197"
+			IL_073d: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:197"
 			IL_0742: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2267,7 +2307,7 @@
 
 			IL_07ac: ldarg.3
 			IL_07ad: ldstr "features"
-			IL_07b2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:210"
+			IL_07b2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:210"
 			IL_07b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2283,7 +2323,7 @@
 
 			IL_07de: ldloc.2
 			IL_07df: ldstr "length"
-			IL_07e4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:212"
+			IL_07e4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:212"
 			IL_07e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_07ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2322,7 +2362,7 @@
 
 			IL_0843: ldarg.3
 			IL_0844: ldstr "features"
-			IL_0849: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:223"
+			IL_0849: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:223"
 			IL_084e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2365,7 +2405,7 @@
 
 			IL_08b8: ldarg.3
 			IL_08b9: ldstr "features"
-			IL_08be: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:236"
+			IL_08be: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:236"
 			IL_08c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_08c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2408,7 +2448,7 @@
 
 			IL_092d: ldarg.3
 			IL_092e: ldstr "locale"
-			IL_0933: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:249"
+			IL_0933: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:249"
 			IL_0938: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_093d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2424,7 +2464,7 @@
 
 			IL_095f: ldloc.2
 			IL_0960: ldstr "length"
-			IL_0965: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:251"
+			IL_0965: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:251"
 			IL_096a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_096f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2463,7 +2503,7 @@
 
 			IL_09c4: ldarg.3
 			IL_09c5: ldstr "locale"
-			IL_09ca: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:262"
+			IL_09ca: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:262"
 			IL_09cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_09d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2506,7 +2546,7 @@
 
 			IL_0a39: ldarg.3
 			IL_0a3a: ldstr "defines"
-			IL_0a3f: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:275"
+			IL_0a3f: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:275"
 			IL_0a44: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_0a49: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2522,7 +2562,7 @@
 
 			IL_0a6b: ldloc.2
 			IL_0a6c: ldstr "length"
-			IL_0a71: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:277"
+			IL_0a71: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:277"
 			IL_0a76: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_0a7b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2561,7 +2601,7 @@
 
 			IL_0ad0: ldarg.3
 			IL_0ad1: ldstr "defines"
-			IL_0ad6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:288"
+			IL_0ad6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:288"
 			IL_0adb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_0ae0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2604,7 +2644,7 @@
 
 			IL_0b45: ldarg.3
 			IL_0b46: ldstr "negative"
-			IL_0b4b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:301"
+			IL_0b4b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:301"
 			IL_0b50: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0b55: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2643,7 +2683,7 @@
 
 			IL_0baa: ldarg.3
 			IL_0bab: ldstr "execution"
-			IL_0bb0: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:312"
+			IL_0bb0: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:312"
 			IL_0bb5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_0bba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2659,7 +2699,7 @@
 
 			IL_0bdc: ldloc.2
 			IL_0bdd: ldstr "sourceType"
-			IL_0be2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:314"
+			IL_0be2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:314"
 			IL_0be7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 			IL_0bec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2698,7 +2738,7 @@
 
 			IL_0c41: ldarg.3
 			IL_0c42: ldstr "execution"
-			IL_0c47: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:325"
+			IL_0c47: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:325"
 			IL_0c4c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 			IL_0c51: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2714,7 +2754,7 @@
 
 			IL_0c73: ldloc.2
 			IL_0c74: ldstr "strictMode"
-			IL_0c79: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:327"
+			IL_0c79: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:327"
 			IL_0c7e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 			IL_0c83: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2753,7 +2793,7 @@
 
 			IL_0cd8: ldarg.3
 			IL_0cd9: ldstr "execution"
-			IL_0cde: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:338"
+			IL_0cde: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:338"
 			IL_0ce3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 			IL_0ce8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2769,7 +2809,7 @@
 
 			IL_0d0a: ldloc.2
 			IL_0d0b: ldstr "defaultHarnessIncludes"
-			IL_0d10: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:340"
+			IL_0d10: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:340"
 			IL_0d15: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 			IL_0d1a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2785,7 +2825,7 @@
 
 			IL_0d3c: ldloc.2
 			IL_0d3d: ldstr "length"
-			IL_0d42: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:342"
+			IL_0d42: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:342"
 			IL_0d47: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 			IL_0d4c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2824,7 +2864,7 @@
 
 			IL_0da1: ldarg.3
 			IL_0da2: ldstr "execution"
-			IL_0da7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:353"
+			IL_0da7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:353"
 			IL_0dac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 			IL_0db1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2840,7 +2880,7 @@
 
 			IL_0dd3: ldloc.2
 			IL_0dd4: ldstr "defaultHarnessIncludes"
-			IL_0dd9: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:355"
+			IL_0dd9: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:355"
 			IL_0dde: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 			IL_0de3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2883,7 +2923,7 @@
 
 			IL_0e48: ldarg.3
 			IL_0e49: ldstr "execution"
-			IL_0e4e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:368"
+			IL_0e4e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:368"
 			IL_0e53: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 			IL_0e58: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2899,7 +2939,7 @@
 
 			IL_0e7a: ldloc.2
 			IL_0e7b: ldstr "defaultHarnessIncludes"
-			IL_0e80: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:370"
+			IL_0e80: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:370"
 			IL_0e85: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
 			IL_0e8a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2942,7 +2982,7 @@
 
 			IL_0eef: ldarg.3
 			IL_0ef0: ldstr "execution"
-			IL_0ef5: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:383"
+			IL_0ef5: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:383"
 			IL_0efa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
 			IL_0eff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2958,7 +2998,7 @@
 
 			IL_0f21: ldloc.2
 			IL_0f22: ldstr "harnessIncludes"
-			IL_0f27: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:385"
+			IL_0f27: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:385"
 			IL_0f2c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
 			IL_0f31: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2974,7 +3014,7 @@
 
 			IL_0f53: ldloc.2
 			IL_0f54: ldstr "length"
-			IL_0f59: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:387"
+			IL_0f59: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:387"
 			IL_0f5e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
 			IL_0f63: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3013,7 +3053,7 @@
 
 			IL_0fb8: ldarg.3
 			IL_0fb9: ldstr "execution"
-			IL_0fbe: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:398"
+			IL_0fbe: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:398"
 			IL_0fc3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
 			IL_0fc8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3029,7 +3069,7 @@
 
 			IL_0fea: ldloc.2
 			IL_0feb: ldstr "harnessIncludes"
-			IL_0ff0: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:400"
+			IL_0ff0: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:400"
 			IL_0ff5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
 			IL_0ffa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3072,7 +3112,7 @@
 
 			IL_105f: ldarg.3
 			IL_1060: ldstr "execution"
-			IL_1065: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:413"
+			IL_1065: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:413"
 			IL_106a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
 			IL_106f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3088,7 +3128,7 @@
 
 			IL_1091: ldloc.2
 			IL_1092: ldstr "harnessIncludes"
-			IL_1097: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:415"
+			IL_1097: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:415"
 			IL_109c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
 			IL_10a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3131,7 +3171,7 @@
 
 			IL_1106: ldarg.3
 			IL_1107: ldstr "execution"
-			IL_110c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:428"
+			IL_110c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:428"
 			IL_1111: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
 			IL_1116: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3147,7 +3187,7 @@
 
 			IL_1138: ldloc.2
 			IL_1139: ldstr "harnessIncludes"
-			IL_113e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:430"
+			IL_113e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:430"
 			IL_1143: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
 			IL_1148: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3190,7 +3230,7 @@
 
 			IL_11ad: ldarg.3
 			IL_11ae: ldstr "execution"
-			IL_11b3: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:443"
+			IL_11b3: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:443"
 			IL_11b8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
 			IL_11bd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3206,7 +3246,7 @@
 
 			IL_11df: ldloc.2
 			IL_11e0: ldstr "harnessIncludes"
-			IL_11e5: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:445"
+			IL_11e5: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:445"
 			IL_11ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
 			IL_11ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3249,7 +3289,7 @@
 
 			IL_1254: ldarg.3
 			IL_1255: ldstr "execution"
-			IL_125a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:458"
+			IL_125a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:458"
 			IL_125f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
 			IL_1264: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3265,7 +3305,7 @@
 
 			IL_1286: ldloc.2
 			IL_1287: ldstr "requiresDefaultHarness"
-			IL_128c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:460"
+			IL_128c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:460"
 			IL_1291: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
 			IL_1296: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3304,7 +3344,7 @@
 
 			IL_12eb: ldarg.3
 			IL_12ec: ldstr "execution"
-			IL_12f1: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:471"
+			IL_12f1: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:471"
 			IL_12f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
 			IL_12fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3320,7 +3360,7 @@
 
 			IL_131d: ldloc.2
 			IL_131e: ldstr "requiresAsyncHarness"
-			IL_1323: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:473"
+			IL_1323: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:473"
 			IL_1328: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
 			IL_132d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3359,7 +3399,7 @@
 
 			IL_1382: ldarg.3
 			IL_1383: ldstr "execution"
-			IL_1388: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:484"
+			IL_1388: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:484"
 			IL_138d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
 			IL_1392: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3375,7 +3415,7 @@
 
 			IL_13b4: ldloc.2
 			IL_13b5: ldstr "requiresAgent"
-			IL_13ba: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:486"
+			IL_13ba: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:486"
 			IL_13bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
 			IL_13c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3414,7 +3454,7 @@
 
 			IL_1419: ldarg.3
 			IL_141a: ldstr "execution"
-			IL_141f: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:497"
+			IL_141f: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:497"
 			IL_1424: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
 			IL_1429: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3430,7 +3470,7 @@
 
 			IL_144b: ldloc.2
 			IL_144c: ldstr "canBlock"
-			IL_1451: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:499"
+			IL_1451: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:499"
 			IL_1456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
 			IL_145b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3469,7 +3509,7 @@
 
 			IL_14b0: ldarg.3
 			IL_14b1: ldstr "execution"
-			IL_14b6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:510"
+			IL_14b6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:510"
 			IL_14bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
 			IL_14c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3485,7 +3525,7 @@
 
 			IL_14e2: ldloc.2
 			IL_14e3: ldstr "isModule"
-			IL_14e8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:512"
+			IL_14e8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:512"
 			IL_14ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
 			IL_14f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3524,7 +3564,7 @@
 
 			IL_1547: ldarg.3
 			IL_1548: ldstr "execution"
-			IL_154d: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:523"
+			IL_154d: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:523"
 			IL_1552: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
 			IL_1557: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3540,7 +3580,7 @@
 
 			IL_1579: ldloc.2
 			IL_157a: ldstr "isRaw"
-			IL_157f: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:525"
+			IL_157f: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:525"
 			IL_1584: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
 			IL_1589: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3579,7 +3619,7 @@
 
 			IL_15de: ldarg.3
 			IL_15df: ldstr "execution"
-			IL_15e4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:536"
+			IL_15e4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:536"
 			IL_15e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
 			IL_15ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3595,7 +3635,7 @@
 
 			IL_1610: ldloc.2
 			IL_1611: ldstr "isAsync"
-			IL_1616: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:538"
+			IL_1616: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:538"
 			IL_161b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
 			IL_1620: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3634,7 +3674,7 @@
 
 			IL_1675: ldarg.3
 			IL_1676: ldstr "execution"
-			IL_167b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:549"
+			IL_167b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:549"
 			IL_1680: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
 			IL_1685: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3650,7 +3690,7 @@
 
 			IL_16a7: ldloc.2
 			IL_16a8: ldstr "isGenerated"
-			IL_16ad: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:551"
+			IL_16ad: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:551"
 			IL_16b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
 			IL_16b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3689,7 +3729,7 @@
 
 			IL_170c: ldarg.3
 			IL_170d: ldstr "execution"
-			IL_1712: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:562"
+			IL_1712: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:562"
 			IL_1717: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
 			IL_171c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3705,7 +3745,7 @@
 
 			IL_173e: ldloc.2
 			IL_173f: ldstr "isNonDeterministic"
-			IL_1744: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:564"
+			IL_1744: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:564"
 			IL_1749: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
 			IL_174e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3744,7 +3784,7 @@
 
 			IL_17a3: ldarg.3
 			IL_17a4: ldstr "execution"
-			IL_17a9: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:575"
+			IL_17a9: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:575"
 			IL_17ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
 			IL_17b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3760,7 +3800,7 @@
 
 			IL_17d5: ldloc.2
 			IL_17d6: ldstr "isFixture"
-			IL_17db: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:577"
+			IL_17db: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:577"
 			IL_17e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
 			IL_17e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3799,7 +3839,7 @@
 
 			IL_183a: ldarg.3
 			IL_183b: ldstr "mvpBlockers"
-			IL_1840: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:588"
+			IL_1840: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:588"
 			IL_1845: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
 			IL_184a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3815,7 +3855,7 @@
 
 			IL_186c: ldloc.2
 			IL_186d: ldstr "length"
-			IL_1872: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:590"
+			IL_1872: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:590"
 			IL_1877: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
 			IL_187c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3854,7 +3894,7 @@
 
 			IL_18d1: ldarg.3
 			IL_18d2: ldstr "mvpBlockers"
-			IL_18d7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:601"
+			IL_18d7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:601"
 			IL_18dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
 			IL_18e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3897,7 +3937,7 @@
 
 			IL_1946: ldarg.3
 			IL_1947: ldstr "mvpBlockers"
-			IL_194c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:614"
+			IL_194c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:614"
 			IL_1951: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
 			IL_1956: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3940,7 +3980,7 @@
 
 			IL_19bb: ldarg.3
 			IL_19bc: ldstr "mvpBlockers"
-			IL_19c1: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:627"
+			IL_19c1: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:627"
 			IL_19c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
 			IL_19cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3983,7 +4023,7 @@
 
 			IL_1a30: ldarg.3
 			IL_1a31: ldstr "mvpBlockers"
-			IL_1a36: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:640"
+			IL_1a36: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:640"
 			IL_1a3b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
 			IL_1a40: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4026,7 +4066,7 @@
 
 			IL_1aa5: ldarg.3
 			IL_1aa6: ldstr "unsupported"
-			IL_1aab: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:653"
+			IL_1aab: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:653"
 			IL_1ab0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
 			IL_1ab5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4042,7 +4082,7 @@
 
 			IL_1ad7: ldloc.2
 			IL_1ad8: ldstr "length"
-			IL_1add: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:655"
+			IL_1add: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:655"
 			IL_1ae2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
 			IL_1ae7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4081,7 +4121,7 @@
 
 			IL_1b3c: ldarg.3
 			IL_1b3d: ldstr "unsupported"
-			IL_1b42: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:666"
+			IL_1b42: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:666"
 			IL_1b47: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
 			IL_1b4c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4124,7 +4164,7 @@
 
 			IL_1bb1: ldarg.3
 			IL_1bb2: ldstr "unsupported"
-			IL_1bb7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:679"
+			IL_1bb7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:679"
 			IL_1bbc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
 			IL_1bc1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4866,7 +4906,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 159 (0x9f)
@@ -5134,7 +5174,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 538 (0x21a)
@@ -5166,7 +5206,7 @@
 
 			IL_001c: ldarg.2
 			IL_001d: ldstr "length"
-			IL_0022: ldstr "test262/metadataParser:<TwoPhaseDummy_M27>:__js_call__:3"
+			IL_0022: ldstr "test262/metadataParser:<TwoPhaseDummy_M29>:__js_call__:3"
 			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5194,7 +5234,7 @@
 
 			IL_0077: ldarg.2
 			IL_0078: ldstr "length"
-			IL_007d: ldstr "test262/metadataParser:<TwoPhaseDummy_M27>:__js_call__:17"
+			IL_007d: ldstr "test262/metadataParser:<TwoPhaseDummy_M29>:__js_call__:17"
 			IL_0082: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
 			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5292,7 +5332,7 @@
 
 			IL_0184: ldarg.2
 			IL_0185: ldstr "length"
-			IL_018a: ldstr "test262/metadataParser:<TwoPhaseDummy_M27>:__js_call__:66"
+			IL_018a: ldstr "test262/metadataParser:<TwoPhaseDummy_M29>:__js_call__:66"
 			IL_018f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
 			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5571,7 +5611,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 567 (0x237)
@@ -5605,7 +5645,7 @@
 
 			IL_0024: ldarg.2
 			IL_0025: ldstr "length"
-			IL_002a: ldstr "test262/metadataParser:<TwoPhaseDummy_M28>:__js_call__:7"
+			IL_002a: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:7"
 			IL_002f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
 			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5707,7 +5747,7 @@
 
 			IL_014f: ldstr "split"
 			IL_0154: ldstr ","
-			IL_0159: ldstr "test262/metadataParser:<TwoPhaseDummy_M28>:__js_call__:27"
+			IL_0159: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:27"
 			IL_015e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
 			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -5962,7 +6002,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 348 (0x15c)
@@ -6394,7 +6434,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 337 (0x151)
@@ -6489,7 +6529,7 @@
 				IL_00d2: ldstr "\n"
 				IL_00d7: ldstr "repeat"
 				IL_00dc: ldloc.s 7
-				IL_00de: ldstr "test262/metadataParser:<TwoPhaseDummy_M30>:__js_call__:50"
+				IL_00de: ldstr "test262/metadataParser:<TwoPhaseDummy_M32>:__js_call__:50"
 				IL_00e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
 				IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -6783,7 +6823,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 673 (0x2a1)
@@ -6823,7 +6863,7 @@
 
 				IL_0037: ldarg.3
 				IL_0038: ldstr "index"
-				IL_003d: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:12"
+				IL_003d: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:12"
 				IL_0042: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
 				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6839,7 +6879,7 @@
 
 				IL_006a: ldarg.2
 				IL_006b: ldstr "length"
-				IL_0070: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:15"
+				IL_0070: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:15"
 				IL_0075: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
 				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6862,7 +6902,7 @@
 
 				IL_00b2: ldarg.3
 				IL_00b3: ldstr "index"
-				IL_00b8: ldstr "test262/metadataParser:<TwoPhaseDummy_M31>:__js_call__:24"
+				IL_00b8: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:24"
 				IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
 				IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7275,7 +7315,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 537 (0x219)
@@ -7306,7 +7346,7 @@
 
 			IL_001c: ldarg.3
 			IL_001d: ldstr "index"
-			IL_0022: ldstr "test262/metadataParser:<TwoPhaseDummy_M32>:__js_call__:3"
+			IL_0022: ldstr "test262/metadataParser:<TwoPhaseDummy_M34>:__js_call__:3"
 			IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7325,7 +7365,7 @@
 
 				IL_0050: ldarg.2
 				IL_0051: ldstr "length"
-				IL_0056: ldstr "test262/metadataParser:<TwoPhaseDummy_M32>:__js_call__:10"
+				IL_0056: ldstr "test262/metadataParser:<TwoPhaseDummy_M34>:__js_call__:10"
 				IL_005b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
 				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7425,7 +7465,7 @@
 
 			IL_0154: ldarg.2
 			IL_0155: ldstr "length"
-			IL_015a: ldstr "test262/metadataParser:<TwoPhaseDummy_M32>:__js_call__:44"
+			IL_015a: ldstr "test262/metadataParser:<TwoPhaseDummy_M34>:__js_call__:44"
 			IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
 			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7832,7 +7872,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 1268 (0x4f4)
@@ -7876,7 +7916,7 @@
 
 				IL_0022: ldarg.3
 				IL_0023: ldstr "index"
-				IL_0028: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:7"
+				IL_0028: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:7"
 				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
 				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7892,7 +7932,7 @@
 
 				IL_0055: ldarg.2
 				IL_0056: ldstr "length"
-				IL_005b: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:10"
+				IL_005b: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:10"
 				IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
 				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7915,7 +7955,7 @@
 
 				IL_009d: ldarg.3
 				IL_009e: ldstr "index"
-				IL_00a3: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:19"
+				IL_00a3: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:19"
 				IL_00a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_156
 				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8014,7 +8054,7 @@
 
 				IL_01a4: ldarg.3
 				IL_01a5: ldstr "index"
-				IL_01aa: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:59"
+				IL_01aa: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:59"
 				IL_01af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_157
 				IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8099,7 +8139,7 @@
 				IL_0295: ldloc.s 17
 				IL_0297: ldstr "exec"
 				IL_029c: ldloc.s 4
-				IL_029e: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:79"
+				IL_029e: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:79"
 				IL_02a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_158
 				IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -8123,7 +8163,7 @@
 
 				IL_02de: ldarg.3
 				IL_02df: ldstr "index"
-				IL_02e4: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:88"
+				IL_02e4: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:88"
 				IL_02e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
 				IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -8467,7 +8507,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 156 (0x9c)
@@ -8505,7 +8545,7 @@
 
 			IL_003f: ldstr "split"
 			IL_0044: ldstr "\n"
-			IL_0049: ldstr "test262/metadataParser:<TwoPhaseDummy_M34>:__js_call__:7"
+			IL_0049: ldstr "test262/metadataParser:<TwoPhaseDummy_M36>:__js_call__:7"
 			IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -8742,7 +8782,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 638 (0x27e)
@@ -9580,7 +9620,7 @@
 
 			IL_0022: ldstr "indexOf"
 			IL_0027: ldarg.2
-			IL_0028: ldstr "test262/metadataParser:<TwoPhaseDummy_M38>:__js_call__:4"
+			IL_0028: ldstr "test262/metadataParser:<TwoPhaseDummy_M40>:__js_call__:4"
 			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -10043,7 +10083,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 416 (0x1a0)
@@ -10444,7 +10484,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 229 (0xe5)
@@ -10853,7 +10893,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 1085 (0x43d)
@@ -11033,7 +11073,7 @@
 
 			IL_0175: ldarg.2
 			IL_0176: ldstr "phase"
-			IL_017b: ldstr "test262/metadataParser:<TwoPhaseDummy_M42>:__js_call__:81"
+			IL_017b: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:81"
 			IL_0180: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
 			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -11064,7 +11104,7 @@
 
 			IL_01ca: ldarg.2
 			IL_01cb: ldstr "type"
-			IL_01d0: ldstr "test262/metadataParser:<TwoPhaseDummy_M42>:__js_call__:91"
+			IL_01d0: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:91"
 			IL_01d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
 			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -11701,7 +11741,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 1692 (0x69c)
@@ -12261,7 +12301,7 @@
 
 			IL_053f: ldloc.s 13
 			IL_0541: ldstr "length"
-			IL_0546: ldstr "test262/metadataParser:<TwoPhaseDummy_M43>:__js_call__:271"
+			IL_0546: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:271"
 			IL_054b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
 			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -12676,7 +12716,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 954 (0x3ba)
@@ -12709,7 +12749,7 @@
 
 			IL_0024: ldarg.s execution
 			IL_0026: ldstr "isFixture"
-			IL_002b: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:6"
+			IL_002b: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:6"
 			IL_0030: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
 			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -12763,7 +12803,7 @@
 
 			IL_00aa: ldarg.s execution
 			IL_00ac: ldstr "isModule"
-			IL_00b1: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:28"
+			IL_00b1: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:28"
 			IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
 			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -12804,7 +12844,7 @@
 
 			IL_0117: ldarg.s execution
 			IL_0119: ldstr "isRaw"
-			IL_011e: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:42"
+			IL_011e: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:42"
 			IL_0123: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
 			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -12845,7 +12885,7 @@
 
 			IL_0184: ldarg.s execution
 			IL_0186: ldstr "requiresAsyncHarness"
-			IL_018b: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:56"
+			IL_018b: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:56"
 			IL_0190: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
 			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -12886,7 +12926,7 @@
 
 			IL_01f1: ldarg.s execution
 			IL_01f3: ldstr "requiresAgent"
-			IL_01f8: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:70"
+			IL_01f8: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:70"
 			IL_01fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_169
 			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -12927,7 +12967,7 @@
 
 			IL_025e: ldarg.s execution
 			IL_0260: ldstr "canBlock"
-			IL_0265: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:84"
+			IL_0265: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:84"
 			IL_026a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_170
 			IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -12960,7 +13000,7 @@
 
 			IL_02b7: ldarg.s execution
 			IL_02b9: ldstr "canBlock"
-			IL_02be: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:95"
+			IL_02be: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:95"
 			IL_02c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_171
 			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13012,7 +13052,7 @@
 
 			IL_0348: ldarg.3
 			IL_0349: ldstr "phase"
-			IL_034e: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:117"
+			IL_034e: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:117"
 			IL_0353: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_172
 			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13354,7 +13394,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 2290 (0x8f2)
@@ -13440,7 +13480,7 @@
 
 			IL_0055: ldloc.0
 			IL_0056: ldstr "filePath"
-			IL_005b: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:15"
+			IL_005b: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:15"
 			IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_173
 			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13618,7 +13658,7 @@
 
 			IL_021b: ldloc.s 7
 			IL_021d: ldstr "includes"
-			IL_0222: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:104"
+			IL_0222: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:104"
 			IL_0227: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_174
 			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13649,7 +13689,7 @@
 
 			IL_0274: ldloc.s 7
 			IL_0276: ldstr "flags"
-			IL_027b: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:112"
+			IL_027b: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:112"
 			IL_0280: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_175
 			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13680,7 +13720,7 @@
 
 			IL_02cd: ldloc.s 7
 			IL_02cf: ldstr "features"
-			IL_02d4: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:120"
+			IL_02d4: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:120"
 			IL_02d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_176
 			IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13711,7 +13751,7 @@
 
 			IL_0326: ldloc.s 7
 			IL_0328: ldstr "locale"
-			IL_032d: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:128"
+			IL_032d: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:128"
 			IL_0332: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_177
 			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13742,7 +13782,7 @@
 
 			IL_037f: ldloc.s 7
 			IL_0381: ldstr "defines"
-			IL_0386: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:136"
+			IL_0386: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:136"
 			IL_038b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_178
 			IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13773,7 +13813,7 @@
 
 			IL_03d8: ldloc.s 7
 			IL_03da: ldstr "negative"
-			IL_03df: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:144"
+			IL_03df: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:144"
 			IL_03e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_179
 			IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13889,7 +13929,7 @@
 
 			IL_0518: ldloc.s 19
 			IL_051a: ldstr "strictMode"
-			IL_051f: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:191"
+			IL_051f: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:191"
 			IL_0524: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_180
 			IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13968,7 +14008,7 @@
 
 			IL_05e1: ldloc.s 7
 			IL_05e3: ldstr "description"
-			IL_05e8: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:225"
+			IL_05e8: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:225"
 			IL_05ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_181
 			IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -13999,7 +14039,7 @@
 
 			IL_063a: ldloc.s 7
 			IL_063c: ldstr "info"
-			IL_0641: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:231"
+			IL_0641: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:231"
 			IL_0646: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_182
 			IL_064b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -14030,7 +14070,7 @@
 
 			IL_0693: ldloc.s 7
 			IL_0695: ldstr "esid"
-			IL_069a: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:237"
+			IL_069a: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:237"
 			IL_069f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_183
 			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -14061,7 +14101,7 @@
 
 			IL_06ec: ldloc.s 7
 			IL_06ee: ldstr "es5id"
-			IL_06f3: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:243"
+			IL_06f3: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:243"
 			IL_06f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_184
 			IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -14092,7 +14132,7 @@
 
 			IL_0745: ldloc.s 7
 			IL_0747: ldstr "es6id"
-			IL_074c: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:249"
+			IL_074c: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:249"
 			IL_0751: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_185
 			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -14123,7 +14163,7 @@
 
 			IL_079e: ldloc.s 7
 			IL_07a0: ldstr "author"
-			IL_07a5: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:255"
+			IL_07a5: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:255"
 			IL_07aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_186
 			IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -14377,7 +14417,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 37 00 00 02
+				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
 			// Code size: 70 (0x46)

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Async_TopLevelAwait_ImportedNamedFunction
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/AsyncGenerator/ExecutionTests.cs
+++ b/tests/Jroc.Tests/AsyncGenerator/ExecutionTests.cs
@@ -28,6 +28,9 @@ namespace Jroc.Tests.AsyncGenerator
         public Task AsyncGenerator_TryCatchFinally() { var testName = nameof(AsyncGenerator_TryCatchFinally); return ExecutionTest(testName); }
 
         [Fact]
+        public Task AsyncGenerator_AwaitRejectionTryCatchFinally() { var testName = nameof(AsyncGenerator_AwaitRejectionTryCatchFinally); return ExecutionTest(testName); }
+
+        [Fact]
         public Task AsyncGenerator_ExplicitReceiverAbi() { var testName = nameof(AsyncGenerator_ExplicitReceiverAbi); return ExecutionTest(testName); }
     }
 }

--- a/tests/Jroc.Tests/AsyncGenerator/GeneratorTests.cs
+++ b/tests/Jroc.Tests/AsyncGenerator/GeneratorTests.cs
@@ -28,6 +28,9 @@ namespace Jroc.Tests.AsyncGenerator
         public Task AsyncGenerator_TryCatchFinally() { var testName = nameof(AsyncGenerator_TryCatchFinally); return GenerateTest(testName); }
 
         [Fact]
+        public Task AsyncGenerator_AwaitRejectionTryCatchFinally() { var testName = nameof(AsyncGenerator_AwaitRejectionTryCatchFinally); return GenerateTest(testName); }
+
+        [Fact]
         public Task AsyncGenerator_ExplicitReceiverAbi() { var testName = nameof(AsyncGenerator_ExplicitReceiverAbi); return GenerateTest(testName); }
     }
 }

--- a/tests/Jroc.Tests/AsyncGenerator/JavaScript/AsyncGenerator_AwaitRejectionTryCatchFinally.js
+++ b/tests/Jroc.Tests/AsyncGenerator/JavaScript/AsyncGenerator_AwaitRejectionTryCatchFinally.js
@@ -1,0 +1,22 @@
+"use strict";
+
+async function* values() {
+  try {
+    yield "before";
+    await Promise.reject(new Error("await boom"));
+    yield "unreachable";
+  } catch (error) {
+    console.log("catch=" + error.message);
+    yield "caught";
+  } finally {
+    console.log("finally");
+  }
+
+  yield "after";
+}
+
+(async () => {
+  for await (const value of values()) {
+    console.log("value=" + value);
+  }
+})();

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/ExecutionTests.AsyncGenerator_AwaitRejectionTryCatchFinally.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/ExecutionTests.AsyncGenerator_AwaitRejectionTryCatchFinally.verified.txt
@@ -1,0 +1,5 @@
+value=before
+catch=await boom
+value=caught
+finally
+value=after

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_AwaitRejectionTryCatchFinally.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_AwaitRejectionTryCatchFinally.verified.txt
@@ -1,0 +1,1784 @@
+﻿// IL code: AsyncGenerator_AwaitRejectionTryCatchFinally
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi abstract sealed beforefieldinit AsyncGenerator_AwaitRejectionTryCatchFinally
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit Scripts
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit AsyncGenerator_AwaitRejectionTryCatchFinally
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig static 
+				void Run (
+					string[] args
+				) cil managed 
+			{
+				.param [1]
+					.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+						01 00 00 00
+					)
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldftn void Modules.AsyncGenerator_AwaitRejectionTryCatchFinally::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+				IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+				IL_000c: ldstr "AsyncGenerator_AwaitRejectionTryCatchFinally"
+				IL_0011: ldarg.0
+				IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+				IL_0017: ret
+			} // end of method AsyncGenerator_AwaitRejectionTryCatchFinally::Run
+
+		} // end of class AsyncGenerator_AwaitRejectionTryCatchFinally
+
+
+	} // end of class Scripts
+
+
+	// Methods
+	.method public hidebysig static 
+		void Run (
+			string[] args
+		) cil managed 
+	{
+		.param [1]
+			.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+				01 00 00 00
+			)
+		// Header size: 1
+		// Code size: 24 (0x18)
+		.maxstack 8
+
+		IL_0000: ldnull
+		IL_0001: ldftn void Modules.AsyncGenerator_AwaitRejectionTryCatchFinally::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_000c: ldstr "AsyncGenerator_AwaitRejectionTryCatchFinally"
+		IL_0011: ldarg.0
+		IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+		IL_0017: ret
+	} // end of method AsyncGenerator_AwaitRejectionTryCatchFinally::Run
+
+} // end of class AsyncGenerator_AwaitRejectionTryCatchFinally
+
+.class private auto ansi beforefieldinit Modules.AsyncGenerator_AwaitRejectionTryCatchFinally
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit values
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 1b 53 63 6f 70 65 20 5f 61 77 61 69 74 65
+				64 31 3d 7b 5f 61 77 61 69 74 65 64 31 7d 00 00
+			)
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L4C6
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L4C6::.ctor
+
+			} // end of class Block_L4C6
+
+			.class nested public auto ansi beforefieldinit Block_L8C18
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L8C18::.ctor
+
+			} // end of class Block_L8C18
+
+			.class nested public auto ansi beforefieldinit Block_L11C12
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L11C12::.ctor
+
+			} // end of class Block_L11C12
+
+
+			// Fields
+			.field public object _awaited1
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 22 (0x16)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.3
+				IL_0008: ldc.i4.0
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ldarg.0
+				IL_000f: ldarg.1
+				IL_0010: stfld object[] Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/FunctionObject::_transitionalScopes
+				IL_0015: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/FunctionObject::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values::__js_call__(object[], object)
+				IL_0010: ldarg.0
+				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+				IL_0016: ret
+			} // end of method FunctionObject::CallCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 1837 (0x72d)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/Scope,
+				[1] bool,
+				[2] object,
+				[3] bool,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.Error,
+				[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[7] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.0
+			IL_0002: ldelem.ref
+			IL_0003: isinst Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/Scope
+			IL_0008: dup
+			IL_0009: brtrue IL_0073
+
+			IL_000e: pop
+			IL_000f: newobj instance void Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/Scope::.ctor()
+			IL_0014: stloc.0
+			IL_0015: ldloc.0
+			IL_0016: ldarg.0
+			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
+			IL_001c: starg.s scopes
+			IL_001e: ldloc.0
+			IL_001f: ldnull
+			IL_0020: ldftn object Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values::__js_call__(object[], object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_002b: ldarg.0
+			IL_002c: ldtoken Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/FunctionObject
+			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0036: ldc.i4.0
+			IL_0037: newarr [System.Runtime]System.Object
+			IL_003c: call object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentArgumentsForGeneratedCallableOrFallback(class [System.Runtime]System.Type, object[])
+			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation::Create(object, object[], object[])
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_004b: ldloc.0
+			IL_004c: ldc.i4.1
+			IL_004d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parameterInitializationOnly
+			IL_0052: ldloc.0
+			IL_0053: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0058: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation::Resume()
+			IL_005d: pop
+			IL_005e: ldloc.0
+			IL_005f: ldc.i4.0
+			IL_0060: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parameterInitializationOnly
+			IL_0065: ldloc.0
+			IL_0066: ldc.i4.0
+			IL_0067: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_started
+			IL_006c: ldarg.0
+			IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorObject::.ctor(object[])
+			IL_0072: ret
+
+			IL_0073: stloc.0
+			IL_0074: ldloc.0
+			IL_0075: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_007a: brtrue IL_008b
+
+			IL_007f: ldloc.0
+			IL_0080: ldc.i4.7
+			IL_0081: newarr [System.Runtime]System.Object
+			IL_0086: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+
+			IL_008b: ldloc.0
+			IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0091: ldc.i4.0
+			IL_0092: bgt IL_00a3
+
+			IL_0097: ldloc.0
+			IL_0098: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_009d: ldc.i4.0
+			IL_009e: ble IL_00de
+
+			IL_00a3: ldloc.0
+			IL_00a4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00a9: dup
+			IL_00aa: ldc.i4.0
+			IL_00ab: ldelem.ref
+			IL_00ac: unbox.any [System.Runtime]System.Boolean
+			IL_00b1: stloc.1
+			IL_00b2: dup
+			IL_00b3: ldc.i4.1
+			IL_00b4: ldelem.ref
+			IL_00b5: stloc.2
+			IL_00b6: dup
+			IL_00b7: ldc.i4.2
+			IL_00b8: ldelem.ref
+			IL_00b9: unbox.any [System.Runtime]System.Boolean
+			IL_00be: stloc.3
+			IL_00bf: dup
+			IL_00c0: ldc.i4.3
+			IL_00c1: ldelem.ref
+			IL_00c2: stloc.s 4
+			IL_00c4: dup
+			IL_00c5: ldc.i4.4
+			IL_00c6: ldelem.ref
+			IL_00c7: castclass [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00cc: stloc.s 5
+			IL_00ce: dup
+			IL_00cf: ldc.i4.5
+			IL_00d0: ldelem.ref
+			IL_00d1: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+			IL_00d6: stloc.s 6
+			IL_00d8: dup
+			IL_00d9: ldc.i4.6
+			IL_00da: ldelem.ref
+			IL_00db: stloc.s 7
+			IL_00dd: pop
+
+			IL_00de: ldloc.0
+			IL_00df: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00e4: switch (IL_00fd, IL_03d5, IL_0554, IL_0585, IL_02d2)
+
+			IL_00fd: ldloc.0
+			IL_00fe: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_0103: switch (IL_011c, IL_01dd, IL_034a, IL_04c9, IL_0687)
+
+			IL_011c: ldloc.0
+			IL_011d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parametersInitialized
+			IL_0122: stloc.1
+			IL_0123: ldloc.1
+			IL_0124: brtrue IL_0146
+
+			IL_0129: ldloc.0
+			IL_012a: ldc.i4.1
+			IL_012b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parametersInitialized
+			IL_0130: ldloc.0
+			IL_0131: ldc.i4.1
+			IL_0132: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_started
+			IL_0137: ldloc.0
+			IL_0138: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parameterInitializationOnly
+			IL_013d: stloc.3
+			IL_013e: ldloc.3
+			IL_013f: brfalse IL_0146
+
+			IL_0144: ldnull
+			IL_0145: ret
+
+			IL_0146: ldloc.0
+			IL_0147: ldc.i4.0
+			IL_0148: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_014d: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0152: ldloc.0
+			IL_0153: ldc.i4.0
+			IL_0154: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0159: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_015e: ldloc.0
+			IL_015f: ldc.i4.0
+			IL_0160: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0165: ldloc.0
+			IL_0166: ldc.i4.0
+			IL_0167: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_016c: ldloc.0
+			IL_016d: ldc.i4.1
+			IL_016e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_0173: ldloc.0
+			IL_0174: ldc.i4.m1
+			IL_0175: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_017a: ldloc.0
+			IL_017b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0180: dup
+			IL_0181: ldc.i4.0
+			IL_0182: ldloc.1
+			IL_0183: box [System.Runtime]System.Boolean
+			IL_0188: stelem.ref
+			IL_0189: dup
+			IL_018a: ldc.i4.1
+			IL_018b: ldloc.2
+			IL_018c: stelem.ref
+			IL_018d: dup
+			IL_018e: ldc.i4.2
+			IL_018f: ldloc.3
+			IL_0190: box [System.Runtime]System.Boolean
+			IL_0195: stelem.ref
+			IL_0196: dup
+			IL_0197: ldc.i4.3
+			IL_0198: ldloc.s 4
+			IL_019a: stelem.ref
+			IL_019b: dup
+			IL_019c: ldc.i4.4
+			IL_019d: ldloc.s 5
+			IL_019f: stelem.ref
+			IL_01a0: dup
+			IL_01a1: ldc.i4.5
+			IL_01a2: ldloc.s 6
+			IL_01a4: stelem.ref
+			IL_01a5: dup
+			IL_01a6: ldc.i4.6
+			IL_01a7: ldloc.s 7
+			IL_01a9: stelem.ref
+			IL_01aa: pop
+			IL_01ab: ldloc.0
+			IL_01ac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_01b6: ldarg.0
+			IL_01b7: ldc.i4.1
+			IL_01b8: newarr [System.Runtime]System.Object
+			IL_01bd: dup
+			IL_01be: ldc.i4.0
+			IL_01bf: ldstr "before"
+			IL_01c4: ldc.i4.0
+			IL_01c5: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_01ca: stelem.ref
+			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01d0: pop
+			IL_01d1: ldloc.0
+			IL_01d2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01d7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01dc: ret
+
+			IL_01dd: ldloc.0
+			IL_01de: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_01e3: stloc.3
+			IL_01e4: ldloc.3
+			IL_01e5: brfalse IL_0220
+
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_01f0: stloc.s 4
+			IL_01f2: ldloc.0
+			IL_01f3: ldloc.s 4
+			IL_01f5: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_01fa: ldloc.0
+			IL_01fb: ldc.i4.1
+			IL_01fc: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0201: ldloc.0
+			IL_0202: ldc.i4.0
+			IL_0203: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0208: ldloc.0
+			IL_0209: ldc.i4.0
+			IL_020a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_020f: ldloc.0
+			IL_0210: ldc.i4.0
+			IL_0211: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0216: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_021b: br IL_0567
+
+			IL_0220: ldloc.0
+			IL_0221: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0226: stloc.3
+			IL_0227: ldloc.3
+			IL_0228: brfalse IL_0263
+
+			IL_022d: ldloc.0
+			IL_022e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_0233: stloc.s 4
+			IL_0235: ldloc.0
+			IL_0236: ldloc.s 4
+			IL_0238: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_023d: ldloc.0
+			IL_023e: ldc.i4.0
+			IL_023f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0244: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0249: ldloc.0
+			IL_024a: ldc.i4.1
+			IL_024b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0250: ldloc.0
+			IL_0251: ldc.i4.0
+			IL_0252: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0257: ldloc.0
+			IL_0258: ldc.i4.0
+			IL_0259: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_025e: br IL_03e8
+
+			IL_0263: ldstr "await boom"
+			IL_0268: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_026d: stloc.s 5
+			IL_026f: ldloc.s 5
+			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::reject(object)
+			IL_0276: stloc.s 4
+			IL_0278: ldloc.0
+			IL_0279: ldc.i4.4
+			IL_027a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_027f: ldloc.0
+			IL_0280: ldloc.s 4
+			IL_0282: ldarg.0
+			IL_0283: ldc.i4.1
+			IL_0284: ldloc.0
+			IL_0285: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_028a: ldc.i4.1
+			IL_028b: ldstr "_genPendingException"
+			IL_0290: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
+			IL_0295: ldloc.0
+			IL_0296: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_029b: dup
+			IL_029c: ldc.i4.0
+			IL_029d: ldloc.1
+			IL_029e: box [System.Runtime]System.Boolean
+			IL_02a3: stelem.ref
+			IL_02a4: dup
+			IL_02a5: ldc.i4.1
+			IL_02a6: ldloc.2
+			IL_02a7: stelem.ref
+			IL_02a8: dup
+			IL_02a9: ldc.i4.2
+			IL_02aa: ldloc.3
+			IL_02ab: box [System.Runtime]System.Boolean
+			IL_02b0: stelem.ref
+			IL_02b1: dup
+			IL_02b2: ldc.i4.3
+			IL_02b3: ldloc.s 4
+			IL_02b5: stelem.ref
+			IL_02b6: dup
+			IL_02b7: ldc.i4.4
+			IL_02b8: ldloc.s 5
+			IL_02ba: stelem.ref
+			IL_02bb: dup
+			IL_02bc: ldc.i4.5
+			IL_02bd: ldloc.s 6
+			IL_02bf: stelem.ref
+			IL_02c0: dup
+			IL_02c1: ldc.i4.6
+			IL_02c2: ldloc.s 7
+			IL_02c4: stelem.ref
+			IL_02c5: pop
+			IL_02c6: ldloc.0
+			IL_02c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02cc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02d1: ret
+
+			IL_02d2: ldloc.0
+			IL_02d3: ldfld object Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/Scope::_awaited1
+			IL_02d8: pop
+			IL_02d9: ldloc.0
+			IL_02da: ldc.i4.2
+			IL_02db: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_02e0: ldloc.0
+			IL_02e1: ldc.i4.m1
+			IL_02e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02e7: ldloc.0
+			IL_02e8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02ed: dup
+			IL_02ee: ldc.i4.0
+			IL_02ef: ldloc.1
+			IL_02f0: box [System.Runtime]System.Boolean
+			IL_02f5: stelem.ref
+			IL_02f6: dup
+			IL_02f7: ldc.i4.1
+			IL_02f8: ldloc.2
+			IL_02f9: stelem.ref
+			IL_02fa: dup
+			IL_02fb: ldc.i4.2
+			IL_02fc: ldloc.3
+			IL_02fd: box [System.Runtime]System.Boolean
+			IL_0302: stelem.ref
+			IL_0303: dup
+			IL_0304: ldc.i4.3
+			IL_0305: ldloc.s 4
+			IL_0307: stelem.ref
+			IL_0308: dup
+			IL_0309: ldc.i4.4
+			IL_030a: ldloc.s 5
+			IL_030c: stelem.ref
+			IL_030d: dup
+			IL_030e: ldc.i4.5
+			IL_030f: ldloc.s 6
+			IL_0311: stelem.ref
+			IL_0312: dup
+			IL_0313: ldc.i4.6
+			IL_0314: ldloc.s 7
+			IL_0316: stelem.ref
+			IL_0317: pop
+			IL_0318: ldloc.0
+			IL_0319: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_031e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0323: ldarg.0
+			IL_0324: ldc.i4.1
+			IL_0325: newarr [System.Runtime]System.Object
+			IL_032a: dup
+			IL_032b: ldc.i4.0
+			IL_032c: ldstr "unreachable"
+			IL_0331: ldc.i4.0
+			IL_0332: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0337: stelem.ref
+			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_033d: pop
+			IL_033e: ldloc.0
+			IL_033f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0344: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0349: ret
+
+			IL_034a: ldloc.0
+			IL_034b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0350: stloc.3
+			IL_0351: ldloc.3
+			IL_0352: brfalse IL_038d
+
+			IL_0357: ldloc.0
+			IL_0358: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_035d: stloc.s 4
+			IL_035f: ldloc.0
+			IL_0360: ldloc.s 4
+			IL_0362: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0367: ldloc.0
+			IL_0368: ldc.i4.1
+			IL_0369: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_036e: ldloc.0
+			IL_036f: ldc.i4.0
+			IL_0370: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0375: ldloc.0
+			IL_0376: ldc.i4.0
+			IL_0377: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_037c: ldloc.0
+			IL_037d: ldc.i4.0
+			IL_037e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0383: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0388: br IL_0567
+
+			IL_038d: ldloc.0
+			IL_038e: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0393: stloc.3
+			IL_0394: ldloc.3
+			IL_0395: brfalse IL_03d0
+
+			IL_039a: ldloc.0
+			IL_039b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_03a0: stloc.s 4
+			IL_03a2: ldloc.0
+			IL_03a3: ldloc.s 4
+			IL_03a5: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_03aa: ldloc.0
+			IL_03ab: ldc.i4.0
+			IL_03ac: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03b1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_03b6: ldloc.0
+			IL_03b7: ldc.i4.1
+			IL_03b8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_03bd: ldloc.0
+			IL_03be: ldc.i4.0
+			IL_03bf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_03c4: ldloc.0
+			IL_03c5: ldc.i4.0
+			IL_03c6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_03cb: br IL_03e8
+
+			IL_03d0: br IL_0567
+
+			IL_03d5: ldloc.0
+			IL_03d6: ldc.i4.1
+			IL_03d7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_03dc: ldloc.0
+			IL_03dd: ldc.i4.0
+			IL_03de: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_03e3: br IL_03e8
+
+			IL_03e8: ldloc.0
+			IL_03e9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_03ee: stloc.s 4
+			IL_03f0: ldloc.0
+			IL_03f1: ldc.i4.0
+			IL_03f2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_03f7: ldloc.0
+			IL_03f8: ldc.i4.0
+			IL_03f9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03fe: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0403: ldloc.s 4
+			IL_0405: stloc.2
+			IL_0406: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_040b: stloc.s 6
+			IL_040d: volatile.
+			IL_040f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0414: brfalse IL_0429
+
+			IL_0419: ldloc.2
+			IL_041a: ldstr "message"
+			IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0424: br IL_043e
+
+			IL_0429: ldloc.2
+			IL_042a: ldstr "message"
+			IL_042f: ldstr "AsyncGenerator_AwaitRejectionTryCatchFinally:<TwoPhaseDummy_M4>:__js_call__:94"
+			IL_0434: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_043e: stloc.s 4
+			IL_0440: ldstr "catch="
+			IL_0445: ldloc.s 4
+			IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_044c: stloc.s 7
+			IL_044e: ldloc.s 6
+			IL_0450: ldloc.s 7
+			IL_0452: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0457: pop
+			IL_0458: ldloc.0
+			IL_0459: ldc.i4.3
+			IL_045a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_045f: ldloc.0
+			IL_0460: ldc.i4.m1
+			IL_0461: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0466: ldloc.0
+			IL_0467: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_046c: dup
+			IL_046d: ldc.i4.0
+			IL_046e: ldloc.1
+			IL_046f: box [System.Runtime]System.Boolean
+			IL_0474: stelem.ref
+			IL_0475: dup
+			IL_0476: ldc.i4.1
+			IL_0477: ldloc.2
+			IL_0478: stelem.ref
+			IL_0479: dup
+			IL_047a: ldc.i4.2
+			IL_047b: ldloc.3
+			IL_047c: box [System.Runtime]System.Boolean
+			IL_0481: stelem.ref
+			IL_0482: dup
+			IL_0483: ldc.i4.3
+			IL_0484: ldloc.s 4
+			IL_0486: stelem.ref
+			IL_0487: dup
+			IL_0488: ldc.i4.4
+			IL_0489: ldloc.s 5
+			IL_048b: stelem.ref
+			IL_048c: dup
+			IL_048d: ldc.i4.5
+			IL_048e: ldloc.s 6
+			IL_0490: stelem.ref
+			IL_0491: dup
+			IL_0492: ldc.i4.6
+			IL_0493: ldloc.s 7
+			IL_0495: stelem.ref
+			IL_0496: pop
+			IL_0497: ldloc.0
+			IL_0498: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_049d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04a2: ldarg.0
+			IL_04a3: ldc.i4.1
+			IL_04a4: newarr [System.Runtime]System.Object
+			IL_04a9: dup
+			IL_04aa: ldc.i4.0
+			IL_04ab: ldstr "caught"
+			IL_04b0: ldc.i4.0
+			IL_04b1: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_04b6: stelem.ref
+			IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04bc: pop
+			IL_04bd: ldloc.0
+			IL_04be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04c3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04c8: ret
+
+			IL_04c9: ldloc.0
+			IL_04ca: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_04cf: stloc.3
+			IL_04d0: ldloc.3
+			IL_04d1: brfalse IL_050c
+
+			IL_04d6: ldloc.0
+			IL_04d7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_04dc: stloc.s 4
+			IL_04de: ldloc.0
+			IL_04df: ldloc.s 4
+			IL_04e1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_04e6: ldloc.0
+			IL_04e7: ldc.i4.1
+			IL_04e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_04ed: ldloc.0
+			IL_04ee: ldc.i4.0
+			IL_04ef: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_04f4: ldloc.0
+			IL_04f5: ldc.i4.0
+			IL_04f6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_04fb: ldloc.0
+			IL_04fc: ldc.i4.0
+			IL_04fd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0502: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0507: br IL_0567
+
+			IL_050c: ldloc.0
+			IL_050d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0512: stloc.3
+			IL_0513: ldloc.3
+			IL_0514: brfalse IL_054f
+
+			IL_0519: ldloc.0
+			IL_051a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_051f: stloc.s 4
+			IL_0521: ldloc.0
+			IL_0522: ldloc.s 4
+			IL_0524: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0529: ldloc.0
+			IL_052a: ldc.i4.0
+			IL_052b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0530: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0535: ldloc.0
+			IL_0536: ldc.i4.1
+			IL_0537: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_053c: ldloc.0
+			IL_053d: ldc.i4.0
+			IL_053e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0543: ldloc.0
+			IL_0544: ldc.i4.0
+			IL_0545: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_054a: br IL_0567
+
+			IL_054f: br IL_0567
+
+			IL_0554: ldloc.0
+			IL_0555: ldc.i4.1
+			IL_0556: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_055b: ldloc.0
+			IL_055c: ldc.i4.0
+			IL_055d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0562: br IL_0567
+
+			IL_0567: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
+			IL_056c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0571: stloc.s 6
+			IL_0573: ldloc.s 6
+			IL_0575: ldstr "finally"
+			IL_057a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_057f: pop
+			IL_0580: br IL_0598
+
+			IL_0585: ldloc.0
+			IL_0586: ldc.i4.1
+			IL_0587: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_058c: ldloc.0
+			IL_058d: ldc.i4.0
+			IL_058e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0593: br IL_0598
+
+			IL_0598: ldloc.0
+			IL_0599: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_059e: stloc.3
+			IL_059f: ldloc.3
+			IL_05a0: brfalse IL_05c4
+
+			IL_05a5: ldloc.0
+			IL_05a6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_05ab: stloc.s 4
+			IL_05ad: ldloc.s 4
+			IL_05af: isinst [System.Runtime]System.Exception
+			IL_05b4: dup
+			IL_05b5: brtrue IL_05c3
+
+			IL_05ba: pop
+			IL_05bb: ldloc.s 4
+			IL_05bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_05c2: throw
+
+			IL_05c3: throw
+
+			IL_05c4: ldloc.0
+			IL_05c5: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_05ca: stloc.3
+			IL_05cb: ldloc.3
+			IL_05cc: brfalse IL_0616
+
+			IL_05d1: ldloc.0
+			IL_05d2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_05d7: stloc.s 4
+			IL_05d9: ldloc.0
+			IL_05da: ldc.i4.1
+			IL_05db: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_05e0: ldloc.0
+			IL_05e1: ldc.i4.m1
+			IL_05e2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05e7: ldloc.0
+			IL_05e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_05f2: ldarg.0
+			IL_05f3: ldc.i4.1
+			IL_05f4: newarr [System.Runtime]System.Object
+			IL_05f9: dup
+			IL_05fa: ldc.i4.0
+			IL_05fb: ldloc.s 4
+			IL_05fd: ldc.i4.1
+			IL_05fe: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0603: stelem.ref
+			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0609: pop
+			IL_060a: ldloc.0
+			IL_060b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0610: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0615: ret
+
+			IL_0616: ldloc.0
+			IL_0617: ldc.i4.4
+			IL_0618: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_061d: ldloc.0
+			IL_061e: ldc.i4.m1
+			IL_061f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0624: ldloc.0
+			IL_0625: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_062a: dup
+			IL_062b: ldc.i4.0
+			IL_062c: ldloc.1
+			IL_062d: box [System.Runtime]System.Boolean
+			IL_0632: stelem.ref
+			IL_0633: dup
+			IL_0634: ldc.i4.1
+			IL_0635: ldloc.2
+			IL_0636: stelem.ref
+			IL_0637: dup
+			IL_0638: ldc.i4.2
+			IL_0639: ldloc.3
+			IL_063a: box [System.Runtime]System.Boolean
+			IL_063f: stelem.ref
+			IL_0640: dup
+			IL_0641: ldc.i4.3
+			IL_0642: ldloc.s 4
+			IL_0644: stelem.ref
+			IL_0645: dup
+			IL_0646: ldc.i4.4
+			IL_0647: ldloc.s 5
+			IL_0649: stelem.ref
+			IL_064a: dup
+			IL_064b: ldc.i4.5
+			IL_064c: ldloc.s 6
+			IL_064e: stelem.ref
+			IL_064f: dup
+			IL_0650: ldc.i4.6
+			IL_0651: ldloc.s 7
+			IL_0653: stelem.ref
+			IL_0654: pop
+			IL_0655: ldloc.0
+			IL_0656: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_065b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0660: ldarg.0
+			IL_0661: ldc.i4.1
+			IL_0662: newarr [System.Runtime]System.Object
+			IL_0667: dup
+			IL_0668: ldc.i4.0
+			IL_0669: ldstr "after"
+			IL_066e: ldc.i4.0
+			IL_066f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0674: stelem.ref
+			IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_067a: pop
+			IL_067b: ldloc.0
+			IL_067c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0681: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0686: ret
+
+			IL_0687: ldloc.0
+			IL_0688: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_068d: brfalse IL_06d3
+
+			IL_0692: ldloc.0
+			IL_0693: ldc.i4.1
+			IL_0694: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_0699: ldloc.0
+			IL_069a: ldc.i4.m1
+			IL_069b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06a0: ldloc.0
+			IL_06a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06ab: ldarg.0
+			IL_06ac: ldc.i4.1
+			IL_06ad: newarr [System.Runtime]System.Object
+			IL_06b2: dup
+			IL_06b3: ldc.i4.0
+			IL_06b4: ldloc.0
+			IL_06b5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_06ba: ldc.i4.1
+			IL_06bb: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_06c0: stelem.ref
+			IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06c6: pop
+			IL_06c7: ldloc.0
+			IL_06c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06cd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06d2: ret
+
+			IL_06d3: ldloc.0
+			IL_06d4: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_06d9: brfalse IL_06f1
+
+			IL_06de: ldloc.0
+			IL_06df: ldc.i4.0
+			IL_06e0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_06e5: ldloc.0
+			IL_06e6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_06eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_06f0: throw
+
+			IL_06f1: ldloc.0
+			IL_06f2: ldc.i4.1
+			IL_06f3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_06f8: ldloc.0
+			IL_06f9: ldc.i4.m1
+			IL_06fa: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06ff: ldloc.0
+			IL_0700: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0705: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_070a: ldarg.0
+			IL_070b: ldc.i4.1
+			IL_070c: newarr [System.Runtime]System.Object
+			IL_0711: dup
+			IL_0712: ldc.i4.0
+			IL_0713: ldnull
+			IL_0714: ldc.i4.1
+			IL_0715: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_071a: stelem.ref
+			IL_071b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0720: pop
+			IL_0721: ldloc.0
+			IL_0722: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0727: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_072c: ret
+		} // end of method values::__js_call__
+
+	} // end of class values
+
+	.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L18C2
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
+		{
+			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+				01 00 32 53 63 6f 70 65 20 5f 61 77 61 69 74 65
+				64 31 3d 7b 5f 61 77 61 69 74 65 64 31 7d 2c 20
+				5f 61 77 61 69 74 65 64 32 3d 7b 5f 61 77 61 69
+				74 65 64 32 7d 00 00
+			)
+			// Fields
+			.field public object _awaited1
+			.field public object _awaited2
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_ForOf_L19C13
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L19C38
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L19C38::.ctor
+
+			} // end of class Block_L19C38
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_ForOf_L19C13::.ctor
+
+		} // end of class Scope_ForOf_L19C13
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope _environment0_AsyncGenerator_AwaitRejectionTryCatchFinally
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/FunctionObject::_environment0_AsyncGenerator_AwaitRejectionTryCatchFinally
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/FunctionObject::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/FunctionObject::_transitionalScopes
+				IL_0006: ldnull
+				IL_0007: call object Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2::__js_call__(object[], object)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
+				IL_0011: ret
+			} // end of method FunctionObject::CallCoreAsync
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object[] scopes,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 02 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 939 (0x3ab)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/Scope,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator,
+				[2] bool,
+				[3] bool,
+				[4] object,
+				[5] bool,
+				[6] bool,
+				[7] object[],
+				[8] object,
+				[9] bool,
+				[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[11] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldc.i4.0
+			IL_0002: ldelem.ref
+			IL_0003: isinst Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/Scope
+			IL_0008: dup
+			IL_0009: brtrue IL_0050
+
+			IL_000e: pop
+			IL_000f: newobj instance void Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/Scope::.ctor()
+			IL_0014: stloc.0
+			IL_0015: ldloc.0
+			IL_0016: ldarg.0
+			IL_0017: call object[] [JavaScriptRuntime]JavaScriptRuntime.Promise::PrependScopeToArray(object, object[])
+			IL_001c: starg.s scopes
+			IL_001e: ldloc.0
+			IL_001f: ldnull
+			IL_0020: ldftn object Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2::__js_call__(object[], object)
+			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_002b: ldarg.0
+			IL_002c: ldtoken Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/FunctionObject
+			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+			IL_0036: ldc.i4.0
+			IL_0037: newarr [System.Runtime]System.Object
+			IL_003c: call object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentArgumentsForGeneratedCallableOrFallback(class [System.Runtime]System.Type, object[])
+			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation::Create(object, object[], object[])
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_004b: br IL_0051
+
+			IL_0050: stloc.0
+
+			IL_0051: ldloc.0
+			IL_0052: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0057: brtrue IL_0069
+
+			IL_005c: ldloc.0
+			IL_005d: ldc.i4.s 11
+			IL_005f: newarr [System.Runtime]System.Object
+			IL_0064: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+
+			IL_0069: ldloc.0
+			IL_006a: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_006f: ldc.i4.0
+			IL_0070: ble IL_00da
+
+			IL_0075: ldloc.0
+			IL_0076: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_007b: dup
+			IL_007c: ldc.i4.0
+			IL_007d: ldelem.ref
+			IL_007e: castclass [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator
+			IL_0083: stloc.1
+			IL_0084: dup
+			IL_0085: ldc.i4.1
+			IL_0086: ldelem.ref
+			IL_0087: unbox.any [System.Runtime]System.Boolean
+			IL_008c: stloc.2
+			IL_008d: dup
+			IL_008e: ldc.i4.2
+			IL_008f: ldelem.ref
+			IL_0090: unbox.any [System.Runtime]System.Boolean
+			IL_0095: stloc.3
+			IL_0096: dup
+			IL_0097: ldc.i4.3
+			IL_0098: ldelem.ref
+			IL_0099: stloc.s 4
+			IL_009b: dup
+			IL_009c: ldc.i4.4
+			IL_009d: ldelem.ref
+			IL_009e: unbox.any [System.Runtime]System.Boolean
+			IL_00a3: stloc.s 5
+			IL_00a5: dup
+			IL_00a6: ldc.i4.5
+			IL_00a7: ldelem.ref
+			IL_00a8: unbox.any [System.Runtime]System.Boolean
+			IL_00ad: stloc.s 6
+			IL_00af: dup
+			IL_00b0: ldc.i4.6
+			IL_00b1: ldelem.ref
+			IL_00b2: castclass object[]
+			IL_00b7: stloc.s 7
+			IL_00b9: dup
+			IL_00ba: ldc.i4.7
+			IL_00bb: ldelem.ref
+			IL_00bc: stloc.s 8
+			IL_00be: dup
+			IL_00bf: ldc.i4.8
+			IL_00c0: ldelem.ref
+			IL_00c1: unbox.any [System.Runtime]System.Boolean
+			IL_00c6: stloc.s 9
+			IL_00c8: dup
+			IL_00c9: ldc.i4.s 9
+			IL_00cb: ldelem.ref
+			IL_00cc: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
+			IL_00d1: stloc.s 10
+			IL_00d3: dup
+			IL_00d4: ldc.i4.s 10
+			IL_00d6: ldelem.ref
+			IL_00d7: stloc.s 11
+			IL_00d9: pop
+
+			IL_00da: ldloc.0
+			IL_00db: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00e0: switch (IL_00f9, IL_022b, IL_02df, IL_01d6, IL_02d3)
+
+			IL_00f9: ldarg.0
+			IL_00fa: ldc.i4.1
+			IL_00fb: ldelem.ref
+			IL_00fc: castclass Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope
+			IL_0101: ldfld object Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope::values
+			IL_0106: ldc.i4.1
+			IL_0107: newarr [System.Runtime]System.Object
+			IL_010c: dup
+			IL_010d: ldc.i4.0
+			IL_010e: ldarg.0
+			IL_010f: ldc.i4.1
+			IL_0110: ldelem.ref
+			IL_0111: stelem.ref
+			IL_0112: stloc.s 7
+			IL_0114: ldloc.s 7
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_011b: stloc.s 8
+			IL_011d: ldloc.s 8
+			IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetAsyncIterator(object)
+			IL_0124: stloc.1
+			IL_0125: ldc.i4.0
+			IL_0126: stloc.2
+			IL_0127: ldc.i4.0
+			IL_0128: stloc.3
+			IL_0129: ldloc.0
+			IL_012a: ldc.i4.0
+			IL_012b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0130: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0135: ldloc.0
+			IL_0136: ldc.i4.0
+			IL_0137: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_013c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_0141: ldloc.0
+			IL_0142: ldc.i4.0
+			IL_0143: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0148: ldloc.0
+			IL_0149: ldc.i4.0
+			IL_014a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+
+			IL_014f: ldloc.1
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorNext(object)
+			IL_0155: stloc.s 8
+			IL_0157: ldloc.0
+			IL_0158: ldc.i4.3
+			IL_0159: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_015e: ldloc.0
+			IL_015f: ldloc.s 8
+			IL_0161: ldarg.0
+			IL_0162: ldc.i4.1
+			IL_0163: ldloc.0
+			IL_0164: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0169: ldc.i4.1
+			IL_016a: ldstr "_pendingException"
+			IL_016f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
+			IL_0174: ldloc.0
+			IL_0175: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_017a: dup
+			IL_017b: ldc.i4.0
+			IL_017c: ldloc.1
+			IL_017d: stelem.ref
+			IL_017e: dup
+			IL_017f: ldc.i4.1
+			IL_0180: ldloc.2
+			IL_0181: box [System.Runtime]System.Boolean
+			IL_0186: stelem.ref
+			IL_0187: dup
+			IL_0188: ldc.i4.2
+			IL_0189: ldloc.3
+			IL_018a: box [System.Runtime]System.Boolean
+			IL_018f: stelem.ref
+			IL_0190: dup
+			IL_0191: ldc.i4.3
+			IL_0192: ldloc.s 4
+			IL_0194: stelem.ref
+			IL_0195: dup
+			IL_0196: ldc.i4.4
+			IL_0197: ldloc.s 5
+			IL_0199: box [System.Runtime]System.Boolean
+			IL_019e: stelem.ref
+			IL_019f: dup
+			IL_01a0: ldc.i4.5
+			IL_01a1: ldloc.s 6
+			IL_01a3: box [System.Runtime]System.Boolean
+			IL_01a8: stelem.ref
+			IL_01a9: dup
+			IL_01aa: ldc.i4.6
+			IL_01ab: ldloc.s 7
+			IL_01ad: stelem.ref
+			IL_01ae: dup
+			IL_01af: ldc.i4.7
+			IL_01b0: ldloc.s 8
+			IL_01b2: stelem.ref
+			IL_01b3: dup
+			IL_01b4: ldc.i4.8
+			IL_01b5: ldloc.s 9
+			IL_01b7: box [System.Runtime]System.Boolean
+			IL_01bc: stelem.ref
+			IL_01bd: dup
+			IL_01be: ldc.i4.s 9
+			IL_01c0: ldloc.s 10
+			IL_01c2: stelem.ref
+			IL_01c3: dup
+			IL_01c4: ldc.i4.s 10
+			IL_01c6: ldloc.s 11
+			IL_01c8: stelem.ref
+			IL_01c9: pop
+			IL_01ca: ldloc.0
+			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01d0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01d5: ret
+
+			IL_01d6: ldloc.0
+			IL_01d7: ldfld object Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/Scope::_awaited1
+			IL_01dc: stloc.s 8
+			IL_01de: ldloc.s 8
+			IL_01e0: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+			IL_01e5: stloc.s 9
+			IL_01e7: ldloc.s 9
+			IL_01e9: brtrue IL_0224
+
+			IL_01ee: ldloc.s 8
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+			IL_01f5: stloc.s 8
+			IL_01f7: ldloc.s 8
+			IL_01f9: stloc.s 4
+			IL_01fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0200: stloc.s 10
+			IL_0202: ldstr "value="
+			IL_0207: ldloc.s 4
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_020e: stloc.s 11
+			IL_0210: ldloc.s 10
+			IL_0212: ldloc.s 11
+			IL_0214: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0219: pop
+			IL_021a: br IL_014f
+
+			IL_021f: br IL_023e
+
+			IL_0224: ldc.i4.1
+			IL_0225: stloc.2
+			IL_0226: br IL_023e
+
+			IL_022b: ldloc.0
+			IL_022c: ldc.i4.1
+			IL_022d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0232: ldloc.0
+			IL_0233: ldc.i4.0
+			IL_0234: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0239: br IL_023e
+
+			IL_023e: ldloc.2
+			IL_023f: brtrue IL_02da
+
+			IL_0244: ldloc.3
+			IL_0245: brtrue IL_02da
+
+			IL_024a: ldc.i4.1
+			IL_024b: stloc.3
+			IL_024c: ldloc.1
+			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::AsyncIteratorClose(object)
+			IL_0252: stloc.s 8
+			IL_0254: ldloc.0
+			IL_0255: ldc.i4.4
+			IL_0256: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_025b: ldloc.0
+			IL_025c: ldloc.s 8
+			IL_025e: ldarg.0
+			IL_025f: ldc.i4.2
+			IL_0260: ldloc.0
+			IL_0261: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0266: ldc.i4.2
+			IL_0267: ldstr "_pendingException"
+			IL_026c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
+			IL_0271: ldloc.0
+			IL_0272: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0277: dup
+			IL_0278: ldc.i4.0
+			IL_0279: ldloc.1
+			IL_027a: stelem.ref
+			IL_027b: dup
+			IL_027c: ldc.i4.1
+			IL_027d: ldloc.2
+			IL_027e: box [System.Runtime]System.Boolean
+			IL_0283: stelem.ref
+			IL_0284: dup
+			IL_0285: ldc.i4.2
+			IL_0286: ldloc.3
+			IL_0287: box [System.Runtime]System.Boolean
+			IL_028c: stelem.ref
+			IL_028d: dup
+			IL_028e: ldc.i4.3
+			IL_028f: ldloc.s 4
+			IL_0291: stelem.ref
+			IL_0292: dup
+			IL_0293: ldc.i4.4
+			IL_0294: ldloc.s 5
+			IL_0296: box [System.Runtime]System.Boolean
+			IL_029b: stelem.ref
+			IL_029c: dup
+			IL_029d: ldc.i4.5
+			IL_029e: ldloc.s 6
+			IL_02a0: box [System.Runtime]System.Boolean
+			IL_02a5: stelem.ref
+			IL_02a6: dup
+			IL_02a7: ldc.i4.6
+			IL_02a8: ldloc.s 7
+			IL_02aa: stelem.ref
+			IL_02ab: dup
+			IL_02ac: ldc.i4.7
+			IL_02ad: ldloc.s 8
+			IL_02af: stelem.ref
+			IL_02b0: dup
+			IL_02b1: ldc.i4.8
+			IL_02b2: ldloc.s 9
+			IL_02b4: box [System.Runtime]System.Boolean
+			IL_02b9: stelem.ref
+			IL_02ba: dup
+			IL_02bb: ldc.i4.s 9
+			IL_02bd: ldloc.s 10
+			IL_02bf: stelem.ref
+			IL_02c0: dup
+			IL_02c1: ldc.i4.s 10
+			IL_02c3: ldloc.s 11
+			IL_02c5: stelem.ref
+			IL_02c6: pop
+			IL_02c7: ldloc.0
+			IL_02c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02cd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02d2: ret
+
+			IL_02d3: ldloc.0
+			IL_02d4: ldfld object Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/Scope::_awaited2
+			IL_02d9: pop
+
+			IL_02da: br IL_02f2
+
+			IL_02df: ldloc.0
+			IL_02e0: ldc.i4.1
+			IL_02e1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02e6: ldloc.0
+			IL_02e7: ldc.i4.0
+			IL_02e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02ed: br IL_02f2
+
+			IL_02f2: ldloc.0
+			IL_02f3: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02f8: stloc.s 5
+			IL_02fa: ldloc.s 5
+			IL_02fc: brfalse IL_0339
+
+			IL_0301: ldloc.0
+			IL_0302: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0307: stloc.s 8
+			IL_0309: ldloc.0
+			IL_030a: ldc.i4.m1
+			IL_030b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0310: ldloc.0
+			IL_0311: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0316: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_031b: ldarg.0
+			IL_031c: ldc.i4.1
+			IL_031d: newarr [System.Runtime]System.Object
+			IL_0322: dup
+			IL_0323: ldc.i4.0
+			IL_0324: ldloc.s 8
+			IL_0326: stelem.ref
+			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_032c: pop
+			IL_032d: ldloc.0
+			IL_032e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0333: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0338: ret
+
+			IL_0339: ldloc.0
+			IL_033a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_033f: stloc.s 6
+			IL_0341: ldloc.s 6
+			IL_0343: brfalse IL_0380
+
+			IL_0348: ldloc.0
+			IL_0349: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_034e: stloc.s 8
+			IL_0350: ldloc.0
+			IL_0351: ldc.i4.m1
+			IL_0352: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0357: ldloc.0
+			IL_0358: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_035d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0362: ldarg.0
+			IL_0363: ldc.i4.1
+			IL_0364: newarr [System.Runtime]System.Object
+			IL_0369: dup
+			IL_036a: ldc.i4.0
+			IL_036b: ldloc.s 8
+			IL_036d: stelem.ref
+			IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0373: pop
+			IL_0374: ldloc.0
+			IL_0375: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_037a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_037f: ret
+
+			IL_0380: ldloc.0
+			IL_0381: ldc.i4.m1
+			IL_0382: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0387: ldloc.0
+			IL_0388: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_038d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0392: ldarg.0
+			IL_0393: ldc.i4.1
+			IL_0394: newarr [System.Runtime]System.Object
+			IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_039e: pop
+			IL_039f: ldloc.0
+			IL_03a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03a5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03aa: ret
+		} // end of method ArrowFunction_L18C2::__js_call__
+
+	} // end of class ArrowFunction_L18C2
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 15 53 63 6f 70 65 20 76 61 6c 75 65 73 3d
+			7b 76 61 6c 75 65 73 7d 00 00
+		)
+		// Fields
+		.field public object values
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 115 (0x73)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope,
+			[1] object[],
+			[2] class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/FunctionObject,
+			[3] class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/FunctionObject
+		)
+
+		IL_0000: newobj instance void Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldloc.0
+		IL_000f: stelem.ref
+		IL_0010: stloc.1
+		IL_0011: ldloc.1
+		IL_0012: newobj instance void Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/FunctionObject::.ctor(object[])
+		IL_0017: ldc.i4.0
+		IL_0018: conv.r8
+		IL_0019: ldstr "values"
+		IL_001e: ldc.i4.1
+		IL_001f: ldc.i4.1
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
+		IL_002a: castclass Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/values/FunctionObject
+		IL_002f: stloc.2
+		IL_0030: ldloc.0
+		IL_0031: ldloc.2
+		IL_0032: stfld object Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope::values
+		IL_0037: nop
+		IL_0038: nop
+		IL_0039: ldc.i4.1
+		IL_003a: newarr [System.Runtime]System.Object
+		IL_003f: dup
+		IL_0040: ldc.i4.0
+		IL_0041: ldloc.0
+		IL_0042: stelem.ref
+		IL_0043: stloc.1
+		IL_0044: ldloc.1
+		IL_0045: ldc.i4.0
+		IL_0046: ldelem.ref
+		IL_0047: castclass Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope
+		IL_004c: ldloc.1
+		IL_004d: newobj instance void Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/FunctionObject::.ctor(class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/Scope, object[])
+		IL_0052: ldc.i4.0
+		IL_0053: conv.r8
+		IL_0054: ldstr ""
+		IL_0059: ldc.i4.0
+		IL_005a: ldc.i4.0
+		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally/ArrowFunction_L18C2/FunctionObject>(!!0)
+		IL_0065: stloc.3
+		IL_0066: ldloc.3
+		IL_0067: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0071: pop
+		IL_0072: ret
+	} // end of method AsyncGenerator_AwaitRejectionTryCatchFinally::__js_module_init__
+
+} // end of class Modules.AsyncGenerator_AwaitRejectionTryCatchFinally
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main (
+			string[] args
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: ldarg.0
+		IL_0001: call void AsyncGenerator_AwaitRejectionTryCatchFinally::Run(string[])
+		IL_0006: ret
+	} // end of method Program::Main
+
+} // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_8
+
+} // end of class Jroc.Generated.DynamicLookupSites
+

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ExplicitReceiverAbi.verified.txt
@@ -218,7 +218,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 1572 (0x624)
+			// Code size: 1610 (0x64a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_ExplicitReceiverAbi/g/Scope,
@@ -336,7 +336,7 @@
 
 			IL_00de: ldloc.0
 			IL_00df: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_00e4: switch (IL_00f9, IL_01ca, IL_031b, IL_0489)
+			IL_00e4: switch (IL_00f9, IL_01ca, IL_031b, IL_049c)
 
 			IL_00f9: ldloc.0
 			IL_00fa: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parametersInitialized
@@ -514,7 +514,7 @@
 			IL_0288: ldloc.0
 			IL_0289: ldc.i4.0
 			IL_028a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_028f: br IL_03e2
+			IL_028f: br IL_03f5
 
 			IL_0294: ldloc.s 5
 			IL_0296: stloc.2
@@ -659,259 +659,275 @@
 			IL_03d1: ldloc.0
 			IL_03d2: ldc.i4.0
 			IL_03d3: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_03d8: br IL_03e2
+			IL_03d8: br IL_03f5
 
-			IL_03dd: br IL_05e4
+			IL_03dd: br IL_060a
 
 			IL_03e2: ldloc.0
-			IL_03e3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_03e8: stloc.s 5
-			IL_03ea: ldloc.0
-			IL_03eb: ldc.i4.0
-			IL_03ec: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_03f1: ldloc.0
-			IL_03f2: ldc.i4.0
-			IL_03f3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03f8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_03fd: ldloc.s 5
-			IL_03ff: stloc.3
-			IL_0400: ldloc.3
-			IL_0401: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0406: stloc.s 8
-			IL_0408: ldstr "caught:"
-			IL_040d: ldloc.s 8
-			IL_040f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0414: stloc.s 8
-			IL_0416: ldloc.0
-			IL_0417: ldc.i4.3
-			IL_0418: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_041d: ldloc.0
-			IL_041e: ldc.i4.m1
-			IL_041f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0424: ldloc.0
-			IL_0425: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_042a: dup
-			IL_042b: ldc.i4.0
-			IL_042c: ldloc.1
-			IL_042d: box [System.Runtime]System.Boolean
-			IL_0432: stelem.ref
-			IL_0433: dup
-			IL_0434: ldc.i4.1
-			IL_0435: ldloc.2
-			IL_0436: stelem.ref
-			IL_0437: dup
-			IL_0438: ldc.i4.2
-			IL_0439: ldloc.3
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.3
-			IL_043d: ldloc.s 4
-			IL_043f: box [System.Runtime]System.Boolean
-			IL_0444: stelem.ref
-			IL_0445: dup
-			IL_0446: ldc.i4.4
-			IL_0447: ldloc.s 5
+			IL_03e3: ldc.i4.1
+			IL_03e4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_03e9: ldloc.0
+			IL_03ea: ldc.i4.0
+			IL_03eb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_03f0: br IL_03f5
+
+			IL_03f5: ldloc.0
+			IL_03f6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_03fb: stloc.s 5
+			IL_03fd: ldloc.0
+			IL_03fe: ldc.i4.0
+			IL_03ff: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0404: ldloc.0
+			IL_0405: ldc.i4.0
+			IL_0406: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_040b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0410: ldloc.s 5
+			IL_0412: stloc.3
+			IL_0413: ldloc.3
+			IL_0414: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0419: stloc.s 8
+			IL_041b: ldstr "caught:"
+			IL_0420: ldloc.s 8
+			IL_0422: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0427: stloc.s 8
+			IL_0429: ldloc.0
+			IL_042a: ldc.i4.3
+			IL_042b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_0430: ldloc.0
+			IL_0431: ldc.i4.m1
+			IL_0432: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0437: ldloc.0
+			IL_0438: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_043d: dup
+			IL_043e: ldc.i4.0
+			IL_043f: ldloc.1
+			IL_0440: box [System.Runtime]System.Boolean
+			IL_0445: stelem.ref
+			IL_0446: dup
+			IL_0447: ldc.i4.1
+			IL_0448: ldloc.2
 			IL_0449: stelem.ref
 			IL_044a: dup
-			IL_044b: ldc.i4.5
-			IL_044c: ldloc.s 6
-			IL_044e: stelem.ref
-			IL_044f: dup
-			IL_0450: ldc.i4.6
-			IL_0451: ldloc.s 7
-			IL_0453: stelem.ref
-			IL_0454: dup
-			IL_0455: ldc.i4.7
-			IL_0456: ldloc.s 8
-			IL_0458: stelem.ref
-			IL_0459: pop
-			IL_045a: ldloc.0
-			IL_045b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0460: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0465: ldarg.0
-			IL_0466: ldc.i4.1
-			IL_0467: newarr [System.Runtime]System.Object
-			IL_046c: dup
-			IL_046d: ldc.i4.0
-			IL_046e: ldloc.s 8
-			IL_0470: ldc.i4.0
-			IL_0471: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0476: stelem.ref
-			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_047c: pop
-			IL_047d: ldloc.0
-			IL_047e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0483: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0488: ret
+			IL_044b: ldc.i4.2
+			IL_044c: ldloc.3
+			IL_044d: stelem.ref
+			IL_044e: dup
+			IL_044f: ldc.i4.3
+			IL_0450: ldloc.s 4
+			IL_0452: box [System.Runtime]System.Boolean
+			IL_0457: stelem.ref
+			IL_0458: dup
+			IL_0459: ldc.i4.4
+			IL_045a: ldloc.s 5
+			IL_045c: stelem.ref
+			IL_045d: dup
+			IL_045e: ldc.i4.5
+			IL_045f: ldloc.s 6
+			IL_0461: stelem.ref
+			IL_0462: dup
+			IL_0463: ldc.i4.6
+			IL_0464: ldloc.s 7
+			IL_0466: stelem.ref
+			IL_0467: dup
+			IL_0468: ldc.i4.7
+			IL_0469: ldloc.s 8
+			IL_046b: stelem.ref
+			IL_046c: pop
+			IL_046d: ldloc.0
+			IL_046e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0473: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0478: ldarg.0
+			IL_0479: ldc.i4.1
+			IL_047a: newarr [System.Runtime]System.Object
+			IL_047f: dup
+			IL_0480: ldc.i4.0
+			IL_0481: ldloc.s 8
+			IL_0483: ldc.i4.0
+			IL_0484: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0489: stelem.ref
+			IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_048f: pop
+			IL_0490: ldloc.0
+			IL_0491: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0496: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_049b: ret
 
-			IL_0489: ldloc.0
-			IL_048a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_048f: stloc.s 4
-			IL_0491: ldloc.s 4
-			IL_0493: brfalse IL_0506
+			IL_049c: ldloc.0
+			IL_049d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_04a2: stloc.s 4
+			IL_04a4: ldloc.s 4
+			IL_04a6: brfalse IL_0519
 
-			IL_0498: ldloc.0
-			IL_0499: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_049e: stloc.s 5
-			IL_04a0: ldloc.0
-			IL_04a1: ldloc.s 5
-			IL_04a3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_04a8: ldloc.0
-			IL_04a9: ldc.i4.1
-			IL_04aa: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_04af: ldloc.0
-			IL_04b0: ldc.i4.0
-			IL_04b1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_04b6: ldloc.0
-			IL_04b7: ldc.i4.0
-			IL_04b8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_04bd: ldloc.0
-			IL_04be: ldc.i4.0
-			IL_04bf: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04c4: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_04ab: ldloc.0
+			IL_04ac: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_04b1: stloc.s 5
+			IL_04b3: ldloc.0
+			IL_04b4: ldloc.s 5
+			IL_04b6: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_04bb: ldloc.0
+			IL_04bc: ldc.i4.1
+			IL_04bd: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_04c2: ldloc.0
+			IL_04c3: ldc.i4.0
+			IL_04c4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
 			IL_04c9: ldloc.0
-			IL_04ca: ldc.i4.1
-			IL_04cb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_04ca: ldc.i4.0
+			IL_04cb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
 			IL_04d0: ldloc.0
-			IL_04d1: ldc.i4.m1
-			IL_04d2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04d7: ldloc.0
-			IL_04d8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_04e2: ldarg.0
-			IL_04e3: ldc.i4.1
-			IL_04e4: newarr [System.Runtime]System.Object
-			IL_04e9: dup
-			IL_04ea: ldc.i4.0
-			IL_04eb: ldloc.s 5
-			IL_04ed: ldc.i4.1
-			IL_04ee: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_04f3: stelem.ref
-			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_04f9: pop
-			IL_04fa: ldloc.0
-			IL_04fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0500: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0505: ret
+			IL_04d1: ldc.i4.0
+			IL_04d2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04d7: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_04dc: ldloc.0
+			IL_04dd: ldc.i4.1
+			IL_04de: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_04e3: ldloc.0
+			IL_04e4: ldc.i4.m1
+			IL_04e5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04ea: ldloc.0
+			IL_04eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04f5: ldarg.0
+			IL_04f6: ldc.i4.1
+			IL_04f7: newarr [System.Runtime]System.Object
+			IL_04fc: dup
+			IL_04fd: ldc.i4.0
+			IL_04fe: ldloc.s 5
+			IL_0500: ldc.i4.1
+			IL_0501: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0506: stelem.ref
+			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_050c: pop
+			IL_050d: ldloc.0
+			IL_050e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0513: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0518: ret
 
-			IL_0506: ldloc.0
-			IL_0507: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_050c: stloc.s 4
-			IL_050e: ldloc.s 4
-			IL_0510: brfalse IL_055d
+			IL_0519: ldloc.0
+			IL_051a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_051f: stloc.s 4
+			IL_0521: ldloc.s 4
+			IL_0523: brfalse IL_0570
 
-			IL_0515: ldloc.0
-			IL_0516: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_051b: stloc.s 5
-			IL_051d: ldloc.0
-			IL_051e: ldloc.s 5
-			IL_0520: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0525: ldloc.0
-			IL_0526: ldc.i4.0
-			IL_0527: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_052c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_0531: ldloc.0
-			IL_0532: ldc.i4.1
-			IL_0533: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0528: ldloc.0
+			IL_0529: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_052e: stloc.s 5
+			IL_0530: ldloc.0
+			IL_0531: ldloc.s 5
+			IL_0533: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
 			IL_0538: ldloc.0
 			IL_0539: ldc.i4.0
-			IL_053a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_053f: ldloc.0
-			IL_0540: ldc.i4.0
-			IL_0541: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0546: ldloc.s 5
-			IL_0548: isinst [System.Runtime]System.Exception
-			IL_054d: dup
-			IL_054e: brtrue IL_055c
+			IL_053a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_053f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0544: ldloc.0
+			IL_0545: ldc.i4.1
+			IL_0546: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_054b: ldloc.0
+			IL_054c: ldc.i4.0
+			IL_054d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0552: ldloc.0
+			IL_0553: ldc.i4.0
+			IL_0554: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0559: ldloc.s 5
+			IL_055b: isinst [System.Runtime]System.Exception
+			IL_0560: dup
+			IL_0561: brtrue IL_056f
 
-			IL_0553: pop
-			IL_0554: ldloc.s 5
-			IL_0556: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_055b: throw
+			IL_0566: pop
+			IL_0567: ldloc.s 5
+			IL_0569: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_056e: throw
 
-			IL_055c: throw
+			IL_056f: throw
 
-			IL_055d: br IL_05e4
+			IL_0570: br IL_060a
 
-			IL_0562: ldloc.0
-			IL_0563: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_0568: stloc.s 4
-			IL_056a: ldloc.s 4
-			IL_056c: brfalse IL_0590
+			IL_0575: ldloc.0
+			IL_0576: ldc.i4.1
+			IL_0577: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_057c: ldloc.0
+			IL_057d: ldc.i4.0
+			IL_057e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0583: br IL_0588
 
-			IL_0571: ldloc.0
-			IL_0572: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0577: stloc.s 5
-			IL_0579: ldloc.s 5
-			IL_057b: isinst [System.Runtime]System.Exception
-			IL_0580: dup
-			IL_0581: brtrue IL_058f
+			IL_0588: ldloc.0
+			IL_0589: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_058e: stloc.s 4
+			IL_0590: ldloc.s 4
+			IL_0592: brfalse IL_05b6
 
-			IL_0586: pop
-			IL_0587: ldloc.s 5
-			IL_0589: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_058e: throw
+			IL_0597: ldloc.0
+			IL_0598: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_059d: stloc.s 5
+			IL_059f: ldloc.s 5
+			IL_05a1: isinst [System.Runtime]System.Exception
+			IL_05a6: dup
+			IL_05a7: brtrue IL_05b5
 
-			IL_058f: throw
+			IL_05ac: pop
+			IL_05ad: ldloc.s 5
+			IL_05af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_05b4: throw
 
-			IL_0590: ldloc.0
-			IL_0591: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_0596: stloc.s 4
-			IL_0598: ldloc.s 4
-			IL_059a: brfalse IL_05e4
+			IL_05b5: throw
 
-			IL_059f: ldloc.0
-			IL_05a0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_05a5: stloc.s 5
-			IL_05a7: ldloc.0
-			IL_05a8: ldc.i4.1
-			IL_05a9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_05ae: ldloc.0
-			IL_05af: ldc.i4.m1
-			IL_05b0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05b5: ldloc.0
-			IL_05b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_05c0: ldarg.0
-			IL_05c1: ldc.i4.1
-			IL_05c2: newarr [System.Runtime]System.Object
-			IL_05c7: dup
-			IL_05c8: ldc.i4.0
-			IL_05c9: ldloc.s 5
-			IL_05cb: ldc.i4.1
-			IL_05cc: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_05d1: stelem.ref
-			IL_05d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05d7: pop
-			IL_05d8: ldloc.0
-			IL_05d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05de: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05e3: ret
+			IL_05b6: ldloc.0
+			IL_05b7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_05bc: stloc.s 4
+			IL_05be: ldloc.s 4
+			IL_05c0: brfalse IL_060a
 
-			IL_05e4: ldloc.0
-			IL_05e5: ldc.i4.1
-			IL_05e6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_05eb: ldloc.0
-			IL_05ec: ldc.i4.m1
-			IL_05ed: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05f2: ldloc.0
-			IL_05f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_05fd: ldarg.0
-			IL_05fe: ldc.i4.1
-			IL_05ff: newarr [System.Runtime]System.Object
-			IL_0604: dup
-			IL_0605: ldc.i4.0
-			IL_0606: ldstr "done-value"
+			IL_05c5: ldloc.0
+			IL_05c6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_05cb: stloc.s 5
+			IL_05cd: ldloc.0
+			IL_05ce: ldc.i4.1
+			IL_05cf: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_05d4: ldloc.0
+			IL_05d5: ldc.i4.m1
+			IL_05d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05db: ldloc.0
+			IL_05dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_05e6: ldarg.0
+			IL_05e7: ldc.i4.1
+			IL_05e8: newarr [System.Runtime]System.Object
+			IL_05ed: dup
+			IL_05ee: ldc.i4.0
+			IL_05ef: ldloc.s 5
+			IL_05f1: ldc.i4.1
+			IL_05f2: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_05f7: stelem.ref
+			IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05fd: pop
+			IL_05fe: ldloc.0
+			IL_05ff: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0604: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0609: ret
+
+			IL_060a: ldloc.0
 			IL_060b: ldc.i4.1
-			IL_060c: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0611: stelem.ref
-			IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0617: pop
+			IL_060c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_0611: ldloc.0
+			IL_0612: ldc.i4.m1
+			IL_0613: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0618: ldloc.0
 			IL_0619: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_061e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0623: ret
+			IL_061e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0623: ldarg.0
+			IL_0624: ldc.i4.1
+			IL_0625: newarr [System.Runtime]System.Object
+			IL_062a: dup
+			IL_062b: ldc.i4.0
+			IL_062c: ldstr "done-value"
+			IL_0631: ldc.i4.1
+			IL_0632: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0637: stelem.ref
+			IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_063d: pop
+			IL_063e: ldloc.0
+			IL_063f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0644: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0649: ret
 		} // end of method g::__js_call__
 
 	} // end of class g

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
@@ -218,7 +218,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 1042 (0x412)
+			// Code size: 1080 (0x438)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_Return/g/Scope,
@@ -431,7 +431,7 @@
 			IL_01e1: ldc.i4.0
 			IL_01e2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_01e7: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_01ec: br IL_033c
+			IL_01ec: br IL_034f
 
 			IL_01f1: ldloc.0
 			IL_01f2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
@@ -458,7 +458,7 @@
 			IL_0228: ldloc.0
 			IL_0229: ldc.i4.0
 			IL_022a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_022f: br IL_033c
+			IL_022f: br IL_034f
 
 			IL_0234: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0239: stloc.3
@@ -538,7 +538,7 @@
 			IL_02e4: ldc.i4.0
 			IL_02e5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_02ea: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_02ef: br IL_033c
+			IL_02ef: br IL_034f
 
 			IL_02f4: ldloc.0
 			IL_02f5: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
@@ -565,98 +565,114 @@
 			IL_032b: ldloc.0
 			IL_032c: ldc.i4.0
 			IL_032d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0332: br IL_033c
+			IL_0332: br IL_034f
 
-			IL_0337: br IL_033c
+			IL_0337: br IL_034f
 
-			IL_033c: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
-			IL_0341: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0346: stloc.3
-			IL_0347: ldloc.3
-			IL_0348: ldstr "finally"
-			IL_034d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0352: pop
-			IL_0353: br IL_0358
+			IL_033c: ldloc.0
+			IL_033d: ldc.i4.1
+			IL_033e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0343: ldloc.0
+			IL_0344: ldc.i4.0
+			IL_0345: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_034a: br IL_034f
 
-			IL_0358: ldloc.0
-			IL_0359: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_035e: stloc.2
-			IL_035f: ldloc.2
-			IL_0360: brfalse IL_0384
+			IL_034f: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
+			IL_0354: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0359: stloc.3
+			IL_035a: ldloc.3
+			IL_035b: ldstr "finally"
+			IL_0360: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0365: pop
+			IL_0366: br IL_037e
 
-			IL_0365: ldloc.0
-			IL_0366: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_036b: stloc.s 4
-			IL_036d: ldloc.s 4
-			IL_036f: isinst [System.Runtime]System.Exception
-			IL_0374: dup
-			IL_0375: brtrue IL_0383
+			IL_036b: ldloc.0
+			IL_036c: ldc.i4.1
+			IL_036d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0372: ldloc.0
+			IL_0373: ldc.i4.0
+			IL_0374: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0379: br IL_037e
 
-			IL_037a: pop
-			IL_037b: ldloc.s 4
-			IL_037d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0382: throw
+			IL_037e: ldloc.0
+			IL_037f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0384: stloc.2
+			IL_0385: ldloc.2
+			IL_0386: brfalse IL_03aa
 
-			IL_0383: throw
+			IL_038b: ldloc.0
+			IL_038c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0391: stloc.s 4
+			IL_0393: ldloc.s 4
+			IL_0395: isinst [System.Runtime]System.Exception
+			IL_039a: dup
+			IL_039b: brtrue IL_03a9
 
-			IL_0384: ldloc.0
-			IL_0385: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_038a: stloc.2
-			IL_038b: ldloc.2
-			IL_038c: brfalse IL_03d6
+			IL_03a0: pop
+			IL_03a1: ldloc.s 4
+			IL_03a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03a8: throw
 
-			IL_0391: ldloc.0
-			IL_0392: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_0397: stloc.s 4
-			IL_0399: ldloc.0
-			IL_039a: ldc.i4.1
-			IL_039b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_03a0: ldloc.0
-			IL_03a1: ldc.i4.m1
-			IL_03a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03a7: ldloc.0
-			IL_03a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03b2: ldarg.0
-			IL_03b3: ldc.i4.1
-			IL_03b4: newarr [System.Runtime]System.Object
-			IL_03b9: dup
-			IL_03ba: ldc.i4.0
-			IL_03bb: ldloc.s 4
-			IL_03bd: ldc.i4.1
-			IL_03be: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_03c3: stelem.ref
-			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_03c9: pop
-			IL_03ca: ldloc.0
-			IL_03cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03d0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_03d5: ret
+			IL_03a9: throw
 
-			IL_03d6: ldloc.0
-			IL_03d7: ldc.i4.1
-			IL_03d8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_03dd: ldloc.0
-			IL_03de: ldc.i4.m1
-			IL_03df: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03e4: ldloc.0
-			IL_03e5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03ef: ldarg.0
-			IL_03f0: ldc.i4.1
-			IL_03f1: newarr [System.Runtime]System.Object
-			IL_03f6: dup
-			IL_03f7: ldc.i4.0
-			IL_03f8: ldnull
-			IL_03f9: ldc.i4.1
-			IL_03fa: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_03ff: stelem.ref
-			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0405: pop
-			IL_0406: ldloc.0
-			IL_0407: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_040c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0411: ret
+			IL_03aa: ldloc.0
+			IL_03ab: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_03b0: stloc.2
+			IL_03b1: ldloc.2
+			IL_03b2: brfalse IL_03fc
+
+			IL_03b7: ldloc.0
+			IL_03b8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_03bd: stloc.s 4
+			IL_03bf: ldloc.0
+			IL_03c0: ldc.i4.1
+			IL_03c1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_03c6: ldloc.0
+			IL_03c7: ldc.i4.m1
+			IL_03c8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03cd: ldloc.0
+			IL_03ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_03d8: ldarg.0
+			IL_03d9: ldc.i4.1
+			IL_03da: newarr [System.Runtime]System.Object
+			IL_03df: dup
+			IL_03e0: ldc.i4.0
+			IL_03e1: ldloc.s 4
+			IL_03e3: ldc.i4.1
+			IL_03e4: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_03e9: stelem.ref
+			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_03ef: pop
+			IL_03f0: ldloc.0
+			IL_03f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03f6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03fb: ret
+
+			IL_03fc: ldloc.0
+			IL_03fd: ldc.i4.1
+			IL_03fe: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_0403: ldloc.0
+			IL_0404: ldc.i4.m1
+			IL_0405: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_040a: ldloc.0
+			IL_040b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0410: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0415: ldarg.0
+			IL_0416: ldc.i4.1
+			IL_0417: newarr [System.Runtime]System.Object
+			IL_041c: dup
+			IL_041d: ldc.i4.0
+			IL_041e: ldnull
+			IL_041f: ldc.i4.1
+			IL_0420: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0425: stelem.ref
+			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_042b: pop
+			IL_042c: ldloc.0
+			IL_042d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0432: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0437: ret
 		} // end of method g::__js_call__
 
 	} // end of class g

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
@@ -237,7 +237,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 1123 (0x463)
+			// Code size: 1180 (0x49c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_Throw/g/Scope,
@@ -345,7 +345,7 @@
 
 			IL_00d4: ldloc.0
 			IL_00d5: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_00da: switch (IL_00eb, IL_01c4, IL_0300)
+			IL_00da: switch (IL_00eb, IL_01c4, IL_0313)
 
 			IL_00eb: ldloc.0
 			IL_00ec: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parametersInitialized
@@ -468,7 +468,7 @@
 			IL_01f7: ldc.i4.0
 			IL_01f8: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_01fd: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0202: br IL_038b
+			IL_0202: br IL_03b1
 
 			IL_0207: ldloc.0
 			IL_0208: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
@@ -495,231 +495,255 @@
 			IL_023e: ldloc.0
 			IL_023f: ldc.i4.0
 			IL_0240: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0245: br IL_024f
+			IL_0245: br IL_0262
 
-			IL_024a: br IL_038b
+			IL_024a: br IL_03b1
 
 			IL_024f: ldloc.0
-			IL_0250: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0255: stloc.s 5
-			IL_0257: ldloc.0
-			IL_0258: ldc.i4.0
-			IL_0259: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_025e: ldloc.0
-			IL_025f: ldc.i4.0
-			IL_0260: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0265: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_026a: ldloc.s 5
-			IL_026c: stloc.2
-			IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0272: stloc.s 4
-			IL_0274: ldstr "catch="
-			IL_0279: ldloc.2
-			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_027f: stloc.s 6
-			IL_0281: ldloc.s 4
-			IL_0283: ldloc.s 6
-			IL_0285: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_028a: pop
-			IL_028b: ldloc.0
-			IL_028c: ldc.i4.2
-			IL_028d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_0292: ldloc.0
-			IL_0293: ldc.i4.m1
-			IL_0294: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0299: ldloc.0
-			IL_029a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_029f: dup
-			IL_02a0: ldc.i4.0
-			IL_02a1: ldloc.1
-			IL_02a2: box [System.Runtime]System.Boolean
-			IL_02a7: stelem.ref
-			IL_02a8: dup
-			IL_02a9: ldc.i4.1
-			IL_02aa: ldloc.2
-			IL_02ab: stelem.ref
-			IL_02ac: dup
-			IL_02ad: ldc.i4.2
-			IL_02ae: ldloc.3
-			IL_02af: box [System.Runtime]System.Boolean
-			IL_02b4: stelem.ref
-			IL_02b5: dup
-			IL_02b6: ldc.i4.3
-			IL_02b7: ldloc.s 4
-			IL_02b9: stelem.ref
-			IL_02ba: dup
-			IL_02bb: ldc.i4.4
-			IL_02bc: ldloc.s 5
+			IL_0250: ldc.i4.1
+			IL_0251: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0256: ldloc.0
+			IL_0257: ldc.i4.0
+			IL_0258: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_025d: br IL_0262
+
+			IL_0262: ldloc.0
+			IL_0263: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0268: stloc.s 5
+			IL_026a: ldloc.0
+			IL_026b: ldc.i4.0
+			IL_026c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0271: ldloc.0
+			IL_0272: ldc.i4.0
+			IL_0273: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0278: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_027d: ldloc.s 5
+			IL_027f: stloc.2
+			IL_0280: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0285: stloc.s 4
+			IL_0287: ldstr "catch="
+			IL_028c: ldloc.2
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0292: stloc.s 6
+			IL_0294: ldloc.s 4
+			IL_0296: ldloc.s 6
+			IL_0298: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_029d: pop
+			IL_029e: ldloc.0
+			IL_029f: ldc.i4.2
+			IL_02a0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_02a5: ldloc.0
+			IL_02a6: ldc.i4.m1
+			IL_02a7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02ac: ldloc.0
+			IL_02ad: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02b2: dup
+			IL_02b3: ldc.i4.0
+			IL_02b4: ldloc.1
+			IL_02b5: box [System.Runtime]System.Boolean
+			IL_02ba: stelem.ref
+			IL_02bb: dup
+			IL_02bc: ldc.i4.1
+			IL_02bd: ldloc.2
 			IL_02be: stelem.ref
 			IL_02bf: dup
-			IL_02c0: ldc.i4.5
-			IL_02c1: ldloc.s 6
-			IL_02c3: stelem.ref
-			IL_02c4: pop
-			IL_02c5: ldloc.0
-			IL_02c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_02d0: ldarg.0
-			IL_02d1: ldc.i4.1
-			IL_02d2: newarr [System.Runtime]System.Object
-			IL_02d7: dup
-			IL_02d8: ldc.i4.0
-			IL_02d9: ldc.r8 2
-			IL_02e2: box [System.Runtime]System.Double
-			IL_02e7: ldc.i4.0
-			IL_02e8: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02ed: stelem.ref
-			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02f3: pop
-			IL_02f4: ldloc.0
-			IL_02f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02fa: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02ff: ret
+			IL_02c0: ldc.i4.2
+			IL_02c1: ldloc.3
+			IL_02c2: box [System.Runtime]System.Boolean
+			IL_02c7: stelem.ref
+			IL_02c8: dup
+			IL_02c9: ldc.i4.3
+			IL_02ca: ldloc.s 4
+			IL_02cc: stelem.ref
+			IL_02cd: dup
+			IL_02ce: ldc.i4.4
+			IL_02cf: ldloc.s 5
+			IL_02d1: stelem.ref
+			IL_02d2: dup
+			IL_02d3: ldc.i4.5
+			IL_02d4: ldloc.s 6
+			IL_02d6: stelem.ref
+			IL_02d7: pop
+			IL_02d8: ldloc.0
+			IL_02d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02e3: ldarg.0
+			IL_02e4: ldc.i4.1
+			IL_02e5: newarr [System.Runtime]System.Object
+			IL_02ea: dup
+			IL_02eb: ldc.i4.0
+			IL_02ec: ldc.r8 2
+			IL_02f5: box [System.Runtime]System.Double
+			IL_02fa: ldc.i4.0
+			IL_02fb: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0300: stelem.ref
+			IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0306: pop
+			IL_0307: ldloc.0
+			IL_0308: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_030d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0312: ret
 
-			IL_0300: ldloc.0
-			IL_0301: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_0306: stloc.3
-			IL_0307: ldloc.3
-			IL_0308: brfalse IL_0343
+			IL_0313: ldloc.0
+			IL_0314: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0319: stloc.3
+			IL_031a: ldloc.3
+			IL_031b: brfalse IL_0356
 
-			IL_030d: ldloc.0
-			IL_030e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_0313: stloc.s 5
-			IL_0315: ldloc.0
-			IL_0316: ldloc.s 5
-			IL_0318: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_031d: ldloc.0
-			IL_031e: ldc.i4.1
-			IL_031f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_0324: ldloc.0
-			IL_0325: ldc.i4.0
-			IL_0326: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_032b: ldloc.0
-			IL_032c: ldc.i4.0
-			IL_032d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_0332: ldloc.0
-			IL_0333: ldc.i4.0
-			IL_0334: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0339: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_033e: br IL_038b
+			IL_0320: ldloc.0
+			IL_0321: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_0326: stloc.s 5
+			IL_0328: ldloc.0
+			IL_0329: ldloc.s 5
+			IL_032b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0330: ldloc.0
+			IL_0331: ldc.i4.1
+			IL_0332: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0337: ldloc.0
+			IL_0338: ldc.i4.0
+			IL_0339: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_033e: ldloc.0
+			IL_033f: ldc.i4.0
+			IL_0340: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0345: ldloc.0
+			IL_0346: ldc.i4.0
+			IL_0347: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_034c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0351: br IL_03b1
 
-			IL_0343: ldloc.0
-			IL_0344: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0349: stloc.3
-			IL_034a: ldloc.3
-			IL_034b: brfalse IL_0386
+			IL_0356: ldloc.0
+			IL_0357: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_035c: stloc.3
+			IL_035d: ldloc.3
+			IL_035e: brfalse IL_0399
 
-			IL_0350: ldloc.0
-			IL_0351: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_0356: stloc.s 5
-			IL_0358: ldloc.0
-			IL_0359: ldloc.s 5
-			IL_035b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0360: ldloc.0
-			IL_0361: ldc.i4.0
-			IL_0362: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0367: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_036c: ldloc.0
-			IL_036d: ldc.i4.1
-			IL_036e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0363: ldloc.0
+			IL_0364: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_0369: stloc.s 5
+			IL_036b: ldloc.0
+			IL_036c: ldloc.s 5
+			IL_036e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
 			IL_0373: ldloc.0
 			IL_0374: ldc.i4.0
-			IL_0375: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_037a: ldloc.0
-			IL_037b: ldc.i4.0
-			IL_037c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0381: br IL_038b
+			IL_0375: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_037a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_037f: ldloc.0
+			IL_0380: ldc.i4.1
+			IL_0381: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0386: ldloc.0
+			IL_0387: ldc.i4.0
+			IL_0388: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_038d: ldloc.0
+			IL_038e: ldc.i4.0
+			IL_038f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0394: br IL_03b1
 
-			IL_0386: br IL_038b
+			IL_0399: br IL_03b1
 
-			IL_038b: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
-			IL_0390: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0395: stloc.s 4
-			IL_0397: ldloc.s 4
-			IL_0399: ldstr "finally"
-			IL_039e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03a3: pop
-			IL_03a4: br IL_03a9
+			IL_039e: ldloc.0
+			IL_039f: ldc.i4.1
+			IL_03a0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_03a5: ldloc.0
+			IL_03a6: ldc.i4.0
+			IL_03a7: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_03ac: br IL_03b1
 
-			IL_03a9: ldloc.0
-			IL_03aa: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_03af: stloc.3
-			IL_03b0: ldloc.3
-			IL_03b1: brfalse IL_03d5
+			IL_03b1: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
+			IL_03b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03bb: stloc.s 4
+			IL_03bd: ldloc.s 4
+			IL_03bf: ldstr "finally"
+			IL_03c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03c9: pop
+			IL_03ca: br IL_03e2
 
-			IL_03b6: ldloc.0
-			IL_03b7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_03bc: stloc.s 5
-			IL_03be: ldloc.s 5
-			IL_03c0: isinst [System.Runtime]System.Exception
-			IL_03c5: dup
-			IL_03c6: brtrue IL_03d4
-
-			IL_03cb: pop
-			IL_03cc: ldloc.s 5
-			IL_03ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03d3: throw
-
-			IL_03d4: throw
-
-			IL_03d5: ldloc.0
-			IL_03d6: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_03db: stloc.3
-			IL_03dc: ldloc.3
-			IL_03dd: brfalse IL_0427
+			IL_03cf: ldloc.0
+			IL_03d0: ldc.i4.1
+			IL_03d1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_03d6: ldloc.0
+			IL_03d7: ldc.i4.0
+			IL_03d8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_03dd: br IL_03e2
 
 			IL_03e2: ldloc.0
-			IL_03e3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_03e8: stloc.s 5
-			IL_03ea: ldloc.0
-			IL_03eb: ldc.i4.1
-			IL_03ec: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_03f1: ldloc.0
-			IL_03f2: ldc.i4.m1
-			IL_03f3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03f8: ldloc.0
-			IL_03f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0403: ldarg.0
-			IL_0404: ldc.i4.1
-			IL_0405: newarr [System.Runtime]System.Object
-			IL_040a: dup
-			IL_040b: ldc.i4.0
-			IL_040c: ldloc.s 5
-			IL_040e: ldc.i4.1
-			IL_040f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0414: stelem.ref
-			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_041a: pop
-			IL_041b: ldloc.0
-			IL_041c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0421: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0426: ret
+			IL_03e3: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_03e8: stloc.3
+			IL_03e9: ldloc.3
+			IL_03ea: brfalse IL_040e
 
-			IL_0427: ldloc.0
-			IL_0428: ldc.i4.1
-			IL_0429: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_042e: ldloc.0
-			IL_042f: ldc.i4.m1
-			IL_0430: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0435: ldloc.0
-			IL_0436: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_043b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0440: ldarg.0
-			IL_0441: ldc.i4.1
-			IL_0442: newarr [System.Runtime]System.Object
-			IL_0447: dup
-			IL_0448: ldc.i4.0
-			IL_0449: ldnull
-			IL_044a: ldc.i4.1
-			IL_044b: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0450: stelem.ref
-			IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0456: pop
-			IL_0457: ldloc.0
-			IL_0458: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_045d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0462: ret
+			IL_03ef: ldloc.0
+			IL_03f0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_03f5: stloc.s 5
+			IL_03f7: ldloc.s 5
+			IL_03f9: isinst [System.Runtime]System.Exception
+			IL_03fe: dup
+			IL_03ff: brtrue IL_040d
+
+			IL_0404: pop
+			IL_0405: ldloc.s 5
+			IL_0407: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_040c: throw
+
+			IL_040d: throw
+
+			IL_040e: ldloc.0
+			IL_040f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0414: stloc.3
+			IL_0415: ldloc.3
+			IL_0416: brfalse IL_0460
+
+			IL_041b: ldloc.0
+			IL_041c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0421: stloc.s 5
+			IL_0423: ldloc.0
+			IL_0424: ldc.i4.1
+			IL_0425: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_042a: ldloc.0
+			IL_042b: ldc.i4.m1
+			IL_042c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0431: ldloc.0
+			IL_0432: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0437: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_043c: ldarg.0
+			IL_043d: ldc.i4.1
+			IL_043e: newarr [System.Runtime]System.Object
+			IL_0443: dup
+			IL_0444: ldc.i4.0
+			IL_0445: ldloc.s 5
+			IL_0447: ldc.i4.1
+			IL_0448: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_044d: stelem.ref
+			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0453: pop
+			IL_0454: ldloc.0
+			IL_0455: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_045a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_045f: ret
+
+			IL_0460: ldloc.0
+			IL_0461: ldc.i4.1
+			IL_0462: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_0467: ldloc.0
+			IL_0468: ldc.i4.m1
+			IL_0469: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_046e: ldloc.0
+			IL_046f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0474: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0479: ldarg.0
+			IL_047a: ldc.i4.1
+			IL_047b: newarr [System.Runtime]System.Object
+			IL_0480: dup
+			IL_0481: ldc.i4.0
+			IL_0482: ldnull
+			IL_0483: ldc.i4.1
+			IL_0484: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0489: stelem.ref
+			IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_048f: pop
+			IL_0490: ldloc.0
+			IL_0491: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0496: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_049b: ret
 		} // end of method g::__js_call__
 
 	} // end of class g

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
@@ -244,7 +244,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 1663 (0x67f)
+			// Code size: 1720 (0x6b8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_TryCatchFinally/g/Scope,
@@ -352,7 +352,7 @@
 
 			IL_00d4: ldloc.0
 			IL_00d5: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_00da: switch (IL_00f3, IL_01cc, IL_02ed, IL_0429, IL_05d9)
+			IL_00da: switch (IL_00f3, IL_01cc, IL_02ed, IL_043c, IL_0612)
 
 			IL_00f3: ldloc.0
 			IL_00f4: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_parametersInitialized
@@ -475,7 +475,7 @@
 			IL_01ff: ldc.i4.0
 			IL_0200: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_0205: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_020a: br IL_04b4
+			IL_020a: br IL_04da
 
 			IL_020f: ldloc.0
 			IL_0210: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
@@ -502,7 +502,7 @@
 			IL_0246: ldloc.0
 			IL_0247: ldc.i4.0
 			IL_0248: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_024d: br IL_0378
+			IL_024d: br IL_038b
 
 			IL_0252: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0257: stloc.s 4
@@ -596,7 +596,7 @@
 			IL_0320: ldc.i4.0
 			IL_0321: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_0326: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_032b: br IL_04b4
+			IL_032b: br IL_04da
 
 			IL_0330: ldloc.0
 			IL_0331: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
@@ -623,334 +623,358 @@
 			IL_0367: ldloc.0
 			IL_0368: ldc.i4.0
 			IL_0369: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_036e: br IL_0378
+			IL_036e: br IL_038b
 
-			IL_0373: br IL_04b4
+			IL_0373: br IL_04da
 
 			IL_0378: ldloc.0
-			IL_0379: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_037e: stloc.s 5
-			IL_0380: ldloc.0
-			IL_0381: ldc.i4.0
-			IL_0382: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_0387: ldloc.0
-			IL_0388: ldc.i4.0
-			IL_0389: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_038e: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0393: ldloc.s 5
-			IL_0395: stloc.2
-			IL_0396: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_039b: stloc.s 4
-			IL_039d: ldstr "catch="
-			IL_03a2: ldloc.2
-			IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03a8: stloc.s 6
-			IL_03aa: ldloc.s 4
-			IL_03ac: ldloc.s 6
-			IL_03ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03b3: pop
-			IL_03b4: ldloc.0
-			IL_03b5: ldc.i4.3
-			IL_03b6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_03bb: ldloc.0
-			IL_03bc: ldc.i4.m1
-			IL_03bd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03c2: ldloc.0
-			IL_03c3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03c8: dup
-			IL_03c9: ldc.i4.0
-			IL_03ca: ldloc.1
-			IL_03cb: box [System.Runtime]System.Boolean
-			IL_03d0: stelem.ref
-			IL_03d1: dup
-			IL_03d2: ldc.i4.1
-			IL_03d3: ldloc.2
-			IL_03d4: stelem.ref
-			IL_03d5: dup
-			IL_03d6: ldc.i4.2
-			IL_03d7: ldloc.3
-			IL_03d8: box [System.Runtime]System.Boolean
-			IL_03dd: stelem.ref
-			IL_03de: dup
-			IL_03df: ldc.i4.3
-			IL_03e0: ldloc.s 4
-			IL_03e2: stelem.ref
-			IL_03e3: dup
-			IL_03e4: ldc.i4.4
-			IL_03e5: ldloc.s 5
+			IL_0379: ldc.i4.1
+			IL_037a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_037f: ldloc.0
+			IL_0380: ldc.i4.0
+			IL_0381: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0386: br IL_038b
+
+			IL_038b: ldloc.0
+			IL_038c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_0391: stloc.s 5
+			IL_0393: ldloc.0
+			IL_0394: ldc.i4.0
+			IL_0395: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_039a: ldloc.0
+			IL_039b: ldc.i4.0
+			IL_039c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03a1: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_03a6: ldloc.s 5
+			IL_03a8: stloc.2
+			IL_03a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ae: stloc.s 4
+			IL_03b0: ldstr "catch="
+			IL_03b5: ldloc.2
+			IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03bb: stloc.s 6
+			IL_03bd: ldloc.s 4
+			IL_03bf: ldloc.s 6
+			IL_03c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03c6: pop
+			IL_03c7: ldloc.0
+			IL_03c8: ldc.i4.3
+			IL_03c9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_03ce: ldloc.0
+			IL_03cf: ldc.i4.m1
+			IL_03d0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03d5: ldloc.0
+			IL_03d6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03db: dup
+			IL_03dc: ldc.i4.0
+			IL_03dd: ldloc.1
+			IL_03de: box [System.Runtime]System.Boolean
+			IL_03e3: stelem.ref
+			IL_03e4: dup
+			IL_03e5: ldc.i4.1
+			IL_03e6: ldloc.2
 			IL_03e7: stelem.ref
 			IL_03e8: dup
-			IL_03e9: ldc.i4.5
-			IL_03ea: ldloc.s 6
-			IL_03ec: stelem.ref
-			IL_03ed: pop
-			IL_03ee: ldloc.0
-			IL_03ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_03f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_03f9: ldarg.0
-			IL_03fa: ldc.i4.1
-			IL_03fb: newarr [System.Runtime]System.Object
-			IL_0400: dup
-			IL_0401: ldc.i4.0
-			IL_0402: ldc.r8 3
-			IL_040b: box [System.Runtime]System.Double
-			IL_0410: ldc.i4.0
-			IL_0411: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0416: stelem.ref
-			IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_041c: pop
-			IL_041d: ldloc.0
-			IL_041e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0423: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0428: ret
+			IL_03e9: ldc.i4.2
+			IL_03ea: ldloc.3
+			IL_03eb: box [System.Runtime]System.Boolean
+			IL_03f0: stelem.ref
+			IL_03f1: dup
+			IL_03f2: ldc.i4.3
+			IL_03f3: ldloc.s 4
+			IL_03f5: stelem.ref
+			IL_03f6: dup
+			IL_03f7: ldc.i4.4
+			IL_03f8: ldloc.s 5
+			IL_03fa: stelem.ref
+			IL_03fb: dup
+			IL_03fc: ldc.i4.5
+			IL_03fd: ldloc.s 6
+			IL_03ff: stelem.ref
+			IL_0400: pop
+			IL_0401: ldloc.0
+			IL_0402: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0407: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_040c: ldarg.0
+			IL_040d: ldc.i4.1
+			IL_040e: newarr [System.Runtime]System.Object
+			IL_0413: dup
+			IL_0414: ldc.i4.0
+			IL_0415: ldc.r8 3
+			IL_041e: box [System.Runtime]System.Double
+			IL_0423: ldc.i4.0
+			IL_0424: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0429: stelem.ref
+			IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_042f: pop
+			IL_0430: ldloc.0
+			IL_0431: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0436: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_043b: ret
 
-			IL_0429: ldloc.0
-			IL_042a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_042f: stloc.3
-			IL_0430: ldloc.3
-			IL_0431: brfalse IL_046c
+			IL_043c: ldloc.0
+			IL_043d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0442: stloc.3
+			IL_0443: ldloc.3
+			IL_0444: brfalse IL_047f
 
-			IL_0436: ldloc.0
-			IL_0437: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_043c: stloc.s 5
-			IL_043e: ldloc.0
-			IL_043f: ldloc.s 5
-			IL_0441: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_0446: ldloc.0
-			IL_0447: ldc.i4.1
-			IL_0448: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_044d: ldloc.0
-			IL_044e: ldc.i4.0
-			IL_044f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_0454: ldloc.0
-			IL_0455: ldc.i4.0
-			IL_0456: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_045b: ldloc.0
-			IL_045c: ldc.i4.0
-			IL_045d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0462: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0467: br IL_04b4
+			IL_0449: ldloc.0
+			IL_044a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_044f: stloc.s 5
+			IL_0451: ldloc.0
+			IL_0452: ldloc.s 5
+			IL_0454: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_0459: ldloc.0
+			IL_045a: ldc.i4.1
+			IL_045b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0460: ldloc.0
+			IL_0461: ldc.i4.0
+			IL_0462: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0467: ldloc.0
+			IL_0468: ldc.i4.0
+			IL_0469: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_046e: ldloc.0
+			IL_046f: ldc.i4.0
+			IL_0470: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0475: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_047a: br IL_04da
 
-			IL_046c: ldloc.0
-			IL_046d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0472: stloc.3
-			IL_0473: ldloc.3
-			IL_0474: brfalse IL_04af
+			IL_047f: ldloc.0
+			IL_0480: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0485: stloc.3
+			IL_0486: ldloc.3
+			IL_0487: brfalse IL_04c2
 
-			IL_0479: ldloc.0
-			IL_047a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_047f: stloc.s 5
-			IL_0481: ldloc.0
-			IL_0482: ldloc.s 5
-			IL_0484: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_0489: ldloc.0
-			IL_048a: ldc.i4.0
-			IL_048b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0490: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_0495: ldloc.0
-			IL_0496: ldc.i4.1
-			IL_0497: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_048c: ldloc.0
+			IL_048d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_0492: stloc.s 5
+			IL_0494: ldloc.0
+			IL_0495: ldloc.s 5
+			IL_0497: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
 			IL_049c: ldloc.0
 			IL_049d: ldc.i4.0
-			IL_049e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_04a3: ldloc.0
-			IL_04a4: ldc.i4.0
-			IL_04a5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_04aa: br IL_04b4
+			IL_049e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04a3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_04a8: ldloc.0
+			IL_04a9: ldc.i4.1
+			IL_04aa: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_04af: ldloc.0
+			IL_04b0: ldc.i4.0
+			IL_04b1: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_04b6: ldloc.0
+			IL_04b7: ldc.i4.0
+			IL_04b8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_04bd: br IL_04da
 
-			IL_04af: br IL_04b4
+			IL_04c2: br IL_04da
 
-			IL_04b4: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
-			IL_04b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04be: stloc.s 4
-			IL_04c0: ldloc.s 4
-			IL_04c2: ldstr "finally"
-			IL_04c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04cc: pop
-			IL_04cd: br IL_04d2
+			IL_04c7: ldloc.0
+			IL_04c8: ldc.i4.1
+			IL_04c9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_04ce: ldloc.0
+			IL_04cf: ldc.i4.0
+			IL_04d0: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_04d5: br IL_04da
 
-			IL_04d2: ldloc.0
-			IL_04d3: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
-			IL_04d8: stloc.3
-			IL_04d9: ldloc.3
-			IL_04da: brfalse IL_04fe
+			IL_04da: call void [JavaScriptRuntime]JavaScriptRuntime.ScriptProcessExitControl::ThrowIfRequested()
+			IL_04df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04e4: stloc.s 4
+			IL_04e6: ldloc.s 4
+			IL_04e8: ldstr "finally"
+			IL_04ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04f2: pop
+			IL_04f3: br IL_050b
 
-			IL_04df: ldloc.0
-			IL_04e0: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
-			IL_04e5: stloc.s 5
-			IL_04e7: ldloc.s 5
-			IL_04e9: isinst [System.Runtime]System.Exception
-			IL_04ee: dup
-			IL_04ef: brtrue IL_04fd
-
-			IL_04f4: pop
-			IL_04f5: ldloc.s 5
-			IL_04f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_04fc: throw
-
-			IL_04fd: throw
-
-			IL_04fe: ldloc.0
-			IL_04ff: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
-			IL_0504: stloc.3
-			IL_0505: ldloc.3
-			IL_0506: brfalse IL_0550
+			IL_04f8: ldloc.0
+			IL_04f9: ldc.i4.1
+			IL_04fa: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_04ff: ldloc.0
+			IL_0500: ldc.i4.0
+			IL_0501: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_0506: br IL_050b
 
 			IL_050b: ldloc.0
-			IL_050c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
-			IL_0511: stloc.s 5
-			IL_0513: ldloc.0
-			IL_0514: ldc.i4.1
-			IL_0515: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_051a: ldloc.0
-			IL_051b: ldc.i4.m1
-			IL_051c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0521: ldloc.0
-			IL_0522: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0527: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_052c: ldarg.0
-			IL_052d: ldc.i4.1
-			IL_052e: newarr [System.Runtime]System.Object
-			IL_0533: dup
-			IL_0534: ldc.i4.0
-			IL_0535: ldloc.s 5
-			IL_0537: ldc.i4.1
-			IL_0538: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_053d: stelem.ref
-			IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0543: pop
+			IL_050c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingException
+			IL_0511: stloc.3
+			IL_0512: ldloc.3
+			IL_0513: brfalse IL_0537
+
+			IL_0518: ldloc.0
+			IL_0519: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingException
+			IL_051e: stloc.s 5
+			IL_0520: ldloc.s 5
+			IL_0522: isinst [System.Runtime]System.Exception
+			IL_0527: dup
+			IL_0528: brtrue IL_0536
+
+			IL_052d: pop
+			IL_052e: ldloc.s 5
+			IL_0530: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0535: throw
+
+			IL_0536: throw
+
+			IL_0537: ldloc.0
+			IL_0538: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasGenPendingReturn
+			IL_053d: stloc.3
+			IL_053e: ldloc.3
+			IL_053f: brfalse IL_0589
+
 			IL_0544: ldloc.0
-			IL_0545: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_054a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_054f: ret
+			IL_0545: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genPendingReturnValue
+			IL_054a: stloc.s 5
+			IL_054c: ldloc.0
+			IL_054d: ldc.i4.1
+			IL_054e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_0553: ldloc.0
+			IL_0554: ldc.i4.m1
+			IL_0555: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_055a: ldloc.0
+			IL_055b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0560: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0565: ldarg.0
+			IL_0566: ldc.i4.1
+			IL_0567: newarr [System.Runtime]System.Object
+			IL_056c: dup
+			IL_056d: ldc.i4.0
+			IL_056e: ldloc.s 5
+			IL_0570: ldc.i4.1
+			IL_0571: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0576: stelem.ref
+			IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_057c: pop
+			IL_057d: ldloc.0
+			IL_057e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0583: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0588: ret
 
-			IL_0550: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0555: stloc.s 4
-			IL_0557: ldloc.s 4
-			IL_0559: ldstr "after"
-			IL_055e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0563: pop
-			IL_0564: ldloc.0
-			IL_0565: ldc.i4.4
-			IL_0566: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
-			IL_056b: ldloc.0
-			IL_056c: ldc.i4.m1
-			IL_056d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0572: ldloc.0
-			IL_0573: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0578: dup
-			IL_0579: ldc.i4.0
-			IL_057a: ldloc.1
-			IL_057b: box [System.Runtime]System.Boolean
-			IL_0580: stelem.ref
-			IL_0581: dup
-			IL_0582: ldc.i4.1
-			IL_0583: ldloc.2
-			IL_0584: stelem.ref
-			IL_0585: dup
-			IL_0586: ldc.i4.2
-			IL_0587: ldloc.3
-			IL_0588: box [System.Runtime]System.Boolean
-			IL_058d: stelem.ref
-			IL_058e: dup
-			IL_058f: ldc.i4.3
+			IL_0589: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_058e: stloc.s 4
 			IL_0590: ldloc.s 4
-			IL_0592: stelem.ref
-			IL_0593: dup
-			IL_0594: ldc.i4.4
-			IL_0595: ldloc.s 5
-			IL_0597: stelem.ref
-			IL_0598: dup
-			IL_0599: ldc.i4.5
-			IL_059a: ldloc.s 6
-			IL_059c: stelem.ref
-			IL_059d: pop
-			IL_059e: ldloc.0
-			IL_059f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_05a9: ldarg.0
-			IL_05aa: ldc.i4.1
-			IL_05ab: newarr [System.Runtime]System.Object
-			IL_05b0: dup
-			IL_05b1: ldc.i4.0
-			IL_05b2: ldc.r8 4
-			IL_05bb: box [System.Runtime]System.Double
-			IL_05c0: ldc.i4.0
-			IL_05c1: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0592: ldstr "after"
+			IL_0597: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_059c: pop
+			IL_059d: ldloc.0
+			IL_059e: ldc.i4.4
+			IL_059f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_genState
+			IL_05a4: ldloc.0
+			IL_05a5: ldc.i4.m1
+			IL_05a6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05ab: ldloc.0
+			IL_05ac: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05b1: dup
+			IL_05b2: ldc.i4.0
+			IL_05b3: ldloc.1
+			IL_05b4: box [System.Runtime]System.Boolean
+			IL_05b9: stelem.ref
+			IL_05ba: dup
+			IL_05bb: ldc.i4.1
+			IL_05bc: ldloc.2
+			IL_05bd: stelem.ref
+			IL_05be: dup
+			IL_05bf: ldc.i4.2
+			IL_05c0: ldloc.3
+			IL_05c1: box [System.Runtime]System.Boolean
 			IL_05c6: stelem.ref
-			IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05cc: pop
-			IL_05cd: ldloc.0
-			IL_05ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05d8: ret
-
-			IL_05d9: ldloc.0
-			IL_05da: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
-			IL_05df: brfalse IL_0625
-
-			IL_05e4: ldloc.0
-			IL_05e5: ldc.i4.1
-			IL_05e6: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_05eb: ldloc.0
-			IL_05ec: ldc.i4.m1
-			IL_05ed: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05f2: ldloc.0
-			IL_05f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_05fd: ldarg.0
-			IL_05fe: ldc.i4.1
-			IL_05ff: newarr [System.Runtime]System.Object
-			IL_0604: dup
-			IL_0605: ldc.i4.0
+			IL_05c7: dup
+			IL_05c8: ldc.i4.3
+			IL_05c9: ldloc.s 4
+			IL_05cb: stelem.ref
+			IL_05cc: dup
+			IL_05cd: ldc.i4.4
+			IL_05ce: ldloc.s 5
+			IL_05d0: stelem.ref
+			IL_05d1: dup
+			IL_05d2: ldc.i4.5
+			IL_05d3: ldloc.s 6
+			IL_05d5: stelem.ref
+			IL_05d6: pop
+			IL_05d7: ldloc.0
+			IL_05d8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_05e2: ldarg.0
+			IL_05e3: ldc.i4.1
+			IL_05e4: newarr [System.Runtime]System.Object
+			IL_05e9: dup
+			IL_05ea: ldc.i4.0
+			IL_05eb: ldc.r8 4
+			IL_05f4: box [System.Runtime]System.Double
+			IL_05f9: ldc.i4.0
+			IL_05fa: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_05ff: stelem.ref
+			IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0605: pop
 			IL_0606: ldloc.0
-			IL_0607: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
-			IL_060c: ldc.i4.1
-			IL_060d: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0612: stelem.ref
-			IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0618: pop
-			IL_0619: ldloc.0
-			IL_061a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_061f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0624: ret
+			IL_0607: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_060c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0611: ret
 
-			IL_0625: ldloc.0
-			IL_0626: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_062b: brfalse IL_0643
+			IL_0612: ldloc.0
+			IL_0613: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasReturn
+			IL_0618: brfalse IL_065e
 
-			IL_0630: ldloc.0
-			IL_0631: ldc.i4.0
-			IL_0632: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
-			IL_0637: ldloc.0
-			IL_0638: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
-			IL_063d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0642: throw
+			IL_061d: ldloc.0
+			IL_061e: ldc.i4.1
+			IL_061f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_0624: ldloc.0
+			IL_0625: ldc.i4.m1
+			IL_0626: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_062b: ldloc.0
+			IL_062c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0631: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0636: ldarg.0
+			IL_0637: ldc.i4.1
+			IL_0638: newarr [System.Runtime]System.Object
+			IL_063d: dup
+			IL_063e: ldc.i4.0
+			IL_063f: ldloc.0
+			IL_0640: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_returnValue
+			IL_0645: ldc.i4.1
+			IL_0646: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_064b: stelem.ref
+			IL_064c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0651: pop
+			IL_0652: ldloc.0
+			IL_0653: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0658: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_065d: ret
 
-			IL_0643: ldloc.0
-			IL_0644: ldc.i4.1
-			IL_0645: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
-			IL_064a: ldloc.0
-			IL_064b: ldc.i4.m1
-			IL_064c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0651: ldloc.0
-			IL_0652: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0657: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_065c: ldarg.0
-			IL_065d: ldc.i4.1
-			IL_065e: newarr [System.Runtime]System.Object
-			IL_0663: dup
-			IL_0664: ldc.i4.0
-			IL_0665: ldnull
-			IL_0666: ldc.i4.1
-			IL_0667: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_066c: stelem.ref
-			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0672: pop
-			IL_0673: ldloc.0
-			IL_0674: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0679: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_067e: ret
+			IL_065e: ldloc.0
+			IL_065f: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0664: brfalse IL_067c
+
+			IL_0669: ldloc.0
+			IL_066a: ldc.i4.0
+			IL_066b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_hasResumeException
+			IL_0670: ldloc.0
+			IL_0671: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_resumeException
+			IL_0676: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_067b: throw
+
+			IL_067c: ldloc.0
+			IL_067d: ldc.i4.1
+			IL_067e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope::_done
+			IL_0683: ldloc.0
+			IL_0684: ldc.i4.m1
+			IL_0685: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_068a: ldloc.0
+			IL_068b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0690: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0695: ldarg.0
+			IL_0696: ldc.i4.1
+			IL_0697: newarr [System.Runtime]System.Object
+			IL_069c: dup
+			IL_069d: ldc.i4.0
+			IL_069e: ldnull
+			IL_069f: ldc.i4.1
+			IL_06a0: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_06a5: stelem.ref
+			IL_06a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06ab: pop
+			IL_06ac: ldloc.0
+			IL_06ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06b2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06b7: ret
 		} // end of method g::__js_call__
 
 	} // end of class g

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Export_Class
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Export_ClassWithConstructor
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Function.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Function.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Export_Function
 	extends [System.Runtime]System.Object
 {
@@ -155,6 +175,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -164,7 +204,7 @@
 				)
 				// Methods
 				.method public hidebysig specialname newslot abstract virtual 
-					instance object get_Value () cil managed 
+					instance class CommonJS_Export_Function/Scripts/CommonJS_Export_Function_Lib/ICallable get_Value () cil managed 
 				{
 					.custom instance void Jroc.Generated.Metadata.JsExportValueAttribute::.ctor() = (
 						01 00 00 00
@@ -196,9 +236,9 @@
 				} // end of method IExports::Construct
 
 				// Properties
-				.property instance object Value()
+				.property instance class CommonJS_Export_Function/Scripts/CommonJS_Export_Function_Lib/ICallable Value()
 				{
-					.get instance object CommonJS_Export_Function/Scripts/CommonJS_Export_Function_Lib/IExports::get_Value()
+					.get instance class CommonJS_Export_Function/Scripts/CommonJS_Export_Function_Lib/ICallable CommonJS_Export_Function/Scripts/CommonJS_Export_Function_Lib/IExports::get_Value()
 				}
 
 			} // end of class IExports

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Export_NestedObjects
 	extends [System.Runtime]System.Object
 {
@@ -155,6 +175,57 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract IObject
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsObjectContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object GetDynamicProperty (
+						string name
+					) cil managed 
+				{
+				} // end of method IObject::GetDynamicProperty
+
+				.method public hidebysig newslot abstract virtual 
+					instance void SetDynamicProperty (
+						string name,
+						object 'value'
+					) cil managed 
+				{
+				} // end of method IObject::SetDynamicProperty
+
+				.method public hidebysig newslot abstract virtual 
+					instance bool HasDynamicProperty (
+						string name
+					) cil managed 
+				{
+				} // end of method IObject::HasDynamicProperty
+
+			} // end of class IObject
+
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Export_ObjectWithClosure
 	extends [System.Runtime]System.Object
 {
@@ -185,6 +205,26 @@
 				} // end of method IObject::HasDynamicProperty
 
 			} // end of class IObject
+
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
 
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
@@ -592,7 +632,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 14 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
 			// Code size: 23 (0x17)
@@ -944,7 +984,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 14 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
 			// Code size: 107 (0x6b)

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Export_ObjectWithFunctions
 	extends [System.Runtime]System.Object
 {
@@ -155,6 +175,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Global_ErrorPrototype_Read.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Global_ErrorPrototype_Read.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Global_ErrorPrototype_Read
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Module_Exports_ChainedAssignment
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Module_Exports_ClassExpression_ExtendsArray
 	extends [System.Runtime]System.Object
 {
@@ -127,6 +147,54 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract IObject
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsObjectContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object GetDynamicProperty (
+						string name
+					) cil managed 
+				{
+				} // end of method IObject::GetDynamicProperty
+
+				.method public hidebysig newslot abstract virtual 
+					instance void SetDynamicProperty (
+						string name,
+						object 'value'
+					) cil managed 
+				{
+				} // end of method IObject::SetDynamicProperty
+
+				.method public hidebysig newslot abstract virtual 
+					instance bool HasDynamicProperty (
+						string name
+					) cil managed 
+				{
+				} // end of method IObject::HasDynamicProperty
+
+			} // end of class IObject
+
+			.class interface nested public auto ansi abstract IConstructor
+				implements [System.Runtime]System.IDisposable
+			{
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance class CommonJS_Module_Exports_ClassExpression_ExtendsArray/Scripts/CommonJS_Module_Exports_ClassExpression_ExtendsArray/IObject Construct (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method IConstructor::Construct
+
+			} // end of class IConstructor
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -606,7 +674,7 @@
 
 			IL_0029: ldarg.1
 			IL_002a: ldstr "length"
-			IL_002f: ldstr "CommonJS_Module_Exports_ClassExpression_ExtendsArray:<TwoPhaseDummy_M17>:.ctor:6"
+			IL_002f: ldstr "CommonJS_Module_Exports_ClassExpression_ExtendsArray:<TwoPhaseDummy_M22>:.ctor:6"
 			IL_0034: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
 			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Function.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Function.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Module_Exports_Function
 	extends [System.Runtime]System.Object
 {
@@ -127,6 +147,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -137,7 +177,7 @@
 				)
 				// Methods
 				.method public hidebysig specialname newslot abstract virtual 
-					instance object get_Value () cil managed 
+					instance class CommonJS_Module_Exports_Function/Scripts/CommonJS_Module_Exports_Function/ICallable get_Value () cil managed 
 				{
 					.custom instance void Jroc.Generated.Metadata.JsExportValueAttribute::.ctor() = (
 						01 00 00 00
@@ -169,9 +209,9 @@
 				} // end of method IExports::Construct
 
 				// Properties
-				.property instance object Value()
+				.property instance class CommonJS_Module_Exports_Function/Scripts/CommonJS_Module_Exports_Function/ICallable Value()
 				{
-					.get instance object CommonJS_Module_Exports_Function/Scripts/CommonJS_Module_Exports_Function/IExports::get_Value()
+					.get instance class CommonJS_Module_Exports_Function/Scripts/CommonJS_Module_Exports_Function/ICallable CommonJS_Module_Exports_Function/Scripts/CommonJS_Module_Exports_Function/IExports::get_Value()
 				}
 
 			} // end of class IExports

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Object.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Object.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Module_Exports_Object
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Reassign.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Reassign.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Module_Exports_Reassign
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_ParentChildren.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_ParentChildren.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Module_ParentChildren
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Require_Captures_Shadowed_Global_URL
 	extends [System.Runtime]System.Object
 {
@@ -155,6 +175,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -166,7 +206,7 @@
 				)
 				// Methods
 				.method public hidebysig specialname newslot abstract virtual 
-					instance object get_Value () cil managed 
+					instance class CommonJS_Require_Captures_Shadowed_Global_URL/Scripts/CommonJS_Require_Captures_Shadowed_Global_URL_Lib/ICallable get_Value () cil managed 
 				{
 					.custom instance void Jroc.Generated.Metadata.JsExportValueAttribute::.ctor() = (
 						01 00 00 00
@@ -198,9 +238,9 @@
 				} // end of method IExports::Construct
 
 				// Properties
-				.property instance object Value()
+				.property instance class CommonJS_Require_Captures_Shadowed_Global_URL/Scripts/CommonJS_Require_Captures_Shadowed_Global_URL_Lib/ICallable Value()
 				{
-					.get instance object CommonJS_Require_Captures_Shadowed_Global_URL/Scripts/CommonJS_Require_Captures_Shadowed_Global_URL_Lib/IExports::get_Value()
+					.get instance class CommonJS_Require_Captures_Shadowed_Global_URL/Scripts/CommonJS_Require_Captures_Shadowed_Global_URL_Lib/ICallable CommonJS_Require_Captures_Shadowed_Global_URL/Scripts/CommonJS_Require_Captures_Shadowed_Global_URL_Lib/IExports::get_Value()
 				}
 
 			} // end of class IExports
@@ -424,7 +464,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 12 00 00 02
+				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
 			// Header size: 12
 			// Code size: 78 (0x4e)
@@ -454,7 +494,7 @@
 
 			IL_0036: ldstr "resolve"
 			IL_003b: ldarg.2
-			IL_003c: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL:<TwoPhaseDummy_M16>:__js_call__:6"
+			IL_003c: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL:<TwoPhaseDummy_M18>:__js_call__:6"
 			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
 			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -999,7 +1039,7 @@
 			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
 			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
 			IL_0031: ldstr "base"
-			IL_0036: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL_Lib:<TwoPhaseDummy_M18>:__js_call__:3"
+			IL_0036: ldstr "CommonJS_Require_Captures_Shadowed_Global_URL_Lib:<TwoPhaseDummy_M20>:__js_call__:3"
 			IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
 			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_FunctionValueIdentity.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_FunctionValueIdentity.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Require_FunctionValueIdentity
 	extends [System.Runtime]System.Object
 {
@@ -155,6 +175,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -574,7 +614,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 12 00 00 02
+				74 61 54 6f 6b 65 6e 14 00 00 02
 			)
 			// Header size: 1
 			// Code size: 12 (0xc)
@@ -1320,7 +1360,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 17 00 00 02
+				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
 			// Header size: 1
 			// Code size: 12 (0xc)

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit CommonJS_Require_OptionalChain_InNestedFunction
 	extends [System.Runtime]System.Object
 {
@@ -464,7 +484,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 10 00 00 02
+				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
 			// Header size: 12
 			// Code size: 191 (0xbf)
@@ -509,7 +529,7 @@
 
 				IL_0049: ldloc.s 5
 				IL_004b: ldstr "value"
-				IL_0050: ldstr "CommonJS_Require_OptionalChain_InNestedFunction:<TwoPhaseDummy_M15>:__js_call__:14"
+				IL_0050: ldstr "CommonJS_Require_OptionalChain_InNestedFunction:<TwoPhaseDummy_M16>:__js_call__:14"
 				IL_0055: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
 				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableMaterialization_IdentityAndCaptures.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableMaterialization_IdentityAndCaptures.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Function_CallableMaterialization_IdentityAndCaptures
 	extends [System.Runtime]System.Object
 {
@@ -127,6 +147,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -353,7 +393,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
 			// Code size: 29 (0x1d)
@@ -490,7 +530,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
 			// Code size: 29 (0x1d)
@@ -802,7 +842,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
 			// Code size: 69 (0x45)
@@ -1329,7 +1369,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
 			// Code size: 92 (0x5c)
@@ -1488,7 +1528,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
 			// Code size: 97 (0x61)
@@ -1652,7 +1692,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
 			// Code size: 74 (0x4a)

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature
 	extends [System.Runtime]System.Object
 {
@@ -127,6 +147,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -139,7 +179,7 @@
 				)
 				// Methods
 				.method public hidebysig specialname newslot abstract virtual 
-					instance object get_Value () cil managed 
+					instance class Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/ICallable get_Value () cil managed 
 				{
 					.custom instance void Jroc.Generated.Metadata.JsExportValueAttribute::.ctor() = (
 						01 00 00 00
@@ -172,9 +212,9 @@
 				} // end of method IExports::Construct
 
 				// Properties
-				.property instance object Value()
+				.property instance class Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/ICallable Value()
 				{
-					.get instance object Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/IExports::get_Value()
+					.get instance class Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/ICallable Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedArrow_KeepsObjectSignature/IExports::get_Value()
 				}
 
 			} // end of class IExports

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature
 	extends [System.Runtime]System.Object
 {
@@ -127,6 +147,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -139,7 +179,7 @@
 				)
 				// Methods
 				.method public hidebysig specialname newslot abstract virtual 
-					instance object get_Value () cil managed 
+					instance class Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/ICallable get_Value () cil managed 
 				{
 					.custom instance void Jroc.Generated.Metadata.JsExportValueAttribute::.ctor() = (
 						01 00 00 00
@@ -172,9 +212,9 @@
 				} // end of method IExports::Construct
 
 				// Properties
-				.property instance object Value()
+				.property instance class Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/ICallable Value()
 				{
-					.get instance object Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/IExports::get_Value()
+					.get instance class Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/ICallable Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scripts/Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/IExports::get_Value()
 				}
 
 			} // end of class IExports

--- a/tests/Jroc.Tests/GeneratedFacadePhaseFourTests.cs
+++ b/tests/Jroc.Tests/GeneratedFacadePhaseFourTests.cs
@@ -1,0 +1,1630 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Jroc.Tests;
+
+public sealed class GeneratedFacadePhaseFourTests
+{
+    [Fact]
+    public void SyncGeneratorsAndIterables_PreserveProtocolSemanticsAndCleanup()
+    {
+        using var harness = new GeneratedAssemblyConsumerHarness(
+            SyncIterableJavaScript,
+            "PhaseFourSync");
+
+        var result = harness.Build(
+            """
+            var cleanup = new List<string>();
+            Action<object?> notify = value => cleanup.Add(Convert.ToString(value)!);
+
+            using var exports = PhaseFourSync.Import();
+
+            Console.WriteLine(string.Join(",", exports.Sequence("a", notify)));
+
+            using (var early = exports.Sequence("early", notify).GetEnumerator())
+            {
+                Console.WriteLine(early.MoveNext());
+                Console.WriteLine(early.Current);
+            }
+            Console.WriteLine(string.Join(",", cleanup));
+
+            using var left = exports.Sequence("left", notify).GetEnumerator();
+            using var right = exports.Sequence("right", notify).GetEnumerator();
+            left.MoveNext();
+            right.MoveNext();
+            Console.WriteLine($"{left.Current},{right.Current}");
+
+            Console.WriteLine(string.Join(",", exports.Single));
+            Console.WriteLine(string.Join(",", exports.Single));
+
+            using (var custom = exports.CreateCustom(notify).GetEnumerator())
+            {
+                custom.MoveNext();
+                Console.WriteLine(custom.Current);
+            }
+            Console.WriteLine(string.Join(",", cleanup));
+
+            using var reusableLeft = exports.Reusable.GetEnumerator();
+            using var reusableRight = exports.Reusable.GetEnumerator();
+            reusableLeft.MoveNext();
+            reusableRight.MoveNext();
+            Console.WriteLine($"{reusableLeft.Current},{reusableRight.Current}");
+            Console.WriteLine(string.Join(",", exports.Reusable));
+            Console.WriteLine(string.Join(",", exports.CustomIterator));
+            Console.WriteLine(exports.CustomIterator.Count());
+
+            try
+            {
+                foreach (var value in exports.Failing())
+                {
+                    Console.WriteLine(value);
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception.GetType().Name);
+                Console.WriteLine(exception.Message.Contains("failing", StringComparison.OrdinalIgnoreCase));
+                Console.WriteLine(exception.InnerException?.Message.Contains("iteration boom", StringComparison.Ordinal) == true);
+                var contextualException = exception.GetType().GetProperty("JsStack") != null
+                    ? exception
+                    : exception.InnerException;
+                var jsStack = (string?)contextualException?.GetType()
+                    .GetProperty("JsStack")?.GetValue(contextualException);
+                Console.WriteLine(jsStack?.Contains("entry.js", StringComparison.Ordinal) == true);
+            }
+
+            var methodValues = new List<object?>();
+            foreach (var value in exports.MethodGenerator("m"))
+            {
+                methodValues.Add(value);
+            }
+            Console.WriteLine(string.Join(",", methodValues));
+            """,
+            run: true);
+
+        AssertConsumerSucceeded(result);
+        Assert.Equal(
+            [
+                "a1,a2",
+                "True",
+                "early1",
+                "a,early",
+                "left1,right1",
+                "single1,single2",
+                "custom1",
+                "a,early,custom",
+                "reuse1,reuse1",
+                "reuse1,reuse2",
+                "iterator1,iterator2",
+                "0",
+                "before-error",
+                "JsInvocationException",
+                "True",
+                "True",
+                "True",
+                "m1,m2"
+            ],
+            OutputLines(result.RunStandardOutput));
+    }
+
+    [Fact]
+    public void AsyncGeneratorsAndIterables_PreserveDelayFailureCancellationAndRootCleanup()
+    {
+        using var harness = new GeneratedAssemblyConsumerHarness(
+            AsyncIterableJavaScript,
+            "PhaseFourAsync");
+
+        var result = harness.Build(
+            """
+            var cleanup = new List<string>();
+            Action<object?> notify = value => cleanup.Add(Convert.ToString(value)!);
+
+            using var exports = PhaseFourAsync.Import();
+
+            var full = new List<object?>();
+            await foreach (var value in exports.Delayed("full", notify))
+            {
+                full.Add(value);
+            }
+            Console.WriteLine(string.Join(",", full));
+            Console.WriteLine(string.Join(",", cleanup));
+
+            await using (var early = exports.Delayed("early", notify).GetAsyncEnumerator())
+            {
+                Console.WriteLine(await early.MoveNextAsync());
+                Console.WriteLine(early.Current);
+            }
+            Console.WriteLine(string.Join(",", cleanup));
+
+            var customValues = new List<object?>();
+            await foreach (var value in exports.CreateCustom(notify))
+            {
+                customValues.Add(value);
+                break;
+            }
+            Console.WriteLine(string.Join(",", customValues));
+            Console.WriteLine(string.Join(",", cleanup));
+
+            var directCustomValues = new List<object?>();
+            await foreach (var value in exports.DirectCustom)
+            {
+                directCustomValues.Add(value);
+            }
+            Console.WriteLine(string.Join(",", directCustomValues));
+
+            var thenableValues = new List<object?>();
+            await foreach (var value in exports.CreateThenable(notify))
+            {
+                thenableValues.Add(value);
+                break;
+            }
+            Console.WriteLine(string.Join(",", thenableValues));
+            Console.WriteLine(string.Join(",", cleanup));
+
+            try
+            {
+                await foreach (var value in exports.CreatePrimitiveResult())
+                {
+                    Console.WriteLine(value);
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception.GetType().Name);
+                Console.WriteLine(exception.Message.Contains(
+                    "createPrimitiveResult",
+                    StringComparison.OrdinalIgnoreCase));
+                Console.WriteLine(exception.InnerException?.Message.Contains(
+                    "did not return an object",
+                    StringComparison.Ordinal) == true);
+            }
+
+            var directIteratorValues = new List<object?>();
+            await foreach (var value in exports.DirectIterator)
+            {
+                directIteratorValues.Add(value);
+            }
+            Console.WriteLine(string.Join(",", directIteratorValues));
+            var directIteratorCount = 0;
+            await foreach (var value in exports.DirectIterator)
+            {
+                directIteratorCount++;
+            }
+            Console.WriteLine(directIteratorCount);
+
+            var singleValues = new List<object?>();
+            await foreach (var value in exports.Single)
+            {
+                singleValues.Add(value);
+            }
+            Console.WriteLine(string.Join(",", singleValues));
+            var singleCount = 0;
+            await foreach (var value in exports.Single)
+            {
+                singleCount++;
+            }
+            Console.WriteLine(singleCount);
+
+            try
+            {
+                await foreach (var value in exports.Failing())
+                {
+                    Console.WriteLine(value);
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception.GetType().Name);
+                Console.WriteLine(exception.Message.Contains("failing", StringComparison.OrdinalIgnoreCase));
+                Console.WriteLine(exception.Message.Contains("async iteration boom", StringComparison.Ordinal)
+                    || exception.InnerException?.Message.Contains("async iteration boom", StringComparison.Ordinal) == true);
+                var contextualException = exception.GetType().GetProperty("JsStack") != null
+                    ? exception
+                    : exception.InnerException;
+                var jsStack = (string?)contextualException?.GetType()
+                    .GetProperty("JsStack")?.GetValue(contextualException);
+                Console.WriteLine(jsStack?.Contains("entry.js", StringComparison.Ordinal) == true);
+            }
+
+            using var cancellation = new CancellationTokenSource();
+            await using (var cancelled = exports.Delayed("cancel", notify)
+                .GetAsyncEnumerator(cancellation.Token))
+            {
+                await cancelled.MoveNextAsync();
+                cancellation.Cancel();
+                try { await cancelled.MoveNextAsync(); }
+                catch (OperationCanceledException) { Console.WriteLine("cancelled"); }
+            }
+            Console.WriteLine(string.Join(",", cleanup));
+
+            var methodValues = new List<object?>();
+            await foreach (var value in exports.MethodGenerator("method"))
+            {
+                methodValues.Add(value);
+            }
+            Console.WriteLine(string.Join(",", methodValues));
+
+            var left = exports.Delayed("left", notify).GetAsyncEnumerator();
+            var right = exports.Delayed("right", notify).GetAsyncEnumerator();
+            await left.MoveNextAsync();
+            await right.MoveNextAsync();
+            Console.WriteLine($"{left.Current},{right.Current}");
+            await left.DisposeAsync();
+            await right.DisposeAsync();
+
+            var root = exports.Delayed("root", notify).GetAsyncEnumerator();
+            await root.MoveNextAsync();
+            exports.Dispose();
+            Console.WriteLine(cleanup.Contains("root"));
+            try { await root.MoveNextAsync(); }
+            catch (ObjectDisposedException) { Console.WriteLine("root-disposed"); }
+
+            var runtimeCleanup = new TaskCompletionSource<string>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Action<object?> runtimeNotify = value =>
+                runtimeCleanup.TrySetResult(Convert.ToString(value)!);
+            using var runtimeThreadExports = PhaseFourAsync.Import();
+            var runtimeThreadIterator = runtimeThreadExports
+                .CreatePromiseCleanup(runtimeNotify)
+                .GetAsyncEnumerator();
+            await runtimeThreadIterator.MoveNextAsync();
+            Console.WriteLine(runtimeThreadIterator.Current);
+            runtimeThreadExports.DisposeFromRuntime(
+                new Action(runtimeThreadExports.Dispose));
+            Console.WriteLine(await runtimeCleanup.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            try { await runtimeThreadIterator.MoveNextAsync(); }
+            catch (ObjectDisposedException) { Console.WriteLine("runtime-root-disposed"); }
+
+            var concurrentCleanup = new TaskCompletionSource<string>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Action<object?> concurrentNotify = value =>
+                concurrentCleanup.TrySetResult(Convert.ToString(value)!);
+            using var concurrentExports = PhaseFourAsync.Import();
+            var concurrentIterator = concurrentExports
+                .CreateSlowCleanup(concurrentNotify)
+                .GetAsyncEnumerator();
+            await concurrentIterator.MoveNextAsync();
+            Console.WriteLine(concurrentIterator.Current);
+            var inFlightDispose = concurrentIterator.DisposeAsync().AsTask();
+            concurrentExports.Dispose();
+            Console.WriteLine(await concurrentCleanup.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+            Console.WriteLine(inFlightDispose.IsCompletedSuccessfully);
+            """,
+            run: true);
+
+        AssertConsumerSucceeded(result);
+        Assert.Equal(
+            [
+                "full1,full2",
+                "full",
+                "True",
+                "early1",
+                "full,early",
+                "custom1",
+                "full,early,custom",
+                "direct1,direct2",
+                "thenable1",
+                "full,early,custom,thenable",
+                "JsInvocationException",
+                "True",
+                "True",
+                "async-iterator1,async-iterator2",
+                "0",
+                "single1,single2",
+                "0",
+                "before-async-error",
+                "JsErrorException",
+                "True",
+                "True",
+                "True",
+                "cancelled",
+                "full,early,custom,thenable,cancel",
+                "method1,method2",
+                "left1,right1",
+                "True",
+                "root-disposed",
+                "runtime1",
+                "runtime-thread",
+                "runtime-root-disposed",
+                "concurrent1",
+                "concurrent",
+                "True"
+            ],
+            OutputLines(result.RunStandardOutput));
+    }
+
+    [Fact]
+    public void Builtins_ProjectDateRegExpErrorAndSymbolWithIdentityAndMutation()
+    {
+        using var harness = new GeneratedAssemblyConsumerHarness(
+            BuiltinJavaScript,
+            "PhaseFourBuiltins");
+
+        var result = harness.Build(
+            """
+            using var exports = PhaseFourBuiltins.Import();
+
+            Console.WriteLine(ReferenceEquals(exports.Date, exports.DateAlias));
+            Console.WriteLine(ReferenceEquals(exports.Date, exports.Nested.Date));
+            Console.WriteLine(ReferenceEquals(exports.Pattern, exports.Nested.Pattern));
+            Console.WriteLine(ReferenceEquals(exports.Error, exports.Nested.Error));
+            Console.WriteLine(ReferenceEquals(exports.GlobalSymbol, exports.Nested.GlobalSymbol));
+            Console.WriteLine(ReferenceEquals(exports.Pattern, exports.GetPattern()));
+            Console.WriteLine(ReferenceEquals(exports.Error, exports.GetError()));
+            Console.WriteLine(ReferenceEquals(exports.GlobalSymbol, exports.GetSymbol()));
+            Console.WriteLine(exports.Date.GetTime());
+            exports.Date.SetTime(2500);
+            Console.WriteLine(exports.DateAlias.GetTime());
+            Console.WriteLine(exports.MakeDate().GetTime());
+            Console.WriteLine(double.IsNaN(exports.InvalidDate.GetTime()));
+            Console.WriteLine(exports.InvalidDate.ToDisplayString());
+            try { exports.InvalidDate.ToISOString(); }
+            catch (Exception exception) { Console.WriteLine(exception.GetType().Name); }
+
+            Console.WriteLine(exports.Pattern.Source);
+            Console.WriteLine(exports.Pattern.Flags);
+            exports.Pattern.LastIndex = 0;
+            var match = exports.Pattern.Exec("baaa");
+            Console.WriteLine(match.Get(0));
+            Console.WriteLine(exports.Pattern.LastIndex);
+            Console.WriteLine(exports.Pattern.Test("zz"));
+            Console.WriteLine(exports.Pattern.LastIndex);
+            Console.WriteLine(exports.Pattern.Exec("zz") == null);
+
+            Console.WriteLine(exports.Error.Name);
+            Console.WriteLine(exports.Error.Message);
+            Console.WriteLine(exports.Error.Cause != null);
+            Console.WriteLine(ReferenceEquals(exports.Error.Cause, exports.Error.Cause));
+            Console.WriteLine(exports.Error.Stack.Contains("TypeError", StringComparison.Ordinal));
+            exports.Error.Name = "HostedError";
+            exports.Error.Message = "changed";
+            exports.Error.Cause = "host-cause";
+            Console.WriteLine($"{exports.ErrorAlias.Name}:{exports.ErrorAlias.Message}:{exports.ErrorAlias.Cause}");
+            Console.WriteLine(exports.RangeError.Name);
+            Console.WriteLine(exports.SyntaxError.Name);
+            Console.WriteLine(exports.EvalError.Name);
+            Console.WriteLine(exports.ReferenceError.Name);
+            Console.WriteLine(exports.UriError.Name);
+            Console.WriteLine(exports.AggregateError.Name);
+            Console.WriteLine(exports.SuppressedError.Name);
+
+            Console.WriteLine(exports.LocalSymbol.Description);
+            Console.WriteLine(exports.LocalSymbol.RegistryKey == null);
+            Console.WriteLine(exports.GlobalSymbol.RegistryKey);
+            Console.WriteLine(ReferenceEquals(exports.GlobalSymbol, exports.GlobalSymbolAlias));
+            Console.WriteLine(exports.WellKnownSymbol.WellKnownName);
+            Console.WriteLine(exports.WellKnownSymbol.ToDisplayString());
+            Console.WriteLine(!ReferenceEquals(exports.LocalSymbol, exports.OtherLocalSymbol));
+
+            using var constructedDate = exports.DateConstructor.Construct(3000);
+            Console.WriteLine(constructedDate.GetTime());
+            Console.WriteLine(exports.DateConstructor.Now());
+            Console.WriteLine(exports.DateConstructor.Parse("ignored"));
+            Console.WriteLine(exports.DateConstructor.Utc(1970, 0, 1));
+            using var constructedPattern = exports.RegExpConstructor.Construct("b+", "g");
+            Console.WriteLine(constructedPattern.Test("abb"));
+            Console.WriteLine(exports.RegExpConstructor.Escape("a+b"));
+            using var constructedError = exports.ErrorConstructor.Construct("host error");
+            Console.WriteLine($"{constructedError.Name}:{constructedError.Message}");
+            using var createdSymbol = exports.SymbolConstructor.Create("created");
+            using var registeredSymbol = exports.SymbolConstructor.For("host-registry");
+            Console.WriteLine(createdSymbol.Description);
+            Console.WriteLine(exports.SymbolConstructor.KeyFor(registeredSymbol));
+            Console.WriteLine(ReferenceEquals(
+                exports.SymbolConstructor.Iterator,
+                exports.WellKnownSymbol));
+
+            try { exports.RegExpConstructor.Construct("x", "gg"); }
+            catch (Exception exception) { Console.WriteLine(exception.GetType().Name); }
+            """,
+            run: true);
+
+        AssertConsumerSucceeded(result);
+        Assert.Equal(
+            [
+                "True",
+                "True",
+                "True",
+                "True",
+                "True",
+                "True",
+                "True",
+                "True",
+                "1000",
+                "2500",
+                "5000",
+                "True",
+                "Invalid Date",
+                "JsInvocationException",
+                "a+",
+                "g",
+                "aaa",
+                "4",
+                "False",
+                "0",
+                "True",
+                "TypeError",
+                "boom",
+                "True",
+                "True",
+                "True",
+                "HostedError:changed:host-cause",
+                "RangeError",
+                "SyntaxError",
+                "EvalError",
+                "ReferenceError",
+                "URIError",
+                "AggregateError",
+                "SuppressedError",
+                "local",
+                "True",
+                "registry",
+                "True",
+                "iterator",
+                "Symbol(Symbol.iterator)",
+                "True",
+                "3000",
+                "111",
+                "222",
+                "333",
+                "True",
+                "patched:a+b",
+                "TypeError:host error",
+                "created",
+                "host-registry",
+                "True",
+                "JsInvocationException"
+            ],
+            OutputLines(result.RunStandardOutput));
+
+        using var directHarness = new GeneratedAssemblyConsumerHarness(
+            "module.exports = new Date(42);",
+            "PhaseFourDirectDate");
+        var directResult = directHarness.Build(
+            """
+            using var exports = PhaseFourDirectDate.Import();
+            Console.WriteLine(exports.Value.GetTime());
+            """,
+            run: true);
+        AssertConsumerSucceeded(directResult);
+        Assert.Equal(["42"], OutputLines(directResult.RunStandardOutput));
+
+        using var defaultHarness = new GeneratedAssemblyConsumerHarness(
+            "export default new RegExp('z+', 'i');",
+            "PhaseFourDefaultRegExp");
+        var defaultResult = defaultHarness.Build(
+            """
+            using var exports = PhaseFourDefaultRegExp.Import();
+            Console.WriteLine(exports.Default.Source);
+            Console.WriteLine(exports.Default.Flags);
+            """,
+            run: true);
+        AssertConsumerSucceeded(defaultResult);
+        Assert.Equal(["z+", "i"], OutputLines(defaultResult.RunStandardOutput));
+    }
+
+    [Fact]
+    public void Collections_PreserveJavaScriptOrderingIdentityWeakSemanticsAndLifetime()
+    {
+        using var harness = new GeneratedAssemblyConsumerHarness(
+            CollectionJavaScript,
+            "PhaseFourCollections");
+
+        var result = harness.Build(
+            """
+            using var exports = PhaseFourCollections.Import();
+            var map = exports.Map;
+            var keyFromMap = map.Keys().Single(item => item is not string);
+            var valueFromMap = map.Get(keyFromMap);
+            var key = exports.GetKey();
+            var value = exports.GetValue();
+
+            Console.WriteLine(ReferenceEquals(map, exports.MapAlias));
+            Console.WriteLine(ReferenceEquals(map, exports.Nested.Map));
+            Console.WriteLine(ReferenceEquals(map, exports.GetMap()));
+            Console.WriteLine(ReferenceEquals(key, exports.GetKey()));
+            Console.WriteLine(ReferenceEquals(value, exports.GetValue()));
+            Console.WriteLine(map.Count);
+            Console.WriteLine(map.Has(key));
+            Console.WriteLine(ReferenceEquals(map.Get(key), map.Get(key)));
+            Console.WriteLine(ReferenceEquals(value, valueFromMap));
+            Console.WriteLine(ReferenceEquals(
+                key,
+                keyFromMap));
+            Console.WriteLine(ReferenceEquals(
+                value,
+                map.Values().Single(item => item is not double)));
+
+            foreach (var entry in map)
+            {
+                var keyText = entry.Key is string text ? text : "object-key";
+                var valueText = entry.Value is double number
+                    ? number.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    : "object-value";
+                Console.WriteLine($"{keyText}:{valueText}");
+            }
+            Console.WriteLine(ReferenceEquals(
+                value,
+                map.Single(entry => entry.Key is not string).Value));
+
+            Console.WriteLine(string.Join(",", map.Keys().Select(item => item is string text ? text : "object-key")));
+            Console.WriteLine(string.Join(",", map.Values().Select(item => item is double number
+                ? number.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                : "object-value")));
+
+            map.Set("added", 4);
+            Console.WriteLine(map.Get("added"));
+            Console.WriteLine(map.Delete("first"));
+            Console.WriteLine(map.Count);
+
+            var set = exports.Set;
+            Console.WriteLine(ReferenceEquals(set, exports.Nested.Set));
+            Console.WriteLine(string.Join(",", set.Select(item => item is string text ? text : "object-value")));
+            Console.WriteLine(set.Has(value));
+            Console.WriteLine(ReferenceEquals(
+                value,
+                set.Single(item => item is not string)));
+            set.Add("added");
+            Console.WriteLine(set.Count);
+            Console.WriteLine(set.Delete("first"));
+
+            Console.WriteLine(exports.WeakMap.Has(key));
+            Console.WriteLine(ReferenceEquals(exports.WeakMap.Get(key), exports.WeakMap.Get(key)));
+            Console.WriteLine(ReferenceEquals(value, exports.WeakMap.Get(key)));
+            exports.WeakMap.Set(value, "second");
+            Console.WriteLine(exports.WeakMap.Get(value));
+            Console.WriteLine(exports.WeakMap.Delete(value));
+            try { exports.WeakMap.Set("primitive", 1); }
+            catch (Exception exception) { Console.WriteLine(exception.GetType().Name); }
+
+            Console.WriteLine(exports.WeakSet.Has(key));
+            exports.WeakSet.Add(value);
+            Console.WriteLine(exports.WeakSet.Has(value));
+            Console.WriteLine(exports.WeakSet.Delete(value));
+            try { exports.WeakSet.Add("primitive"); }
+            catch (Exception exception) { Console.WriteLine(exception.GetType().Name); }
+
+            Console.WriteLine(!exports.WeakMap.GetType().GetInterfaces()
+                .Any(type => type.IsGenericType
+                    && type.GetGenericTypeDefinition() == typeof(IEnumerable<>)));
+            Console.WriteLine(!exports.WeakSet.GetType().GetInterfaces()
+                .Any(type => type.IsGenericType
+                    && type.GetGenericTypeDefinition() == typeof(IEnumerable<>)));
+
+            var callableFromMap = exports.CallableMap.Keys().Single();
+            var callable = exports.GetCallable();
+            Console.WriteLine(ReferenceEquals(callable, callableFromMap));
+            Console.WriteLine(ReferenceEquals(
+                callable,
+                exports.CallableMap.Get(callable)));
+            Console.WriteLine(ReferenceEquals(
+                callable,
+                exports.CallableWeakMap.Get(callable)));
+            Console.WriteLine(ReferenceEquals(
+                callable,
+                exports.CallableMap.Single().Value));
+
+            exports.Dispose();
+            try { Console.WriteLine(map.Count); }
+            catch (ObjectDisposedException) { Console.WriteLine("map-disposed"); }
+            """,
+            run: true);
+
+        AssertConsumerSucceeded(result);
+        Assert.Equal(
+            [
+                "True",
+                "True",
+                "True",
+                "True",
+                "True",
+                "3",
+                "True",
+                "True",
+                "True",
+                "True",
+                "True",
+                "first:1",
+                "object-key:object-value",
+                "last:3",
+                "True",
+                "first,object-key,last",
+                "1,object-value,3",
+                "4",
+                "True",
+                "3",
+                "True",
+                "first,object-value,last",
+                "True",
+                "True",
+                "4",
+                "True",
+                "True",
+                "True",
+                "True",
+                "second",
+                "True",
+                "JsInvocationException",
+                "True",
+                "True",
+                "True",
+                "JsInvocationException",
+                "True",
+                "True",
+                "True",
+                "True",
+                "True",
+                "True",
+                "map-disposed"
+            ],
+            OutputLines(result.RunStandardOutput));
+
+        using var directHarness = new GeneratedAssemblyConsumerHarness(
+            "module.exports = new Set(['a', 'b']);",
+            "PhaseFourDirectSet");
+        var directResult = directHarness.Build(
+            """
+            using var exports = PhaseFourDirectSet.Import();
+            Console.WriteLine(exports.Value.Count);
+            Console.WriteLine(string.Join(",", exports.Value));
+            """,
+            run: true);
+        AssertConsumerSucceeded(directResult);
+        Assert.Equal(["2", "a,b"], OutputLines(directResult.RunStandardOutput));
+    }
+
+    [Fact]
+    public void BinaryValues_PreserveKindsOffsetsBackingStoresMutationAndLifetime()
+    {
+        using var harness = new GeneratedAssemblyConsumerHarness(
+            BinaryJavaScript,
+            "PhaseFourBinary");
+
+        var result = harness.Build(
+            """
+            using var exports = PhaseFourBinary.Import();
+
+            Console.WriteLine(exports.Buffer.ByteLength);
+            Console.WriteLine(!exports.Buffer.IsShared);
+            Console.WriteLine(ReferenceEquals(exports.Buffer, exports.Bytes.Buffer));
+            Console.WriteLine(ReferenceEquals(exports.Buffer, exports.View.Buffer));
+            Console.WriteLine(ReferenceEquals(exports.Bytes, exports.Nested.Bytes));
+            Console.WriteLine(ReferenceEquals(exports.Bytes, exports.GetBytes()));
+            Console.WriteLine(exports.Bytes.ByteOffset);
+            Console.WriteLine(exports.Bytes.ByteLength);
+            Console.WriteLine(exports.Bytes.Length);
+            Console.WriteLine(exports.Bytes.BytesPerElement);
+            Console.WriteLine(exports.View.ByteOffset);
+            Console.WriteLine(exports.View.ByteLength);
+
+            exports.View.SetUint16(0, 0x1234, true);
+            Console.WriteLine(exports.Bytes.Get(2));
+            Console.WriteLine(exports.Bytes.Get(3));
+            exports.Bytes.Set(4, 77);
+            Console.WriteLine(exports.View.GetUint8(2));
+
+            using var slice = exports.Buffer.Slice(2, 6);
+            using var sliceView = exports.MakeView(slice);
+            Console.WriteLine(slice.ByteLength);
+            Console.WriteLine(sliceView.Get(0));
+            sliceView.Set(0, 99);
+            Console.WriteLine(exports.MakeView(exports.Buffer).Get(2));
+
+            Console.WriteLine(exports.Shared.IsShared);
+            Console.WriteLine(ReferenceEquals(exports.Shared, exports.SharedBytes.Buffer));
+            exports.SharedView.SetUint8(1, 44);
+            Console.WriteLine(exports.SharedBytes.Get(1));
+            using var sharedSlice = exports.Shared.Slice(0, 4);
+            using var sharedSliceBytes = exports.MakeView(sharedSlice);
+            Console.WriteLine(sharedSlice.IsShared);
+            Console.WriteLine(sharedSlice.ByteLength);
+            Console.WriteLine(sharedSliceBytes.Get(1));
+            sharedSliceBytes.Set(1, 55);
+            Console.WriteLine(exports.SharedBytes.Get(1));
+
+            var arrays = new[]
+            {
+                exports.Int8,
+                exports.Uint8,
+                exports.Uint8Clamped,
+                exports.Int16,
+                exports.Uint16,
+                exports.Int32,
+                exports.Uint32,
+                exports.Float32,
+                exports.Float64
+            };
+            foreach (var array in arrays)
+            {
+                var before = array.Get(0);
+                array.Set(0, before + 1);
+                Console.WriteLine($"{array.Kind}:{array.Get(0)}:{array.Length}:{array.BytesPerElement}");
+            }
+
+            try { exports.Bytes.Get(100); }
+            catch (ArgumentOutOfRangeException) { Console.WriteLine("typed-index"); }
+            try { exports.View.GetInt32(99, false); }
+            catch (Exception exception) { Console.WriteLine(exception.GetType().Name); }
+            try { exports.Buffer.Resize(4); }
+            catch (Exception exception) { Console.WriteLine(exception.GetType().Name); }
+            Console.WriteLine(exports.Buffer.GetType().GetMethod("Detach") == null);
+
+            var bytes = exports.Bytes;
+            exports.Dispose();
+            try { bytes.Get(0); }
+            catch (ObjectDisposedException) { Console.WriteLine("bytes-disposed"); }
+            """,
+            run: true);
+
+        AssertConsumerSucceeded(result);
+        Assert.Equal(
+            [
+                "16",
+                "True",
+                "True",
+                "True",
+                "True",
+                "True",
+                "2",
+                "8",
+                "8",
+                "1",
+                "4",
+                "8",
+                "52",
+                "18",
+                "77",
+                "4",
+                "9",
+                "9",
+                "True",
+                "True",
+                "44",
+                "True",
+                "4",
+                "44",
+                "44",
+                "Int8Array:0:2:1",
+                "Uint8Array:2:2:1",
+                "Uint8ClampedArray:255:2:1",
+                "Int16Array:0:2:2",
+                "Uint16Array:2:2:2",
+                "Int32Array:0:2:4",
+                "Uint32Array:2:2:4",
+                "Float32Array:2.5:2:4",
+                "Float64Array:2.5:2:8",
+                "typed-index",
+                "JsInvocationException",
+                "JsInvocationException",
+                "True",
+                "bytes-disposed"
+            ],
+            OutputLines(result.RunStandardOutput));
+
+        using var directHarness = new GeneratedAssemblyConsumerHarness(
+            "module.exports = new Uint16Array([4, 5]);",
+            "PhaseFourDirectBinary");
+        var directResult = directHarness.Build(
+            """
+            using var exports = PhaseFourDirectBinary.Import();
+            Console.WriteLine(exports.Value.Kind);
+            Console.WriteLine(exports.Value.Get(1));
+            """,
+            run: true);
+        AssertConsumerSucceeded(directResult);
+        Assert.Equal(["Uint16Array", "5"], OutputLines(directResult.RunStandardOutput));
+    }
+
+    [Fact]
+    public void NestedControlFlowReturns_PreservePhaseFourProjectionKinds()
+    {
+        using var harness = new GeneratedAssemblyConsumerHarness(
+            """
+            const date = new Date(321);
+            const map = new Map([["nested", 7]]);
+            const buffer = new ArrayBuffer(4);
+            const iterable = {
+              [Symbol.iterator]() {
+                let index = 0;
+                return {
+                  next() {
+                    index++;
+                    return index <= 2
+                      ? { value: "nested" + index, done: false }
+                      : { value: undefined, done: true };
+                  }
+                };
+              }
+            };
+
+            function dateFromBranch(flag) {
+              if (flag) {
+                return date;
+              }
+              return date;
+            }
+
+            function mapFromTry(flag) {
+              try {
+                if (flag) {
+                  return map;
+                }
+              } catch {
+                return map;
+              }
+              return map;
+            }
+
+            function bufferFromSwitch(value) {
+              switch (value) {
+                case 1:
+                  return buffer;
+                default:
+                  return buffer;
+              }
+            }
+
+            function iterableFromLoop(flag) {
+              while (flag) {
+                return iterable;
+              }
+              return iterable;
+            }
+
+            module.exports = {
+              dateFromBranch,
+              mapFromTry,
+              bufferFromSwitch,
+              iterableFromLoop
+            };
+            """,
+            "PhaseFourNestedReturns");
+
+        var result = harness.Build(
+            """
+            using var exports = PhaseFourNestedReturns.Import();
+            Console.WriteLine(exports.DateFromBranch(true).GetTime());
+            Console.WriteLine(exports.MapFromTry(true).Get("nested"));
+            Console.WriteLine(exports.BufferFromSwitch(1).ByteLength);
+            Console.WriteLine(string.Join(",", exports.IterableFromLoop(false)));
+            """,
+            run: true);
+
+        AssertConsumerSucceeded(result);
+        Assert.Equal(
+            ["321", "7", "4", "nested1,nested2"],
+            OutputLines(result.RunStandardOutput));
+    }
+
+    [Fact]
+    public void ClassInstances_ProjectInheritedSyncAndAsyncIterableContracts()
+    {
+        using var harness = new GeneratedAssemblyConsumerHarness(
+            """
+            class SyncBase {
+              [Symbol.iterator]() {
+                let index = 0;
+                return {
+                  next() {
+                    index++;
+                    return index <= 2
+                      ? { value: "class-sync" + index, done: false }
+                      : { value: undefined, done: true };
+                  }
+                };
+              }
+            }
+
+            class SyncDerived extends SyncBase {}
+
+            class AsyncBase {
+              [Symbol.asyncIterator]() {
+                let index = 0;
+                return {
+                  next() {
+                    index++;
+                    return Promise.resolve(index <= 2
+                      ? { value: "class-async" + index, done: false }
+                      : { value: undefined, done: true });
+                  }
+                };
+              }
+            }
+
+            class AsyncDerived extends AsyncBase {}
+
+            module.exports = {
+              sync: new SyncDerived(),
+              async: new AsyncDerived(),
+              SyncDerived,
+              AsyncDerived
+            };
+            """,
+            "PhaseFourClassIterables");
+
+        var result = harness.Build(
+            """
+            using var exports = PhaseFourClassIterables.Import();
+            Console.WriteLine(string.Join(",", exports.Sync));
+
+            var asyncValues = new List<object?>();
+            await foreach (var value in exports.Async)
+            {
+                asyncValues.Add(value);
+            }
+            Console.WriteLine(string.Join(",", asyncValues));
+
+            using var constructedSync = exports.SyncDerived.Construct();
+            Console.WriteLine(string.Join(",", constructedSync));
+
+            using var constructedAsync = exports.AsyncDerived.Construct();
+            var constructedAsyncValues = new List<object?>();
+            await foreach (var value in constructedAsync)
+            {
+                constructedAsyncValues.Add(value);
+            }
+            Console.WriteLine(string.Join(",", constructedAsyncValues));
+            """,
+            run: true);
+
+        AssertConsumerSucceeded(result);
+        Assert.Equal(
+            [
+                "class-sync1,class-sync2",
+                "class-async1,class-async2",
+                "class-sync1,class-sync2",
+                "class-async1,class-async2"
+            ],
+            OutputLines(result.RunStandardOutput));
+    }
+
+    [Fact]
+    public void PublicContracts_RecursivelyUseOnlyGeneratedOrBclTypes()
+    {
+        using var harness = new GeneratedAssemblyConsumerHarness(
+            LeakAuditJavaScript,
+            "PhaseFourLeakAudit");
+        using var loaded = JrocInMemoryAssemblyLoader.Load(harness.Artifact);
+
+        var publicTypes = loaded.Assembly
+            .GetTypes()
+            .Where(type => type.IsVisible)
+            .ToArray();
+
+        Assert.NotEmpty(publicTypes);
+        foreach (var type in publicTypes)
+        {
+            AssertAllowedPublicType(type, loaded.Assembly, $"{type.FullName} type");
+            if (type.BaseType != null)
+            {
+                AssertAllowedPublicType(type.BaseType, loaded.Assembly, $"{type.FullName} base");
+            }
+            foreach (var iface in type.GetInterfaces())
+            {
+                AssertAllowedPublicType(iface, loaded.Assembly, $"{type.FullName} interface");
+            }
+
+            foreach (var method in type.GetMethods(
+                         BindingFlags.Public
+                         | BindingFlags.Instance
+                         | BindingFlags.Static
+                         | BindingFlags.DeclaredOnly))
+            {
+                AssertAllowedPublicType(method.ReturnType, loaded.Assembly, method.ToString()!);
+                foreach (var parameter in method.GetParameters())
+                {
+                    AssertAllowedPublicType(
+                        parameter.ParameterType,
+                        loaded.Assembly,
+                        parameter.ToString());
+                }
+            }
+
+            foreach (var property in type.GetProperties(
+                         BindingFlags.Public
+                         | BindingFlags.Instance
+                         | BindingFlags.Static
+                         | BindingFlags.DeclaredOnly))
+            {
+                AssertAllowedPublicType(
+                    property.PropertyType,
+                    loaded.Assembly,
+                    property.ToString()!);
+            }
+        }
+    }
+
+    [Fact]
+    public void NodeObservableOrderingCleanupAndMutationMatch()
+    {
+        var nodeOutput = RunNode(
+            NodeParityJavaScript
+            + """
+
+            const exported = module.exports;
+            console.log(Array.from(exported.values()).join(","));
+            const iterator = exported.values();
+            console.log(iterator.next().value);
+            iterator.return();
+            console.log(exported.cleanup.join(","));
+            console.log(Array.from(exported.map, entry =>
+              (typeof entry[0] === "string" ? entry[0] : "object") + ":" + entry[1]).join(","));
+            console.log(Array.from(exported.set).join(","));
+            exported.view.setUint16(0, 4660, true);
+            console.log(exported.bytes[0] + "," + exported.bytes[1]);
+            console.log(exported.pattern.exec("baaa")[0] + ":" + exported.pattern.lastIndex);
+            console.log(exported.date.getTime());
+            """);
+
+        using var harness = new GeneratedAssemblyConsumerHarness(
+            NodeParityJavaScript,
+            "PhaseFourNodeParity");
+        var result = harness.Build(
+            """
+            using var exports = PhaseFourNodeParity.Import();
+            Console.WriteLine(string.Join(",", exports.Values()));
+            using (var iterator = exports.Values().GetEnumerator())
+            {
+                iterator.MoveNext();
+                Console.WriteLine(iterator.Current);
+            }
+            Console.WriteLine(string.Join(",", Enumerable.Range(0, (int)exports.Cleanup.Length)
+                .Select(index => exports.Cleanup.Get(index))));
+            Console.WriteLine(string.Join(",", exports.Map.Select(entry =>
+                $"{(entry.Key is string text ? text : "object")}:{entry.Value}")));
+            Console.WriteLine(string.Join(",", exports.Set));
+            exports.View.SetUint16(0, 4660, true);
+            Console.WriteLine($"{exports.Bytes.Get(0)},{exports.Bytes.Get(1)}");
+            Console.WriteLine($"{exports.Pattern.Exec("baaa").Get(0)}:{exports.Pattern.LastIndex}");
+            Console.WriteLine(exports.Date.GetTime());
+            """,
+            run: true);
+
+        AssertConsumerSucceeded(result);
+        Assert.Equal(
+            OutputLines(nodeOutput),
+            OutputLines(result.RunStandardOutput));
+    }
+
+    private const string SyncIterableJavaScript =
+        """
+        function* sequence(prefix, notify) {
+          try {
+            yield prefix + "1";
+            yield prefix + "2";
+          } finally {
+            notify(prefix);
+          }
+        }
+
+        function* failing() {
+          yield "before-error";
+          throw new Error("iteration boom");
+        }
+
+        const single = sequence("single", () => {});
+        function createCustom(notify) {
+          return {
+            [Symbol.iterator]() {
+              let index = 0;
+              return {
+                next() {
+                  index++;
+                  return index <= 2
+                    ? { value: "custom" + index, done: false }
+                    : { value: undefined, done: true };
+                },
+                return() {
+                  notify("custom");
+                  return { value: undefined, done: true };
+                },
+                [Symbol.iterator]() { return this; }
+              };
+            }
+          };
+        }
+
+        const reusable = {
+          [Symbol.iterator]() {
+            let index = 0;
+            return {
+              next() {
+                index++;
+                return index <= 2
+                  ? { value: "reuse" + index, done: false }
+                  : { value: undefined, done: true };
+              },
+              [Symbol.iterator]() { return this; }
+            };
+          }
+        };
+
+        const customIterator = {
+          index: 0,
+          next() {
+            this.index++;
+            return this.index <= 2
+              ? { value: "iterator" + this.index, done: false }
+              : { value: undefined, done: true };
+          },
+          [Symbol.iterator]() { return this; }
+        };
+
+        module.exports = {
+          sequence,
+          failing,
+          single,
+          reusable,
+          customIterator,
+          createCustom,
+          *methodGenerator(prefix) {
+            yield prefix + "1";
+            yield prefix + "2";
+          }
+        };
+        """;
+
+    private const string AsyncIterableJavaScript =
+        """
+        async function* delayed(prefix, notify) {
+          try {
+            yield prefix + "1";
+            await new Promise(resolve => setTimeout(resolve, 5));
+            yield prefix + "2";
+          } finally {
+            notify(prefix);
+          }
+        }
+
+        async function* failing() {
+          yield "before-async-error";
+          throw new Error("async iteration boom");
+        }
+
+        async function* singleSource() {
+          yield "single1";
+          yield "single2";
+        }
+        const single = singleSource();
+
+        function createCustom(notify) {
+          return {
+            [Symbol.asyncIterator]() {
+              let index = 0;
+              return {
+                next() {
+                  index++;
+                  return Promise.resolve(index <= 2
+                    ? { value: "custom" + index, done: false }
+                    : { value: undefined, done: true });
+                },
+                return() {
+                  notify("custom");
+                  return Promise.resolve({ value: undefined, done: true });
+                }
+              };
+            }
+          };
+        }
+
+        function createThenable(notify) {
+          let index = 0;
+          return {
+            [Symbol.asyncIterator]() {
+              return {
+                next() {
+                  index++;
+                  return {
+                    then(resolve) {
+                      Promise.resolve().then(() => resolve(index <= 2
+                        ? { value: "thenable" + index, done: false }
+                        : { value: undefined, done: true }));
+                    }
+                  };
+                },
+                return() {
+                  return {
+                    then(resolve) {
+                      Promise.resolve().then(() => {
+                        notify("thenable");
+                        resolve({ value: undefined, done: true });
+                      });
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+
+        function createPrimitiveResult() {
+          return {
+            [Symbol.asyncIterator]() {
+              return {
+                next() {
+                  return {
+                    then(resolve) {
+                      resolve(42);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+
+        function createPromiseCleanup(notify) {
+          let done = false;
+          return {
+            [Symbol.asyncIterator]() {
+              return {
+                next() {
+                  if (done) {
+                    return Promise.resolve({ value: undefined, done: true });
+                  }
+                  done = true;
+                  return Promise.resolve({ value: "runtime1", done: false });
+                },
+                return() {
+                  return new Promise(resolve => setTimeout(() => {
+                    notify("runtime-thread");
+                    resolve({ value: undefined, done: true });
+                  }, 5));
+                }
+              };
+            }
+          };
+        }
+
+        function createSlowCleanup(notify) {
+          let done = false;
+          return {
+            [Symbol.asyncIterator]() {
+              return {
+                next() {
+                  if (done) {
+                    return Promise.resolve({ value: undefined, done: true });
+                  }
+                  done = true;
+                  return Promise.resolve({ value: "concurrent1", done: false });
+                },
+                return() {
+                  return new Promise(resolve => setTimeout(() => {
+                    notify("concurrent");
+                    resolve({ value: undefined, done: true });
+                  }, 20));
+                }
+              };
+            }
+          };
+        }
+
+        function disposeFromRuntime(callback) {
+          callback();
+        }
+
+        const directCustom = {
+          [Symbol.asyncIterator]() {
+            let index = 0;
+            return {
+              next() {
+                index++;
+                return Promise.resolve(index <= 2
+                  ? { value: "direct" + index, done: false }
+                  : { value: undefined, done: true });
+              }
+            };
+          }
+        };
+
+        const directIterator = {
+          index: 0,
+          next() {
+            this.index++;
+            return Promise.resolve(this.index <= 2
+              ? { value: "async-iterator" + this.index, done: false }
+              : { value: undefined, done: true });
+          },
+          [Symbol.asyncIterator]() { return this; }
+        };
+
+        module.exports = {
+          delayed,
+          failing,
+          createCustom,
+          createThenable,
+          createPrimitiveResult,
+          createPromiseCleanup,
+          createSlowCleanup,
+          disposeFromRuntime,
+          directCustom,
+          directIterator,
+          single,
+          async *methodGenerator(prefix) {
+            yield prefix + "1";
+            await Promise.resolve();
+            yield prefix + "2";
+          }
+        };
+        """;
+
+    private const string BuiltinJavaScript =
+        """
+        const cause = { code: 7 };
+        const date = new Date(1000);
+        const invalidDate = new Date("not-a-date");
+        const pattern = new RegExp("a+", "g");
+        const error = new TypeError("boom", { cause });
+        const rangeError = new RangeError("range");
+        const syntaxError = new SyntaxError("syntax");
+        const evalError = new EvalError("eval");
+        const referenceError = new ReferenceError("reference");
+        const uriError = new URIError("uri");
+        const aggregateError = new AggregateError([], "aggregate");
+        const suppressedError = new SuppressedError(
+          new Error("primary"),
+          new Error("suppressed"),
+          "combined");
+        const localSymbol = Symbol("local");
+        const otherLocalSymbol = Symbol("local");
+        const globalSymbol = Symbol.for("registry");
+        const wellKnownSymbol = Symbol.iterator;
+        Date.now = () => 111;
+        Date.parse = () => 222;
+        Date.UTC = () => 333;
+        RegExp.escape = value => "patched:" + value;
+
+        module.exports = {
+          date,
+          dateAlias: date,
+          invalidDate,
+          pattern,
+          error,
+          errorAlias: error,
+          rangeError,
+          syntaxError,
+          evalError,
+          referenceError,
+          uriError,
+          aggregateError,
+          suppressedError,
+          localSymbol,
+          otherLocalSymbol,
+          globalSymbol,
+          globalSymbolAlias: globalSymbol,
+          wellKnownSymbol,
+          nested: { date, pattern, error, globalSymbol },
+          makeDate() { return new Date(5000); },
+          getPattern() { return pattern; },
+          getError() { return error; },
+          getSymbol() { return globalSymbol; },
+          DateConstructor: Date,
+          RegExpConstructor: RegExp,
+          ErrorConstructor: TypeError,
+          SymbolConstructor: Symbol
+        };
+        """;
+
+    private const string CollectionJavaScript =
+        """
+        const key = { id: "key" };
+        const value = { id: "value" };
+        const map = new Map([
+          ["first", 1],
+          [key, value],
+          ["last", 3]
+        ]);
+        const set = new Set(["first", value, "last"]);
+        const weakMap = new WeakMap([[key, value]]);
+        const weakSet = new WeakSet([key]);
+        const callable = value => value;
+        const callableMap = new Map([[callable, callable]]);
+        const callableWeakMap = new WeakMap([[callable, callable]]);
+
+        module.exports = {
+          map,
+          mapAlias: map,
+          set,
+          weakMap,
+          weakSet,
+          callableMap,
+          callableWeakMap,
+          nested: { map, set },
+          getMap() { return map; },
+          getKey() { return key; },
+          getValue() { return value; },
+          getCallable() { return callable; }
+        };
+        """;
+
+    private const string BinaryJavaScript =
+        """
+        const buffer = new ArrayBuffer(16);
+        const allBytes = new Uint8Array(buffer);
+        allBytes[2] = 9;
+        allBytes[3] = 8;
+        allBytes[4] = 7;
+        allBytes[5] = 6;
+        const bytes = new Uint8Array(buffer, 2, 8);
+        const view = new DataView(buffer, 4, 8);
+
+        const shared = new SharedArrayBuffer(8);
+        const sharedBytes = new Uint8Array(shared);
+        const sharedView = new DataView(shared);
+
+        const int8 = new Int8Array([-1, 2]);
+        const uint8 = new Uint8Array([1, 2]);
+        const uint8Clamped = new Uint8ClampedArray([255, 2]);
+        const int16 = new Int16Array([-1, 2]);
+        const uint16 = new Uint16Array([1, 2]);
+        const int32 = new Int32Array([-1, 2]);
+        const uint32 = new Uint32Array([1, 2]);
+        const float32 = new Float32Array([1.5, 2.5]);
+        const float64 = new Float64Array([1.5, 2.5]);
+
+        module.exports = {
+          buffer,
+          bytes,
+          view,
+          shared,
+          sharedBytes,
+          sharedView,
+          int8,
+          uint8,
+          uint8Clamped,
+          int16,
+          uint16,
+          int32,
+          uint32,
+          float32,
+          float64,
+          nested: { bytes, view },
+          getBytes() { return bytes; },
+          makeView(target) { return new Uint8Array(target); }
+        };
+        """;
+
+    private const string LeakAuditJavaScript =
+        """
+        function* syncValues() { yield 1; }
+        async function* asyncValues() { yield 2; }
+        const buffer = new ArrayBuffer(8);
+        const key = {};
+
+        module.exports = {
+          syncValues,
+          asyncValues,
+          date: new Date(0),
+          pattern: new RegExp("x", "g"),
+          error: new Error("boom"),
+          symbol: Symbol.for("leak-audit"),
+          map: new Map([[key, 1]]),
+          set: new Set([key]),
+          weakMap: new WeakMap([[key, 1]]),
+          weakSet: new WeakSet([key]),
+          buffer,
+          shared: new SharedArrayBuffer(8),
+          view: new DataView(buffer),
+          typed: new Float64Array(buffer),
+          nested: {
+            date: new Date(1),
+            map: new Map(),
+            typed: new Uint8Array(buffer)
+          }
+        };
+        """;
+
+    private const string NodeParityJavaScript =
+        """
+        const cleanup = [];
+        function* values() {
+          try {
+            yield "g1";
+            yield "g2";
+          } finally {
+            cleanup.push("closed");
+          }
+        }
+        const key = {};
+        const map = new Map([["first", 1], [key, 2], ["last", 3]]);
+        const set = new Set(["a", "b"]);
+        const buffer = new ArrayBuffer(4);
+        const bytes = new Uint8Array(buffer);
+        const view = new DataView(buffer);
+        const pattern = new RegExp("a+", "g");
+        const date = new Date(1234);
+        module.exports = { cleanup, values, map, set, bytes, view, pattern, date };
+        """;
+
+    private static void AssertAllowedPublicType(
+        Type type,
+        Assembly generatedAssembly,
+        string context)
+    {
+        foreach (var inspected in FlattenType(type))
+        {
+            Assert.False(IsRuntimeType(inspected), $"{context} leaks {inspected.FullName}");
+            Assert.True(
+                inspected.Assembly == generatedAssembly
+                || inspected.Namespace?.StartsWith("System", StringComparison.Ordinal) == true,
+                $"{context} uses non-generated/non-BCL type {inspected.FullName}");
+        }
+    }
+
+    private static IEnumerable<Type> FlattenType(Type type)
+    {
+        if (type.IsByRef || type.IsPointer || type.IsArray)
+        {
+            foreach (var nested in FlattenType(type.GetElementType()!))
+            {
+                yield return nested;
+            }
+            yield break;
+        }
+
+        if (type.IsGenericType)
+        {
+            yield return type.GetGenericTypeDefinition();
+            foreach (var argument in type.GetGenericArguments())
+            {
+                foreach (var nested in FlattenType(argument))
+                {
+                    yield return nested;
+                }
+            }
+            yield break;
+        }
+
+        if (!type.IsGenericParameter)
+        {
+            yield return type;
+        }
+    }
+
+    private static bool IsRuntimeType(Type type)
+        => string.Equals(
+               type.Assembly.GetName().Name,
+               "JavaScriptRuntime",
+               StringComparison.Ordinal)
+           || type.Namespace?.StartsWith("Jroc.Runtime", StringComparison.Ordinal) == true
+           || type.Namespace?.StartsWith("JavaScriptRuntime", StringComparison.Ordinal) == true;
+
+    private static string RunNode(string source)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "node",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("-e");
+        startInfo.ArgumentList.Add(source);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start Node.js.");
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        Assert.True(process.WaitForExit(30_000), "Node.js parity process timed out.");
+        Assert.True(
+            process.ExitCode == 0,
+            $"Node.js parity process failed.{Environment.NewLine}{standardError.GetAwaiter().GetResult()}");
+        return standardOutput.GetAwaiter().GetResult();
+    }
+
+    private static void AssertConsumerSucceeded(GeneratedAssemblyConsumerResult result)
+    {
+        Assert.True(
+            result.BuildExitCode == 0,
+            $"Consumer build failed.{Environment.NewLine}{result.BuildDiagnostics}");
+        Assert.True(
+            result.RunExitCode == 0,
+            $"Consumer run failed.{Environment.NewLine}" +
+            $"{result.RunStandardOutput}{Environment.NewLine}{result.RunStandardError}");
+    }
+
+    private static string[] OutputLines(string output)
+        => output.Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+}

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultAnonClass.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultAnonClass.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_DefaultAnonClass
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultAnonFunction.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultAnonFunction.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_DefaultAnonFunction
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultNamedClass.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultNamedClass.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_DefaultNamedClass
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_DynamicImport_Cjs_Namespace
 	extends [System.Runtime]System.Object
 {
@@ -155,6 +175,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -431,7 +471,7 @@
 				IL_0067: br IL_0080
 
 				IL_006c: ldstr "sort"
-				IL_0071: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M17>:__js_call__:14"
+				IL_0071: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M19>:__js_call__:14"
 				IL_0076: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -449,7 +489,7 @@
 
 				IL_00a7: ldstr "join"
 				IL_00ac: ldstr ","
-				IL_00b1: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M17>:__js_call__:17"
+				IL_00b1: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M19>:__js_call__:17"
 				IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -475,7 +515,7 @@
 				IL_00f7: br IL_0110
 
 				IL_00fc: ldstr "default"
-				IL_0101: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M17>:__js_call__:24"
+				IL_0101: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M19>:__js_call__:24"
 				IL_0106: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -494,7 +534,7 @@
 				IL_0134: br IL_014d
 
 				IL_0139: ldstr "module.exports"
-				IL_013e: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M17>:__js_call__:27"
+				IL_013e: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M19>:__js_call__:27"
 				IL_0143: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 				IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -527,7 +567,7 @@
 				IL_0195: br IL_01ae
 
 				IL_019a: ldstr "value"
-				IL_019f: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M17>:__js_call__:36"
+				IL_019f: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M19>:__js_call__:36"
 				IL_01a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -552,7 +592,7 @@
 				IL_01e6: br IL_01ff
 
 				IL_01eb: ldstr "inc"
-				IL_01f0: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M17>:__js_call__:41"
+				IL_01f0: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M19>:__js_call__:41"
 				IL_01f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 				IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -570,7 +610,7 @@
 
 				IL_0222: ldarg.2
 				IL_0223: ldstr "value"
-				IL_0228: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M17>:__js_call__:47"
+				IL_0228: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M19>:__js_call__:47"
 				IL_022d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 				IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -596,7 +636,7 @@
 				IL_0270: br IL_0289
 
 				IL_0275: ldstr "default"
-				IL_027a: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M17>:__js_call__:54"
+				IL_027a: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M19>:__js_call__:54"
 				IL_027f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 				IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -612,7 +652,7 @@
 
 				IL_02a8: ldloc.s 4
 				IL_02aa: ldstr "value"
-				IL_02af: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M17>:__js_call__:56"
+				IL_02af: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M19>:__js_call__:56"
 				IL_02b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 				IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -734,7 +774,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 14 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
 			// Code size: 141 (0x8d)
@@ -945,7 +985,7 @@
 
 			IL_0039: ldarg.1
 			IL_003a: ldstr "message"
-			IL_003f: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M16>:__js_call__:10"
+			IL_003f: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M18>:__js_call__:10"
 			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -974,7 +1014,7 @@
 
 			IL_0084: ldarg.1
 			IL_0085: ldstr "message"
-			IL_008a: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M16>:__js_call__:20"
+			IL_008a: ldstr "Import_DynamicImport_Cjs_Namespace:<TwoPhaseDummy_M18>:__js_call__:20"
 			IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
 			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1240,7 +1280,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
 			// Code size: 32 (0x20)
@@ -1365,7 +1405,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 1
 			// Code size: 7 (0x7)

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_DynamicImport_Esm_Namespace
 	extends [System.Runtime]System.Object
 {
@@ -455,7 +475,7 @@
 				IL_0067: br IL_0080
 
 				IL_006c: ldstr "sort"
-				IL_0071: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M19>:__js_call__:14"
+				IL_0071: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M20>:__js_call__:14"
 				IL_0076: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -473,7 +493,7 @@
 
 				IL_00a7: ldstr "join"
 				IL_00ac: ldstr ","
-				IL_00b1: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M19>:__js_call__:17"
+				IL_00b1: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M20>:__js_call__:17"
 				IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 				IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -499,7 +519,7 @@
 				IL_00f7: br IL_0110
 
 				IL_00fc: ldstr "value"
-				IL_0101: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M19>:__js_call__:24"
+				IL_0101: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M20>:__js_call__:24"
 				IL_0106: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -524,7 +544,7 @@
 				IL_0146: br IL_015f
 
 				IL_014b: ldstr "inc"
-				IL_0150: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M19>:__js_call__:29"
+				IL_0150: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M20>:__js_call__:29"
 				IL_0155: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 				IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -542,7 +562,7 @@
 
 				IL_0182: ldarg.2
 				IL_0183: ldstr "value"
-				IL_0188: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M19>:__js_call__:35"
+				IL_0188: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M20>:__js_call__:35"
 				IL_018d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 				IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -569,7 +589,7 @@
 				IL_01d3: br IL_01ec
 
 				IL_01d8: ldstr "default"
-				IL_01dd: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M19>:__js_call__:42"
+				IL_01dd: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M20>:__js_call__:42"
 				IL_01e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 				IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -691,7 +711,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 14 00 00 02
+				74 61 54 6f 6b 65 6e 15 00 00 02
 			)
 			// Header size: 12
 			// Code size: 141 (0x8d)
@@ -902,7 +922,7 @@
 
 			IL_0039: ldarg.1
 			IL_003a: ldstr "message"
-			IL_003f: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M18>:__js_call__:10"
+			IL_003f: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M19>:__js_call__:10"
 			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -931,7 +951,7 @@
 
 			IL_0084: ldarg.1
 			IL_0085: ldstr "message"
-			IL_008a: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M18>:__js_call__:20"
+			IL_008a: ldstr "Import_DynamicImport_Esm_Namespace:<TwoPhaseDummy_M19>:__js_call__:20"
 			IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1233,7 +1253,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
 			// Header size: 12
 			// Code size: 49 (0x31)
@@ -1399,7 +1419,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
 			// Header size: 1
 			// Code size: 7 (0x7)

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_ExportNamedFrom
 	extends [System.Runtime]System.Object
 {
@@ -155,6 +175,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -248,6 +288,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportRenamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportRenamedFrom.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_ExportRenamedFrom
 	extends [System.Runtime]System.Object
 {
@@ -757,7 +777,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 15 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
 			// Code size: 49 (0x31)

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarAsNamespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarAsNamespace.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_ExportStarAsNamespace
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_ExportStarFrom
 	extends [System.Runtime]System.Object
 {
@@ -155,6 +175,37 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract IObject
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsObjectContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object GetDynamicProperty (
+						string name
+					) cil managed 
+				{
+				} // end of method IObject::GetDynamicProperty
+
+				.method public hidebysig newslot abstract virtual 
+					instance void SetDynamicProperty (
+						string name,
+						object 'value'
+					) cil managed 
+				{
+				} // end of method IObject::SetDynamicProperty
+
+				.method public hidebysig newslot abstract virtual 
+					instance bool HasDynamicProperty (
+						string name
+					) cil managed 
+				{
+				} // end of method IObject::HasDynamicProperty
+
+			} // end of class IObject
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -164,7 +215,7 @@
 				)
 				// Methods
 				.method public hidebysig specialname newslot abstract virtual 
-					instance object get_Value () cil managed 
+					instance class Import_ExportStarFrom/Scripts/Import_ExportStarFrom_LibA/IObject get_Value () cil managed 
 				{
 					.custom instance void Jroc.Generated.Metadata.JsExportValueAttribute::.ctor() = (
 						01 00 00 00
@@ -172,9 +223,9 @@
 				} // end of method IExports::get_Value
 
 				// Properties
-				.property instance object Value()
+				.property instance class Import_ExportStarFrom/Scripts/Import_ExportStarFrom_LibA/IObject Value()
 				{
-					.get instance object Import_ExportStarFrom/Scripts/Import_ExportStarFrom_LibA/IExports::get_Value()
+					.get instance class Import_ExportStarFrom/Scripts/Import_ExportStarFrom_LibA/IObject Import_ExportStarFrom/Scripts/Import_ExportStarFrom_LibA/IExports::get_Value()
 				}
 
 			} // end of class IExports

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_ExportStarFromMultiHop
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_ImportMeta_Url
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_LiveBindings_Cycle
 	extends [System.Runtime]System.Object
 {
@@ -733,7 +753,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 17 00 00 02
+				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
 			// Header size: 12
 			// Code size: 49 (0x31)
@@ -899,7 +919,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 17 00 00 02
+				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
 			// Header size: 12
 			// Code size: 19 (0x13)
@@ -1202,7 +1222,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
 			// Code size: 49 (0x31)
@@ -1368,7 +1388,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1a 00 00 02
+				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
 			// Code size: 19 (0x13)

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_LiveBindings_Named
 	extends [System.Runtime]System.Object
 {
@@ -516,7 +536,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 11 00 00 02
+				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
 			// Code size: 49 (0x31)

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_Namespace_Esm_Basic
 	extends [System.Runtime]System.Object
 {
@@ -784,7 +804,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 12 00 00 02
+				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 12
 			// Code size: 49 (0x31)
@@ -950,7 +970,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 12 00 00 02
+				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 1
 			// Code size: 7 (0x7)

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_Namespace_FromCjs_Stable
 	extends [System.Runtime]System.Object
 {
@@ -323,6 +343,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -955,7 +995,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 18 00 00 02
+				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
 			// Code size: 93 (0x5d)
@@ -980,7 +1020,7 @@
 			IL_0023: br IL_003c
 
 			IL_0028: ldstr "x"
-			IL_002d: ldstr "Import_Namespace_FromCjs_Stable_Lib:<TwoPhaseDummy_M26>:__js_call__:4"
+			IL_002d: ldstr "Import_Namespace_FromCjs_Stable_Lib:<TwoPhaseDummy_M28>:__js_call__:4"
 			IL_0032: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
 			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_RequireEsmModule
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Import_StaticImport_FromCjs
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 	extends [System.Runtime]System.Object
 {
@@ -159,6 +179,26 @@
 				extends [System.Runtime]System.Object
 			{
 				// Nested Types
+				.class interface nested public auto ansi abstract ICallable
+					implements [System.Runtime]System.IDisposable
+				{
+					.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+						01 00 00 00
+					)
+					// Methods
+					.method public hidebysig newslot abstract virtual 
+						instance object Invoke (
+							object[] arguments
+						) cil managed 
+					{
+						.param [1]
+							.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+								01 00 00 00
+							)
+					} // end of method ICallable::Invoke
+
+				} // end of class ICallable
+
 				.class interface nested public auto ansi abstract IExports
 					implements [System.Runtime]System.IDisposable
 				{
@@ -168,7 +208,7 @@
 					)
 					// Methods
 					.method public hidebysig specialname newslot abstract virtual 
-						instance object get_Value () cil managed 
+						instance class Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scripts/turndown/index/ICallable get_Value () cil managed 
 					{
 						.custom instance void Jroc.Generated.Metadata.JsExportValueAttribute::.ctor() = (
 							01 00 00 00
@@ -198,9 +238,9 @@
 					} // end of method IExports::Construct
 
 					// Properties
-					.property instance object Value()
+					.property instance class Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scripts/turndown/index/ICallable Value()
 					{
-						.get instance object Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scripts/turndown/index/IExports::get_Value()
+						.get instance class Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scripts/turndown/index/ICallable Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scripts/turndown/index/IExports::get_Value()
 					}
 
 				} // end of class IExports
@@ -545,7 +585,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1b 00 00 02
+				74 61 54 6f 6b 65 6e 1d 00 00 02
 			)
 			// Header size: 12
 			// Code size: 918 (0x396)
@@ -1045,7 +1085,7 @@
 
 				IL_001c: ldarg.2
 				IL_001d: ldstr "nodeName"
-				IL_0022: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M19>:__js_call__:3"
+				IL_0022: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M21>:__js_call__:3"
 				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1147,7 +1187,7 @@
 				IL_0148: ldstr "#"
 				IL_014d: ldstr "repeat"
 				IL_0152: ldloc.s 11
-				IL_0154: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M19>:__js_call__:49"
+				IL_0154: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M21>:__js_call__:49"
 				IL_0159: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 				IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1522,7 +1562,7 @@
 
 				IL_001c: ldarg.1
 				IL_001d: ldstr "nodeName"
-				IL_0022: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M21>:__js_call__:3"
+				IL_0022: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M23>:__js_call__:3"
 				IL_0027: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 				IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1674,7 +1714,7 @@
 
 					IL_0029: ldarg.1
 					IL_002a: ldstr "getAttribute"
-					IL_002f: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M23>:__js_call__:6"
+					IL_002f: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M25>:__js_call__:6"
 					IL_0034: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
 					IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1705,7 +1745,7 @@
 
 					IL_0080: ldstr "getAttribute"
 					IL_0085: ldstr "class"
-					IL_008a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M23>:__js_call__:17"
+					IL_008a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M25>:__js_call__:17"
 					IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
 					IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1742,7 +1782,7 @@
 					IL_00e7: ldloc.s 7
 					IL_00e9: ldstr "exec"
 					IL_00ee: ldloc.1
-					IL_00ef: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M23>:__js_call__:31"
+					IL_00ef: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M25>:__js_call__:31"
 					IL_00f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
 					IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1951,7 +1991,7 @@
 
 				IL_0022: ldarg.3
 				IL_0023: ldstr "textContent"
-				IL_0028: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M22>:__js_call__:4"
+				IL_0028: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M24>:__js_call__:4"
 				IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
 				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2012,7 +2052,7 @@
 
 				IL_00d0: ldarg.3
 				IL_00d1: ldstr "querySelector"
-				IL_00d6: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M22>:__js_call__:33"
+				IL_00d6: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M24>:__js_call__:33"
 				IL_00db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
 				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2043,7 +2083,7 @@
 
 				IL_012a: ldstr "querySelector"
 				IL_012f: ldstr "code"
-				IL_0134: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M22>:__js_call__:45"
+				IL_0134: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M24>:__js_call__:45"
 				IL_0139: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
 				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -2259,7 +2299,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1b 00 00 02
+				74 61 54 6f 6b 65 6e 1d 00 00 02
 			)
 			// Header size: 12
 			// Code size: 719 (0x2cf)
@@ -2481,7 +2521,7 @@
 
 			IL_0236: ldstr "turndown"
 			IL_023b: ldarg.2
-			IL_023c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M17>:__js_call__:56"
+			IL_023c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M19>:__js_call__:56"
 			IL_0241: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -2674,7 +2714,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 1b 00 00 02
+				74 61 54 6f 6b 65 6e 1d 00 00 02
 			)
 			// Header size: 12
 			// Code size: 1365 (0x555)
@@ -2719,7 +2759,7 @@
 			IL_0032: br IL_004b
 
 			IL_0037: ldstr "argv"
-			IL_003c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:6"
+			IL_003c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:6"
 			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2739,7 +2779,7 @@
 
 			IL_0073: ldloc.0
 			IL_0074: ldstr "inFile"
-			IL_0079: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:11"
+			IL_0079: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:11"
 			IL_007e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2778,7 +2818,7 @@
 
 			IL_00d9: ldloc.0
 			IL_00da: ldstr "outFile"
-			IL_00df: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:22"
+			IL_00df: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:22"
 			IL_00e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2821,7 +2861,7 @@
 			IL_0150: br IL_0169
 
 			IL_0155: ldstr "cwd"
-			IL_015a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:36"
+			IL_015a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:36"
 			IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2837,7 +2877,7 @@
 
 			IL_0187: ldloc.0
 			IL_0188: ldstr "inFile"
-			IL_018d: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:38"
+			IL_018d: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:38"
 			IL_0192: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2892,7 +2932,7 @@
 			IL_0216: br IL_022f
 
 			IL_021b: ldstr "cwd"
-			IL_0220: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:46"
+			IL_0220: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:46"
 			IL_0225: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2908,7 +2948,7 @@
 
 			IL_024d: ldloc.0
 			IL_024e: ldstr "outFile"
-			IL_0253: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:48"
+			IL_0253: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:48"
 			IL_0258: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3005,7 +3045,7 @@
 
 			IL_0342: ldstr "dirname"
 			IL_0347: ldloc.s 4
-			IL_0349: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:64"
+			IL_0349: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:64"
 			IL_034e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -3090,7 +3130,7 @@
 
 			IL_0422: ldloc.0
 			IL_0423: ldstr "inFile"
-			IL_0428: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:76"
+			IL_0428: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:76"
 			IL_042d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3114,7 +3154,7 @@
 
 			IL_0474: ldloc.0
 			IL_0475: ldstr "outFile"
-			IL_047a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:82"
+			IL_047a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:82"
 			IL_047f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3146,7 +3186,7 @@
 			IL_04de: ldloc.s 8
 			IL_04e0: ldstr "split"
 			IL_04e5: ldloc.s 16
-			IL_04e7: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:91"
+			IL_04e7: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:91"
 			IL_04ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 			IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -3162,7 +3202,7 @@
 
 			IL_0515: ldloc.s 8
 			IL_0517: ldstr "length"
-			IL_051c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M18>:__js_call__:93"
+			IL_051c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:93"
 			IL_0521: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 			IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
 	extends [System.Runtime]System.Object
 {
@@ -155,6 +175,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -464,7 +504,7 @@
 
 			IL_00dc: ldloc.3
 			IL_00dd: ldstr "runHarnessCli"
-			IL_00e2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M14>:__js_call__:8"
+			IL_00e2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M16>:__js_call__:8"
 			IL_00e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -655,7 +695,7 @@
 
 			IL_0039: ldarg.1
 			IL_003a: ldstr "stack"
-			IL_003f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M15>:__js_call__:9"
+			IL_003f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M17>:__js_call__:9"
 			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -684,7 +724,7 @@
 
 			IL_0086: ldarg.1
 			IL_0087: ldstr "stack"
-			IL_008c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M15>:__js_call__:19"
+			IL_008c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M17>:__js_call__:19"
 			IL_0091: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -710,7 +750,7 @@
 
 			IL_00ce: ldarg.1
 			IL_00cf: ldstr "message"
-			IL_00d4: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M15>:__js_call__:28"
+			IL_00d4: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M17>:__js_call__:28"
 			IL_00d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -739,7 +779,7 @@
 
 			IL_011b: ldarg.1
 			IL_011c: ldstr "message"
-			IL_0121: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M15>:__js_call__:38"
+			IL_0121: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M17>:__js_call__:38"
 			IL_0126: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -767,7 +807,7 @@
 			IL_015b: ldloc.2
 			IL_015c: ldstr "error"
 			IL_0161: ldloc.0
-			IL_0162: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M15>:__js_call__:47"
+			IL_0162: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_AutoMode:<TwoPhaseDummy_M17>:__js_call__:47"
 			IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1557,7 +1597,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 754 (0x2f2)
@@ -2434,7 +2474,7 @@
 
 					IL_0022: ldarg.2
 					IL_0023: ldstr "statusCode"
-					IL_0028: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:4"
+					IL_0028: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:4"
 					IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 					IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2466,7 +2506,7 @@
 
 					IL_0081: ldarg.2
 					IL_0082: ldstr "headers"
-					IL_0087: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:18"
+					IL_0087: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:18"
 					IL_008c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 					IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2482,7 +2522,7 @@
 
 					IL_00b5: ldloc.s 4
 					IL_00b7: ldstr "location"
-					IL_00bc: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:20"
+					IL_00bc: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:20"
 					IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 					IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2557,7 +2597,7 @@
 					IL_018d: br IL_01a6
 
 					IL_0192: ldstr "resume"
-					IL_0197: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:56"
+					IL_0197: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:56"
 					IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 					IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2642,7 +2682,7 @@
 					IL_0255: br IL_026e
 
 					IL_025a: ldstr "toString"
-					IL_025f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:75"
+					IL_025f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:75"
 					IL_0264: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 					IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2658,7 +2698,7 @@
 					IL_028b: br IL_02a4
 
 					IL_0290: ldstr "resume"
-					IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:80"
+					IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:80"
 					IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 					IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2778,7 +2818,7 @@
 					IL_03bd: br IL_03d6
 
 					IL_03c2: ldstr "resume"
-					IL_03c7: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:119"
+					IL_03c7: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:119"
 					IL_03cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 					IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2854,7 +2894,7 @@
 
 					IL_047c: ldstr "setEncoding"
 					IL_0481: ldstr "utf8"
-					IL_0486: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:141"
+					IL_0486: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:141"
 					IL_048b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
 					IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -3293,7 +3333,7 @@
 				IL_00fd: br IL_0116
 
 				IL_0102: ldstr "protocol"
-				IL_0107: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M25>:__js_call__:42"
+				IL_0107: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M27>:__js_call__:42"
 				IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 				IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3421,7 +3461,7 @@
 				IL_0259: br IL_0272
 
 				IL_025e: ldstr "end"
-				IL_0263: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M25>:__js_call__:73"
+				IL_0263: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M27>:__js_call__:73"
 				IL_0268: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 				IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -3609,7 +3649,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 108 (0x6c)
@@ -4040,7 +4080,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 599 (0x257)
@@ -4124,7 +4164,7 @@
 
 				IL_0098: ldarg.2
 				IL_0099: ldstr "length"
-				IL_009e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M20>:__js_call__:34"
+				IL_009e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M22>:__js_call__:34"
 				IL_00a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4645,7 +4685,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 1385 (0x569)
@@ -4968,7 +5008,7 @@
 				IL_031d: ldloc.s 8
 				IL_031f: ldstr "exec"
 				IL_0324: ldarg.2
-				IL_0325: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M21>:__js_call__:122"
+				IL_0325: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:122"
 				IL_032a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 				IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -5006,7 +5046,7 @@
 
 				IL_0398: ldloc.s 11
 				IL_039a: ldstr "index"
-				IL_039f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M21>:__js_call__:142"
+				IL_039f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:142"
 				IL_03a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5078,7 +5118,7 @@
 
 				IL_046b: ldloc.s 8
 				IL_046d: ldstr "lastIndex"
-				IL_0472: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M21>:__js_call__:165"
+				IL_0472: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:165"
 				IL_0477: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 				IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5344,7 +5384,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 623 (0x26f)
@@ -5408,7 +5448,7 @@
 			IL_0065: ldloc.1
 			IL_0066: ldstr "exec"
 			IL_006b: ldarg.2
-			IL_006c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M22>:__js_call__:17"
+			IL_006c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:17"
 			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -6331,7 +6371,7 @@
 
 			IL_01d1: ldloc.s 22
 			IL_01d3: ldstr "argv"
-			IL_01d8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:7"
+			IL_01d8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:7"
 			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6351,7 +6391,7 @@
 
 			IL_020f: ldloc.1
 			IL_0210: ldstr "section"
-			IL_0215: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:12"
+			IL_0215: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:12"
 			IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6398,7 +6438,7 @@
 
 			IL_028f: ldloc.1
 			IL_0290: ldstr "outFile"
-			IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:23"
+			IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:23"
 			IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6445,7 +6485,7 @@
 
 			IL_030f: ldloc.1
 			IL_0310: ldstr "url"
-			IL_0315: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:34"
+			IL_0315: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:34"
 			IL_031a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6478,7 +6518,7 @@
 
 			IL_037b: ldloc.1
 			IL_037c: ldstr "auto"
-			IL_0381: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:48"
+			IL_0381: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:48"
 			IL_0386: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6546,7 +6586,7 @@
 
 			IL_044b: ldloc.1
 			IL_044c: ldstr "id"
-			IL_0451: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:78"
+			IL_0451: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:78"
 			IL_0456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6595,7 +6635,7 @@
 
 			IL_04da: ldloc.1
 			IL_04db: ldstr "auto"
-			IL_04e0: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:95"
+			IL_04e0: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:95"
 			IL_04e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6617,7 +6657,7 @@
 
 			IL_051d: ldloc.1
 			IL_051e: ldstr "indexUrl"
-			IL_0523: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:100"
+			IL_0523: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:100"
 			IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6850,7 +6890,7 @@
 
 			IL_06d3: ldloc.1
 			IL_06d4: ldstr "section"
-			IL_06d9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:114"
+			IL_06d9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:114"
 			IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6910,7 +6950,7 @@
 
 			IL_0777: ldloc.1
 			IL_0778: ldstr "section"
-			IL_077d: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:125"
+			IL_077d: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:125"
 			IL_0782: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6969,7 +7009,7 @@
 
 			IL_0824: ldloc.s 13
 			IL_0826: ldstr "filePart"
-			IL_082b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:139"
+			IL_082b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:139"
 			IL_0830: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6991,7 +7031,7 @@
 
 			IL_0869: ldloc.s 13
 			IL_086b: ldstr "href"
-			IL_0870: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:143"
+			IL_0870: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:143"
 			IL_0875: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7023,7 +7063,7 @@
 
 			IL_08c2: ldloc.s 26
 			IL_08c4: ldstr "toString"
-			IL_08c9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:151"
+			IL_08c9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:151"
 			IL_08ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -7225,7 +7265,7 @@
 
 			IL_0a2d: ldloc.s 13
 			IL_0a2f: ldstr "fragment"
-			IL_0a34: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:168"
+			IL_0a34: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:168"
 			IL_0a39: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_0a3e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7259,7 +7299,7 @@
 
 			IL_0a8a: ldloc.1
 			IL_0a8b: ldstr "url"
-			IL_0a90: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:184"
+			IL_0a90: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:184"
 			IL_0a95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7492,7 +7532,7 @@
 
 			IL_0c42: ldloc.1
 			IL_0c43: ldstr "section"
-			IL_0c48: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:205"
+			IL_0c48: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:205"
 			IL_0c4d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_0c52: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7571,7 +7611,7 @@
 
 			IL_0d1c: ldloc.s 26
 			IL_0d1e: ldstr "cwd"
-			IL_0d23: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:224"
+			IL_0d23: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:224"
 			IL_0d28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_0d2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -7587,7 +7627,7 @@
 
 			IL_0d50: ldloc.1
 			IL_0d51: ldstr "outFile"
-			IL_0d56: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:226"
+			IL_0d56: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:226"
 			IL_0d5b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_0d60: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7630,7 +7670,7 @@
 
 			IL_0db8: ldloc.s 18
 			IL_0dba: ldstr "html"
-			IL_0dbf: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:233"
+			IL_0dbf: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:233"
 			IL_0dc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_0dc9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7646,7 +7686,7 @@
 
 			IL_0dec: ldloc.1
 			IL_0ded: ldstr "section"
-			IL_0df2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:236"
+			IL_0df2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:236"
 			IL_0df7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_0dfc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7702,7 +7742,7 @@
 
 			IL_0e86: ldloc.1
 			IL_0e87: ldstr "section"
-			IL_0e8c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:251"
+			IL_0e8c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:251"
 			IL_0e91: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0e96: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7733,7 +7773,7 @@
 
 			IL_0ef3: ldloc.s 18
 			IL_0ef5: ldstr "tagName"
-			IL_0efa: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:261"
+			IL_0efa: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:261"
 			IL_0eff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_0f04: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
 	extends [System.Runtime]System.Object
 {
@@ -127,6 +147,26 @@
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
+			.class interface nested public auto ansi abstract ICallable
+				implements [System.Runtime]System.IDisposable
+			{
+				.custom instance void Jroc.Generated.Metadata.JsCallableContractAttribute::.ctor() = (
+					01 00 00 00
+				)
+				// Methods
+				.method public hidebysig newslot abstract virtual 
+					instance object Invoke (
+						object[] arguments
+					) cil managed 
+				{
+					.param [1]
+						.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+							01 00 00 00
+						)
+				} // end of method ICallable::Invoke
+
+			} // end of class ICallable
+
 			.class interface nested public auto ansi abstract IExports
 				implements [System.Runtime]System.IDisposable
 			{
@@ -464,7 +504,7 @@
 
 			IL_00dc: ldloc.3
 			IL_00dd: ldstr "runHarnessCli"
-			IL_00e2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M14>:__js_call__:8"
+			IL_00e2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M16>:__js_call__:8"
 			IL_00e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
 			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -655,7 +695,7 @@
 
 			IL_0039: ldarg.1
 			IL_003a: ldstr "stack"
-			IL_003f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M15>:__js_call__:9"
+			IL_003f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M17>:__js_call__:9"
 			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -684,7 +724,7 @@
 
 			IL_0086: ldarg.1
 			IL_0087: ldstr "stack"
-			IL_008c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M15>:__js_call__:19"
+			IL_008c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M17>:__js_call__:19"
 			IL_0091: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
 			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -710,7 +750,7 @@
 
 			IL_00ce: ldarg.1
 			IL_00cf: ldstr "message"
-			IL_00d4: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M15>:__js_call__:28"
+			IL_00d4: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M17>:__js_call__:28"
 			IL_00d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
 			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -739,7 +779,7 @@
 
 			IL_011b: ldarg.1
 			IL_011c: ldstr "message"
-			IL_0121: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M15>:__js_call__:38"
+			IL_0121: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M17>:__js_call__:38"
 			IL_0126: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
 			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -767,7 +807,7 @@
 			IL_015b: ldloc.2
 			IL_015c: ldstr "error"
 			IL_0161: ldloc.0
-			IL_0162: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M15>:__js_call__:47"
+			IL_0162: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_UrlMode:<TwoPhaseDummy_M17>:__js_call__:47"
 			IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
 			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1557,7 +1597,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 754 (0x2f2)
@@ -2434,7 +2474,7 @@
 
 					IL_0022: ldarg.2
 					IL_0023: ldstr "statusCode"
-					IL_0028: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:4"
+					IL_0028: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:4"
 					IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
 					IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2466,7 +2506,7 @@
 
 					IL_0081: ldarg.2
 					IL_0082: ldstr "headers"
-					IL_0087: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:18"
+					IL_0087: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:18"
 					IL_008c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
 					IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2482,7 +2522,7 @@
 
 					IL_00b5: ldloc.s 4
 					IL_00b7: ldstr "location"
-					IL_00bc: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:20"
+					IL_00bc: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:20"
 					IL_00c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
 					IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -2557,7 +2597,7 @@
 					IL_018d: br IL_01a6
 
 					IL_0192: ldstr "resume"
-					IL_0197: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:56"
+					IL_0197: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:56"
 					IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
 					IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2642,7 +2682,7 @@
 					IL_0255: br IL_026e
 
 					IL_025a: ldstr "toString"
-					IL_025f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:75"
+					IL_025f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:75"
 					IL_0264: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
 					IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2658,7 +2698,7 @@
 					IL_028b: br IL_02a4
 
 					IL_0290: ldstr "resume"
-					IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:80"
+					IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:80"
 					IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
 					IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2778,7 +2818,7 @@
 					IL_03bd: br IL_03d6
 
 					IL_03c2: ldstr "resume"
-					IL_03c7: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:119"
+					IL_03c7: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:119"
 					IL_03cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
 					IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -2854,7 +2894,7 @@
 
 					IL_047c: ldstr "setEncoding"
 					IL_0481: ldstr "utf8"
-					IL_0486: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:141"
+					IL_0486: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:141"
 					IL_048b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
 					IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -3293,7 +3333,7 @@
 				IL_00fd: br IL_0116
 
 				IL_0102: ldstr "protocol"
-				IL_0107: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M25>:__js_call__:42"
+				IL_0107: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M27>:__js_call__:42"
 				IL_010c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
 				IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -3421,7 +3461,7 @@
 				IL_0259: br IL_0272
 
 				IL_025e: ldstr "end"
-				IL_0263: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M25>:__js_call__:73"
+				IL_0263: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M27>:__js_call__:73"
 				IL_0268: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
 				IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -3609,7 +3649,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 108 (0x6c)
@@ -4040,7 +4080,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 599 (0x257)
@@ -4124,7 +4164,7 @@
 
 				IL_0098: ldarg.2
 				IL_0099: ldstr "length"
-				IL_009e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M20>:__js_call__:34"
+				IL_009e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M22>:__js_call__:34"
 				IL_00a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
 				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -4645,7 +4685,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 1385 (0x569)
@@ -4968,7 +5008,7 @@
 				IL_031d: ldloc.s 8
 				IL_031f: ldstr "exec"
 				IL_0324: ldarg.2
-				IL_0325: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M21>:__js_call__:122"
+				IL_0325: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:122"
 				IL_032a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
 				IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -5006,7 +5046,7 @@
 
 				IL_0398: ldloc.s 11
 				IL_039a: ldstr "index"
-				IL_039f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M21>:__js_call__:142"
+				IL_039f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:142"
 				IL_03a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
 				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5078,7 +5118,7 @@
 
 				IL_046b: ldloc.s 8
 				IL_046d: ldstr "lastIndex"
-				IL_0472: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M21>:__js_call__:165"
+				IL_0472: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:165"
 				IL_0477: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
 				IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -5344,7 +5384,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 21 00 00 02
+				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
 			// Code size: 623 (0x26f)
@@ -5408,7 +5448,7 @@
 			IL_0065: ldloc.1
 			IL_0066: ldstr "exec"
 			IL_006b: ldarg.2
-			IL_006c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M22>:__js_call__:17"
+			IL_006c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:17"
 			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
 			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -6331,7 +6371,7 @@
 
 			IL_01d1: ldloc.s 22
 			IL_01d3: ldstr "argv"
-			IL_01d8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:7"
+			IL_01d8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:7"
 			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
 			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6351,7 +6391,7 @@
 
 			IL_020f: ldloc.1
 			IL_0210: ldstr "section"
-			IL_0215: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:12"
+			IL_0215: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:12"
 			IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
 			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6398,7 +6438,7 @@
 
 			IL_028f: ldloc.1
 			IL_0290: ldstr "outFile"
-			IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:23"
+			IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:23"
 			IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
 			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6445,7 +6485,7 @@
 
 			IL_030f: ldloc.1
 			IL_0310: ldstr "url"
-			IL_0315: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:34"
+			IL_0315: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:34"
 			IL_031a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
 			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6478,7 +6518,7 @@
 
 			IL_037b: ldloc.1
 			IL_037c: ldstr "auto"
-			IL_0381: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:48"
+			IL_0381: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:48"
 			IL_0386: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
 			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6546,7 +6586,7 @@
 
 			IL_044b: ldloc.1
 			IL_044c: ldstr "id"
-			IL_0451: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:78"
+			IL_0451: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:78"
 			IL_0456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
 			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6595,7 +6635,7 @@
 
 			IL_04da: ldloc.1
 			IL_04db: ldstr "auto"
-			IL_04e0: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:95"
+			IL_04e0: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:95"
 			IL_04e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
 			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6617,7 +6657,7 @@
 
 			IL_051d: ldloc.1
 			IL_051e: ldstr "indexUrl"
-			IL_0523: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:100"
+			IL_0523: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:100"
 			IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
 			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6850,7 +6890,7 @@
 
 			IL_06d3: ldloc.1
 			IL_06d4: ldstr "section"
-			IL_06d9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:114"
+			IL_06d9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:114"
 			IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
 			IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6910,7 +6950,7 @@
 
 			IL_0777: ldloc.1
 			IL_0778: ldstr "section"
-			IL_077d: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:125"
+			IL_077d: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:125"
 			IL_0782: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
 			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6969,7 +7009,7 @@
 
 			IL_0824: ldloc.s 13
 			IL_0826: ldstr "filePart"
-			IL_082b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:139"
+			IL_082b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:139"
 			IL_0830: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
 			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -6991,7 +7031,7 @@
 
 			IL_0869: ldloc.s 13
 			IL_086b: ldstr "href"
-			IL_0870: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:143"
+			IL_0870: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:143"
 			IL_0875: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
 			IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7023,7 +7063,7 @@
 
 			IL_08c2: ldloc.s 26
 			IL_08c4: ldstr "toString"
-			IL_08c9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:151"
+			IL_08c9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:151"
 			IL_08ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
 			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -7225,7 +7265,7 @@
 
 			IL_0a2d: ldloc.s 13
 			IL_0a2f: ldstr "fragment"
-			IL_0a34: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:168"
+			IL_0a34: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:168"
 			IL_0a39: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
 			IL_0a3e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7259,7 +7299,7 @@
 
 			IL_0a8a: ldloc.1
 			IL_0a8b: ldstr "url"
-			IL_0a90: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:184"
+			IL_0a90: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:184"
 			IL_0a95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
 			IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7492,7 +7532,7 @@
 
 			IL_0c42: ldloc.1
 			IL_0c43: ldstr "section"
-			IL_0c48: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:205"
+			IL_0c48: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:205"
 			IL_0c4d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
 			IL_0c52: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7571,7 +7611,7 @@
 
 			IL_0d1c: ldloc.s 26
 			IL_0d1e: ldstr "cwd"
-			IL_0d23: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:224"
+			IL_0d23: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:224"
 			IL_0d28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
 			IL_0d2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -7587,7 +7627,7 @@
 
 			IL_0d50: ldloc.1
 			IL_0d51: ldstr "outFile"
-			IL_0d56: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:226"
+			IL_0d56: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:226"
 			IL_0d5b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
 			IL_0d60: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7630,7 +7670,7 @@
 
 			IL_0db8: ldloc.s 18
 			IL_0dba: ldstr "html"
-			IL_0dbf: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:233"
+			IL_0dbf: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:233"
 			IL_0dc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
 			IL_0dc9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7646,7 +7686,7 @@
 
 			IL_0dec: ldloc.1
 			IL_0ded: ldstr "section"
-			IL_0df2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:236"
+			IL_0df2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:236"
 			IL_0df7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
 			IL_0dfc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7702,7 +7742,7 @@
 
 			IL_0e86: ldloc.1
 			IL_0e87: ldstr "section"
-			IL_0e8c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:251"
+			IL_0e8c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:251"
 			IL_0e91: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
 			IL_0e96: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -7733,7 +7773,7 @@
 
 			IL_0ef3: ldloc.s 18
 			IL_0ef5: ldstr "tagName"
-			IL_0efa: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:261"
+			IL_0efa: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:261"
 			IL_0eff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
 			IL_0f04: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Get_Loopback_SelfSigned.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Https_Get_Loopback_SelfSigned
 	extends [System.Runtime]System.Object
 {
@@ -416,7 +436,7 @@
 
 			IL_0022: ldarg.1
 			IL_0023: ldstr "method"
-			IL_0028: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M17>:__js_call__:5"
+			IL_0028: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M18>:__js_call__:5"
 			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -440,7 +460,7 @@
 
 			IL_006c: ldarg.1
 			IL_006d: ldstr "url"
-			IL_0072: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M17>:__js_call__:11"
+			IL_0072: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M18>:__js_call__:11"
 			IL_0077: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -479,7 +499,7 @@
 
 			IL_00e9: ldstr "end"
 			IL_00ee: ldstr "secure hello"
-			IL_00f3: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M17>:__js_call__:29"
+			IL_00f3: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M18>:__js_call__:29"
 			IL_00f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -932,7 +952,7 @@
 					IL_0087: ldloc.2
 					IL_0088: ldstr "close"
 					IL_008d: ldloc.s 5
-					IL_008f: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M21>:__js_call__:12"
+					IL_008f: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M22>:__js_call__:12"
 					IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 					IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1083,7 +1103,7 @@
 
 				IL_002c: ldstr "setEncoding"
 				IL_0031: ldstr "utf8"
-				IL_0036: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M19>:__js_call__:5"
+				IL_0036: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M20>:__js_call__:5"
 				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1101,7 +1121,7 @@
 
 				IL_0068: ldarg.2
 				IL_0069: ldstr "statusCode"
-				IL_006e: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M19>:__js_call__:11"
+				IL_006e: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M20>:__js_call__:11"
 				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1310,7 +1330,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 15 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
 			// Code size: 335 (0x14f)
@@ -1341,7 +1361,7 @@
 			IL_0027: br IL_0040
 
 			IL_002c: ldstr "address"
-			IL_0031: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M18>:__js_call__:4"
+			IL_0031: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M19>:__js_call__:4"
 			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -1359,7 +1379,7 @@
 
 			IL_0063: ldloc.1
 			IL_0064: ldstr "address"
-			IL_0069: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M18>:__js_call__:10"
+			IL_0069: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M19>:__js_call__:10"
 			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1390,7 +1410,7 @@
 
 			IL_00c1: ldloc.1
 			IL_00c2: ldstr "port"
-			IL_00c7: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M18>:__js_call__:19"
+			IL_00c7: ldstr "Https_Get_Loopback_SelfSigned:<TwoPhaseDummy_M19>:__js_call__:19"
 			IL_00cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_Post_Basic.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Https_Request_Post_Basic
 	extends [System.Runtime]System.Object
 {
@@ -579,7 +599,7 @@
 				IL_0029: br IL_0042
 
 				IL_002e: ldstr "method"
-				IL_0033: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M20>:__js_call__:5"
+				IL_0033: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M21>:__js_call__:5"
 				IL_0038: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
 				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -606,7 +626,7 @@
 				IL_007e: br IL_0097
 
 				IL_0083: ldstr "url"
-				IL_0088: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M20>:__js_call__:11"
+				IL_0088: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M21>:__js_call__:11"
 				IL_008d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
 				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -675,7 +695,7 @@
 				IL_0138: ldloc.1
 				IL_0139: ldstr "end"
 				IL_013e: ldloc.2
-				IL_013f: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M20>:__js_call__:29"
+				IL_013f: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M21>:__js_call__:29"
 				IL_0144: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
 				IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -800,7 +820,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 17 00 00 02
+				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
 			// Header size: 12
 			// Code size: 278 (0x116)
@@ -835,7 +855,7 @@
 
 			IL_003f: ldstr "setEncoding"
 			IL_0044: ldstr "utf8"
-			IL_0049: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M17>:__js_call__:9"
+			IL_0049: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M18>:__js_call__:9"
 			IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1369,7 +1389,7 @@
 					IL_0087: ldloc.2
 					IL_0088: ldstr "close"
 					IL_008d: ldloc.s 5
-					IL_008f: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M23>:__js_call__:12"
+					IL_008f: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M24>:__js_call__:12"
 					IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
 					IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1520,7 +1540,7 @@
 
 				IL_002c: ldstr "setEncoding"
 				IL_0031: ldstr "utf8"
-				IL_0036: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M21>:__js_call__:5"
+				IL_0036: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M22>:__js_call__:5"
 				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1538,7 +1558,7 @@
 
 				IL_0068: ldarg.2
 				IL_0069: ldstr "statusCode"
-				IL_006e: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M21>:__js_call__:11"
+				IL_006e: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M22>:__js_call__:11"
 				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
 				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1747,7 +1767,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 17 00 00 02
+				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
 			// Header size: 12
 			// Code size: 334 (0x14e)
@@ -1776,7 +1796,7 @@
 			IL_0027: br IL_0040
 
 			IL_002c: ldstr "address"
-			IL_0031: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M18>:__js_call__:4"
+			IL_0031: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M19>:__js_call__:4"
 			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -1794,7 +1814,7 @@
 
 			IL_0063: ldloc.1
 			IL_0064: ldstr "port"
-			IL_0069: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M18>:__js_call__:10"
+			IL_0069: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M19>:__js_call__:10"
 			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1864,7 +1884,7 @@
 
 			IL_0132: ldstr "end"
 			IL_0137: ldstr "hello tls"
-			IL_013c: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M18>:__js_call__:22"
+			IL_013c: ldstr "Https_Request_Post_Basic:<TwoPhaseDummy_M19>:__js_call__:22"
 			IL_0141: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Https_Request_UrlObject_WithOptions.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Https_Request_UrlObject_WithOptions
 	extends [System.Runtime]System.Object
 {
@@ -416,7 +436,7 @@
 
 			IL_0022: ldarg.1
 			IL_0023: ldstr "method"
-			IL_0028: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M17>:__js_call__:5"
+			IL_0028: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M18>:__js_call__:5"
 			IL_002d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -440,7 +460,7 @@
 
 			IL_006c: ldarg.1
 			IL_006d: ldstr "url"
-			IL_0072: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M17>:__js_call__:11"
+			IL_0072: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M18>:__js_call__:11"
 			IL_0077: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -464,7 +484,7 @@
 
 			IL_00b2: ldarg.1
 			IL_00b3: ldstr "headers"
-			IL_00b8: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M17>:__js_call__:17"
+			IL_00b8: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M18>:__js_call__:17"
 			IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -480,7 +500,7 @@
 
 			IL_00e4: ldloc.1
 			IL_00e5: ldstr "accept-encoding"
-			IL_00ea: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M17>:__js_call__:19"
+			IL_00ea: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M18>:__js_call__:19"
 			IL_00ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -512,7 +532,7 @@
 
 			IL_0146: ldstr "end"
 			IL_014b: ldstr "url-object-ok"
-			IL_0150: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M17>:__js_call__:31"
+			IL_0150: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M18>:__js_call__:31"
 			IL_0155: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -965,7 +985,7 @@
 					IL_0087: ldloc.2
 					IL_0088: ldstr "close"
 					IL_008d: ldloc.s 5
-					IL_008f: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M21>:__js_call__:12"
+					IL_008f: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M22>:__js_call__:12"
 					IL_0094: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
 					IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1116,7 +1136,7 @@
 
 				IL_002c: ldstr "setEncoding"
 				IL_0031: ldstr "utf8"
-				IL_0036: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M19>:__js_call__:5"
+				IL_0036: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M20>:__js_call__:5"
 				IL_003b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
 				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1134,7 +1154,7 @@
 
 				IL_0068: ldarg.2
 				IL_0069: ldstr "statusCode"
-				IL_006e: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M19>:__js_call__:11"
+				IL_006e: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M20>:__js_call__:11"
 				IL_0073: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
 				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1343,7 +1363,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 15 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
 			// Code size: 361 (0x169)
@@ -1375,7 +1395,7 @@
 			IL_0027: br IL_0040
 
 			IL_002c: ldstr "address"
-			IL_0031: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M18>:__js_call__:4"
+			IL_0031: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M19>:__js_call__:4"
 			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -1394,7 +1414,7 @@
 
 			IL_0065: ldloc.1
 			IL_0066: ldstr "port"
-			IL_006b: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M18>:__js_call__:10"
+			IL_006b: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M19>:__js_call__:10"
 			IL_0070: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
 			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1474,7 +1494,7 @@
 			IL_014d: br IL_0166
 
 			IL_0152: ldstr "end"
-			IL_0157: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M18>:__js_call__:29"
+			IL_0157: ldstr "Https_Request_UrlObject_WithOptions:<TwoPhaseDummy_M19>:__js_call__:29"
 			IL_015c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
 			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateSecureContext_Server_Handshake.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Tls_CreateSecureContext_Server_Handshake
 	extends [System.Runtime]System.Object
 {
@@ -406,7 +426,7 @@
 
 			IL_0026: ldstr "end"
 			IL_002b: ldstr "ctx-ok"
-			IL_0030: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M17>:__js_call__:4"
+			IL_0030: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M18>:__js_call__:4"
 			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -553,7 +573,7 @@
 
 				IL_003c: ldstr "setEncoding"
 				IL_0041: ldstr "utf8"
-				IL_0046: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M19>:__js_call__:4"
+				IL_0046: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M20>:__js_call__:4"
 				IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -953,7 +973,7 @@
 				IL_005c: ldloc.1
 				IL_005d: ldstr "close"
 				IL_0062: ldloc.3
-				IL_0063: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M21>:__js_call__:6"
+				IL_0063: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M22>:__js_call__:6"
 				IL_0068: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1069,7 +1089,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 15 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
 			// Code size: 434 (0x1b2)
@@ -1099,7 +1119,7 @@
 			IL_0027: br IL_0040
 
 			IL_002c: ldstr "address"
-			IL_0031: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M18>:__js_call__:4"
+			IL_0031: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M19>:__js_call__:4"
 			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -1117,7 +1137,7 @@
 
 			IL_0063: ldloc.1
 			IL_0064: ldstr "port"
-			IL_0069: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M18>:__js_call__:9"
+			IL_0069: ldstr "Tls_CreateSecureContext_Server_Handshake:<TwoPhaseDummy_M19>:__js_call__:9"
 			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Connect_Basic.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Tls_CreateServer_Connect_Basic
 	extends [System.Runtime]System.Object
 {
@@ -406,7 +426,7 @@
 
 			IL_0026: ldstr "setEncoding"
 			IL_002b: ldstr "utf8"
-			IL_0030: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M17>:__js_call__:4"
+			IL_0030: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M18>:__js_call__:4"
 			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
 			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -424,7 +444,7 @@
 
 			IL_0066: ldstr "end"
 			IL_006b: ldstr "pong"
-			IL_0070: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M17>:__js_call__:9"
+			IL_0070: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M18>:__js_call__:9"
 			IL_0075: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
 			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -578,7 +598,7 @@
 
 				IL_003c: ldstr "setEncoding"
 				IL_0041: ldstr "utf8"
-				IL_0046: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M19>:__js_call__:4"
+				IL_0046: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M20>:__js_call__:4"
 				IL_004b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
 				IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -601,7 +621,7 @@
 				IL_0089: br IL_00a2
 
 				IL_008e: ldstr "encrypted"
-				IL_0093: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M19>:__js_call__:10"
+				IL_0093: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M20>:__js_call__:10"
 				IL_0098: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
 				IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -630,7 +650,7 @@
 				IL_00e8: br IL_0101
 
 				IL_00ed: ldstr "authorized"
-				IL_00f2: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M19>:__js_call__:16"
+				IL_00f2: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M20>:__js_call__:16"
 				IL_00f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
 				IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -659,7 +679,7 @@
 				IL_0143: br IL_015c
 
 				IL_0148: ldstr "authorizationError"
-				IL_014d: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M19>:__js_call__:22"
+				IL_014d: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M20>:__js_call__:22"
 				IL_0152: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
 				IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -703,7 +723,7 @@
 
 				IL_01c1: ldstr "write"
 				IL_01c6: ldstr "ping"
-				IL_01cb: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M19>:__js_call__:32"
+				IL_01cb: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M20>:__js_call__:32"
 				IL_01d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
 				IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1103,7 +1123,7 @@
 				IL_005c: ldloc.1
 				IL_005d: ldstr "close"
 				IL_0062: ldloc.3
-				IL_0063: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M21>:__js_call__:6"
+				IL_0063: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M22>:__js_call__:6"
 				IL_0068: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
 				IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
@@ -1219,7 +1239,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 15 00 00 02
+				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
 			// Code size: 528 (0x210)
@@ -1251,7 +1271,7 @@
 			IL_0027: br IL_0040
 
 			IL_002c: ldstr "address"
-			IL_0031: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M18>:__js_call__:4"
+			IL_0031: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M19>:__js_call__:4"
 			IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
 			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
@@ -1269,7 +1289,7 @@
 
 			IL_0063: ldloc.1
 			IL_0064: ldstr "address"
-			IL_0069: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M18>:__js_call__:10"
+			IL_0069: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M19>:__js_call__:10"
 			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
 			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
@@ -1299,7 +1319,7 @@
 
 			IL_00bf: ldloc.1
 			IL_00c0: ldstr "port"
-			IL_00c5: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M18>:__js_call__:18"
+			IL_00c5: ldstr "Tls_CreateServer_Connect_Basic:<TwoPhaseDummy_M19>:__js_call__:18"
 			IL_00ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
 			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 

--- a/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly.verified.txt
+++ b/tests/Jroc.Tests/Node/Https/Snapshots/GeneratorTests.Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit Tls_CreateServer_Unsupported_RequestCert_Fails_Clearly
 	extends [System.Runtime]System.Object
 {

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_VoidOperator.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_VoidOperator.verified.txt
@@ -115,6 +115,26 @@
 
 } // end of class Jroc.Generated.Metadata.JsCallableContractAttribute
 
+.class private auto ansi sealed beforefieldinit Jroc.Generated.Metadata.JsBuiltinContractAttribute
+	extends [System.Runtime]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor (
+			string 'value'
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method JsBuiltinContractAttribute::.ctor
+
+} // end of class Jroc.Generated.Metadata.JsBuiltinContractAttribute
+
 .class public auto ansi abstract sealed beforefieldinit UnaryOperator_VoidOperator
 	extends [System.Runtime]System.Object
 {


### PR DESCRIPTION
## Summary

- generate BCL-only sync and async iterable facades with JavaScript iterator cleanup, cancellation, thenable assimilation, and contextual errors
- project Date, RegExp, Error, Symbol, Map, Set, weak collections, buffers, DataView, and supported typed arrays while preserving identity, mutation, sharing, and runtime ownership
- cover nested returns, inherited class iterables, callable aliases, async-generator rejection cleanup, constructor mutations, binary slicing, and deterministic disposal
- document public contract mappings, lifecycle behavior, and explicit unsupported operations

## Validation

- `dotnet build jroc.sln --no-restore --nologo` (0 warnings, 0 errors)
- focused Phase 2/3/4 and hosting tests (85 passed)
- all `Jroc.Tests` generator tests (1,060 passed)
- test262 integration generator tests (2 passed)
- no received snapshots or non-snapshot whitespace errors

Closes #1943
Closes #1944
Closes #1945
Closes #1946
Closes #1947

Part of #1917
